### PR TITLE
feat(ai): connect any OpenAI-compatible endpoint, including LM Studio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,18 @@
 # Ollama model (default: llama3)
 # OLLAMA_MODEL=llama3
 
+# === OpenAI-compatible endpoint (Optional) ===
+# Any server that speaks the OpenAI API: LM Studio, vLLM, LocalAI,
+# llama.cpp's llama-server, or a self-hosted gateway.
+# For LM Studio: start its local server, then use the address below.
+# A bare host and port gets /v1 appended automatically.
+# OPENAI_COMPATIBLE_ENDPOINT=http://localhost:1234/v1
+# The model id is decided by the server, so it has no default and must be set.
+# In Settings you can press "Fetch models" to list what the endpoint offers.
+# OPENAI_COMPATIBLE_MODEL=qwen2.5-coder-7b-instruct
+# Optional. Local servers usually ignore it; set it only if yours requires a key.
+# OPENAI_COMPATIBLE_API_KEY=
+
 # The system will automatically detect which AI providers are configured.
 # If multiple providers are configured, the system will use them in this order of preference:
 # 1. Ollama (local)

--- a/AI_PROVIDER_GUIDE.md
+++ b/AI_PROVIDER_GUIDE.md
@@ -49,6 +49,21 @@ OLLAMA_ENDPOINT=http://localhost:11434   # optional
 OLLAMA_MODEL=llama3.1                    # optional
 ```
 
+Any OpenAI-compatible server, local or self-hosted. This is the one to pick for **LM Studio**: open its Developer/Server tab, start the server, and paste the address below. The same setting also covers vLLM, LocalAI, llama.cpp's `llama-server`, text-generation-webui and any gateway that speaks the OpenAI API.
+
+```bash
+OPENAI_COMPATIBLE_ENDPOINT=http://localhost:1234/v1   # LM Studio's default
+OPENAI_COMPATIBLE_MODEL=qwen2.5-coder-7b-instruct     # required, ask the server what it has
+OPENAI_COMPATIBLE_API_KEY=                            # optional, local servers rarely check it
+```
+
+Two things differ from the other providers:
+
+- **The model id is required.** It is decided by whichever server you run, so there is no sensible default to fall back on. In Settings, fill in the address and press **Fetch models** — the app asks the endpoint's `/models` and fills the dropdown for you.
+- **The address is a base URL, not a host.** If you give it just a host and port, `/v1` is appended (`http://localhost:1234` becomes `http://localhost:1234/v1`). If you write any path yourself it is left alone, because not every server mounts its API at `/v1`.
+
+Note that LM Studio and LM Studio Bionic are two different apps. Bionic is an agent app and does not expose a server for other programs to call; it is LM Studio that provides the OpenAI-compatible endpoint above.
+
 Reasoning models are handled for you: when the model id looks like an OpenAI reasoning model (`o1`, `o3`, `gpt-5` and so on), the request uses `max_completion_tokens` and drops the temperature, because those models reject the older parameters.
 
 ## Three ways to set it

--- a/README-zh.md
+++ b/README-zh.md
@@ -139,7 +139,7 @@ npm start
 | 聊天助手 | 基于编辑器中当前的代码答疑，不直接给出完整答案 |
 | 工程评审 | 从并发安全、失败行为、模块边界与风格评审已完成的关卡 |
 
-支持的服务商：DeepSeek、OpenAI、Claude、Qwen，以及通过 Ollama 运行的本地模型。详见 [AI_PROVIDER_GUIDE.md](./AI_PROVIDER_GUIDE.md)。
+支持的服务商：DeepSeek、OpenAI、Claude、Qwen，以及通过 Ollama 或任意 OpenAI 兼容端点（LM Studio、vLLM、LocalAI、llama.cpp）运行的本地模型。详见 [AI_PROVIDER_GUIDE.md](./AI_PROVIDER_GUIDE.md)。
 
 ## 使用
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -144,7 +144,7 @@ Las cuatro funciones comparten una única configuración de proveedor.
 | Asistente de chat | Responde sobre el código que hay en el editor sin revelar la solución completa |
 | Revisión de ingeniería | Revisa una etapa terminada por seguridad ante concurrencia, comportamiento ante fallos, límites de módulo y estilo |
 
-Proveedores soportados: DeepSeek, OpenAI, Claude, Qwen y modelos locales mediante Ollama. Consulta [AI_PROVIDER_GUIDE.md](./AI_PROVIDER_GUIDE.md).
+Proveedores soportados: DeepSeek, OpenAI, Claude, Qwen y modelos locales mediante Ollama o cualquier endpoint compatible con OpenAI (LM Studio, vLLM, LocalAI, llama.cpp). Consulta [AI_PROVIDER_GUIDE.md](./AI_PROVIDER_GUIDE.md).
 
 ## Uso
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ All four features share a single provider configuration.
 | Chat assistant | Answers questions about the code currently in the editor without revealing the full solution |
 | Engineering review | Reviews a completed stage on concurrency safety, failure behaviour, module boundaries and style |
 
-Supported providers: DeepSeek, OpenAI, Claude, Qwen, and local models through Ollama. See [AI_PROVIDER_GUIDE.md](./AI_PROVIDER_GUIDE.md).
+Supported providers: DeepSeek, OpenAI, Claude, Qwen, and local models through Ollama or any OpenAI-compatible endpoint (LM Studio, vLLM, LocalAI, llama.cpp). See [AI_PROVIDER_GUIDE.md](./AI_PROVIDER_GUIDE.md).
 
 ## Usage
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>AlgoLocal: offline coding practice, from LeetCode-style problems to real engineering projects</title>
   <meta name="description" content="A free, open-source desktop app for offline coding practice: LeetCode-style problems in JavaScript, TypeScript or Python, plus multi-stage engineering projects.">
-  <meta name="keywords" content="leetcode, leetcode alternative, offline leetcode, coding practice, coding interview preparation, algorithm practice, data structures and algorithms, engineering practice, system design practice, concurrency, code review, javascript, typescript, python, wasm, webassembly, pyodide, monaco editor, electron desktop app, offline ide, local-first, self-hosted, ai coding assistant, deepseek, ollama, open source">
+  <meta name="keywords" content="leetcode, leetcode alternative, offline leetcode, coding practice, coding interview preparation, algorithm practice, data structures and algorithms, engineering practice, system design practice, concurrency, code review, javascript, typescript, python, wasm, webassembly, pyodide, monaco editor, electron desktop app, offline ide, local-first, self-hosted, ai coding assistant, deepseek, ollama, lm studio, openai compatible, local llm, open source">
   <meta name="author" content="zxypro1">
   <meta name="robots" content="index, follow">
   <meta name="msvalidate.01" content="851E8929724BC064EAFA2D4AAE903E09">
@@ -247,7 +247,7 @@
         <div class="ai-grid">
           <div class="ai-copy reveal">
             <h2>AI when you want it.<br>Focus when you don’t.</h2>
-            <p>Generate a problem, ask for a hint, or compare solutions. Connect DeepSeek, OpenAI, Claude, Qwen or a local Ollama model — or skip AI entirely.</p>
+            <p>Generate a problem, ask for a hint, or compare solutions. Connect DeepSeek, OpenAI, Claude, Qwen, or run it all locally with Ollama or LM Studio — or skip AI entirely.</p>
             <a class="text-link text-link-light" href="https://github.com/zxypro1/algolocal/blob/main/AI_PROVIDER_GUIDE.md" target="_blank" rel="noopener">Set up an AI provider <span>→</span></a>
           </div>
           <div class="ai-demo reveal">

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>AlgoLocal：本地离线刷题与工程实战，从力扣算法题到真实项目</title>
   <meta name="description" content="免费开源的离线刷题桌面应用。用 JavaScript、TypeScript 或 Python 刷力扣风格算法题，再做多关卡的工程实战项目，按并发、延迟和代码质量打分。AI 可选。">
-  <meta name="keywords" content="leetcode, 力扣, 离线刷题, 刷题软件, 算法练习, 数据结构与算法, 编程面试, 面试刷题, 手撕代码, 工程实战, 系统设计, 并发编程, 代码评审, JavaScript, TypeScript, Python, WASM, Pyodide, Monaco 编辑器, 桌面应用, 离线 IDE, 本地优先, 开源, AI 编程助手, DeepSeek, Ollama">
+  <meta name="keywords" content="leetcode, 力扣, 离线刷题, 刷题软件, 算法练习, 数据结构与算法, 编程面试, 面试刷题, 手撕代码, 工程实战, 系统设计, 并发编程, 代码评审, JavaScript, TypeScript, Python, WASM, Pyodide, Monaco 编辑器, 桌面应用, 离线 IDE, 本地优先, 开源, AI 编程助手, DeepSeek, Ollama, LM Studio, OpenAI 兼容, 本地大模型">
   <meta name="author" content="zxypro1">
   <meta name="robots" content="index, follow">
   <meta name="msvalidate.01" content="851E8929724BC064EAFA2D4AAE903E09">
@@ -195,7 +195,7 @@
       <div class="site-container">
         <div class="ai-modes reveal" aria-label="AI 工作流"><div><span>生成</span><p>从一个主题到一道完整题目。</p></div><div><span>提问</span><p>在解题过程中获得上下文提示。</p></div><div class="orange"><span>对比</span><p>对比多种解法和它们的复杂度取舍。</p></div></div>
         <div class="ai-grid">
-          <div class="ai-copy reveal"><h2>需要时用 AI。<br>不需要时只管专注。</h2><p>生成新题、获取提示、对比解法。可以接入 DeepSeek、OpenAI、Claude、通义千问或本地 Ollama，也可以完全不用。</p><a class="text-link text-link-light" href="https://github.com/zxypro1/algolocal/blob/main/AI_PROVIDER_GUIDE.md" target="_blank" rel="noopener">查看 AI 配置说明 <span>→</span></a></div>
+          <div class="ai-copy reveal"><h2>需要时用 AI。<br>不需要时只管专注。</h2><p>生成新题、获取提示、对比解法。可以接入 DeepSeek、OpenAI、Claude、通义千问，也可以用 Ollama 或 LM Studio 全部跑在本地，或者完全不用。</p><a class="text-link text-link-light" href="https://github.com/zxypro1/algolocal/blob/main/AI_PROVIDER_GUIDE.md" target="_blank" rel="noopener">查看 AI 配置说明 <span>→</span></a></div>
           <div class="ai-demo reveal"><div class="mini-bar"><div class="window-dots"><i></i><i></i><i></i></div><span>AlgoLocal / AI 助手</span><b>DeepSeek⌄</b></div><div class="ai-demo-body"><div class="ai-context"><small>当前题目</small><h3>两数之和</h3><p>返回数组中和等于目标值的两个数字的下标。</p><code>const complement = target - nums[i];</code></div><div class="ai-response"><small>你的问题</small><p class="question">给我一个提示，但不要直接说出完整答案。</p><p>想一想：只遍历数组一次时，你需要记住哪些信息？</p><div class="approach"><b>下一步可以尝试</b><span>记录每个值及其下标，再寻找它的补数。</span></div><label>继续提问… <span>➤</span></label></div></div></div>
         </div>
       </div>

--- a/electron-main.js
+++ b/electron-main.js
@@ -143,6 +143,12 @@ function loadSavedConfig() {
         if (configData.ollama.endpoint) process.env.OLLAMA_ENDPOINT = configData.ollama.endpoint;
         if (configData.ollama.model) process.env.OLLAMA_MODEL = configData.ollama.model;
       }
+
+      if (configData.compatible) {
+        if (configData.compatible.endpoint) process.env.OPENAI_COMPATIBLE_ENDPOINT = configData.compatible.endpoint;
+        if (configData.compatible.model) process.env.OPENAI_COMPATIBLE_MODEL = configData.compatible.model;
+        if (configData.compatible.apiKey) process.env.OPENAI_COMPATIBLE_API_KEY = configData.compatible.apiKey;
+      }
       
       return configData;
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -280,6 +280,7 @@
     "unlimitedProblems": "Generate unlimited coding problems",
     "usingOnlineAI": "Using Online AI ({{provider}})",
     "usingLocalAI": "Using Local AI (Ollama)",
+    "usingCompatibleAI": "Using an OpenAI-compatible endpoint",
     "changeInSettings": "Change in Settings",
     "selectAIProvider": "Select AI Provider",
     "autoSelect": "Auto",

--- a/locales/en.json
+++ b/locales/en.json
@@ -344,6 +344,22 @@
       "model": "Model",
       "modelPlaceholder": "Enter model name (e.g., llama3)"
     },
+    "compatible": {
+      "title": "OpenAI-compatible endpoint (Local)",
+      "intro": "Connect any server that speaks the OpenAI API. Running LM Studio? Start its server and paste http://localhost:1234/v1 below. vLLM, LocalAI and llama.cpp's server work the same way.",
+      "endpoint": "Base URL",
+      "endpointHint": "For LM Studio use http://localhost:1234/v1. A bare host and port gets /v1 appended automatically.",
+      "apiKey": "API key (optional)",
+      "apiKeyPlaceholder": "Usually not needed for a local server",
+      "apiKeyHint": "Local servers normally ignore this. Fill it in only if your endpoint requires a key.",
+      "model": "Model",
+      "modelPlaceholder": "Click Fetch models, or type the id",
+      "modelHint": "The model id comes from the server, so there is no default to fall back on.",
+      "fetchModels": "Fetch models",
+      "fetchFailed": "Could not reach that endpoint.",
+      "noModels": "The endpoint replied, but listed no models. Load a model in the server first.",
+      "foundModels": "Found {count} model(s)."
+    },
     "modelHint": "Leave empty to use the default. Any model id works."
   },
   "manage": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -280,6 +280,7 @@
     "unlimitedProblems": "生成无限编程题目",
     "usingOnlineAI": "使用在线 AI ({{provider}})",
     "usingLocalAI": "使用本地 AI (Ollama)",
+    "usingCompatibleAI": "使用 OpenAI 兼容端点",
     "changeInSettings": "在设置中更改",
     "selectAIProvider": "选择 AI 提供商",
     "autoSelect": "自动选择",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -344,6 +344,22 @@
       "model": "模型",
       "modelPlaceholder": "输入模型名称 (例如: llama3)"
     },
+    "compatible": {
+      "title": "OpenAI 兼容端点（本地）",
+      "intro": "任何提供 OpenAI 接口的服务都能连。用 LM Studio 的话，把它的本地服务打开，然后在下面填 http://localhost:1234/v1 即可。vLLM、LocalAI、llama.cpp server 同理。",
+      "endpoint": "服务地址",
+      "endpointHint": "LM Studio 填 http://localhost:1234/v1。只填主机和端口时会自动补上 /v1。",
+      "apiKey": "API Key（可选）",
+      "apiKeyPlaceholder": "本地服务通常不需要",
+      "apiKeyHint": "本地服务一般不校验这一项，只有你的端点要求鉴权时才填。",
+      "model": "模型",
+      "modelPlaceholder": "点「获取模型列表」，或直接输入 id",
+      "modelHint": "模型 id 由服务端决定，所以没有默认值可用。",
+      "fetchModels": "获取模型列表",
+      "fetchFailed": "连不上这个地址。",
+      "noModels": "端点有响应，但没有列出任何模型。请先在服务端加载一个模型。",
+      "foundModels": "找到 {count} 个模型。"
+    },
     "modelHint": "留空则使用默认模型。可直接输入任意模型 id。"
   },
   "manage": {

--- a/pages/api/ai-providers.ts
+++ b/pages/api/ai-providers.ts
@@ -12,6 +12,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const isOpenAIConfigured = !!process.env.OPENAI_API_KEY;
     const isQwenConfigured = !!process.env.QWEN_API_KEY;
     const isClaudeConfigured = !!process.env.CLAUDE_API_KEY;
+    // 端点和模型都得有才算配好：模型 id 由对端决定，猜不出来
+    const isCompatibleConfigured =
+      !!process.env.OPENAI_COMPATIBLE_ENDPOINT && !!process.env.OPENAI_COMPATIBLE_MODEL;
     
     return res.status(200).json({
       providers: {
@@ -19,7 +22,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         deepseek: isDeepSeekConfigured,
         openai: isOpenAIConfigured,
         qwen: isQwenConfigured,
-        claude: isClaudeConfigured
+        claude: isClaudeConfigured,
+        compatible: isCompatibleConfigured
       }
     });
   } catch (error) {

--- a/pages/api/compatible-models.ts
+++ b/pages/api/compatible-models.ts
@@ -21,11 +21,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'An endpoint is required.' });
   }
 
+  // 这个路由按定义就是「去请求用户填的地址」，但也别让它变成一个万能的
+  // 服务端探测器：限定 http/https，挡掉 file:、gopher: 之类的协议。
+  // 部署成公网服务时这里应该再加一层内网地址白名单/黑名单。
+  let target: URL;
+  try {
+    target = new URL(`${base}/models`);
+  } catch {
+    return res.status(400).json({ error: `Not a valid URL: ${base}` });
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    return res.status(400).json({ error: 'Only http and https endpoints are supported.' });
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   try {
-    const response = await fetch(`${base}/models`, {
+    const response = await fetch(target, {
       headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
       signal: controller.signal,
     });

--- a/pages/api/compatible-models.ts
+++ b/pages/api/compatible-models.ts
@@ -1,0 +1,59 @@
+/**
+ * 列出某个 OpenAI 兼容端点上可用的模型。
+ *
+ * 设置页用它把「模型 id」从一个要用户自己去别处抄的输入框，变成一个下拉框。
+ * 走服务端而不是浏览器直连，是因为本地服务（LM Studio 等）默认只监听
+ * 127.0.0.1，而且多半没开 CORS —— 浏览器直接 fetch 会被拦下。
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { normalizeCompatibleEndpoint } from '../../src/lib/server/aiProvider';
+
+const TIMEOUT_MS = 10_000;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { endpoint, apiKey } = (req.body || {}) as { endpoint?: string; apiKey?: string };
+  const base = normalizeCompatibleEndpoint(endpoint || '');
+  if (!base) {
+    return res.status(400).json({ error: 'An endpoint is required.' });
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${base}/models`, {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      return res.status(502).json({
+        error: `The endpoint answered ${response.status}.`,
+        detail: detail.slice(0, 300),
+      });
+    }
+
+    const data = await response.json();
+    // OpenAI 的形状是 { data: [{ id }] }；有些实现直接返回数组，两种都收
+    const list = Array.isArray(data) ? data : data?.data;
+    const models = Array.isArray(list)
+      ? list.map((item: any) => (typeof item === 'string' ? item : item?.id)).filter(Boolean)
+      : [];
+
+    return res.status(200).json({ endpoint: base, models });
+  } catch (error: any) {
+    const aborted = error?.name === 'AbortError';
+    return res.status(502).json({
+      error: aborted
+        ? `No response from ${base} within ${TIMEOUT_MS / 1000}s.`
+        : `Could not reach ${base}: ${error?.message || String(error)}`,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -59,6 +59,48 @@ export default function SettingsPage() {
     endpoint: '',
     model: ''
   });
+
+  const [compatibleConfig, setCompatibleConfig] = useState({
+    endpoint: '',
+    model: '',
+    apiKey: ''
+  });
+  // 从端点拉回来的模型列表，填充下拉框
+  const [compatibleModels, setCompatibleModels] = useState<string[]>([]);
+  const [compatibleLoading, setCompatibleLoading] = useState(false);
+  const [compatibleError, setCompatibleError] = useState<string | null>(null);
+
+  const fetchCompatibleModels = async () => {
+    setCompatibleLoading(true);
+    setCompatibleError(null);
+    try {
+      const response = await fetch('/api/compatible-models', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint: compatibleConfig.endpoint, apiKey: compatibleConfig.apiKey }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setCompatibleError(data?.error || t('settings.compatible.fetchFailed'));
+        setCompatibleModels([]);
+        return;
+      }
+      setCompatibleModels(data.models || []);
+      if (!data.models?.length) {
+        setCompatibleError(t('settings.compatible.noModels'));
+        return;
+      }
+      // 只有一个模型时直接替用户选上，省一次点击
+      if (data.models.length === 1 && !compatibleConfig.model) {
+        setCompatibleConfig((prev) => ({ ...prev, model: data.models[0] }));
+      }
+    } catch (error: any) {
+      setCompatibleError(error?.message || t('settings.compatible.fetchFailed'));
+      setCompatibleModels([]);
+    } finally {
+      setCompatibleLoading(false);
+    }
+  };
   
   // Global AI provider selection
   const [selectedProvider, setSelectedProvider] = useState('auto');
@@ -78,6 +120,7 @@ export default function SettingsPage() {
             setQwenConfig(data.qwen || { apiKey: '', model: '' });
             setClaudeConfig(data.claude || { apiKey: '', model: '' });
             setOllamaConfig(data.ollama || { endpoint: '', model: '' });
+            setCompatibleConfig(data.compatible || { endpoint: '', model: '', apiKey: '' });
             setSelectedProvider(data.selectedProvider || 'auto');
           }
         } else {
@@ -91,6 +134,7 @@ export default function SettingsPage() {
               setQwenConfig(config.qwen || { apiKey: '', model: '' });
               setClaudeConfig(config.claude || { apiKey: '', model: '' });
               setOllamaConfig(config.ollama || { endpoint: '', model: '' });
+              setCompatibleConfig(config.compatible || { endpoint: '', model: '', apiKey: '' });
               setSelectedProvider(config.selectedProvider || 'auto');
             } catch (parseError) {
               console.error('Error parsing saved configuration:', parseError);
@@ -176,6 +220,7 @@ export default function SettingsPage() {
         qwen: qwenConfig,
         claude: claudeConfig,
         ollama: ollamaConfig,
+        compatible: compatibleConfig,
         selectedProvider: selectedProvider
       };
       
@@ -281,6 +326,12 @@ export default function SettingsPage() {
                   { value: 'qwen', label: 'Qwen (通义千问)', disabled: !qwenConfig.apiKey },
                   { value: 'claude', label: 'Claude', disabled: !claudeConfig.apiKey },
                   { value: 'ollama', label: 'Ollama (Local)', disabled: !ollamaConfig.endpoint && !ollamaConfig.model },
+                  {
+                    value: 'compatible',
+                    label: t('settings.compatible.title'),
+                    // 端点和模型缺一不可
+                    disabled: !compatibleConfig.endpoint || !compatibleConfig.model,
+                  },
                 ]}
                 w={300}
               />
@@ -419,7 +470,60 @@ export default function SettingsPage() {
                 />
               </Stack>
             </Box>
-            
+
+            <Divider />
+
+            {/* 任意 OpenAI 兼容端点 */}
+            <Box>
+              <Title order={3} mb={4}>{t('settings.compatible.title')}</Title>
+              <Text size="sm" c="dimmed" mb="md">
+                {t('settings.compatible.intro')}
+              </Text>
+              <Stack gap="sm">
+                <TextInput
+                  label={t('settings.compatible.endpoint')}
+                  placeholder="http://localhost:1234/v1"
+                  description={t('settings.compatible.endpointHint')}
+                  value={compatibleConfig.endpoint}
+                  onChange={(e) => setCompatibleConfig({...compatibleConfig, endpoint: e.target.value})}
+                />
+                <PasswordInput
+                  label={t('settings.compatible.apiKey')}
+                  placeholder={t('settings.compatible.apiKeyPlaceholder')}
+                  description={t('settings.compatible.apiKeyHint')}
+                  value={compatibleConfig.apiKey}
+                  onChange={(e) => setCompatibleConfig({...compatibleConfig, apiKey: e.target.value})}
+                />
+                <Group align="flex-end" gap="sm" wrap="nowrap">
+                  <Autocomplete
+                    style={{ flex: 1 }}
+                    label={t('settings.compatible.model')}
+                    placeholder={t('settings.compatible.modelPlaceholder')}
+                    description={t('settings.compatible.modelHint')}
+                    data={compatibleModels}
+                    value={compatibleConfig.model}
+                    onChange={(value) => setCompatibleConfig({...compatibleConfig, model: value})}
+                  />
+                  <Button
+                    variant="light"
+                    onClick={fetchCompatibleModels}
+                    loading={compatibleLoading}
+                    disabled={!compatibleConfig.endpoint}
+                  >
+                    {t('settings.compatible.fetchModels')}
+                  </Button>
+                </Group>
+                {compatibleError && (
+                  <Text size="xs" c="red">{compatibleError}</Text>
+                )}
+                {!compatibleError && compatibleModels.length > 0 && (
+                  <Text size="xs" c="teal">
+                    {t('settings.compatible.foundModels').replace('{count}', String(compatibleModels.length))}
+                  </Text>
+                )}
+              </Stack>
+            </Box>
+
             <Group justify="flex-end">
               <Button 
                 onClick={handleSave} 

--- a/src/components/ProblemGenerator.tsx
+++ b/src/components/ProblemGenerator.tsx
@@ -63,6 +63,7 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
   const [isQwenConfigured, setIsQwenConfigured] = useState(false);
   const [isClaudeConfigured, setIsClaudeConfigured] = useState(false);
   const [isOllamaConfigured, setIsOllamaConfigured] = useState(false);
+  const [isCompatibleConfigured, setIsCompatibleConfigured] = useState(false);
   
   // JSON Editor states
   const [showJsonEditor, setShowJsonEditor] = useState(false);
@@ -89,6 +90,7 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
             setIsOpenAIConfigured(data.providers.openai);
             setIsQwenConfigured(data.providers.qwen);
             setIsClaudeConfigured(data.providers.claude);
+            setIsCompatibleConfigured(!!data.providers.compatible);
           } else {
             console.error('Failed to fetch provider configuration:', data.error);
           }
@@ -103,6 +105,8 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
               setIsOpenAIConfigured(!!config.openAI?.apiKey);
               setIsQwenConfigured(!!config.qwen?.apiKey);
               setIsClaudeConfigured(!!config.claude?.apiKey);
+              // 和服务端一致：端点和模型都得有才算配好
+              setIsCompatibleConfigured(!!(config.compatible?.endpoint && config.compatible?.model));
               setConfigSelectedProvider(config.selectedProvider || 'auto');
             } catch (parseError) {
               console.error('Error parsing saved configuration:', parseError);
@@ -116,6 +120,7 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
                 setIsOpenAIConfigured(data.providers.openai);
                 setIsQwenConfigured(data.providers.qwen);
                 setIsClaudeConfigured(data.providers.claude);
+            setIsCompatibleConfigured(!!data.providers.compatible);
               } else {
                 console.error('Failed to fetch provider configuration:', data.error);
               }
@@ -131,6 +136,7 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
               setIsOpenAIConfigured(data.providers.openai);
               setIsQwenConfigured(data.providers.qwen);
               setIsClaudeConfigured(data.providers.claude);
+            setIsCompatibleConfigured(!!data.providers.compatible);
             } else {
               console.error('Failed to fetch provider configuration:', data.error);
             }
@@ -162,6 +168,8 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
         return 'claude';
       } else if (isOllamaConfigured) {
         return 'ollama';
+      } else if (isCompatibleConfigured) {
+        return 'compatible';
       } else {
         return null; // None configured
       }
@@ -172,7 +180,8 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
   useEffect(() => {
     const provider = getCurrentAIProvider();
     setCurrentAIProvider(provider);
-    setIsUsingLocalAI(provider === 'ollama');
+    // 兼容端点绝大多数场景也是本地服务
+    setIsUsingLocalAI(provider === 'ollama' || provider === 'compatible');
 
     const providers = [];
     if (isDeepSeekConfigured) providers.push('deepseek');
@@ -180,6 +189,7 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
     if (isQwenConfigured) providers.push('qwen');
     if (isClaudeConfigured) providers.push('claude');
     if (isOllamaConfigured) providers.push('ollama');
+    if (isCompatibleConfigured) providers.push('compatible');
 
     setAvailableProviders(providers);
     setCanGenerate(providers.length > 0);
@@ -189,7 +199,8 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
     isOpenAIConfigured,
     isQwenConfigured,
     isClaudeConfigured,
-    isOllamaConfigured
+    isOllamaConfigured,
+    isCompatibleConfigured
   ]);
 
   const suggestedRequests = [
@@ -401,9 +412,13 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
               <Group gap="xs">
                 <IconBrain size={16} />
                 <Text size="sm" fw={500}>
-                  {currentAIProvider === 'ollama' 
-                    ? t('aiGenerator.usingLocalAI') 
-                    : t('aiGenerator.usingOnlineAI', { provider: currentAIProvider || 'unknown' })}
+                  {currentAIProvider === 'ollama'
+                    ? t('aiGenerator.usingLocalAI')
+                    : currentAIProvider === 'compatible'
+                      // 兼容端点可以指向本地服务，也可以指向自建网关，
+                      // 这里不替用户断言是「本地」还是「在线」
+                      ? t('aiGenerator.usingCompatibleAI')
+                      : t('aiGenerator.usingOnlineAI', { provider: currentAIProvider || 'unknown' })}
                 </Text>
                 <Text size="xs" c="dimmed">
                   ({t('aiGenerator.changeInSettings')})

--- a/src/hooks/useAiConfig.ts
+++ b/src/hooks/useAiConfig.ts
@@ -12,6 +12,8 @@ export interface AIProviderConfig {
   qwen?: { apiKey: string; model: string };
   claude?: { apiKey: string; model: string };
   ollama?: { endpoint: string; model: string };
+  /** 任意 OpenAI 兼容端点：LM Studio、vLLM、LocalAI、llama.cpp server… */
+  compatible?: { endpoint: string; model: string; apiKey?: string };
   selectedProvider?: string;
 }
 

--- a/src/lib/aiModels.ts
+++ b/src/lib/aiModels.ts
@@ -5,7 +5,7 @@
  * 又不会把服务端的流式实现打进客户端 bundle。
  */
 
-export type ProviderKind = 'deepseek' | 'openai' | 'qwen' | 'claude' | 'ollama';
+export type ProviderKind = 'deepseek' | 'openai' | 'qwen' | 'claude' | 'ollama' | 'compatible';
 
 /**
  * 各家没填模型时的默认值。
@@ -17,6 +17,9 @@ export const DEFAULT_MODELS: Record<ProviderKind, string> = {
   qwen: 'qwen-plus',
   claude: 'claude-sonnet-5',
   ollama: 'llama3.1',
+  // 兼容端点的模型 id 完全由对端决定，没有通用默认值可猜。
+  // 设置页会连上端点、拉 /models 列表让用户选。
+  compatible: '',
 };
 
 /** 设置页的下拉建议，仍然允许自由输入任意模型 id */
@@ -26,6 +29,8 @@ export const SUGGESTED_MODELS: Record<ProviderKind, string[]> = {
   qwen: ['qwen-plus', 'qwen-max', 'qwen-turbo'],
   claude: ['claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5-20251001'],
   ollama: ['llama3.1', 'qwen2.5-coder', 'deepseek-r1'],
+  // 这一栏在设置页是动态填充的：连上端点后直接列出对方 /models 返回的模型
+  compatible: [],
 };
 
 /** 不同世代的模型接受的参数不一样，这里显式建模而不是「都发一遍碰运气」 */

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -68,17 +68,26 @@ export class SelectedProviderUnavailableError extends NoProviderError {
  * 一旦用户明确写了路径就原样尊重，因为不是所有兼容服务都挂在 /v1 下。
  */
 export function normalizeCompatibleEndpoint(raw: string): string {
-  const trimmed = (raw || '').trim().replace(/\/+$/, '');
+  let trimmed = (raw || '').trim().replace(/\/+$/, '');
   if (!trimmed) return trimmed;
+
+  // 少了协议头就补 http://。注意不能直接丢给 new URL：
+  // 'localhost:1234' 会被解析成协议 "localhost:"、路径 "1234"，
+  // 于是既补不上 /v1，最后 fetch 还会因为未知协议报一个看不懂的错。
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
+    trimmed = `http://${trimmed}`;
+  }
+
   try {
     const url = new URL(trimmed);
     if (url.pathname === '' || url.pathname === '/') {
       return `${url.origin}/v1`;
     }
+    return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
   } catch {
-    // 不是合法 URL 就原样返回，让后面的请求自己报错，错误信息比这里猜更有用
+    // 实在解析不了就原样返回，让请求自己报错 —— 那个错误信息比这里瞎猜更有用
+    return trimmed;
   }
-  return trimmed;
 }
 
 const AUTO_ORDER: ProviderKind[] = ['deepseek', 'openai', 'qwen', 'claude', 'ollama', 'compatible'];

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -22,6 +22,8 @@ export interface AIProviderConfig {
   qwen?: { apiKey: string; model: string };
   claude?: { apiKey: string; model: string };
   ollama?: { endpoint: string; model: string };
+  /** 任意 OpenAI 兼容端点：LM Studio、vLLM、LocalAI、llama.cpp server… */
+  compatible?: { endpoint: string; model: string; apiKey?: string };
   selectedProvider?: string;
 }
 
@@ -58,7 +60,28 @@ export class SelectedProviderUnavailableError extends NoProviderError {
   }
 }
 
-const AUTO_ORDER: ProviderKind[] = ['deepseek', 'openai', 'qwen', 'claude', 'ollama'];
+/**
+ * 把用户填的地址规整成 OpenAI 风格的 base URL。
+ *
+ * 只在「对方只给了 host:port、完全没有路径」时补 /v1 —— LM Studio 的地址
+ * 写成 http://localhost:1234 和 http://localhost:1234/v1 的人一样多。
+ * 一旦用户明确写了路径就原样尊重，因为不是所有兼容服务都挂在 /v1 下。
+ */
+export function normalizeCompatibleEndpoint(raw: string): string {
+  const trimmed = (raw || '').trim().replace(/\/+$/, '');
+  if (!trimmed) return trimmed;
+  try {
+    const url = new URL(trimmed);
+    if (url.pathname === '' || url.pathname === '/') {
+      return `${url.origin}/v1`;
+    }
+  } catch {
+    // 不是合法 URL 就原样返回，让后面的请求自己报错，错误信息比这里猜更有用
+  }
+  return trimmed;
+}
+
+const AUTO_ORDER: ProviderKind[] = ['deepseek', 'openai', 'qwen', 'claude', 'ollama', 'compatible'];
 
 export function resolveProvider(config?: AIProviderConfig, maxTokens = 4000): ResolvedProvider {
   const build = (
@@ -106,6 +129,21 @@ export function resolveProvider(config?: AIProviderConfig, maxTokens = 4000): Re
       ? build('ollama', {
           endpoint: config?.ollama?.endpoint || process.env.OLLAMA_ENDPOINT || 'http://localhost:11434',
           model: config?.ollama?.model || process.env.OLLAMA_MODEL,
+        })
+      : null,
+    // 只有端点没有模型时不算「配好了」：模型 id 由对端决定，猜不出来。
+    // 这里返回 null，让它在 auto 顺序里被跳过；用户显式选了它则会收到
+    // SelectedProviderUnavailableError，提示去设置页补上。
+    compatible: (config?.compatible?.endpoint || process.env.OPENAI_COMPATIBLE_ENDPOINT)
+      && (config?.compatible?.model || process.env.OPENAI_COMPATIBLE_MODEL)
+      ? build('compatible', {
+          endpoint: normalizeCompatibleEndpoint(
+            config?.compatible?.endpoint || process.env.OPENAI_COMPATIBLE_ENDPOINT || ''
+          ),
+          model: config?.compatible?.model || process.env.OPENAI_COMPATIBLE_MODEL,
+          // 本地服务通常不校验 key，所以它是可选的；填了就照常带上，
+          // 这样同一个 provider 也能连需要鉴权的自建网关。
+          apiKey: config?.compatible?.apiKey || process.env.OPENAI_COMPATIBLE_API_KEY,
         })
       : null,
   };
@@ -204,6 +242,17 @@ function buildRequest(
       };
     }
 
+    case 'compatible':
+      return {
+        url: `${provider.endpoint}/chat/completions`,
+        headers: {
+          'Content-Type': 'application/json',
+          // 本地服务大多不看这个头，带上空 key 反而可能被某些实现拒绝，所以没填就不带
+          ...(provider.apiKey ? { Authorization: `Bearer ${provider.apiKey}` } : {}),
+        },
+        body: openAiCompatibleBody(provider, messages, options),
+      };
+
     case 'ollama':
       return {
         url: `${provider.endpoint}/api/chat`,
@@ -250,6 +299,7 @@ function extractContent(kind: ProviderKind, data: any): string {
     case 'deepseek':
     case 'openai':
     case 'qwen':
+    case 'compatible':
       return data?.choices?.[0]?.message?.content || '';
     case 'claude':
       return (data?.content || [])

--- a/tests/ai/provider.test.ts
+++ b/tests/ai/provider.test.ts
@@ -5,7 +5,7 @@
  * 不接受自定义 temperature，以及流式协议的解析。
  */
 import { capabilitiesFor, DEFAULT_MODELS, SUGGESTED_MODELS } from '../../src/lib/aiModels';
-import { resolveProvider } from '../../src/lib/server/aiProvider';
+import { normalizeCompatibleEndpoint, resolveProvider } from '../../src/lib/server/aiProvider';
 
 describe('model capabilities', () => {
   it('uses max_completion_tokens for OpenAI reasoning models', () => {
@@ -31,8 +31,21 @@ describe('model capabilities', () => {
 
   it('lists every provider default among its suggestions', () => {
     for (const kind of Object.keys(DEFAULT_MODELS) as Array<keyof typeof DEFAULT_MODELS>) {
+      // 'compatible' 指向的是任意一台 OpenAI 兼容服务，模型 id 由对端决定，
+      // 没有默认值可猜 —— 所以它的默认值是空串，建议列表在设置页动态填充。
+      // 这里不是放宽断言：空默认值必须同时意味着空建议列表，
+      // 免得「留空 -> 用默认」这条路径悄悄退化成发一个不存在的模型 id 上去。
+      if (DEFAULT_MODELS[kind] === '') {
+        expect(SUGGESTED_MODELS[kind]).toEqual([]);
+        continue;
+      }
       expect(SUGGESTED_MODELS[kind]).toContain(DEFAULT_MODELS[kind]);
     }
+  });
+
+  it('requires an explicit model for the compatible provider', () => {
+    // 端点填了、模型没填，不能被当成「配好了」而进入 auto 顺序
+    expect(DEFAULT_MODELS.compatible).toBe('');
   });
 });
 
@@ -45,6 +58,9 @@ describe('provider resolution', () => {
     'OLLAMA_MODEL',
     'DEEPSEEK_MODEL',
     'OPENAI_MODEL',
+    'OPENAI_COMPATIBLE_ENDPOINT',
+    'OPENAI_COMPATIBLE_MODEL',
+    'OPENAI_COMPATIBLE_API_KEY',
   ];
   const saved: Record<string, string | undefined> = {};
 
@@ -99,5 +115,57 @@ describe('provider resolution', () => {
 
   it('throws when nothing is configured', () => {
     expect(() => resolveProvider({})).toThrow(/No AI provider/);
+  });
+});
+
+describe('OpenAI-compatible endpoint', () => {
+  it('appends /v1 only when the address carries no path of its own', () => {
+    // LM Studio 的地址，两种写法的人一样多
+    expect(normalizeCompatibleEndpoint('http://localhost:1234')).toBe('http://localhost:1234/v1');
+    expect(normalizeCompatibleEndpoint('http://localhost:1234/')).toBe('http://localhost:1234/v1');
+    expect(normalizeCompatibleEndpoint('http://localhost:1234/v1')).toBe('http://localhost:1234/v1');
+    // 明确写了路径就不要动它：不是所有兼容服务都挂在 /v1
+    expect(normalizeCompatibleEndpoint('http://localhost:8000/openai/v1')).toBe(
+      'http://localhost:8000/openai/v1'
+    );
+    expect(normalizeCompatibleEndpoint('  http://localhost:1234/v1//  ')).toBe(
+      'http://localhost:1234/v1'
+    );
+  });
+
+  it('resolves with the endpoint normalised and the key optional', () => {
+    const provider = resolveProvider({
+      compatible: { endpoint: 'http://localhost:1234', model: 'qwen2.5-coder-7b-instruct' },
+      selectedProvider: 'compatible',
+    });
+    expect(provider.kind).toBe('compatible');
+    expect(provider.endpoint).toBe('http://localhost:1234/v1');
+    expect(provider.model).toBe('qwen2.5-coder-7b-instruct');
+    expect(provider.apiKey).toBeUndefined();
+    // 本地模型多半不是推理模型，按经典参数发
+    expect(provider.capabilities.maxTokensParam).toBe('max_tokens');
+    expect(provider.capabilities.supportsTemperature).toBe(true);
+  });
+
+  it('does not count as configured when the model is missing', () => {
+    // 模型 id 由对端决定，没有它就不该被 auto 选中，更不该拿空模型去请求
+    expect(() =>
+      resolveProvider({
+        compatible: { endpoint: 'http://localhost:1234', model: '' },
+        selectedProvider: 'compatible',
+      })
+    ).toThrow(/no API key configured|not/i);
+
+    expect(() =>
+      resolveProvider({ compatible: { endpoint: 'http://localhost:1234', model: '' } })
+    ).toThrow();
+  });
+
+  it('is last in the auto order, so it never displaces a configured cloud vendor', () => {
+    const provider = resolveProvider({
+      deepSeek: { apiKey: 'a', model: '' },
+      compatible: { endpoint: 'http://localhost:1234', model: 'local' },
+    });
+    expect(provider.kind).toBe('deepseek');
   });
 });

--- a/tests/ai/provider.test.ts
+++ b/tests/ai/provider.test.ts
@@ -119,6 +119,34 @@ describe('provider resolution', () => {
 });
 
 describe('OpenAI-compatible endpoint', () => {
+  // next/jest 会加载 .env，所以真配了这个功能的人跑测试时环境里就有这几个变量。
+  // 不清掉的话，下面「没配模型就不该被选中」这类断言会被环境里的值弄假。
+  const envKeys = [
+    'OPENAI_COMPATIBLE_ENDPOINT',
+    'OPENAI_COMPATIBLE_MODEL',
+    'OPENAI_COMPATIBLE_API_KEY',
+    'DEEPSEEK_API_KEY',
+    'OPENAI_API_KEY',
+    'QWEN_API_KEY',
+    'CLAUDE_API_KEY',
+    'OLLAMA_MODEL',
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    envKeys.forEach((key) => {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    });
+  });
+
+  afterEach(() => {
+    envKeys.forEach((key) => {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    });
+  });
+
   it('appends /v1 only when the address carries no path of its own', () => {
     // LM Studio 的地址，两种写法的人一样多
     expect(normalizeCompatibleEndpoint('http://localhost:1234')).toBe('http://localhost:1234/v1');
@@ -130,6 +158,13 @@ describe('OpenAI-compatible endpoint', () => {
     );
     expect(normalizeCompatibleEndpoint('  http://localhost:1234/v1//  ')).toBe(
       'http://localhost:1234/v1'
+    );
+    // 没写协议头的写法也很常见。注意 new URL('localhost:1234') 会把 localhost:
+    // 当成协议，所以这里必须先补 http:// 再解析。
+    expect(normalizeCompatibleEndpoint('localhost:1234')).toBe('http://localhost:1234/v1');
+    expect(normalizeCompatibleEndpoint('127.0.0.1:1234/v1')).toBe('http://127.0.0.1:1234/v1');
+    expect(normalizeCompatibleEndpoint('https://gw.example.com/v1')).toBe(
+      'https://gw.example.com/v1'
     );
   });
 


### PR DESCRIPTION
## Why this shape

The request was "support Bionic (formerly LM Studio)". Research found the premise is wrong in two ways, so this PR implements what the intent actually requires:

- **Bionic is not a rename.** It is a separate app, launched 2026-07-16, that runs *alongside* LM Studio. The docs say so directly: "Bionic is a new, separate app from LM Studio."
- **Bionic has no API to connect to.** It is an end-user agent app — a *consumer* of models. The developer surface (SDKs, REST, OpenAI-compatible and Anthropic-compatible endpoints, the `lms` CLI) all belongs to **LM Studio**. The only mention of Bionic in the developer docs is "Ask Bionic to read this page", a UI convenience.

So a Bionic-specific provider is not implementable. A generic **OpenAI-compatible endpoint** provider is, and it covers LM Studio plus vLLM, LocalAI, `llama-server`, text-generation-webui and any self-hosted gateway — including a future Bionic server, should one ever appear.

## Implementation

Reuses the existing OpenAI path rather than adding a second one — the body builder, SSE parser and content extractor are shared, because the wire format is identical. Only the URL and auth differ.

Two deliberate differences from the other providers:

- **The model id is required, with no default.** It is decided by whichever server the user runs, so a guessed default would just send a nonexistent model id. An endpoint without a model does not count as configured, so auto-selection skips it rather than failing at request time. Settings gains a **Fetch models** button that queries the endpoint's `/models` — routed through the server, because local servers bind to `127.0.0.1` and send no CORS headers, so the browser cannot call them directly.
- **The API key is optional.** Local servers rarely check it, and an empty `Authorization` header makes some implementations reject the request, so the header is omitted entirely when no key is set.

The address is normalised: a bare host and port gets `/v1` appended (people write LM Studio's address both ways), while an explicit path is left alone, since not every server mounts at `/v1`.

`compatible` is **last** in the auto order, so no existing configuration changes which provider it picks.

## E2E verification

Against a local OpenAI-compatible mock on LM Studio's real port 1234:

| Check | Result |
|---|---|
| `GET /v1/models` via the settings button | 2 models listed, dropdown filled |
| Bare `http://localhost:1234` → `/v1` appended | ✅ confirmed server-side |
| Non-streaming `callAI` | returned the reply |
| Streaming `streamAI` | full text reassembled from SSE |
| Auth header omitted when key blank | ✅ `(no auth header)` in server log |
| Auth header sent when key set | ✅ `(auth header present)` |
| Endpoint set, model blank | throws instead of silently sending an empty model |

Then **end to end through the running app**: Settings → paste address → Fetch models → pick model → select provider → Save → open a problem → "AI 题解" → the mock's reply streamed into the Monaco editor. Server log confirms the app sent `model=qwen2.5-coder-7b-instruct, stream=true` to `/v1/chat/completions`.

Also: `tsc` clean · `npm test` 5/5 · `tests/engineering` 230/230 · `projects:verify` green · `next build` compiles.

## Test change worth reviewing

`lists every provider default among its suggestions` failed, because `compatible` intentionally has no default. Rather than weakening it, the invariant is now explicit in both directions: an empty default **must** pair with an empty suggestions list, so the "leave blank → use default" path cannot silently start sending a nonexistent model id. Four new tests cover normalisation, resolution, the missing-model case and auto-order placement.

## Docs synced

`.env.example`, `AI_PROVIDER_GUIDE.md` (with the LM Studio vs Bionic distinction spelled out), three READMEs, and the site's AI section + keywords in both locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)