### PR TITLE
feat(ide): record an execution trace you can scrub through

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,21 @@
 {
+  "trace": {
+    "button": "Debug",
+    "title": "Execution trace",
+    "running": "Recording…",
+    "empty": "Nothing was recorded for this run.",
+    "step": "Step",
+    "line": "Line",
+    "variables": "Variables at this step",
+    "noVariables": "No variables in scope yet.",
+    "truncated": "Recording stopped after the step limit; {count} later steps were not kept.",
+    "first": "First step",
+    "prev": "Previous step",
+    "next": "Next step",
+    "last": "Last step",
+    "caseLabel": "Tracing test case {n}",
+    "failed": "Could not record a trace: {error}"
+  },
   "common": {
     "language": "Language",
     "theme": "Theme",

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,13 +8,12 @@
     "line": "Line",
     "variables": "Variables at this step",
     "noVariables": "No variables in scope yet.",
-    "truncated": "Recording stopped after the step limit; {count} later steps were not kept.",
+    "truncated": "Recording stopped after the step limit; {{count}} later steps were not kept.",
     "first": "First step",
     "prev": "Previous step",
     "next": "Next step",
     "last": "Last step",
-    "caseLabel": "Tracing test case {n}",
-    "failed": "Could not record a trace: {error}"
+    "aborted": "The run stopped early: {{error}}"
   },
   "common": {
     "language": "Language",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1,4 +1,21 @@
 {
+  "trace": {
+    "button": "调试",
+    "title": "执行轨迹",
+    "running": "录制中…",
+    "empty": "这次运行没有录到任何步骤。",
+    "step": "第",
+    "line": "行",
+    "variables": "这一步的变量",
+    "noVariables": "当前作用域还没有变量。",
+    "truncated": "步数达到上限后停止录制，后面 {count} 步没有保留。",
+    "first": "第一步",
+    "prev": "上一步",
+    "next": "下一步",
+    "last": "最后一步",
+    "caseLabel": "正在追踪测试用例 {n}",
+    "failed": "无法录制轨迹：{error}"
+  },
   "common": {
     "language": "语言",
     "theme": "主题",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -8,13 +8,12 @@
     "line": "行",
     "variables": "这一步的变量",
     "noVariables": "当前作用域还没有变量。",
-    "truncated": "步数达到上限后停止录制，后面 {count} 步没有保留。",
+    "truncated": "步数达到上限后停止录制，后面 {{count}} 步没有保留。",
     "first": "第一步",
     "prev": "上一步",
     "next": "下一步",
     "last": "最后一步",
-    "caseLabel": "正在追踪测试用例 {n}",
-    "failed": "无法录制轨迹：{error}"
+    "aborted": "这次运行中途停下了：{{error}}"
   },
   "common": {
     "language": "语言",

--- a/src/components/CodeRunner.tsx
+++ b/src/components/CodeRunner.tsx
@@ -29,6 +29,9 @@ import {
   IconWand,
 } from '@tabler/icons-react';
 import Editor from '@monaco-editor/react';
+import { IconBug } from '@tabler/icons-react';
+import { Modal as TraceModal } from '@mantine/core';
+import TracePlayer from './TracePlayer';
 import { useTranslation, useI18n } from '../contexts/I18nContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useWasmExecutor } from '../hooks/useWasmExecutor';
@@ -94,7 +97,7 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
   const { config: aiConfig } = useAiConfig();
   
   // WASM 执行器 hook
-  const { runTests: runWasmTests, runtimeStatus, preloadRuntime } = useWasmExecutor();
+  const { runTests: runWasmTests, traceExecution, runtimeStatus, preloadRuntime } = useWasmExecutor();
 
   // 编辑器偏好与工程实战工作区共用一份，改一次两边都生效
   const [prefs, setPrefs] = useState<EditorPrefs>(DEFAULT_PREFS);
@@ -219,6 +222,29 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
     }
   );
   
+  /** 轨迹回放：只跑第一条用例，录下每一步 */
+  const [trace, setTrace] = useState<any>(null);
+  const [tracing, setTracing] = useState(false);
+  const [traceOpen, setTraceOpen] = useState(false);
+  const [tracedSource, setTracedSource] = useState('');
+
+  const runTrace = async () => {
+    setTracing(true);
+    setTraceOpen(true);
+    // 记下这次录制用的源码：录完之后编辑器里的代码还能继续改，
+    // 高亮必须对着录制那一刻的版本，不然行号会对不上
+    setTracedSource(code);
+    try {
+      const outcome = await traceExecution(problem, code, selectedLanguage, 0);
+      setTrace(outcome.trace);
+    } catch (error: any) {
+      setTrace({ steps: [], droppedSteps: 0, truncated: false, completed: false,
+        error: error?.message || String(error) });
+    } finally {
+      setTracing(false);
+    }
+  };
+
   const runTests = async () => {
     setIsRunning(true);
     const runningStatus = { status: 'running' };
@@ -626,6 +652,14 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
               size="sm"
               w={130}
             />
+            <Button
+              onClick={runTrace}
+              disabled={tracing || isRunning || runtimeStatus[selectedLanguage as 'javascript' | 'typescript' | 'python'] === 'loading'}
+              variant="default"
+              leftSection={tracing ? <Loader size={14} /> : <IconBug size={15} />}
+            >
+              {tracing ? t('trace.running') : t('trace.button')}
+            </Button>
             <Tooltip label="⌘/Ctrl + Enter" position="bottom">
               <Button
                 onClick={runTests}
@@ -798,6 +832,18 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
           </Group>
         </Stack>
       </Modal>
+      <TraceModal
+        opened={traceOpen}
+        onClose={() => setTraceOpen(false)}
+        title={t('trace.title')}
+        size="xl"
+      >
+        {tracing ? (
+          <Group gap="xs"><Loader size={16} /><Text size="sm">{t('trace.running')}</Text></Group>
+        ) : trace ? (
+          <TracePlayer trace={trace} source={tracedSource} />
+        ) : null}
+      </TraceModal>
     </div>
   );
 }

--- a/src/components/TracePlayer.tsx
+++ b/src/components/TracePlayer.tsx
@@ -103,9 +103,16 @@ export default function TracePlayer({ trace, source }: TracePlayerProps) {
         </Text>
       </Group>
 
+      {/* 代码中途抛了异常：轨迹是残缺的，得说清楚，否则最后一步看起来像正常结束 */}
+      {trace.error && (
+        <Alert color="red" variant="light">
+          {t('trace.aborted', { error: trace.error })}
+        </Alert>
+      )}
+
       {trace.truncated && (
         <Text size="xs" c="dimmed" fs="italic">
-          {t('trace.truncated').replace('{count}', String(trace.droppedSteps))}
+          {t('trace.truncated', { count: trace.droppedSteps })}
         </Text>
       )}
 

--- a/src/components/TracePlayer.tsx
+++ b/src/components/TracePlayer.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Box,
+  Code,
+  Group,
+  ScrollArea,
+  Slider,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconPlayerSkipBack,
+  IconPlayerSkipForward,
+} from '@tabler/icons-react';
+import { useTranslation } from '../contexts/I18nContext';
+import type { ExecutionTrace } from '../lib/trace/types';
+
+interface TracePlayerProps {
+  trace: ExecutionTrace;
+  /** 用户源码，按行展示并高亮当前行 */
+  source: string;
+}
+
+/**
+ * 执行轨迹回放。
+ *
+ * 不是断点调试器：代码已经跑完了，这里回放的是录下来的每一步。
+ * 好处是可以往回拖 —— 断点调试器做不到这件事，而做题时
+ * 「上一轮循环 seen 里是什么」恰恰是最常问的问题。
+ */
+export default function TracePlayer({ trace, source }: TracePlayerProps) {
+  const { t } = useTranslation();
+  const [index, setIndex] = useState(0);
+
+  const steps = trace.steps;
+  const total = steps.length;
+
+  // 换了一条轨迹就回到开头，否则会停在上一条轨迹的下标上
+  useEffect(() => {
+    setIndex(0);
+  }, [trace]);
+
+  const lines = useMemo(() => source.split('\n'), [source]);
+  const current = steps[Math.min(index, total - 1)];
+
+  if (total === 0) {
+    return (
+      <Alert color="gray" variant="light">
+        {trace.error || t('trace.empty')}
+      </Alert>
+    );
+  }
+
+  const clamp = (value: number) => Math.max(0, Math.min(total - 1, value));
+  // 用函数式更新，别读闭包里的 index：连点几下时每次点击拿到的都是同一个
+  // 旧值，五次点击只前进一步。
+  const stepBy = (delta: number) => setIndex((current) => clamp(current + delta));
+
+  return (
+    <Stack gap="sm">
+      <Group gap="xs" wrap="nowrap">
+        <ActionIcon variant="default" onClick={() => setIndex(0)} disabled={index === 0}
+          aria-label={t('trace.first')}>
+          <IconPlayerSkipBack size={15} />
+        </ActionIcon>
+        <ActionIcon variant="default" onClick={() => stepBy(-1)} disabled={index === 0}
+          aria-label={t('trace.prev')}>
+          <IconChevronLeft size={15} />
+        </ActionIcon>
+        <Slider
+          style={{ flex: 1 }}
+          min={0}
+          max={total - 1}
+          value={Math.min(index, total - 1)}
+          onChange={setIndex}
+          label={(value) => `${value + 1} / ${total}`}
+        />
+        <ActionIcon variant="default" onClick={() => stepBy(1)} disabled={index >= total - 1}
+          aria-label={t('trace.next')}>
+          <IconChevronRight size={15} />
+        </ActionIcon>
+        <ActionIcon variant="default" onClick={() => setIndex(total - 1)} disabled={index >= total - 1}
+          aria-label={t('trace.last')}>
+          <IconPlayerSkipForward size={15} />
+        </ActionIcon>
+      </Group>
+
+      <Group gap={8}>
+        <Badge size="sm" variant="light">
+          {t('trace.step')} {Math.min(index, total - 1) + 1} / {total}
+        </Badge>
+        <Badge size="sm" variant="light" color="gray">
+          {t('trace.line')} {current.line}
+        </Badge>
+        <Text size="xs" c="dimmed" ff="monospace">
+          {current.stack.join(' › ')}
+        </Text>
+      </Group>
+
+      {trace.truncated && (
+        <Text size="xs" c="dimmed" fs="italic">
+          {t('trace.truncated').replace('{count}', String(trace.droppedSteps))}
+        </Text>
+      )}
+
+      {/* 源码：当前行高亮 */}
+      <ScrollArea.Autosize mah={220}>
+        <Box component="pre" style={{ margin: 0, fontSize: 11, lineHeight: 1.6 }}>
+          {lines.map((text, i) => {
+            const lineNumber = i + 1;
+            const active = lineNumber === current.line;
+            return (
+              <Box
+                key={lineNumber}
+                style={{
+                  display: 'flex',
+                  gap: 10,
+                  padding: '0 6px',
+                  borderRadius: 3,
+                  background: active ? 'var(--mantine-color-blue-light)' : undefined,
+                  fontWeight: active ? 600 : 400,
+                }}
+              >
+                <Text span size="xs" c="dimmed" ff="monospace" style={{ minWidth: 22, textAlign: 'right' }}>
+                  {lineNumber}
+                </Text>
+                <Text span size="xs" ff="monospace" style={{ whiteSpace: 'pre' }}>
+                  {text || ' '}
+                </Text>
+              </Box>
+            );
+          })}
+        </Box>
+      </ScrollArea.Autosize>
+
+      {/* 当前这一步的变量 */}
+      <Box>
+        <Text size="xs" c="dimmed" mb={4}>
+          {t('trace.variables')}
+        </Text>
+        {current.vars.length === 0 ? (
+          <Text size="xs" c="dimmed" fs="italic">
+            {t('trace.noVariables')}
+          </Text>
+        ) : (
+          <ScrollArea.Autosize mah={180}>
+            <Table withTableBorder verticalSpacing={2} horizontalSpacing={8} style={{ fontSize: 11 }}>
+              <Table.Tbody>
+                {current.vars.map((variable) => (
+                  <Table.Tr key={variable.name}>
+                    <Table.Td style={{ width: 100, verticalAlign: 'top' }}>
+                      <Code style={{ fontSize: 11 }}>{variable.name}</Code>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs" ff="monospace" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {variable.value}
+                      </Text>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </ScrollArea.Autosize>
+        )}
+      </Box>
+    </Stack>
+  );
+}

--- a/src/hooks/useWasmExecutor.ts
+++ b/src/hooks/useWasmExecutor.ts
@@ -15,6 +15,12 @@ import {
   type ConsoleCollector,
   type ConsoleLogEntry,
 } from '../lib/consoleCapture';
+import { instrumentSource } from '../lib/trace/instrument';
+import { createTraceRecorder } from '../lib/trace/recorder';
+import { buildPythonTraceProgram } from '../lib/trace/pythonTrace';
+import { EMPTY_TRACE, type ExecutionTrace } from '../lib/trace/types';
+
+export type { ExecutionTrace, TraceStep } from '../lib/trace/types';
 
 export type { ConsoleLogEntry };
 
@@ -88,18 +94,24 @@ let globalRuntime: WasmRuntimeState = {
  * 使用 Function 构造函数安全执行 JavaScript 代码
  * 比 iframe 更可靠，适用于用户自己编写的代码
  */
-export function executeCode(code: string, sandboxConsole?: unknown): any {
+export function executeCode(code: string, sandboxConsole?: unknown, traceApi?: unknown): any {
   try {
     // 用 Function 构造函数创建一个新的函数作用域。
-    // 把 console 作为形参传进去，用户代码里的 console.* 就会命中我们的收集器，
-    // 而不是浏览器的全局 console —— 既能捕获，又不会污染全局或在并发运行时串台。
-    const fn = new Function('console', code);
-    const result = fn(sandboxConsole ?? console);
-    return result;
+    // console 和 __trace 都作为形参传进去：用户代码里的 console.* 命中我们的收集器，
+    // 插桩产生的 __trace.* 命中记录器 —— 既能捕获，又不会污染全局或在并发运行时串台。
+    const fn = new Function('console', '__trace', code);
+    return fn(sandboxConsole ?? console, traceApi ?? NOOP_TRACE);
   } catch (error) {
     throw error;
   }
 }
+
+/** 没开调试时，插桩调用要有个不做事的落点（正常路径下代码根本没被插桩） */
+const NOOP_TRACE = {
+  enter: () => undefined,
+  exit: () => undefined,
+  step: () => undefined,
+};
 
 /**
  * 加载 TypeScript 编译器
@@ -236,7 +248,8 @@ export async function executeJavaScript(
   code: string,
   args: any[],
   isLinkedListProblem: boolean = false,
-  collector?: ConsoleCollector
+  collector?: ConsoleCollector,
+  traceApi?: unknown
 ): Promise<{ result: any; error: string | null; executionTime: number }> {
   const startTime = performance.now();
 
@@ -297,7 +310,7 @@ export async function executeJavaScript(
       `}
     `;
 
-    const result = executeCode(jsCode, collector?.console);
+    const result = executeCode(jsCode, collector?.console, traceApi);
     const executionTime = performance.now() - startTime;
 
     return {
@@ -322,7 +335,8 @@ async function executeTypeScript(
   code: string,
   args: any[],
   isLinkedListProblem: boolean = false,
-  collector?: ConsoleCollector
+  collector?: ConsoleCollector,
+  traceApi?: unknown
 ): Promise<{ result: any; error: string | null; executionTime: number }> {
   const startTime = performance.now();
 
@@ -331,7 +345,7 @@ async function executeTypeScript(
     const jsCode = await transpileTypeScript(code);
     
     // 然后使用 JavaScript 执行逻辑
-    return await executeJavaScript(jsCode, args, isLinkedListProblem, collector);
+    return await executeJavaScript(jsCode, args, isLinkedListProblem, collector, traceApi);
   } catch (error: any) {
     const executionTime = performance.now() - startTime;
     return {
@@ -941,13 +955,106 @@ export function useWasmExecutor() {
     return ['javascript', 'typescript', 'python'];
   }, []);
 
+  /**
+   * 带轨迹地跑**一条**用例。
+   *
+   * 只跑一条是刻意的：轨迹是给「这一条为什么错」用的，
+   * 把所有用例都录一遍既慢又没人看。也不做基准测试的多次运行 ——
+   * 那样会录出四份一模一样的轨迹。
+   */
+  const traceExecution = useCallback(async (
+    problem: any,
+    code: string,
+    language: string,
+    testIndex: number = 0
+  ): Promise<{ trace: ExecutionTrace; result: any; error: string | null; logs: ConsoleLogEntry[] }> => {
+    const test = (problem.tests || [])[testIndex];
+    if (!test) {
+      return { trace: { ...EMPTY_TRACE, error: 'No such test case' }, result: null, error: 'No such test case', logs: [] };
+    }
+
+    const args = parseTestInput(test.input);
+    const collector = createConsoleCollector('user');
+
+    if (language === 'python') {
+      const templateKey = 'python';
+      const functionName = extractFunctionName(problem.template?.[templateKey] || '', 'python');
+      return await tracePython(code, args, functionName, collector);
+    }
+
+    // JS / TS：先插桩，再按平常的方式跑
+    const tsModule = await loadTypeScript();
+    const recorder = createTraceRecorder();
+    let instrumented: string;
+    try {
+      instrumented = instrumentSource(tsModule, code);
+    } catch (error: any) {
+      return {
+        trace: { ...EMPTY_TRACE, error: `Could not instrument the code: ${error?.message || error}` },
+        result: null,
+        error: error?.message || String(error),
+        logs: [],
+      };
+    }
+
+    const isLinkedListProblem = problem.tags?.includes('linked-list');
+    // instrumentSource 已经把 TS 转成 JS 了，所以这里统一走 JS 路径
+    const outcome = await executeJavaScript(instrumented, args, isLinkedListProblem, collector, recorder.api);
+
+    recorder.trace.completed = !outcome.error;
+    if (outcome.error) recorder.trace.error = outcome.error;
+
+    return {
+      trace: recorder.trace,
+      result: outcome.result,
+      error: outcome.error,
+      logs: collector.entries,
+    };
+  }, []);
+
   return {
     runTests,
+    traceExecution,
     isLoading,
     runtimeStatus,
     preloadRuntime,
     getSupportedLanguages
   };
+}
+
+/** Python 走 sys.settrace，不插桩 */
+async function tracePython(
+  code: string,
+  args: any[],
+  functionName: string,
+  collector: ConsoleCollector
+): Promise<{ trace: ExecutionTrace; result: any; error: string | null; logs: ConsoleLogEntry[] }> {
+  try {
+    const pyodide = await loadPyodide();
+    const program = buildPythonTraceProgram(code, functionName, JSON.stringify(args));
+    const output = await pyodide.runPythonAsync(program);
+    const js = output?.toJs ? output.toJs({ dict_converter: Object.fromEntries }) : output;
+
+    const { entries, truncated } = entriesFromPythonOutput(js.stdout || '', js.stderr || '');
+    collector.entries.push(...entries);
+    if (truncated) collector.truncated = true;
+
+    let trace: ExecutionTrace = { ...EMPTY_TRACE };
+    try {
+      trace = JSON.parse(js.trace);
+    } catch {
+      trace = { ...EMPTY_TRACE, error: 'Could not read the trace back from Python' };
+    }
+
+    return { trace, result: js.result ?? null, error: js.error || null, logs: collector.entries };
+  } catch (error: any) {
+    return {
+      trace: { ...EMPTY_TRACE, error: error?.message || String(error) },
+      result: null,
+      error: error?.message || String(error),
+      logs: collector.entries,
+    };
+  }
 }
 
 export default useWasmExecutor;

--- a/src/hooks/useWasmExecutor.ts
+++ b/src/hooks/useWasmExecutor.ts
@@ -18,7 +18,7 @@ import {
 import { instrumentSource } from '../lib/trace/instrument';
 import { createTraceRecorder } from '../lib/trace/recorder';
 import { buildPythonTraceProgram } from '../lib/trace/pythonTrace';
-import { EMPTY_TRACE, type ExecutionTrace } from '../lib/trace/types';
+import { emptyTrace, type ExecutionTrace } from '../lib/trace/types';
 
 export type { ExecutionTrace, TraceStep } from '../lib/trace/types';
 
@@ -970,7 +970,7 @@ export function useWasmExecutor() {
   ): Promise<{ trace: ExecutionTrace; result: any; error: string | null; logs: ConsoleLogEntry[] }> => {
     const test = (problem.tests || [])[testIndex];
     if (!test) {
-      return { trace: { ...EMPTY_TRACE, error: 'No such test case' }, result: null, error: 'No such test case', logs: [] };
+      return { trace: { ...emptyTrace(), error: 'No such test case' }, result: null, error: 'No such test case', logs: [] };
     }
 
     const args = parseTestInput(test.input);
@@ -990,7 +990,7 @@ export function useWasmExecutor() {
       instrumented = instrumentSource(tsModule, code);
     } catch (error: any) {
       return {
-        trace: { ...EMPTY_TRACE, error: `Could not instrument the code: ${error?.message || error}` },
+        trace: { ...emptyTrace(), error: `Could not instrument the code: ${error?.message || error}` },
         result: null,
         error: error?.message || String(error),
         logs: [],
@@ -1001,13 +1001,26 @@ export function useWasmExecutor() {
     // instrumentSource 已经把 TS 转成 JS 了，所以这里统一走 JS 路径
     const outcome = await executeJavaScript(instrumented, args, isLinkedListProblem, collector, recorder.api);
 
-    recorder.trace.completed = !outcome.error;
-    if (outcome.error) recorder.trace.error = outcome.error;
+    // async 解法返回的是 Promise：不等它完成就读轨迹的话，
+    // 拿到的是函数体才跑了一半的快照，而记录器还在往同一个数组里追加。
+    let resolved = outcome.result;
+    let failure = outcome.error;
+    if (resolved && typeof resolved.then === 'function') {
+      try {
+        resolved = await resolved;
+      } catch (error: any) {
+        failure = error?.message || String(error);
+        resolved = null;
+      }
+    }
+
+    recorder.trace.completed = !failure;
+    if (failure) recorder.trace.error = failure;
 
     return {
       trace: recorder.trace,
-      result: outcome.result,
-      error: outcome.error,
+      result: resolved,
+      error: failure,
       logs: collector.entries,
     };
   }, []);
@@ -1039,17 +1052,17 @@ async function tracePython(
     collector.entries.push(...entries);
     if (truncated) collector.truncated = true;
 
-    let trace: ExecutionTrace = { ...EMPTY_TRACE };
+    let trace: ExecutionTrace = emptyTrace();
     try {
       trace = JSON.parse(js.trace);
     } catch {
-      trace = { ...EMPTY_TRACE, error: 'Could not read the trace back from Python' };
+      trace = { ...emptyTrace(), error: 'Could not read the trace back from Python' };
     }
 
     return { trace, result: js.result ?? null, error: js.error || null, logs: collector.entries };
   } catch (error: any) {
     return {
-      trace: { ...EMPTY_TRACE, error: error?.message || String(error) },
+      trace: { ...emptyTrace(), error: error?.message || String(error) },
       result: null,
       error: error?.message || String(error),
       logs: collector.entries,

--- a/src/lib/trace/instrument.ts
+++ b/src/lib/trace/instrument.ts
@@ -46,6 +46,12 @@ function functionDisplayName(ts: TsModule, node: AnyNode): string {
     return parent.name.text;
   }
   if (node.kind === ts.SyntaxKind.ArrowFunction) return '(arrow)';
+  if (node.kind === ts.SyntaxKind.Constructor) {
+    const owner = node.parent && node.parent.name ? node.parent.name.text : '';
+    return owner ? `${owner}.constructor` : 'constructor';
+  }
+  if (node.kind === ts.SyntaxKind.GetAccessor) return `get ${node.name?.text ?? ''}`.trim();
+  if (node.kind === ts.SyntaxKind.SetAccessor) return `set ${node.name?.text ?? ''}`.trim();
   return '(anonymous)';
 }
 
@@ -76,15 +82,47 @@ export function instrumentSource(
      */
     interface Scope {
       names: string[];
+      /**
+       * 本块内**稍后**才声明的 let/const/class 名字。
+       * 这些名字在声明之前处于 TDZ：即使外层有同名变量，块内引用它
+       * 命中的也是这个尚未初始化的内层绑定，直接 ReferenceError。
+       * 所以在声明点之前，这些名字一个都不能进 step。
+       */
+      pending: Set<string>;
       /** 是不是函数边界：往上找可见变量时到这一层为止 */
       fnBoundary: boolean;
     }
-    const scopes: Scope[] = [{ names: [], fnBoundary: true }];
-    const pushScope = (fnBoundary = false) => scopes.push({ names: [], fnBoundary });
+    const scopes: Scope[] = [{ names: [], pending: new Set(), fnBoundary: true }];
+    const pushScope = (fnBoundary = false, pending: Set<string> = new Set()) =>
+      scopes.push({ names: [], pending, fnBoundary });
     const popScope = () => scopes.pop();
     const declare = (name: string) => {
       const top = scopes[scopes.length - 1];
-      if (name && !top.names.includes(name)) top.names.push(name);
+      if (!name) return;
+      // 到了声明点，这个名字不再处于 TDZ
+      top.pending.delete(name);
+      if (!top.names.includes(name)) top.names.push(name);
+    };
+
+    /** 收集一个语句列表里所有 let/const/class 声明的名字（用于 TDZ 判断） */
+    const collectPendingNames = (statements: AnyNode[]): Set<string> => {
+      const pending = new Set<string>();
+      for (const statement of statements) {
+        if (ts.isVariableStatement(statement)) {
+          // var 会提升，不存在 TDZ，只有 let/const 需要挡
+          const isBlockScoped =
+            (statement.declarationList.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0;
+          if (!isBlockScoped) continue;
+          for (const decl of statement.declarationList.declarations) {
+            const names: string[] = [];
+            collectBindingNames(ts, decl.name, names);
+            names.forEach((name) => pending.add(name));
+          }
+        } else if (ts.isClassDeclaration(statement) && statement.name) {
+          pending.add(statement.name.text);
+        }
+      }
+      return pending;
     };
     /**
      * 当前位置可见的名字：从栈顶往下收集，遇到函数边界就停。
@@ -92,10 +130,18 @@ export function instrumentSource(
      * 而且做题时关心的基本都是本函数内的状态。
      */
     const visibleNames = (): string[] => {
+      // 先把当前所有层里「还没到声明点」的名字收起来。哪怕外层有同名变量，
+      // 只要内层稍后会声明同名的 let/const，此刻引用它就是 TDZ。
+      const shadowed = new Set<string>();
+      for (let i = scopes.length - 1; i >= 0; i -= 1) {
+        scopes[i].pending.forEach((name) => shadowed.add(name));
+        if (scopes[i].fnBoundary) break;
+      }
+
       const out: string[] = [];
       for (let i = scopes.length - 1; i >= 0; i -= 1) {
         for (const name of scopes[i].names) {
-          if (!out.includes(name)) out.push(name);
+          if (!shadowed.has(name) && !out.includes(name)) out.push(name);
         }
         if (scopes[i].fnBoundary) break;
       }
@@ -218,11 +264,17 @@ export function instrumentSource(
       const node = normalizeBodies(rawNode);
 
       // ---- 函数：压一层作用域，body 包 try/finally ----
+      // 构造函数和 getter/setter 也是函数边界。漏掉它们的话，
+      // 参数不会被登记、作用域会漏到外层，而且每一步都会报成调用者的栈帧 ——
+      // 链表题里的 class ListNode { constructor(val, next) } 正是这种形状。
       const isFunctionLike =
         ts.isFunctionDeclaration(node) ||
         ts.isFunctionExpression(node) ||
         ts.isArrowFunction(node) ||
-        ts.isMethodDeclaration(node);
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessor(node) ||
+        ts.isSetAccessor(node);
 
       if (isFunctionLike) {
         const displayName = functionDisplayName(ts, node);
@@ -236,6 +288,9 @@ export function instrumentSource(
 
         let newBody: AnyNode;
         if (node.body && ts.isBlock(node.body)) {
+          scopes[scopes.length - 1].pending = collectPendingNames(
+            node.body.statements as unknown as AnyNode[]
+          );
           const inner = instrumentStatements(node.body.statements as unknown as AnyNode[], visitor);
           newBody = factory.createBlock(
             [
@@ -290,6 +345,19 @@ export function instrumentSource(
             node.type, node.equalsGreaterThanToken, newBody
           );
         }
+        if (ts.isConstructorDeclaration(node)) {
+          return factory.updateConstructorDeclaration(node, node.modifiers, node.parameters, newBody);
+        }
+        if (ts.isGetAccessor(node)) {
+          return factory.updateGetAccessorDeclaration(
+            node, node.modifiers, node.name, node.parameters, node.type, newBody
+          );
+        }
+        if (ts.isSetAccessor(node)) {
+          return factory.updateSetAccessorDeclaration(
+            node, node.modifiers, node.name, node.parameters, newBody
+          );
+        }
         return factory.updateMethodDeclaration(
           node, node.modifiers, node.asteriskToken, node.name, node.questionToken,
           node.typeParameters, node.parameters, node.type, newBody
@@ -298,13 +366,25 @@ export function instrumentSource(
 
       // ---- 循环体 / if 分支等：确保是块，然后插桩 ----
       if (ts.isBlock(node)) {
-        pushScope();
+        pushScope(false, collectPendingNames(node.statements as unknown as AnyNode[]));
         const updated = factory.updateBlock(
           node,
           instrumentStatements(node.statements as unknown as AnyNode[], visitor)
         );
         popScope();
         return updated;
+      }
+
+      // switch 的 case/default 下面挂的是裸语句列表，不是 Block，
+      // 不单独处理的话整个 switch 在轨迹里是空白的 —— 和之前不带大括号的
+      // 循环体是同一类静默缺口。
+      if (ts.isCaseClause(node) || ts.isDefaultClause(node)) {
+        pushScope(false, collectPendingNames(node.statements as unknown as AnyNode[]));
+        const statements = instrumentStatements(node.statements as unknown as AnyNode[], visitor);
+        popScope();
+        return ts.isCaseClause(node)
+          ? factory.updateCaseClause(node, node.expression, statements)
+          : factory.updateDefaultClause(node, statements);
       }
 
       // 循环变量的作用域是「循环头 + 循环体」，出了循环就不可见，
@@ -330,6 +410,7 @@ export function instrumentSource(
     };
 
     return (root: AnyNode) => {
+      scopes[0].pending = collectPendingNames(root.statements as unknown as AnyNode[]);
       const statements = instrumentStatements(root.statements as unknown as AnyNode[], visitor);
       return factory.updateSourceFile(root, statements);
     };

--- a/src/lib/trace/instrument.ts
+++ b/src/lib/trace/instrument.ts
@@ -1,0 +1,353 @@
+/**
+ * 给 JS / TS 源码插桩，让它一边跑一边把每步状态报给记录器。
+ *
+ * 用 TypeScript 编译器的 transformer 而不是正则或者文本拼接：
+ * 箭头函数的简写体、getter、类方法、可选链这些形态，文本方案迟早会踩空。
+ * 行号在变换时就从原始节点上取好、写成字面量嵌进去，所以后面 printer
+ * 怎么重排格式都不影响行号的准确性。
+ *
+ * 插入的调用：
+ *   __trace.enter(fnName)      函数进入
+ *   __trace.exit()             函数退出（放在 finally 里，抛异常也会走到）
+ *   __trace.step(line, {vars}) 每条语句执行前
+ */
+
+type TsModule = typeof import('typescript');
+type AnyNode = any;
+
+export interface InstrumentOptions {
+  /** 注入的记录器在代码里的变量名 */
+  recorderName?: string;
+}
+
+/** 收集一个函数作用域里「到这一句为止已经声明」的变量名 */
+function collectBindingNames(ts: TsModule, name: AnyNode, out: string[]): void {
+  if (!name) return;
+  if (ts.isIdentifier(name)) {
+    out.push(name.text);
+    return;
+  }
+  // 解构：const [a, b] = xs / const {x, y} = obj
+  if (ts.isArrayBindingPattern(name) || ts.isObjectBindingPattern(name)) {
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element)) collectBindingNames(ts, element.name, out);
+    }
+  }
+}
+
+function functionDisplayName(ts: TsModule, node: AnyNode): string {
+  if (node.name && ts.isIdentifier(node.name)) return node.name.text;
+  // const f = () => {} / const f = function () {}
+  const parent = node.parent;
+  if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+    return parent.name.text;
+  }
+  if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) {
+    return parent.name.text;
+  }
+  if (node.kind === ts.SyntaxKind.ArrowFunction) return '(arrow)';
+  return '(anonymous)';
+}
+
+export function instrumentSource(
+  ts: TsModule,
+  code: string,
+  options: InstrumentOptions = {}
+): string {
+  const recorder = options.recorderName || '__trace';
+
+  const source = ts.createSourceFile(
+    'user.ts',
+    code,
+    ts.ScriptTarget.ES2020,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS
+  );
+
+  const lineOf = (node: AnyNode): number =>
+    source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+
+  const transformer = (context: AnyNode) => {
+    const factory = context.factory;
+
+    /**
+     * 作用域栈。必须按「块」而不是按「函数」记，否则会生成引用已经离开作用域
+     * 的变量的代码 —— 比如在 for 之后的语句里去读循环里的 const，直接 ReferenceError。
+     */
+    interface Scope {
+      names: string[];
+      /** 是不是函数边界：往上找可见变量时到这一层为止 */
+      fnBoundary: boolean;
+    }
+    const scopes: Scope[] = [{ names: [], fnBoundary: true }];
+    const pushScope = (fnBoundary = false) => scopes.push({ names: [], fnBoundary });
+    const popScope = () => scopes.pop();
+    const declare = (name: string) => {
+      const top = scopes[scopes.length - 1];
+      if (name && !top.names.includes(name)) top.names.push(name);
+    };
+    /**
+     * 当前位置可见的名字：从栈顶往下收集，遇到函数边界就停。
+     * 不跨函数是刻意的 —— 闭包捕获的外层变量每步都快照一遍太贵，
+     * 而且做题时关心的基本都是本函数内的状态。
+     */
+    const visibleNames = (): string[] => {
+      const out: string[] = [];
+      for (let i = scopes.length - 1; i >= 0; i -= 1) {
+        for (const name of scopes[i].names) {
+          if (!out.includes(name)) out.push(name);
+        }
+        if (scopes[i].fnBoundary) break;
+      }
+      return out.reverse();
+    };
+
+    const makeStepCall = (line: number): AnyNode => {
+      const names = visibleNames();
+      const props = names.map((name) =>
+        factory.createPropertyAssignment(
+          factory.createStringLiteral(name),
+          factory.createIdentifier(name)
+        )
+      );
+      return factory.createExpressionStatement(
+        factory.createCallExpression(
+          factory.createPropertyAccessExpression(
+            factory.createIdentifier(recorder),
+            'step'
+          ),
+          undefined,
+          [factory.createNumericLiteral(line), factory.createObjectLiteralExpression(props, false)]
+        )
+      );
+    };
+
+    const makeEnterCall = (name: string): AnyNode =>
+      factory.createExpressionStatement(
+        factory.createCallExpression(
+          factory.createPropertyAccessExpression(factory.createIdentifier(recorder), 'enter'),
+          undefined,
+          [factory.createStringLiteral(name)]
+        )
+      );
+
+    const makeExitCall = (): AnyNode =>
+      factory.createExpressionStatement(
+        factory.createCallExpression(
+          factory.createPropertyAccessExpression(factory.createIdentifier(recorder), 'exit'),
+          undefined,
+          []
+        )
+      );
+
+    /** 在语句列表里逐条插入 step 调用 */
+    const instrumentStatements = (statements: AnyNode[], visitor: AnyNode): AnyNode[] => {
+      const out: AnyNode[] = [];
+      for (const statement of statements) {
+        // 函数声明本身不是「执行的一步」，提前声明名字即可
+        if (ts.isFunctionDeclaration(statement) && statement.name) {
+          declare(statement.name.text);
+          out.push(ts.visitNode(statement, visitor));
+          continue;
+        }
+
+        const line = lineOf(statement);
+        // 先记录，再执行：这一步显示的是「执行这行之前」的状态
+        out.push(makeStepCall(line));
+        const visited = ts.visitNode(statement, visitor);
+
+        // 声明语句要在访问之后登记，这样同一行的 step 不会引用尚未初始化的名字
+        if (ts.isVariableStatement(statement)) {
+          for (const decl of statement.declarationList.declarations) {
+            const names: string[] = [];
+            collectBindingNames(ts, decl.name, names);
+            names.forEach(declare);
+          }
+        }
+        out.push(visited);
+      }
+      return out;
+    };
+
+    /**
+     * 不带大括号的单语句体（`for (...) total += i;`、`if (x) return y;`）
+     * 先补成块，否则它永远不会被插桩 —— 一个两万次的循环只能录到 4 步。
+     * 补大括号不改变语义，因为里面本来就只有一条语句。
+     */
+    const asBlock = (statement: AnyNode): AnyNode =>
+      statement && !ts.isBlock(statement) ? factory.createBlock([statement], true) : statement;
+
+    const normalizeBodies = (node: AnyNode): AnyNode => {
+      if (ts.isIfStatement(node)) {
+        const thenPart = asBlock(node.thenStatement);
+        // else if 保持链式，不要把它包成块，否则会多出一层缩进
+        const elsePart =
+          node.elseStatement && !ts.isIfStatement(node.elseStatement)
+            ? asBlock(node.elseStatement)
+            : node.elseStatement;
+        if (thenPart !== node.thenStatement || elsePart !== node.elseStatement) {
+          return factory.updateIfStatement(node, node.expression, thenPart, elsePart);
+        }
+        return node;
+      }
+      if (ts.isForStatement(node) && !ts.isBlock(node.statement)) {
+        return factory.updateForStatement(
+          node, node.initializer, node.condition, node.incrementor, asBlock(node.statement)
+        );
+      }
+      if (ts.isForOfStatement(node) && !ts.isBlock(node.statement)) {
+        return factory.updateForOfStatement(
+          node, node.awaitModifier, node.initializer, node.expression, asBlock(node.statement)
+        );
+      }
+      if (ts.isForInStatement(node) && !ts.isBlock(node.statement)) {
+        return factory.updateForInStatement(
+          node, node.initializer, node.expression, asBlock(node.statement)
+        );
+      }
+      if (ts.isWhileStatement(node) && !ts.isBlock(node.statement)) {
+        return factory.updateWhileStatement(node, node.expression, asBlock(node.statement));
+      }
+      if (ts.isDoStatement(node) && !ts.isBlock(node.statement)) {
+        return factory.updateDoStatement(node, asBlock(node.statement), node.expression);
+      }
+      return node;
+    };
+
+    const visitor = (rawNode: AnyNode): AnyNode => {
+      const node = normalizeBodies(rawNode);
+
+      // ---- 函数：压一层作用域，body 包 try/finally ----
+      const isFunctionLike =
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node);
+
+      if (isFunctionLike) {
+        const displayName = functionDisplayName(ts, node);
+        pushScope(true);
+        // 参数在函数体里立刻可见
+        for (const param of node.parameters) {
+          const names: string[] = [];
+          collectBindingNames(ts, param.name, names);
+          names.forEach(declare);
+        }
+
+        let newBody: AnyNode;
+        if (node.body && ts.isBlock(node.body)) {
+          const inner = instrumentStatements(node.body.statements as unknown as AnyNode[], visitor);
+          newBody = factory.createBlock(
+            [
+              makeEnterCall(displayName),
+              factory.createTryStatement(
+                factory.createBlock(inner, true),
+                undefined,
+                factory.createBlock([makeExitCall()], true)
+              ),
+            ],
+            true
+          );
+        } else if (node.body) {
+          // 箭头函数简写体：x => expr。先展开成块再插桩，
+          // 否则 return 的位置没法记录。
+          const expr = ts.visitNode(node.body, visitor);
+          newBody = factory.createBlock(
+            [
+              makeEnterCall(displayName),
+              factory.createTryStatement(
+                factory.createBlock(
+                  [makeStepCall(lineOf(node.body)), factory.createReturnStatement(expr)],
+                  true
+                ),
+                undefined,
+                factory.createBlock([makeExitCall()], true)
+              ),
+            ],
+            true
+          );
+        } else {
+          newBody = node.body;
+        }
+
+        popScope();
+
+        if (ts.isFunctionDeclaration(node)) {
+          return factory.updateFunctionDeclaration(
+            node, node.modifiers, node.asteriskToken, node.name,
+            node.typeParameters, node.parameters, node.type, newBody
+          );
+        }
+        if (ts.isFunctionExpression(node)) {
+          return factory.updateFunctionExpression(
+            node, node.modifiers, node.asteriskToken, node.name,
+            node.typeParameters, node.parameters, node.type, newBody
+          );
+        }
+        if (ts.isArrowFunction(node)) {
+          return factory.updateArrowFunction(
+            node, node.modifiers, node.typeParameters, node.parameters,
+            node.type, node.equalsGreaterThanToken, newBody
+          );
+        }
+        return factory.updateMethodDeclaration(
+          node, node.modifiers, node.asteriskToken, node.name, node.questionToken,
+          node.typeParameters, node.parameters, node.type, newBody
+        );
+      }
+
+      // ---- 循环体 / if 分支等：确保是块，然后插桩 ----
+      if (ts.isBlock(node)) {
+        pushScope();
+        const updated = factory.updateBlock(
+          node,
+          instrumentStatements(node.statements as unknown as AnyNode[], visitor)
+        );
+        popScope();
+        return updated;
+      }
+
+      // 循环变量的作用域是「循环头 + 循环体」，出了循环就不可见，
+      // 所以给循环单独开一层，访问完立刻弹掉。
+      const isLoopWithBinding =
+        (ts.isForStatement(node) || ts.isForOfStatement(node) || ts.isForInStatement(node)) &&
+        node.initializer &&
+        ts.isVariableDeclarationList(node.initializer);
+
+      if (isLoopWithBinding) {
+        pushScope();
+        for (const decl of node.initializer.declarations) {
+          const names: string[] = [];
+          collectBindingNames(ts, decl.name, names);
+          names.forEach(declare);
+        }
+        const updated = ts.visitEachChild(node, visitor, context);
+        popScope();
+        return updated;
+      }
+
+      return ts.visitEachChild(node, visitor, context);
+    };
+
+    return (root: AnyNode) => {
+      const statements = instrumentStatements(root.statements as unknown as AnyNode[], visitor);
+      return factory.updateSourceFile(root, statements);
+    };
+  };
+
+  const result = ts.transform(source, [transformer]);
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const output = printer.printFile(result.transformed[0]);
+  result.dispose();
+
+  // 插桩后还带着类型注解，交给 transpile 去掉
+  return ts.transpileModule(output, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      strict: false,
+      esModuleInterop: true,
+      skipLibCheck: true,
+    },
+  }).outputText;
+}

--- a/src/lib/trace/pythonTrace.ts
+++ b/src/lib/trace/pythonTrace.ts
@@ -1,0 +1,126 @@
+/**
+ * Python 的轨迹采集。
+ *
+ * 这边不用插桩：CPython 自带 sys.settrace，逐行回调里能直接拿到
+ * frame.f_locals 和调用栈，比改 AST 简单也更可靠。
+ *
+ * 代价是 settrace 会让代码明显变慢，所以只在用户主动点「调试」时才挂上。
+ */
+
+import { TRACE_LIMITS } from './types';
+
+/**
+ * 生成跑在 Pyodide 里的 Python 源码。
+ *
+ * 约定：
+ * - `__user_source` 是用户代码，会在一个干净的命名空间里 exec；
+ * - 结果放在 `_result` / `_error`；
+ * - 轨迹放在 `_trace`，形状和 JS 那边的 TraceStep 对齐。
+ */
+export function buildPythonTraceProgram(
+  userCode: string,
+  functionName: string,
+  argsJson: string
+): string {
+  const indented = userCode
+    .split('\n')
+    .map((line) => `    ${line}`)
+    .join('\n');
+
+  return `
+import json, sys
+from io import StringIO
+
+_stdout_backup, _stderr_backup = sys.stdout, sys.stderr
+sys.stdout, sys.stderr = StringIO(), StringIO()
+
+_trace = []
+_dropped = [0]
+_MAX_STEPS = ${TRACE_LIMITS.maxSteps}
+_MAX_VALUE = ${TRACE_LIMITS.maxValueChars}
+_MAX_VARS = ${TRACE_LIMITS.maxVarsPerStep}
+_stack = []
+
+def _fmt(value):
+    try:
+        text = repr(value)
+    except Exception:
+        text = '[unreadable]'
+    if len(text) > _MAX_VALUE:
+        text = text[:_MAX_VALUE] + '\\u2026'
+    return text
+
+def _tracer(frame, event, arg):
+    name = frame.f_code.co_name
+    # 只跟用户代码，别把 json/StringIO 这些库函数也录进来
+    if frame.f_code.co_filename != '<user>':
+        return None
+
+    if event == 'call':
+        _stack.append(name)
+        return _tracer
+
+    if event == 'return':
+        if _stack:
+            _stack.pop()
+        return None
+
+    if event == 'line':
+        if len(_trace) >= _MAX_STEPS:
+            _dropped[0] += 1
+            return _tracer
+        variables = []
+        for key, value in list(frame.f_locals.items()):
+            if key.startswith('__'):
+                continue
+            if len(variables) >= _MAX_VARS:
+                break
+            variables.append({'name': key, 'value': _fmt(value)})
+        _trace.append({
+            'line': frame.f_lineno,
+            'depth': max(len(_stack) - 1, 0),
+            'fn': name,
+            'vars': variables,
+            'stack': list(_stack),
+        })
+    return _tracer
+
+_result = None
+_error = None
+_ns = {}
+
+try:
+    _compiled = compile(${JSON.stringify(userCode)}, '<user>', 'exec')
+    exec(_compiled, _ns)
+    _args = json.loads(${JSON.stringify(argsJson)})
+    _fn = _ns.get(${JSON.stringify(functionName)})
+    if _fn is None:
+        raise NameError("function '" + ${JSON.stringify(functionName)} + "' is not defined")
+    sys.settrace(_tracer)
+    try:
+        _result = _fn(*_args) if len(_args) != 1 else _fn(_args[0])
+    finally:
+        sys.settrace(None)
+except Exception as exc:
+    sys.settrace(None)
+    _error = str(exc)
+
+_stdout_content = sys.stdout.getvalue()
+_stderr_content = sys.stderr.getvalue()
+sys.stdout, sys.stderr = _stdout_backup, _stderr_backup
+
+{
+    "result": _result if _error is None else None,
+    "error": _error,
+    "stdout": _stdout_content,
+    "stderr": _stderr_content,
+    "trace": json.dumps({
+        "steps": _trace,
+        "droppedSteps": _dropped[0],
+        "truncated": _dropped[0] > 0,
+        "completed": _error is None,
+        "error": _error,
+    }),
+}
+`.trim();
+}

--- a/src/lib/trace/pythonTrace.ts
+++ b/src/lib/trace/pythonTrace.ts
@@ -22,11 +22,6 @@ export function buildPythonTraceProgram(
   functionName: string,
   argsJson: string
 ): string {
-  const indented = userCode
-    .split('\n')
-    .map((line) => `    ${line}`)
-    .join('\n');
-
   return `
 import json, sys
 from io import StringIO

--- a/src/lib/trace/recorder.ts
+++ b/src/lib/trace/recorder.ts
@@ -1,0 +1,80 @@
+/**
+ * 轨迹记录器：被插桩后的代码在运行时调用它。
+ *
+ * 注入方式和 console 收集器一样，走 new Function 的形参，不碰全局。
+ */
+
+import { formatConsoleValue } from '../consoleFormat';
+import { TRACE_LIMITS, type ExecutionTrace, type TraceStep, type TraceVariable } from './types';
+
+export interface TraceRecorder {
+  /** 注入给插桩代码的对象 */
+  api: {
+    enter(fn: string): void;
+    exit(): void;
+    step(line: number, vars: Record<string, unknown>): void;
+  };
+  trace: ExecutionTrace;
+}
+
+function clip(text: string): string {
+  if (text.length <= TRACE_LIMITS.maxValueChars) return text;
+  return `${text.slice(0, TRACE_LIMITS.maxValueChars)}…`;
+}
+
+export function createTraceRecorder(entryName = '(top level)'): TraceRecorder {
+  const steps: TraceStep[] = [];
+  const stack: string[] = [entryName];
+  let dropped = 0;
+
+  const trace: ExecutionTrace = {
+    steps,
+    droppedSteps: 0,
+    truncated: false,
+    completed: false,
+  };
+
+  return {
+    trace,
+    api: {
+      enter(fn: string) {
+        stack.push(fn);
+      },
+      exit() {
+        // 保底：栈底那一层不弹，插桩配对出问题时也不至于把栈掏空
+        if (stack.length > 1) stack.pop();
+      },
+      step(line: number, vars: Record<string, unknown>) {
+        // 到上限就只计数不再记录。代码继续跑完 —— 中途抛异常反而更难解释。
+        if (steps.length >= TRACE_LIMITS.maxSteps) {
+          dropped += 1;
+          trace.droppedSteps = dropped;
+          trace.truncated = true;
+          return;
+        }
+
+        const snapshot: TraceVariable[] = [];
+        for (const name of Object.keys(vars)) {
+          if (snapshot.length >= TRACE_LIMITS.maxVarsPerStep) break;
+          let value: string;
+          try {
+            // 立刻格式化成字符串 = 快照。存引用的话，
+            // 后面每一次 push/set 都会把之前记录的那一步一起改掉。
+            value = clip(formatConsoleValue(vars[name]));
+          } catch {
+            value = '[unreadable]';
+          }
+          snapshot.push({ name, value });
+        }
+
+        steps.push({
+          line,
+          depth: stack.length - 1,
+          fn: stack[stack.length - 1],
+          vars: snapshot,
+          stack: [...stack],
+        });
+      },
+    },
+  };
+}

--- a/src/lib/trace/types.ts
+++ b/src/lib/trace/types.ts
@@ -1,0 +1,54 @@
+/**
+ * 执行轨迹：把一次运行「录」下来，之后可以来回拖着看。
+ *
+ * 之所以做成轨迹回放而不是断点调试器：浏览器主线程没法真正阻塞，
+ * 想要真断点就得把用户代码搬进 Worker 再配 Atomics.wait。而做题时
+ * 真正想知道的是「循环第 3 轮的时候 seen 里有什么」——
+ * 这种问题拖时间轴比反复设断点、单步、再重跑要快得多，而且能往回看。
+ */
+
+export interface TraceVariable {
+  name: string;
+  /** 已经格式化成字符串的快照。存引用的话，后面的改动会把历史一起改掉。 */
+  value: string;
+}
+
+export interface TraceStep {
+  /** 原始源码的行号（1 起） */
+  line: number;
+  /** 调用栈深度，用于 UI 缩进 */
+  depth: number;
+  /** 当前函数名，栈顶 */
+  fn: string;
+  /** 这一步执行前，当前函数作用域里可见的变量 */
+  vars: TraceVariable[];
+  /** 完整调用栈，栈底在前 */
+  stack: string[];
+}
+
+export interface ExecutionTrace {
+  steps: TraceStep[];
+  /** 因为超出上限而被丢弃的步数 */
+  droppedSteps: number;
+  /** 轨迹是否因为超限而被截断 */
+  truncated: boolean;
+  /** 采集轨迹时代码是否正常结束 */
+  completed: boolean;
+  error?: string;
+}
+
+export const TRACE_LIMITS = {
+  /** 最多记录多少步。超过就停止记录，但代码继续跑完。 */
+  maxSteps: 5000,
+  /** 单个变量值的最大字符数 */
+  maxValueChars: 200,
+  /** 每一步最多记录多少个变量 */
+  maxVarsPerStep: 24,
+} as const;
+
+export const EMPTY_TRACE: ExecutionTrace = {
+  steps: [],
+  droppedSteps: 0,
+  truncated: false,
+  completed: false,
+};

--- a/src/lib/trace/types.ts
+++ b/src/lib/trace/types.ts
@@ -46,9 +46,10 @@ export const TRACE_LIMITS = {
   maxVarsPerStep: 24,
 } as const;
 
-export const EMPTY_TRACE: ExecutionTrace = {
-  steps: [],
-  droppedSteps: 0,
-  truncated: false,
-  completed: false,
-};
+/**
+ * 工厂而不是常量：导出一个共享对象的话，`{ ...EMPTY_TRACE, error }`
+ * 展开出来的每一份都指向同一个 steps 数组。
+ */
+export function emptyTrace(): ExecutionTrace {
+  return { steps: [], droppedSteps: 0, truncated: false, completed: false };
+}

--- a/tests/trace/instrument.test.ts
+++ b/tests/trace/instrument.test.ts
@@ -1,0 +1,215 @@
+/**
+ * 插桩的回归测试
+ *
+ * 重点在两件事：
+ * 1. 插桩后的代码必须还是**同一个程序** —— 返回值、异常、副作用都不能变；
+ * 2. 生成的代码不能引用当前作用域里不存在的名字，否则 ReferenceError。
+ *    这一条踩过：循环变量被记在函数作用域里，循环结束后的语句还去读它。
+ */
+import * as ts from 'typescript';
+import { instrumentSource } from '../../src/lib/trace/instrument';
+import { createTraceRecorder } from '../../src/lib/trace/recorder';
+import { TRACE_LIMITS } from '../../src/lib/trace/types';
+
+function runTraced(source: string, args: unknown[] = []) {
+  const instrumented = instrumentSource(ts, source);
+  const recorder = createTraceRecorder();
+  const fn = new Function(
+    '__trace',
+    'args',
+    `var userExports = null;
+     (function(){ var module = { exports: null }; ${instrumented} userExports = module.exports; })();
+     return userExports.apply(null, args);`
+  );
+  const result = fn(recorder.api, args);
+  return { result, trace: recorder.trace, instrumented };
+}
+
+describe('instrumented code behaves like the original', () => {
+  it('keeps the return value of a plain function', () => {
+    const { result, trace } = runTraced(
+      `function twoSum(nums, target) {
+         const seen = new Map();
+         for (let i = 0; i < nums.length; i++) {
+           const need = target - nums[i];
+           if (seen.has(need)) return [seen.get(need), i];
+           seen.set(nums[i], i);
+         }
+         return [];
+       }
+       module.exports = twoSum;`,
+      [[2, 7, 11, 15], 9]
+    );
+    expect(result).toEqual([0, 1]);
+    expect(trace.steps.length).toBeGreaterThan(0);
+  });
+
+  it('does not reference loop variables after the loop ends', () => {
+    // 这里正是那个 bug：for 之后的语句一度会带上 i / need，直接 ReferenceError
+    const { result, instrumented } = runTraced(
+      `function f(xs) {
+         let total = 0;
+         for (let i = 0; i < xs.length; i++) {
+           const doubled = xs[i] * 2;
+           total += doubled;
+         }
+         return total;
+       }
+       module.exports = f;`,
+      [[1, 2, 3]]
+    );
+    expect(result).toBe(12);
+    // 最后一条 step 属于 return 那一行，不该出现循环内的名字
+    const lastStep = instrumented.slice(instrumented.lastIndexOf('__trace.step'));
+    expect(lastStep).not.toContain('"doubled"');
+    expect(lastStep).not.toContain('"i"');
+  });
+
+  it('handles closures without dragging in outer scopes', () => {
+    const { result } = runTraced(
+      `function makeCounter() {
+         let count = 0;
+         return function tick() { count += 1; return count; };
+       }
+       function run() {
+         const tick = makeCounter();
+         tick(); tick();
+         return tick();
+       }
+       module.exports = run;`
+    );
+    expect(result).toBe(3);
+  });
+
+  it('handles an arrow function with a concise body', () => {
+    const { result, trace } = runTraced(
+      `const double = (x) => x * 2;
+       function run(n) { return double(n) + double(n); }
+       module.exports = run;`,
+      [5]
+    );
+    expect(result).toBe(20);
+    // 简写体被展开成块，所以箭头函数里那一步也被记录了
+    expect(trace.steps.some((step) => step.fn === 'double')).toBe(true);
+  });
+
+  it('handles destructuring in params and declarations', () => {
+    const { result } = runTraced(
+      `function run({ a, b }, [c, d]) {
+         const { x, y } = { x: a + c, y: b + d };
+         return x * y;
+       }
+       module.exports = run;`,
+      [{ a: 1, b: 2 }, [3, 4]]
+    );
+    expect(result).toBe(24);
+  });
+
+  it('survives async/await and preserves the resolved value', async () => {
+    const { result } = runTraced(
+      `async function run(n) {
+         const first = await Promise.resolve(n);
+         const second = await Promise.resolve(first * 2);
+         return second + 1;
+       }
+       module.exports = run;`,
+      [10]
+    );
+    await expect(result as Promise<number>).resolves.toBe(21);
+  });
+
+  it('survives generators', () => {
+    const { result } = runTraced(
+      `function* gen(n) {
+         for (let i = 0; i < n; i++) yield i * i;
+       }
+       function run(n) {
+         let total = 0;
+         for (const v of gen(n)) total += v;
+         return total;
+       }
+       module.exports = run;`,
+      [4]
+    );
+    expect(result).toBe(0 + 1 + 4 + 9);
+  });
+
+  it('records recursion depth on the call stack', () => {
+    const { result, trace } = runTraced(
+      `function fact(n) { return n <= 1 ? 1 : n * fact(n - 1); }
+       module.exports = fact;`,
+      [4]
+    );
+    expect(result).toBe(24);
+    const maxDepth = Math.max(...trace.steps.map((step) => step.depth));
+    expect(maxDepth).toBeGreaterThanOrEqual(4);
+  });
+
+  it('pops the call stack even when the function throws', () => {
+    const source = `function boom() { throw new Error('nope'); }
+       function run() {
+         try { boom(); } catch (e) { return 'caught'; }
+       }
+       module.exports = run;`;
+    const { result, trace } = runTraced(source);
+    expect(result).toBe('caught');
+    // exit 在 finally 里，抛异常也会执行，所以栈深度回得来
+    const depths = trace.steps.map((step) => step.depth);
+    expect(depths[depths.length - 1]).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('trace bounds', () => {
+  it('stops recording past the cap but lets the program finish', () => {
+    const { result, trace } = runTraced(
+      `function run() {
+         let total = 0;
+         for (let i = 0; i < 20000; i++) total += i;
+         return total;
+       }
+       module.exports = run;`
+    );
+    // 程序照常跑完，拿到正确结果
+    expect(result).toBe((19999 * 20000) / 2);
+    // 但轨迹被截断了，没有把内存吃光
+    expect(trace.steps.length).toBe(TRACE_LIMITS.maxSteps);
+    expect(trace.truncated).toBe(true);
+    expect(trace.droppedSteps).toBeGreaterThan(0);
+  });
+
+  it('instruments bodies that have no braces', () => {
+    // 不补大括号的话，这个循环体永远不会被插桩：
+    // 两万次迭代只能录到 4 步，轨迹等于没有
+    const { result, trace } = runTraced(
+      `function run() {
+         let total = 0;
+         for (let i = 0; i < 5; i++) total += i;
+         if (total > 0) total = total * 2;
+         return total;
+       }
+       module.exports = run;`
+    );
+    expect(result).toBe(20);
+    // 循环体每一轮都记一步
+    const loopSteps = trace.steps.filter((step) => step.vars.some((v) => v.name === 'i'));
+    expect(loopSteps.length).toBe(5);
+  });
+
+  it('snapshots values instead of holding references', () => {
+    const { trace } = runTraced(
+      `function run() {
+         const acc = [];
+         acc.push(1);
+         acc.push(2);
+         return acc;
+       }
+       module.exports = run;`
+    );
+    const accStates = trace.steps
+      .map((step) => step.vars.find((v) => v.name === 'acc')?.value)
+      .filter(Boolean);
+    // 存引用的话每一步都会显示最终的 [1, 2]
+    expect(accStates).toContain('[]');
+    expect(accStates.some((value) => value === '[1]')).toBe(true);
+  });
+});

--- a/tests/trace/instrument.test.ts
+++ b/tests/trace/instrument.test.ts
@@ -159,6 +159,76 @@ describe('instrumented code behaves like the original', () => {
   });
 });
 
+describe('instrumentation must not break code that already worked', () => {
+  it('does not put shadowed block-scoped names into the TDZ', () => {
+    // 插桩前跑得好好的代码，插桩后不能变成 ReferenceError。
+    // 内层块稍后声明的 let/const 会遮蔽外层同名变量，声明点之前引用它
+    // 命中的是尚未初始化的内层绑定。
+    const { result } = runTraced(
+      `function run() { let x = 1; { let x = 2; x += 1; } return x; }
+       module.exports = run;`
+    );
+    expect(result).toBe(1);
+  });
+
+  it('handles a loop-local const shadowing an outer name', () => {
+    const { result } = runTraced(
+      `function run(rows) {
+         let count = 0;
+         for (const row of rows) { const count = row.length; }
+         return count;
+       }
+       module.exports = run;`,
+      [[[1, 2], [3]]]
+    );
+    expect(result).toBe(0);
+  });
+
+  it('handles a shadowing const inside an if block', () => {
+    const { result } = runTraced(
+      `function run(c) {
+         const helper = 1;
+         if (c) { const helper = 2; return helper; }
+         return helper;
+       }
+       module.exports = run;`,
+      [true]
+    );
+    expect(result).toBe(2);
+  });
+
+  it('treats constructors as their own frame', () => {
+    const { result, trace } = runTraced(
+      `class Node {
+         constructor(val, next) { this.val = val; this.next = next; }
+       }
+       function run() { const n = new Node(7, null); return n.val; }
+       module.exports = run;`
+    );
+    expect(result).toBe(7);
+    // 不把构造函数当作函数边界的话，这里会报成调用者的栈帧
+    expect(trace.steps.some((step) => step.fn.includes('constructor'))).toBe(true);
+  });
+
+  it('instruments statements under switch cases', () => {
+    const { result, trace } = runTraced(
+      `function run(kind) {
+         let out = '';
+         switch (kind) {
+           case 'a': out = 'first'; break;
+           default: out = 'other';
+         }
+         return out;
+       }
+       module.exports = run;`,
+      ['a']
+    );
+    expect(result).toBe('first');
+    // case 下面挂的是裸语句列表，不单独处理的话整个 switch 在轨迹里是空白
+    expect(trace.steps.some((step) => step.vars.some((v) => v.name === 'out'))).toBe(true);
+  });
+});
+
 describe('trace bounds', () => {
   it('stops recording past the cap but lets the program finish', () => {
     const { result, trace } = runTraced(


### PR DESCRIPTION
This is **L1** from the debugging plan: trace回放, not breakpoints.

A Debug button runs one test case with recording on, then gives you a timeline to drag through. Current line highlighted, variables in scope at that step, call stack. It goes **backwards** as well as forwards — the thing a real breakpoint debugger cannot do, and "what was in `seen` last iteration" is the question that actually comes up while solving a problem.

## Two mechanisms

| Language | How | Why |
|---|---|---|
| JS / TS | TypeScript compiler **transformer** inserts `__trace.step(line, vars)` before each statement; function bodies wrapped in `try/finally` | A transformer rather than text splicing — concise arrow bodies, class methods and optional chaining all defeat text approaches. Line numbers are read off the *original* AST and baked in as literals, so output formatting cannot desync them. |
| Python | `sys.settrace` | Hands over `f_locals` and the frame stack directly. No instrumentation needed. Only installed for a Debug run, since settrace is slow. |

Only **one** test case is traced, and without the benchmark's repeat runs — otherwise you would record four identical traces of every case.

## Correctness details that took a fix

- **Snapshots, not references.** Values are formatted to strings at capture time using the existing console formatter. Holding references would mean every step showed the *final* state of a mutated object — the trace would say `Map(1)` at step 2 of a loop that hadn't run yet. Pinned by a test.
- **Block-level scope tracking.** Tracking at function level emitted code that reads a loop variable *after the loop ended* — a `ReferenceError` in code that was fine before instrumentation. Pinned by a test.
- **Brace-less bodies normalised into blocks.** `for (...) total += i;` was never instrumented, so a 20000-iteration loop recorded **4 steps**. Found by the bounds test failing with `Expected 5000, received 4`.

## Bounds

5000 steps, 200 chars per value, 24 vars per step. Past the cap recording stops but **the program keeps running to completion** — a 20000-iteration loop still returns the right answer with a truncated trace rather than dying halfway.

## E2E verification

Ran in the app for all three languages on two-sum:

- **JavaScript** — 9 steps; stepped to 6/9 (line 8, `seen=Map(0) {}`, `i=0`, `need=7`), then 9/9 (line 6, `seen=Map(1) { 2 => 0 }`, `i=1`, `need=2`). State genuinely differs by step and navigates both ways.
- **Python** — 9 steps via settrace; 1/9 shows `nums=[2, 7, 11, 15]`, `target=9`; 9/9 shows `seen={2: 0}`, `i=1`, `v=7`, `need=2`. Correct Python `repr` formatting.
- **TypeScript** — traces with the original annotated source displayed.

Plus 12 instrumentation tests covering closures, async/await, generators, recursion depth, destructuring, arrow concise bodies, throw-inside-function stack unwinding, the step cap, brace-less bodies and the snapshot property.

`tsc` clean · `npm test` 5/5 · `tests/engineering` 230/230 · `projects:verify` green · `next build` compiles.

## Note on the TS/Python "execution bugs"

I previously reported that TypeScript and Python execution were broken. **That was wrong.** Both work correctly. The failures were an artifact of my test harness writing into a stale Monaco model — Monaco keeps one model per language, and `getModels()[0]` was the JavaScript one, so the app was faithfully executing the untouched template. Verified by instrumenting the live path: the executed source was the 84-char template, not what I had typed. Writing to the correct model makes all cases pass. No fix was needed and none is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)