### PR TITLE
fix(ai): 本地模型下 system message 约束导致的 500

### DIFF
--- a/pages/api/ai-chat.ts
+++ b/pages/api/ai-chat.ts
@@ -6,6 +6,7 @@ import {
   ChatMessage,
   NoProviderError,
   streamAI,
+  statusForError,
 } from '../../src/lib/server/aiProvider';
 
 /**
@@ -128,7 +129,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.error('AI Chat error:', error);
     const message =
       error instanceof NoProviderError ? error.message : (error as Error).message || 'Failed to get AI response';
-    if (!res.headersSent) return res.status(500).json({ error: message });
+    if (!res.headersSent) return res.status(statusForError(error)).json({ error: message });
     res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
     res.end();
   }

--- a/pages/api/ai-solution.ts
+++ b/pages/api/ai-solution.ts
@@ -6,6 +6,7 @@ import {
   ChatMessage,
   NoProviderError,
   streamAI,
+  statusForError,
 } from '../../src/lib/server/aiProvider';
 
 /**
@@ -158,7 +159,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.error('AI Solution error:', error);
     const message =
       error instanceof NoProviderError ? error.message : error.message || 'Failed to generate solution';
-    if (!res.headersSent) return res.status(500).json({ error: message });
+    if (!res.headersSent) return res.status(statusForError(error)).json({ error: message });
     res.write(`\n\n[error] ${message}`);
     res.end();
   }

--- a/pages/api/ai-solution.ts
+++ b/pages/api/ai-solution.ts
@@ -8,6 +8,7 @@ import {
   streamAI,
   statusForError,
 } from '../../src/lib/server/aiProvider';
+import { TEXT_STREAM_ERROR_MARK } from '../../src/lib/textStreamProtocol';
 
 /**
  * 生成「一份文件里包含多个解法」的题解。
@@ -160,7 +161,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const message =
       error instanceof NoProviderError ? error.message : error.message || 'Failed to generate solution';
     if (!res.headersSent) return res.status(statusForError(error)).json({ error: message });
-    res.write(`\n\n[error] ${message}`);
+    res.write(`${TEXT_STREAM_ERROR_MARK}${message}`);
     res.end();
   }
 }

--- a/pages/api/compatible-models.ts
+++ b/pages/api/compatible-models.ts
@@ -7,38 +7,10 @@
  */
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { normalizeCompatibleEndpoint } from '../../src/lib/server/aiProvider';
-import { checkEndpointSyntax, guardedFetch } from '../../src/lib/server/endpointPolicy';
+import { checkEndpointSyntax, describeNetworkError, guardedFetch } from '../../src/lib/server/endpointPolicy';
 
 // 远程端点可能在地球另一端，10 秒对跨洋链路偏紧
 const TIMEOUT_MS = 20_000;
-
-/**
- * 远程端点失败的原因和本地不一样：DNS、证书、防火墙都可能。
- * 原样抛 fetch 的 "fetch failed" 对用户毫无帮助，这里翻译成能行动的说法。
- */
-function describeNetworkError(error: any, base: string): string {
-  if (error?.name === 'AbortError') {
-    return `No response from ${base} within ${TIMEOUT_MS / 1000}s. If it is remote, check that it is reachable from this machine.`;
-  }
-  const code = error?.cause?.code || error?.code;
-  switch (code) {
-    case 'ENOTFOUND':
-    case 'EAI_AGAIN':
-      return `Cannot resolve the host in ${base}. Check the address for typos.`;
-    case 'ECONNREFUSED':
-      return `${base} refused the connection. Check the port, and that the server is running.`;
-    case 'CERT_HAS_EXPIRED':
-      return `The TLS certificate for ${base} has expired.`;
-    case 'DEPTH_ZERO_SELF_SIGNED_CERT':
-    case 'SELF_SIGNED_CERT_IN_CHAIN':
-    case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE':
-      return `${base} uses a certificate this machine does not trust (self-signed or an unknown CA). Use a trusted certificate, or put the gateway behind one.`;
-    case 'ERR_TLS_CERT_ALTNAME_INVALID':
-      return `The TLS certificate for ${base} does not cover that hostname.`;
-    default:
-      return `Could not reach ${base}: ${error?.message || String(error)}`;
-  }
-}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -86,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     return res.status(200).json({ endpoint: base, models });
   } catch (error: any) {
-    return res.status(502).json({ error: describeNetworkError(error, base) });
+    return res.status(502).json({ error: describeNetworkError(error, base, TIMEOUT_MS) });
   } finally {
     clearTimeout(timer);
   }

--- a/pages/api/compatible-models.ts
+++ b/pages/api/compatible-models.ts
@@ -8,6 +8,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { normalizeCompatibleEndpoint } from '../../src/lib/server/aiProvider';
 import { checkEndpointSyntax, describeNetworkError, guardedFetch } from '../../src/lib/server/endpointPolicy';
+import { looksLikeMarkup, readableErrorBody } from '../../src/lib/errorBody';
 
 // 远程端点可能在地球另一端，10 秒对跨洋链路偏紧
 const TIMEOUT_MS = 20_000;
@@ -45,11 +46,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const detail = await response.text();
       return res.status(502).json({
         error: `The endpoint answered ${response.status}.`,
-        detail: detail.slice(0, 300),
+        detail: readableErrorBody(detail) || undefined,
       });
     }
 
-    const data = await response.json();
+    // 不要直接 response.json()：它抛的 SyntaxError 会落进下面的 catch，
+    // 被报成「连不上」—— 但这个地址明明答话了，只是答的是一个网页。
+    const payload = await response.text();
+    let data: any;
+    try {
+      data = JSON.parse(payload);
+    } catch {
+      return res.status(502).json({
+        error: looksLikeMarkup(payload)
+          ? `${base} answered with a web page, not JSON. Check that the URL points at the API (it usually ends in /v1).`
+          : `${base} answered with something that is not JSON.`,
+        detail: readableErrorBody(payload) || undefined,
+      });
+    }
     // OpenAI 的形状是 { data: [{ id }] }；有些实现直接返回数组，两种都收
     const list = Array.isArray(data) ? data : data?.data;
     const models = Array.isArray(list)

--- a/pages/api/compatible-models.ts
+++ b/pages/api/compatible-models.ts
@@ -7,7 +7,12 @@
  */
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { normalizeCompatibleEndpoint } from '../../src/lib/server/aiProvider';
-import { checkEndpointSyntax, describeNetworkError, guardedFetch } from '../../src/lib/server/endpointPolicy';
+import {
+  checkEndpointSyntax,
+  describeNetworkError,
+  EndpointPolicyError,
+  guardedFetch,
+} from '../../src/lib/server/endpointPolicy';
 import { looksLikeMarkup, readableErrorBody } from '../../src/lib/errorBody';
 
 // 远程端点可能在地球另一端，10 秒对跨洋链路偏紧
@@ -44,9 +49,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (!response.ok) {
       const detail = await response.text();
+      const words = readableErrorBody(detail);
       return res.status(502).json({
-        error: `The endpoint answered ${response.status}.`,
-        detail: readableErrorBody(detail) || undefined,
+        error: words
+          ? `The endpoint answered ${response.status}: ${words}`
+          : `The endpoint answered ${response.status}.`,
       });
     }
 
@@ -60,8 +67,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(502).json({
         error: looksLikeMarkup(payload)
           ? `${base} answered with a web page, not JSON. Check that the URL points at the API (it usually ends in /v1).`
-          : `${base} answered with something that is not JSON.`,
-        detail: readableErrorBody(payload) || undefined,
+          : `${base} answered with something that is not JSON: ${readableErrorBody(payload)}`,
       });
     }
     // OpenAI 的形状是 { data: [{ id }] }；有些实现直接返回数组，两种都收
@@ -72,6 +78,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     return res.status(200).json({ endpoint: base, models });
   } catch (error: any) {
+    // 地址被策略拦下时根本没发出请求，报成「连不上」是错的，
+    // 而且它的 message 本来就是写给用户看的那一句
+    if (error instanceof EndpointPolicyError) {
+      return res.status(error.status).json({ error: error.message });
+    }
     return res.status(502).json({ error: describeNetworkError(error, base, TIMEOUT_MS) });
   } finally {
     clearTimeout(timer);

--- a/pages/api/engineering-chat.ts
+++ b/pages/api/engineering-chat.ts
@@ -9,6 +9,19 @@ import {
 } from '../../src/lib/server/aiProvider';
 import { buildWorkspaceContext, WorkspaceContext } from '../../src/lib/server/engineeringPrompt';
 
+/*
+ * 这个路由收的是整个工作区（每个文件的全文 + 最近一次运行报告），
+ * Next 默认的 1mb 一个中等项目就撞穿了，表现是一个 413 —— 功能直接不可用。
+ * 和 generate-project 保持同一个上限。responseLimit 关掉是因为回答是流式的。
+ */
+export const config = {
+  api: {
+    responseLimit: false,
+    bodyParser: { sizeLimit: '8mb' },
+  },
+};
+
+
 interface EngineeringChatRequest {
   messages: ChatMessage[];
   context: WorkspaceContext;

--- a/pages/api/engineering-chat.ts
+++ b/pages/api/engineering-chat.ts
@@ -5,6 +5,7 @@ import {
   ChatMessage,
   NoProviderError,
   streamAI,
+  statusForError,
 } from '../../src/lib/server/aiProvider';
 import { buildWorkspaceContext, WorkspaceContext } from '../../src/lib/server/engineeringPrompt';
 
@@ -78,7 +79,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.error('Engineering chat error:', error);
     const message =
       error instanceof NoProviderError ? error.message : (error as Error).message || 'Failed to get AI response';
-    if (!res.headersSent) return res.status(500).json({ error: message });
+    if (!res.headersSent) return res.status(statusForError(error)).json({ error: message });
     res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
     res.end();
   }

--- a/pages/api/engineering-chat.ts
+++ b/pages/api/engineering-chat.ts
@@ -63,7 +63,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const { messages, context, language = 'zh', config } = req.body as EngineeringChatRequest;
+    // aiConfig 而不是 config：模块顶上那个 export const config 是路由配置，
+    // 同名会让下一个人读到请求体里的东西还以为是它
+    const { messages, context, language = 'zh', config: aiConfig } = req.body as EngineeringChatRequest;
 
     if (!Array.isArray(messages)) {
       return res.status(400).json({ error: 'Messages array is required' });
@@ -81,7 +83,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ...messages,
     ];
 
-    await streamAI(res, fullMessages, config, {
+    await streamAI(res, fullMessages, aiConfig, {
       temperature: 0.6,
       maxTokens: 2500,
       format: 'sse',

--- a/pages/api/engineering-review.ts
+++ b/pages/api/engineering-review.ts
@@ -12,6 +12,19 @@ import { buildWorkspaceContext, WorkspaceContext } from '../../src/lib/server/en
 import { DIMENSION_KEYS } from '../../src/lib/engineering/types';
 import type { AiReview, QualityReport } from '../../src/lib/engineering/types';
 
+/*
+ * 这个路由收的是整个工作区（每个文件的全文 + 最近一次运行报告），
+ * Next 默认的 1mb 一个中等项目就撞穿了，表现是一个 413 —— 功能直接不可用。
+ * 和 generate-project 保持同一个上限。responseLimit 关掉是因为回答是流式的。
+ */
+export const config = {
+  api: {
+    responseLimit: false,
+    bodyParser: { sizeLimit: '8mb' },
+  },
+};
+
+
 interface ReviewRequest {
   context: WorkspaceContext;
   quality?: QualityReport;

--- a/pages/api/engineering-review.ts
+++ b/pages/api/engineering-review.ts
@@ -6,6 +6,7 @@ import {
   extractJson,
   NoProviderError,
   streamStructured,
+  statusForError,
 } from '../../src/lib/server/aiProvider';
 import { buildWorkspaceContext, WorkspaceContext } from '../../src/lib/server/engineeringPrompt';
 import { DIMENSION_KEYS } from '../../src/lib/engineering/types';
@@ -157,6 +158,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       res.end();
       return;
     }
-    return res.status(500).json({ error: message });
+    return res.status(statusForError(error)).json({ error: message });
   }
 }

--- a/pages/api/engineering-review.ts
+++ b/pages/api/engineering-review.ts
@@ -129,7 +129,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const { context, quality, language = 'zh', config } = req.body as ReviewRequest;
+    // aiConfig 而不是 config：模块顶上那个 export const config 是路由配置
+    const { context, quality, language = 'zh', config: aiConfig } = req.body as ReviewRequest;
 
     if (!context || !Array.isArray(context.files) || context.files.length === 0) {
       return res.status(400).json({ error: 'Workspace files are required' });
@@ -153,7 +154,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     ];
 
     // 评审是给人读的长文，没有理由攒到最后一次性甩出来
-    await streamStructured(res, messages, config, {
+    await streamStructured(res, messages, aiConfig, {
       temperature: 0.3,
       maxTokens: 4000,
       signal: abortSignalFor(res),

--- a/pages/api/generate-problem.ts
+++ b/pages/api/generate-problem.ts
@@ -9,6 +9,7 @@ import {
   NoProviderError,
   streamStructured,
   StructuredStreamError,
+  statusForError,
 } from '../../src/lib/server/aiProvider';
 
 interface Problem {
@@ -244,6 +245,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       res.end();
       return;
     }
-    return res.status(500).json({ error: 'Failed to generate problem', details: message });
+    return res.status(statusForError(error)).json({ error: message });
   }
 }

--- a/pages/api/generate-project.ts
+++ b/pages/api/generate-project.ts
@@ -6,6 +6,7 @@ import {
   extractJson,
   NoProviderError,
   streamStructured,
+  statusForError,
 } from '../../src/lib/server/aiProvider';
 import { coerceProject, validateProjectShape } from '../../src/lib/engineering/validateProject';
 import { addUserProject } from '../../src/lib/server/projectStore';
@@ -243,6 +244,6 @@ Remember: reference implementations must actually pass the specs, latency number
       res.end();
       return;
     }
-    return res.status(500).json({ error: message });
+    return res.status(statusForError(error)).json({ error: message });
   }
 }

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -24,6 +24,7 @@ import { useTranslation, useI18n } from '../src/contexts/I18nContext';
 import { AppHeader, HEADER_HEIGHT } from '../src/components/AppHeader';
 import { DEFAULT_MODELS, SUGGESTED_MODELS } from '../src/lib/aiModels';
 import { isInsecureRemote, looksRemote } from '../src/lib/endpointHosts';
+import { readableErrorBody } from '../src/lib/errorBody';
 
 export default function SettingsPage() {
   const { t } = useTranslation();
@@ -95,7 +96,20 @@ export default function SettingsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ endpoint: compatibleConfig.endpoint, apiKey: compatibleConfig.apiKey }),
       });
-      const data = await response.json();
+      // response.json() 直接抛的话，用户看到的是「Unexpected token '<'」——
+      // 而这正是配本地端点时最容易撞到的一种失败（地址指到了网页上）。
+      const payload = await response.text();
+      let data: any = null;
+      try {
+        data = JSON.parse(payload);
+      } catch {
+        setCompatibleError(
+          readableErrorBody(payload) ||
+            `${t('settings.compatible.fetchFailed')} (HTTP ${response.status})`
+        );
+        setCompatibleModels([]);
+        return;
+      }
       if (!response.ok) {
         setCompatibleError(data?.error || t('settings.compatible.fetchFailed'));
         setCompatibleModels([]);

--- a/src/components/CodeRunner.tsx
+++ b/src/components/CodeRunner.tsx
@@ -46,6 +46,7 @@ import {
 } from '../lib/editorPrefs';
 import { clearDraft, loadDraft, saveDraft } from '../lib/problemDrafts';
 import { useAiConfig } from '../hooks/useAiConfig';
+import { readableErrorBody } from '../lib/streamRequest';
 
 // WASM 支持的语言配置
 const WASM_SUPPORTED_LANGUAGES = [
@@ -521,13 +522,17 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
       });
 
       if (!response.ok) {
+        // throw 不能放进 try 里 —— 它会被下面这个 catch 接住，
+        // 于是刚解析出来的那句话又被换回了整段原始响应体。
         const text = await response.text();
+        let message = '';
         try {
-          const data = JSON.parse(text);
-          throw new Error(data.error || 'Failed to generate solution');
+          message = JSON.parse(text).error || '';
         } catch {
-          throw new Error(text || 'Failed to generate solution');
+          // 不是 JSON 的错误体多半是错误页，别整页糊到界面上
+          message = readableErrorBody(text);
         }
+        throw new Error(message || `Failed to generate solution (HTTP ${response.status})`);
       }
 
       const reader = response.body?.getReader();

--- a/src/components/CodeRunner.tsx
+++ b/src/components/CodeRunner.tsx
@@ -47,6 +47,7 @@ import {
 import { clearDraft, loadDraft, saveDraft } from '../lib/problemDrafts';
 import { useAiConfig } from '../hooks/useAiConfig';
 import { readableErrorBody } from '../lib/errorBody';
+import { splitTextStreamError } from '../lib/textStreamProtocol';
 
 // WASM 支持的语言配置
 const WASM_SUPPORTED_LANGUAGES = [
@@ -499,6 +500,8 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
     setIsGeneratingSolution(true);
     setSolutionError(null);
     setConfirmModalOpen(false);
+    // 生成过程会一边流一边替换编辑器内容，失败时要能还原
+    const codeBeforeGeneration = code;
 
     try {
       const response = await fetch('/api/ai-solution', {
@@ -548,24 +551,25 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
         const { done, value } = await reader.read();
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
-        setCode(cleanCodeFromResponse(buffer));
+        setCode(cleanCodeFromResponse(splitTextStreamError(buffer).text));
       }
 
       buffer += decoder.decode();
 
       /*
-       * 这条路径是纯文本流，流开始之后出错只能作为正文里的一行 `[error] ...`
-       * 送过来（头已经发出去了，状态码改不动）。不认它的话，这行字会被当成
-       * 代码写进编辑器，800ms 后连草稿一起覆盖掉 —— 而且界面上不报错。
+       * 这条路径是纯文本流：头发出去之后再出错，错误只能写进正文里。
+       * 不认这个标记的话，那句话会被当成代码写进编辑器，800ms 后连草稿一起
+       * 覆盖掉 —— 而且界面上一点错都不报。
        */
-      const failure = buffer.match(/\n\n\[error\] ([\s\S]*)$/);
-      if (failure) {
-        const partial = buffer.slice(0, failure.index);
-        if (partial.trim()) updateCode(cleanCodeFromResponse(partial));
-        throw new Error(failure[1].trim() || 'Failed to generate AI solution');
+      const { text, error: streamed } = splitTextStreamError(buffer);
+      if (streamed) {
+        // 一个字都没生成出来就失败了，把编辑器恢复原状，
+        // 别把一句报错留在那里当代码
+        updateCode(text.trim() ? cleanCodeFromResponse(text) : codeBeforeGeneration);
+        throw new Error(streamed);
       }
 
-      updateCode(cleanCodeFromResponse(buffer));
+      updateCode(cleanCodeFromResponse(text));
     } catch (error: any) {
       setSolutionError(error.message || 'Failed to generate AI solution');
     } finally {

--- a/src/components/CodeRunner.tsx
+++ b/src/components/CodeRunner.tsx
@@ -46,7 +46,7 @@ import {
 } from '../lib/editorPrefs';
 import { clearDraft, loadDraft, saveDraft } from '../lib/problemDrafts';
 import { useAiConfig } from '../hooks/useAiConfig';
-import { readableErrorBody } from '../lib/streamRequest';
+import { readableErrorBody } from '../lib/errorBody';
 
 // WASM 支持的语言配置
 const WASM_SUPPORTED_LANGUAGES = [
@@ -552,6 +552,19 @@ export default function CodeRunner({ problem, onTestResult, showResults = true, 
       }
 
       buffer += decoder.decode();
+
+      /*
+       * 这条路径是纯文本流，流开始之后出错只能作为正文里的一行 `[error] ...`
+       * 送过来（头已经发出去了，状态码改不动）。不认它的话，这行字会被当成
+       * 代码写进编辑器，800ms 后连草稿一起覆盖掉 —— 而且界面上不报错。
+       */
+      const failure = buffer.match(/\n\n\[error\] ([\s\S]*)$/);
+      if (failure) {
+        const partial = buffer.slice(0, failure.index);
+        if (partial.trim()) updateCode(cleanCodeFromResponse(partial));
+        throw new Error(failure[1].trim() || 'Failed to generate AI solution');
+      }
+
       updateCode(cleanCodeFromResponse(buffer));
     } catch (error: any) {
       setSolutionError(error.message || 'Failed to generate AI solution');

--- a/src/components/ProblemGenerator.tsx
+++ b/src/components/ProblemGenerator.tsx
@@ -21,6 +21,7 @@ import {
 } from '@tabler/icons-react';
 import Editor from '@monaco-editor/react';
 import { requestStructuredStream, StreamRequestError } from '../lib/streamRequest';
+import { readableErrorBody } from '../lib/errorBody';
 
 interface GeneratedProblem {
   id: string;
@@ -316,7 +317,17 @@ const ProblemGenerator: React.FC<ProblemGeneratorProps> = ({ onProblemGenerated,
         body: JSON.stringify({ problem: parsed }),
       });
 
-      const data = await response.json();
+      // 这里不能直接 response.json()：它抛的 SyntaxError 会被下面的 catch
+      // 当成「你编辑的 JSON 有问题」，于是用户对着一段完全正确的 JSON 反复改。
+      const payload = await response.text();
+      let data: any = null;
+      try {
+        data = JSON.parse(payload);
+      } catch {
+        throw new Error(
+          readableErrorBody(payload) || `Failed to save problem (HTTP ${response.status})`
+        );
+      }
 
       if (!response.ok) {
         throw new Error(data.error || 'Failed to save problem');

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -13,7 +13,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createSseParser } from '../lib/chatStreamProtocol';
-import { readableErrorBody } from '../lib/streamRequest';
+import { readableErrorBody } from '../lib/errorBody';
 
 export interface StreamMessage {
   id: string;

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -13,6 +13,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createSseParser } from '../lib/chatStreamProtocol';
+import { readableErrorBody } from '../lib/streamRequest';
 
 export interface StreamMessage {
   id: string;
@@ -132,8 +133,9 @@ export function useChatStream({ url, body }: SendOptions) {
           try {
             message = JSON.parse(detail).error || '';
           } catch {
-            // 不是 JSON 的错误体多半是代理或框架的 HTML 错误页。
-            // 把整页贴进对话框只会给用户一屏标签，状态码才是有用的那部分。
+            // 不是 JSON 的错误体：一句纯文本（例如 Next 的 `Body exceeded 1mb limit`）
+            // 留着，整页 HTML 错误页丢掉 —— 贴进对话框只会给用户一屏标签。
+            message = readableErrorBody(detail);
           }
           throw new Error(message || `Request failed with ${response.status}`);
         }

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -128,11 +128,12 @@ export function useChatStream({ url, body }: SendOptions) {
 
         if (!response.ok) {
           const detail = await response.text();
-          let message = detail;
+          let message = '';
           try {
-            message = JSON.parse(detail).error || detail;
+            message = JSON.parse(detail).error || '';
           } catch {
-            // 非 JSON 错误体，原样使用
+            // 不是 JSON 的错误体多半是代理或框架的 HTML 错误页。
+            // 把整页贴进对话框只会给用户一屏标签，状态码才是有用的那部分。
           }
           throw new Error(message || `Request failed with ${response.status}`);
         }

--- a/src/lib/errorBody.ts
+++ b/src/lib/errorBody.ts
@@ -1,0 +1,22 @@
+/**
+ * 错误响应体里，哪些内容还值得给用户看。
+ *
+ * 服务端和客户端要用同一把尺子：两边各写一套的结果是，一段 250 字符的纯文本
+ * 错误被服务端原样转发、又被客户端丢掉，用户最后只看到一个状态码。
+ *
+ * 规则：
+ *   - HTML（反代和框架的错误页）丢掉 —— 那是一屏标签，没有一句是给人读的
+ *   - 太长的丢掉 —— 真正的错误信息是一句话，不是一页
+ *   - 其余留着 —— 例如 Next 自己的 `Body exceeded 1mb limit`
+ */
+const MAX_READABLE_LENGTH = 300;
+
+export function looksLikeMarkup(body: string): boolean {
+  return (body || '').trim().startsWith('<');
+}
+
+export function readableErrorBody(body: string): string {
+  const text = (body || '').trim();
+  if (!text || looksLikeMarkup(text) || text.length > MAX_READABLE_LENGTH) return '';
+  return text;
+}

--- a/src/lib/errorBody.ts
+++ b/src/lib/errorBody.ts
@@ -17,6 +17,8 @@ export function looksLikeMarkup(body: string): boolean {
 
 export function readableErrorBody(body: string): string {
   const text = (body || '').trim();
-  if (!text || looksLikeMarkup(text) || text.length > MAX_READABLE_LENGTH) return '';
-  return text;
+  if (!text || looksLikeMarkup(text)) return '';
+  // 长的截断，不要整段丢掉：自建网关的报错可能是一段模板渲染栈，
+  // 前 300 个字符里通常就有那句关键的话。
+  return text.length > MAX_READABLE_LENGTH ? `${text.slice(0, MAX_READABLE_LENGTH)}…` : text;
 }

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -11,6 +11,7 @@
 import type { NextApiResponse } from 'next';
 import { describeNetworkError, EndpointPolicyError, guardedFetch } from './endpointPolicy';
 import { looksLikeMarkup, readableErrorBody } from '../errorBody';
+import { TEXT_STREAM_ERROR_MARK } from '../textStreamProtocol';
 import { isPrivateHostname } from '../endpointHosts';
 import {
   capabilitiesFor,
@@ -353,6 +354,8 @@ function buildRequest(
 const DEFAULT_TIMEOUT_MS = 120_000;
 /** 正文两块之间最多能停多久 —— 本地模型慢是常态，卡死不是 */
 const STREAM_IDLE_TIMEOUT_MS = 120_000;
+/** 第一块可以等更久：整段生成完才发第一个字节的上游是存在的 */
+const STREAM_FIRST_CHUNK_TIMEOUT_MS = 600_000;
 
 /**
  * 上游明确拒绝了这次请求。
@@ -407,6 +410,8 @@ export class EmptyConversationError extends Error {
  * 上下文塞满了，或者模板渲染出了一段我们解析不了的东西。
  */
 export class AIEmptyResponseError extends Error {
+  // 目前两个抛点都在响应头之后，所以它实际总是以流里的 error 事件到达前端；
+  // status 是给「哪天在发头之前也能判空」留的，不是当前行为。
   status = 502;
 
   constructor(origin: string) {
@@ -543,8 +548,18 @@ async function fetchUpstream(
         body: JSON.stringify(request.body),
         signal: controller.signal,
       });
+
+      // 读错误正文这一步也要放进来：上游发完头就卡住的话，超时会在这里触发，
+      // 漏在外面的话它会以一个裸的 AbortError 冒出去，被当成「客户端走了」
+      // 而静默收尾 —— 用户又拿到一个空白气泡。
+      if (!response.ok) {
+        const detail = await response.text();
+        throw new AIUpstreamError(describeUpstreamError(response.status, detail), response.status);
+      }
     } catch (error) {
       const origin = originOf(request.url);
+      // 上游自己的拒绝已经是最终结论了，别再往下分类
+      if (error instanceof AIUpstreamError) throw error;
       if (timedOut) {
         throw new AITimeoutError(
           describeNetworkError({ name: 'AbortError' }, origin, DEFAULT_TIMEOUT_MS)
@@ -559,11 +574,6 @@ async function fetchUpstream(
       // 只翻译传输层失败 —— endpointPolicy 的拦截理由本身就是给人看的，别再包一层。
       if (isTransportFailure(error)) throw new AINetworkError(describeNetworkError(error, origin));
       throw error;
-    }
-
-    if (!response.ok) {
-      const detail = await response.text();
-      throw new AIUpstreamError(describeUpstreamError(response.status, detail), response.status);
     }
 
     return response;
@@ -656,20 +666,32 @@ async function pipeUpstream(
    * 的那一段：本地模型加载权重、被 OOM 杀掉、或者干脆不吐 token。没有这道
    * 看门狗的话，连接会一直开着，界面上就是一个永远转下去的圈。
    */
+  let started = false;
   const readNext = async () => {
+    // 第一块给的预算宽得多：上游可能整段生成完才发第一个字节（无视 stream:true
+    // 的实现就是这样），CPU 上跑一个 8B 模型几分钟很正常。开始吐了之后再停两
+    // 分钟，那就是真的卡住了。
+    const budget = started ? STREAM_IDLE_TIMEOUT_MS : STREAM_FIRST_CHUNK_TIMEOUT_MS;
     let timer: NodeJS.Timeout | undefined;
     try {
-      return await Promise.race([
+      const result = await Promise.race([
         reader.read(),
         new Promise<never>((_resolve, reject) => {
-          timer = setTimeout(
-            () => reject(new AITimeoutError(
-              `${origin} stopped sending data for ${Math.round(STREAM_IDLE_TIMEOUT_MS / 1000)}s. If it is a local model, check its own log.`
-            )),
-            STREAM_IDLE_TIMEOUT_MS
-          );
+          timer = setTimeout(() => {
+            // 光 reject 不够：连接还开着，上游会继续生成一段没人看的回答
+            void reader.cancel().catch(() => undefined);
+            reject(
+              new AITimeoutError(
+                started
+                  ? `${origin} stopped sending data for ${Math.round(budget / 1000)}s. If it is a local model, check its own log.`
+                  : `${origin} sent nothing for ${Math.round(budget / 1000)}s. If it is a local model, check that the model is loaded and its own log.`
+              )
+            );
+          }, budget);
         }),
       ]);
+      started = true;
+      return result;
     } finally {
       clearTimeout(timer);
     }
@@ -821,6 +843,8 @@ export async function streamAI(
       const text = await callAI(messages, config, options);
       writeHeaders(res, format);
       declareNotIncremental();
+      // 空回答走的也是失败路径，别在两条分支里只挡一条
+      if (!text) throw new AIEmptyResponseError(provider.kind);
       emit(text);
     } else {
       const request = buildRequest(provider, messages, { stream: true, temperature });
@@ -856,7 +880,7 @@ export async function streamAI(
       return;
     }
     if (format === 'sse') sseEvent(res, { type: 'error', message });
-    else res.write(`\n\n[error] ${message}`);
+    else writeNow(res, `${TEXT_STREAM_ERROR_MARK}${message}`);
     res.end();
   }
 }

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -9,7 +9,7 @@
  *    并且客户端断开时把上游请求一起 abort 掉，不再白烧 token。
  */
 import type { NextApiResponse } from 'next';
-import { guardedFetch } from './endpointPolicy';
+import { describeNetworkError, guardedFetch } from './endpointPolicy';
 import { isPrivateHostname } from '../endpointHosts';
 import {
   capabilitiesFor,
@@ -208,12 +208,38 @@ export function normalizeMessages(messages: ChatMessage[]): ChatMessage[] {
   const rest: ChatMessage[] = [];
 
   for (const message of messages) {
+    // messages 是请求体里来的，路由只校验了它是个数组。这里读到的每个字段
+    // 都可能不是字符串，甚至不是对象 —— 让 .trim() 抛 TypeError 只会变成
+    // 一个内部错误的 500，还不如把这条丢掉。
+    if (!message || typeof message !== 'object') continue;
+    // content 不是字符串就当它不存在。硬转出来的 "[object Object]" 会原样
+    // 变成模型看到的提示词，比少一条消息更糟。
+    const content = typeof message.content === 'string' ? message.content : '';
+
     if (message.role === 'system') {
-      const content = (message.content || '').trim();
-      if (content) systemParts.push(content);
-    } else {
-      rest.push(message);
+      if (content.trim()) systemParts.push(content.trim());
+      continue;
     }
+
+    /*
+     * 空的 user/assistant 也要丢掉。
+     *
+     * 一次失败的请求会在对话历史里留下一条**空的** assistant 消息（内容还没
+     * 流出来就断了），下一次发送会把它一起带上。Anthropic 直接拒绝空的
+     * content block，一部分 chat 模板也一样 —— 于是一次偶发失败会把整个
+     * 会话钉死，用户只能关掉对话框重开。
+     */
+    if (!content.trim()) continue;
+
+    // 丢掉空消息可能让两条同角色的消息挨在一起（user, assistant(空), user）。
+    // Anthropic 要求角色交替，所以这里把它们并成一条，而不是留个坑给上游。
+    const previous = rest[rest.length - 1];
+    if (previous && previous.role === message.role) {
+      rest[rest.length - 1] = { ...previous, content: `${previous.content}\n\n${content}` };
+      continue;
+    }
+
+    rest.push({ ...message, content });
   }
 
   if (systemParts.length === 0) return rest;
@@ -269,10 +295,8 @@ function buildRequest(
       };
 
     case 'claude': {
-      const system = messages
-        .filter((message) => message.role === 'system')
-        .map((message) => message.content)
-        .join('\n\n');
+      // normalizeMessages 保证了：要么没有 system，要么就是唯一一条、在 index 0
+      const system = messages[0]?.role === 'system' ? messages[0].content : '';
       return {
         url: 'https://api.anthropic.com/v1/messages',
         headers: {
@@ -284,7 +308,7 @@ function buildRequest(
         body: {
           model: provider.model,
           system: system || undefined,
-          messages: messages.filter((message) => message.role !== 'system'),
+          messages: system ? messages.slice(1) : messages,
           temperature: options.temperature,
           max_tokens: provider.maxTokens,
           stream: options.stream,
@@ -340,9 +364,40 @@ export class AIUpstreamError extends Error {
   }
 }
 
+/**
+ * 根本没连上上游：服务没起、端口写错、域名解析不了、证书不受信任。
+ *
+ * 和上游返回 4xx 一样，这也是「要改的是配置」，只不过失败发生在更早的一层。
+ */
+export class AINetworkError extends Error {
+  status = 502;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'AINetworkError';
+  }
+}
+
+/**
+ * 上游在超时窗口内没有回应。
+ *
+ * 它必须和「客户端自己走了」区分开：两者都是 AbortError，但前者要告诉用户，
+ * 后者只需要安静收尾。混在一起的后果是，一次超时会变成一个空白的回答气泡 ——
+ * 没有报错、没有内容，用户等了两分钟什么也没得到。
+ */
+export class AITimeoutError extends Error {
+  status = 504;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'AITimeoutError';
+  }
+}
+
 /** 该用哪个状态码回给客户端 */
 export function statusForError(error: unknown): number {
   if (error instanceof AIUpstreamError) return error.status;
+  if (error instanceof AITimeoutError || error instanceof AINetworkError) return error.status;
   // 没配 provider 属于「请求缺前提」，不是服务端故障
   if (error instanceof NoProviderError) return 400;
   return 500;
@@ -371,7 +426,20 @@ function describeUpstreamError(status: number, body: string): string {
     // 不是 JSON，按纯文本处理
   }
 
+  // 代理和框架的错误页是 HTML。把 300 个字符的标签塞进错误提示里，用户看到的
+  // 是一屏 <html><head><title>502 Bad Gateway —— 状态码才是有用的那部分。
+  if (text.startsWith('<')) return `The AI endpoint returned ${status} with an HTML error page, not JSON. Check that the endpoint URL points at the API and not at a web page.`;
+
   return text.slice(0, 300);
+}
+
+/** 只取协议 + 主机，错误提示里没必要出现完整路径 */
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
 }
 
 async function fetchUpstream(
@@ -384,7 +452,13 @@ async function fetchUpstream(
   userSuppliedUrl = false
 ): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  // 超时和「客户端走了」都会 abort 同一个 controller，但后面要分别处理，
+  // 所以这里自己记一笔 —— AbortError 本身分不出是谁触发的。
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, DEFAULT_TIMEOUT_MS);
   // 客户端断开 -> 连带取消上游，不再为没人看的回答付费
   signal?.addEventListener('abort', () => controller.abort(), { once: true });
 
@@ -392,12 +466,29 @@ async function fetchUpstream(
     // 聊天请求打的是同一个用户填的地址，所以 SSRF 面不只是「列模型」那个路由；
     // guardedFetch 会逐跳校验重定向。
     const send = userSuppliedUrl ? guardedFetch : fetch;
-    const response = await send(request.url, {
-      method: 'POST',
-      headers: request.headers,
-      body: JSON.stringify(request.body),
-      signal: controller.signal,
-    });
+    let response: Response;
+    try {
+      response = await send(request.url, {
+        method: 'POST',
+        headers: request.headers,
+        body: JSON.stringify(request.body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const origin = originOf(request.url);
+      if (timedOut) {
+        throw new AITimeoutError(
+          describeNetworkError({ name: 'AbortError' }, origin, DEFAULT_TIMEOUT_MS)
+        );
+      }
+      // 连都没连上：服务没起、端口写错、域名解析不了、证书不受信任。这是本地
+      // 模型场景里最常见的一类失败，不该以「fetch failed」的形式露出来。
+      // 只翻译传输层失败 —— endpointPolicy 的拦截理由本身就是给人看的，别再包一层。
+      const transport =
+        (error as any)?.cause?.code || (error as any)?.code || /fetch failed/i.test((error as Error)?.message || '');
+      if (transport) throw new AINetworkError(describeNetworkError(error, origin));
+      throw error;
+    }
 
     if (!response.ok) {
       const detail = await response.text();

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -188,6 +188,38 @@ interface UpstreamRequest {
   body: Record<string, unknown>;
 }
 
+/**
+ * 把消息规整成「至多一条 system，而且在最前面」。
+ *
+ * 这不是给某个后端打的补丁，是**开放权重模型的 chat 模板普遍要求**：
+ * Qwen 等模型的 Jinja 模板里写着 `raise_exception('System message must be at
+ * the beginning.')`，llama.cpp / LM Studio / Ollama 走模板渲染时会原样抛出来，
+ * 变成一个 400。llama.cpp 把这视为模板的既定行为而不是 bug（#20733 closed as
+ * not planned），也就是说客户端本来就该保证这个前提。
+ *
+ * 托管 API（OpenAI、DeepSeek）接受多条 system、也接受它出现在中间，所以同一份
+ * 代码在它们那里一直是好的 —— 这正是这个 bug 只在本地模型上暴露的原因。
+ *
+ * 我们自己的路由从来只在开头放 system（只是放了两条：一条人设、一条上下文），
+ * 所以这里把它们按顺序拼成一条，语义不变。
+ */
+export function normalizeMessages(messages: ChatMessage[]): ChatMessage[] {
+  const systemParts: string[] = [];
+  const rest: ChatMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === 'system') {
+      const content = (message.content || '').trim();
+      if (content) systemParts.push(content);
+    } else {
+      rest.push(message);
+    }
+  }
+
+  if (systemParts.length === 0) return rest;
+  return [{ role: 'system', content: systemParts.join('\n\n') }, ...rest];
+}
+
 /** OpenAI 兼容格式：DeepSeek、Qwen（compatible-mode）、OpenAI 自己都走这套 */
 function openAiCompatibleBody(
   provider: ResolvedProvider,
@@ -207,9 +239,12 @@ function openAiCompatibleBody(
 
 function buildRequest(
   provider: ResolvedProvider,
-  messages: ChatMessage[],
+  rawMessages: ChatMessage[],
   options: { stream: boolean; temperature: number }
 ): UpstreamRequest {
+  // 所有 provider 共用同一份规整：system 合成一条、放最前
+  const messages = normalizeMessages(rawMessages);
+
   switch (provider.kind) {
     case 'deepseek':
       return {
@@ -284,6 +319,61 @@ function buildRequest(
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 
+/**
+ * 上游明确拒绝了这次请求。
+ *
+ * 它和「我们自己挂了」是两件事，所以要带着上游的状态码往外传：
+ * 端点填错、key 过期、模型名不存在、超出上下文长度，用户看到 400/401/404
+ * 才知道该去改什么；一律报 500 只会让人以为是应用坏了。
+ */
+export class AIUpstreamError extends Error {
+  /** 上游返回的状态码 */
+  upstreamStatus: number;
+  /** 转给客户端用的状态码：上游的 4xx 照传，5xx 归一成 502 */
+  status: number;
+
+  constructor(message: string, upstreamStatus: number) {
+    super(message);
+    this.name = 'AIUpstreamError';
+    this.upstreamStatus = upstreamStatus;
+    this.status = upstreamStatus >= 400 && upstreamStatus < 500 ? upstreamStatus : 502;
+  }
+}
+
+/** 该用哪个状态码回给客户端 */
+export function statusForError(error: unknown): number {
+  if (error instanceof AIUpstreamError) return error.status;
+  // 没配 provider 属于「请求缺前提」，不是服务端故障
+  if (error instanceof NoProviderError) return 400;
+  return 500;
+}
+
+/**
+ * 从上游的错误响应体里抠出一句人能读的话。
+ *
+ * 各家的形状不一样：OpenAI 兼容端点是 { error: { message } }，
+ * Ollama 是 { error: "..." }，还有直接回一段文本的。
+ * 抠不出来就退回截断后的原文 —— 那也比一个纯粹的 500 强。
+ */
+function describeUpstreamError(status: number, body: string): string {
+  const text = (body || '').trim();
+  if (!text) return `The AI endpoint returned ${status} with an empty body.`;
+
+  try {
+    const parsed = JSON.parse(text);
+    const message =
+      (typeof parsed?.error === 'string' && parsed.error) ||
+      parsed?.error?.message ||
+      parsed?.message ||
+      parsed?.detail;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  } catch {
+    // 不是 JSON，按纯文本处理
+  }
+
+  return text.slice(0, 300);
+}
+
 async function fetchUpstream(
   request: UpstreamRequest,
   signal?: AbortSignal,
@@ -311,7 +401,7 @@ async function fetchUpstream(
 
     if (!response.ok) {
       const detail = await response.text();
-      throw new Error(`AI provider error ${response.status}: ${detail.slice(0, 500)}`);
+      throw new AIUpstreamError(describeUpstreamError(response.status, detail), response.status);
     }
 
     return response;
@@ -558,7 +648,8 @@ export async function streamAI(
 
     const message = (error as Error).message || 'AI request failed';
     if (!res.headersSent) {
-      res.status(500).json({ error: message });
+      // 上游拒绝了就把它的状态码传下去：400 是「请求不对」，不是「我们挂了」
+      res.status(statusForError(error)).json({ error: message });
       return;
     }
     if (format === 'sse') sseEvent(res, { type: 'error', message });
@@ -646,7 +737,7 @@ export async function streamStructured<T>(
 
     // 头还没发出去时仍然用 HTTP 状态码报错，保持老调用方的行为
     if (!res.headersSent) {
-      res.status(500).json({ error: message, details, rawContent: raw || undefined });
+      res.status(statusForError(error)).json({ error: message, details, rawContent: raw || undefined });
       return;
     }
     sseEvent(res, { type: 'error', message, details });

--- a/src/lib/server/aiProvider.ts
+++ b/src/lib/server/aiProvider.ts
@@ -9,7 +9,8 @@
  *    并且客户端断开时把上游请求一起 abort 掉，不再白烧 token。
  */
 import type { NextApiResponse } from 'next';
-import { describeNetworkError, guardedFetch } from './endpointPolicy';
+import { describeNetworkError, EndpointPolicyError, guardedFetch } from './endpointPolicy';
+import { looksLikeMarkup, readableErrorBody } from '../errorBody';
 import { isPrivateHostname } from '../endpointHosts';
 import {
   capabilitiesFor,
@@ -212,6 +213,8 @@ export function normalizeMessages(messages: ChatMessage[]): ChatMessage[] {
     // 都可能不是字符串，甚至不是对象 —— 让 .trim() 抛 TypeError 只会变成
     // 一个内部错误的 500，还不如把这条丢掉。
     if (!message || typeof message !== 'object') continue;
+    // role 没写或者写了个我们不认识的值，转发上去只会换来一个看不懂的 400
+    if (message.role !== 'system' && message.role !== 'user' && message.role !== 'assistant') continue;
     // content 不是字符串就当它不存在。硬转出来的 "[object Object]" 会原样
     // 变成模型看到的提示词，比少一条消息更糟。
     const content = typeof message.content === 'string' ? message.content : '';
@@ -270,6 +273,12 @@ function buildRequest(
 ): UpstreamRequest {
   // 所有 provider 共用同一份规整：system 合成一条、放最前
   const messages = normalizeMessages(rawMessages);
+
+  // 规整之后一条对话都不剩（全是空消息，或者本来就没发）。发上去只会换回一个
+  // 各家措辞不同的 400，不如自己说清楚。
+  if (!messages.some((message) => message.role !== 'system')) {
+    throw new EmptyConversationError();
+  }
 
   switch (provider.kind) {
     case 'deepseek':
@@ -342,6 +351,8 @@ function buildRequest(
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+/** 正文两块之间最多能停多久 —— 本地模型慢是常态，卡死不是 */
+const STREAM_IDLE_TIMEOUT_MS = 120_000;
 
 /**
  * 上游明确拒绝了这次请求。
@@ -378,6 +389,34 @@ export class AINetworkError extends Error {
   }
 }
 
+/** 规整之后没有任何一条真正的对话消息 */
+export class EmptyConversationError extends Error {
+  status = 400;
+
+  constructor() {
+    super('There is nothing to send: the conversation has no message with any content.');
+    this.name = 'EmptyConversationError';
+  }
+}
+
+/**
+ * 上游 200 了，但一个字都没有。
+ *
+ * 空回答不能当成成功：界面上是一个空白气泡 —— 没内容、没报错、连重试按钮
+ * 都不亮，用户看不出发生了什么。本地模型上这通常意味着它被换出去了、
+ * 上下文塞满了，或者模板渲染出了一段我们解析不了的东西。
+ */
+export class AIEmptyResponseError extends Error {
+  status = 502;
+
+  constructor(origin: string) {
+    super(
+      `${origin} returned an empty response. If it is a local model, check its own log — it may have run out of context or unloaded the model.`
+    );
+    this.name = 'AIEmptyResponseError';
+  }
+}
+
 /**
  * 上游在超时窗口内没有回应。
  *
@@ -398,6 +437,8 @@ export class AITimeoutError extends Error {
 export function statusForError(error: unknown): number {
   if (error instanceof AIUpstreamError) return error.status;
   if (error instanceof AITimeoutError || error instanceof AINetworkError) return error.status;
+  if (error instanceof AIEmptyResponseError || error instanceof EmptyConversationError) return error.status;
+  if (error instanceof EndpointPolicyError) return error.status;
   // 没配 provider 属于「请求缺前提」，不是服务端故障
   if (error instanceof NoProviderError) return 400;
   return 500;
@@ -426,11 +467,39 @@ function describeUpstreamError(status: number, body: string): string {
     // 不是 JSON，按纯文本处理
   }
 
-  // 代理和框架的错误页是 HTML。把 300 个字符的标签塞进错误提示里，用户看到的
+  // 代理和框架的错误页是 HTML。把几百个字符的标签塞进错误提示里，用户看到的
   // 是一屏 <html><head><title>502 Bad Gateway —— 状态码才是有用的那部分。
-  if (text.startsWith('<')) return `The AI endpoint returned ${status} with an HTML error page, not JSON. Check that the endpoint URL points at the API and not at a web page.`;
+  if (looksLikeMarkup(text)) {
+    return `The AI endpoint returned ${status} with an HTML error page, not JSON. Check that the endpoint URL points at the API and not at a web page.`;
+  }
 
-  return text.slice(0, 300);
+  // 和客户端共用同一把尺子，免得一边转发、一边丢弃
+  return readableErrorBody(text) || `The AI endpoint returned ${status}.`;
+}
+
+/**
+ * 这个错误是不是「网络层没接上/断了」。
+ *
+ * 注意不能只看有没有 code：abort 抛的是 DOMException，它带着遗留的
+ * 数字 code 20，会把「用户关掉了对话框」误判成一次网络故障。
+ */
+function isTransportFailure(error: unknown): boolean {
+  if ((error as Error)?.name === 'AbortError') return false;
+  const code = (error as any)?.cause?.code || (error as any)?.code;
+  if (typeof code === 'string') return true;
+  return /fetch failed|terminated|socket hang up/i.test((error as Error)?.message || '');
+}
+
+/**
+ * 正文读到一半断了，同样要翻译。
+ *
+ * 这一段发生在响应头之后，所以走不到 fetchUpstream 里那个分支 —— 本地模型
+ * 生成到一半被 OOM 杀掉时，用户看到的原本只有一个词：terminated。
+ */
+function translateStreamFailure(error: unknown, origin: string): unknown {
+  if (error instanceof AITimeoutError || error instanceof AINetworkError) return error;
+  if (!isTransportFailure(error)) return error;
+  return new AINetworkError(describeNetworkError(error, origin));
 }
 
 /** 只取协议 + 主机，错误提示里没必要出现完整路径 */
@@ -481,12 +550,14 @@ async function fetchUpstream(
           describeNetworkError({ name: 'AbortError' }, origin, DEFAULT_TIMEOUT_MS)
         );
       }
+      // 客户端自己走了：原样往上抛，让调用方安静收尾。
+      // 这一步必须在传输层判断之前 —— abort 抛的 DOMException 带着遗留的
+      // 数字 code 20，按「有 code 就是传输失败」判会把它误报成 502。
+      if ((error as Error)?.name === 'AbortError') throw error;
       // 连都没连上：服务没起、端口写错、域名解析不了、证书不受信任。这是本地
       // 模型场景里最常见的一类失败，不该以「fetch failed」的形式露出来。
       // 只翻译传输层失败 —— endpointPolicy 的拦截理由本身就是给人看的，别再包一层。
-      const transport =
-        (error as any)?.cause?.code || (error as any)?.code || /fetch failed/i.test((error as Error)?.message || '');
-      if (transport) throw new AINetworkError(describeNetworkError(error, origin));
+      if (isTransportFailure(error)) throw new AINetworkError(describeNetworkError(error, origin));
       throw error;
     }
 
@@ -561,15 +632,48 @@ function parseChunk(kind: ProviderKind, payload: string): string {
  * @returns 是否真的是逐块到达的。false 表示上游无视了 stream:true，
  *          整段内容是一次性拿到的 —— 调用方要如实告诉前端。
  */
+interface PipeResult {
+  /** 是不是逐块到达的。false 表示上游无视了 stream:true */
+  incremental: boolean;
+  /** 有没有拿到任何内容。false 表示这次回答是空的 */
+  delivered: boolean;
+}
+
 async function pipeUpstream(
   kind: ProviderKind,
   upstream: Response,
   onChunk: (text: string) => void,
   /** 确认上游不是流时先回调一次，永远早于第一次 onChunk */
-  onNotIncremental: () => void = () => undefined
-): Promise<boolean> {
+  onNotIncremental: () => void = () => undefined,
+  /** 报错时用得上：是哪个地址停住了 */
+  origin = 'the AI endpoint'
+): Promise<PipeResult> {
   const reader = upstream.body?.getReader();
-  if (!reader) return false;
+  if (!reader) return { incremental: false, delivered: false };
+
+  /**
+   * 响应头到手之后，fetchUpstream 的超时定时器就清掉了 —— 但正文可能才是卡住
+   * 的那一段：本地模型加载权重、被 OOM 杀掉、或者干脆不吐 token。没有这道
+   * 看门狗的话，连接会一直开着，界面上就是一个永远转下去的圈。
+   */
+  const readNext = async () => {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        reader.read(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new AITimeoutError(
+              `${origin} stopped sending data for ${Math.round(STREAM_IDLE_TIMEOUT_MS / 1000)}s. If it is a local model, check its own log.`
+            )),
+            STREAM_IDLE_TIMEOUT_MS
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
 
   const decoder = new TextDecoder('utf-8');
   let buffer = '';
@@ -582,7 +686,7 @@ async function pipeUpstream(
   };
 
   while (true) {
-    const { done, value } = await reader.read();
+    const { done, value } = await readNext();
     if (done) break;
     const decoded = decoder.decode(value, { stream: true });
     if (!emitted) rawSoFar += decoded;
@@ -597,7 +701,7 @@ async function pipeUpstream(
         try {
           const json = JSON.parse(line);
           if (json?.message?.content) emit(json.message.content);
-          if (json?.done) return true;
+          if (json?.done) return { incremental: emitted, delivered: emitted };
         } catch {
           // 半行，等下一批
         }
@@ -619,7 +723,7 @@ async function pipeUpstream(
     }
   }
 
-  if (emitted) return true;
+  if (emitted) return { incremental: true, delivered: true };
 
   /**
    * 走到这里说明整条流读完了，一个 delta 都没解析出来。
@@ -632,11 +736,12 @@ async function pipeUpstream(
     if (text) {
       onNotIncremental();
       onChunk(text);
+      return { incremental: false, delivered: true };
     }
   } catch {
     // 真的什么都解析不出来，交给上层按空回复处理
   }
-  return false;
+  return { incremental: false, delivered: false };
 }
 
 export type StreamFormat = 'sse' | 'text';
@@ -718,13 +823,20 @@ export async function streamAI(
       declareNotIncremental();
       emit(text);
     } else {
-      const upstream = await fetchUpstream(
-        buildRequest(provider, messages, { stream: true, temperature }),
-        options.signal,
-        provider.kind === 'compatible'
-      );
+      const request = buildRequest(provider, messages, { stream: true, temperature });
+      const upstream = await fetchUpstream(request, options.signal, provider.kind === 'compatible');
       writeHeaders(res, format);
-      await pipeUpstream(provider.kind, upstream, emit, declareNotIncremental);
+      const piped = await pipeUpstream(
+        provider.kind,
+        upstream,
+        emit,
+        declareNotIncremental,
+        originOf(request.url)
+      ).catch((error) => {
+        throw translateStreamFailure(error, originOf(request.url));
+      });
+      // 空回答按失败报，别交出一个没有内容也没有解释的气泡
+      if (!piped.delivered) throw new AIEmptyResponseError(originOf(request.url));
     }
 
     if (format === 'sse') sseEvent(res, { type: 'done' });
@@ -794,21 +906,23 @@ export async function streamStructured<T>(
       sseEvent(res, { type: 'meta', incremental: false });
       sseEvent(res, { type: 'delta', text: raw });
     } else {
-      const upstream = await fetchUpstream(
-        buildRequest(provider, messages, { stream: true, temperature }),
-        options.signal,
-        provider.kind === 'compatible'
-      );
+      const request = buildRequest(provider, messages, { stream: true, temperature });
+      const upstream = await fetchUpstream(request, options.signal, provider.kind === 'compatible');
       writeHeaders(res, 'sse');
-      incremental = await pipeUpstream(
+      const piped = await pipeUpstream(
         provider.kind,
         upstream,
         (text) => {
           raw += text;
           sseEvent(res, { type: 'delta', text });
         },
-        () => sseEvent(res, { type: 'meta', incremental: false })
-      );
+        () => sseEvent(res, { type: 'meta', incremental: false }),
+        originOf(request.url)
+      ).catch((error) => {
+        throw translateStreamFailure(error, originOf(request.url));
+      });
+      incremental = piped.incremental;
+      if (!piped.delivered) throw new AIEmptyResponseError(originOf(request.url));
     }
     void incremental;
 

--- a/src/lib/server/endpointPolicy.ts
+++ b/src/lib/server/endpointPolicy.ts
@@ -97,13 +97,28 @@ export interface GuardedFetchInit extends RequestInit {
  * 重定向必须自己跟：交给 fetch 自动跟随的话，一个公网地址 302 到
  * 169.254.169.254 就把前面的检查整个绕过去了 —— 每一跳都要重新查。
  */
+/**
+ * 地址本身被策略拦下了（写错了、指向内网、绕太多跳）。
+ *
+ * 这属于「你填的配置不对」，和上游返回 4xx 是一类，不该以 500 的形式出现 ——
+ * 尤其它的 message 本来就是写给用户看的那一句。
+ */
+export class EndpointPolicyError extends Error {
+  status = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'EndpointPolicyError';
+  }
+}
+
 export async function guardedFetch(url: string, init: GuardedFetchInit = {}): Promise<Response> {
   const { maxRedirects = 5, ...rest } = init;
   let current = url;
 
   for (let hop = 0; hop <= maxRedirects; hop += 1) {
     const verdict = await checkEndpoint(current);
-    if (!verdict.ok) throw new Error(verdict.reason || 'This endpoint is not allowed.');
+    if (!verdict.ok) throw new EndpointPolicyError(verdict.reason || 'This endpoint is not allowed.');
 
     const response = await fetch(current, {
       ...rest,
@@ -119,7 +134,7 @@ export async function guardedFetch(url: string, init: GuardedFetchInit = {}): Pr
     current = new URL(location, current).toString();
   }
 
-  throw new Error(`Too many redirects from ${url}.`);
+  throw new EndpointPolicyError(`Too many redirects from ${url}.`);
 }
 
 /**

--- a/src/lib/server/endpointPolicy.ts
+++ b/src/lib/server/endpointPolicy.ts
@@ -121,3 +121,43 @@ export async function guardedFetch(url: string, init: GuardedFetchInit = {}): Pr
 
   throw new Error(`Too many redirects from ${url}.`);
 }
+
+/**
+ * 把 fetch 的传输层失败翻译成用户能照着改的一句话。
+ *
+ * 「fetch failed」对用户毫无帮助，而端点填错、服务没起、证书不受信任是本地
+ * 模型场景里最常见的三种失败 —— 它们和上游返回的 4xx 一样，都是「你要改的
+ * 是配置」，不该以一个 500 的形式出现。
+ */
+export function describeNetworkError(error: any, base: string, timeoutMs?: number): string {
+  if (error?.name === 'AbortError') {
+    const within = timeoutMs ? ` within ${Math.round(timeoutMs / 1000)}s` : '';
+    return `No response from ${base}${within}. If it is remote, check that it is reachable from this machine.`;
+  }
+  const code = error?.cause?.code || error?.code;
+  switch (code) {
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return `Cannot resolve the host in ${base}. Check the address for typos.`;
+    case 'ECONNREFUSED':
+      return `${base} refused the connection. Check the port, and that the server is running.`;
+    case 'ECONNRESET':
+    // undici 对「连上了但对端把连接关了」用的是这个码。本地模型服务被 OOM
+    // 杀掉、或者地址其实是个非 HTTP 服务时就是它。
+    case 'UND_ERR_SOCKET':
+      return `${base} closed the connection unexpectedly. Check that it is an OpenAI-compatible HTTP endpoint, and look at its own log.`;
+    case 'CERT_HAS_EXPIRED':
+      return `The TLS certificate for ${base} has expired.`;
+    case 'DEPTH_ZERO_SELF_SIGNED_CERT':
+    case 'SELF_SIGNED_CERT_IN_CHAIN':
+    case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE':
+      return `${base} uses a certificate this machine does not trust (self-signed or an unknown CA). Use a trusted certificate, or put the gateway behind one.`;
+    case 'ERR_TLS_CERT_ALTNAME_INVALID':
+      return `The TLS certificate for ${base} does not cover that hostname.`;
+    default: {
+      // 「fetch failed」本身没有信息量，能带上底层原因就带上
+      const detail = error?.cause?.message || error?.message || String(error);
+      return `Could not reach ${base}: ${detail}`;
+    }
+  }
+}

--- a/src/lib/streamRequest.ts
+++ b/src/lib/streamRequest.ts
@@ -28,6 +28,19 @@ export interface StructuredStreamHandlers {
   flushMs?: number;
 }
 
+/**
+ * 非 JSON 的错误体里，哪些还值得给用户看。
+ *
+ * 一律丢掉是过头了：Next 自己的 `Body exceeded 1mb limit`（工程对话把整个
+ * 工作区发上去时会撞到）就是一句纯文本，丢了用户就只剩一个 413。
+ * 真正要挡的是代理和框架的 HTML 错误页 —— 那是一屏标签。
+ */
+export function readableErrorBody(body: string): string {
+  const text = (body || '').trim();
+  if (!text || text.startsWith('<') || text.length > 200) return '';
+  return text;
+}
+
 export class StreamRequestError extends Error {
   /** 服务端附带的数据，例如 JSON 解析失败时的模型原文 */
   details?: unknown;
@@ -61,9 +74,11 @@ export async function requestStructuredStream<T>(
     try {
       data = JSON.parse(text);
     } catch {
-      // 不是 JSON 的响应体多半是代理或框架的 HTML 错误页。
-      // 把整页塞进错误提示里只会让用户看到一屏标签，状态码才是有用的那部分。
-      throw new StreamRequestError(`Request failed with ${response.status}`);
+      // 不是 JSON 的响应体可能是一句纯文本的框架错误，也可能是整页 HTML。
+      // 前者留着（有信息），后者只保留状态码（那只是一屏标签）。
+      throw new StreamRequestError(
+        readableErrorBody(text) || `Request failed with ${response.status}`
+      );
     }
     if (!response.ok) {
       throw new StreamRequestError(

--- a/src/lib/streamRequest.ts
+++ b/src/lib/streamRequest.ts
@@ -12,6 +12,7 @@
  * 它同时兼容「服务端直接回 JSON」的情况 —— 比如纯保存、或者还没进流就失败了。
  */
 import { createSseParser } from './chatStreamProtocol';
+import { readableErrorBody } from './errorBody';
 
 export interface StructuredStreamHandlers {
   /**
@@ -26,19 +27,6 @@ export interface StructuredStreamHandlers {
   onNotIncremental?: () => void;
   /** onDelta 的最小间隔，默认 60ms（约等于一帧） */
   flushMs?: number;
-}
-
-/**
- * 非 JSON 的错误体里，哪些还值得给用户看。
- *
- * 一律丢掉是过头了：Next 自己的 `Body exceeded 1mb limit`（工程对话把整个
- * 工作区发上去时会撞到）就是一句纯文本，丢了用户就只剩一个 413。
- * 真正要挡的是代理和框架的 HTML 错误页 —— 那是一屏标签。
- */
-export function readableErrorBody(body: string): string {
-  const text = (body || '').trim();
-  if (!text || text.startsWith('<') || text.length > 200) return '';
-  return text;
 }
 
 export class StreamRequestError extends Error {

--- a/src/lib/textStreamProtocol.ts
+++ b/src/lib/textStreamProtocol.ts
@@ -1,0 +1,21 @@
+/**
+ * 纯文本流（AI 题解）里怎么报错。
+ *
+ * 这条路径没有 SSE 的事件通道：正文就是代码本身，一边收一边写进编辑器。
+ * 头发出去之后再出错，只能把错误也写进正文里 —— 于是需要一个**代码里不可能
+ * 出现**的分隔符。用 `[error]` 这种可读的写法看着舒服，但模型完全可能在解释
+ * 里写出同样的字，后果是一段正常的题解被从那里截断、还报一个假错误。
+ *
+ * U+0000 不会出现在源码里，也不会出现在模型的输出里。
+ */
+export const TEXT_STREAM_ERROR_MARK = '\u0000[error] ';
+
+/** 从纯文本流的正文里切出「正文」和「错误」两半 */
+export function splitTextStreamError(body: string): { text: string; error: string } {
+  const at = body.lastIndexOf(TEXT_STREAM_ERROR_MARK);
+  if (at < 0) return { text: body, error: '' };
+  return {
+    text: body.slice(0, at),
+    error: body.slice(at + TEXT_STREAM_ERROR_MARK.length).trim(),
+  };
+}

--- a/tests/ai/streaming.test.ts
+++ b/tests/ai/streaming.test.ts
@@ -6,6 +6,7 @@
  */
 import { createSseParser, parseSseLine } from '../../src/lib/chatStreamProtocol';
 import {
+  callAI,
   NoProviderError,
   normalizeMessages,
   resolveProvider,
@@ -126,6 +127,33 @@ describe('message normalisation', () => {
       { role: 'assistant' as const, content: 'hello' },
     ];
     expect(normalizeMessages(messages)).toEqual(messages);
+  });
+
+  /**
+   * 一次失败的请求会在历史里留下一条空的 assistant 消息，下次发送会带上它。
+   * Anthropic 拒绝空的 content block，一部分模板也一样 ——
+   * 结果是一次偶发失败把整个会话钉死。
+   */
+  it('drops the empty assistant turn a failed request leaves behind', () => {
+    expect(
+      normalizeMessages([
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'second' },
+      ])
+    ).toEqual([{ role: 'user', content: 'first\n\nsecond' }]);
+  });
+
+  it('survives a malformed messages array instead of throwing', () => {
+    const messages = [
+      null,
+      { role: 'system', content: { nope: true } },
+      { role: 'user', content: 'hi' },
+    ] as any;
+    expect(() => normalizeMessages(messages)).not.toThrow();
+    // 非字符串的 content 直接丢掉：硬转出来的 "[object Object]" 会变成
+    // 模型真的看到的提示词
+    expect(normalizeMessages(messages)).toEqual([{ role: 'user', content: 'hi' }]);
   });
 });
 
@@ -412,8 +440,117 @@ describe('server streaming', () => {
   it('classifies a missing provider as 400, not 500', () => {
     // 没配 provider 是「你还没设置」，不是「服务器坏了」。
     // resolveProvider 在写响应头之前就抛，由路由的 catch 统一映射状态码。
-    expect(() => resolveProvider({}, 4000)).toThrow(NoProviderError);
-    expect(statusForError(new NoProviderError())).toBe(400);
+    // 这里要把环境变量清干净：本机（或 CI）上导了任意一把 key，auto 顺序就会选中它。
+    const envKeys = [
+      'DEEPSEEK_API_KEY',
+      'OPENAI_API_KEY',
+      'QWEN_API_KEY',
+      'CLAUDE_API_KEY',
+      'OLLAMA_MODEL',
+      'OPENAI_COMPATIBLE_ENDPOINT',
+      'OPENAI_COMPATIBLE_MODEL',
+    ];
+    const saved: Record<string, string | undefined> = {};
+    envKeys.forEach((key) => {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    });
+
+    try {
+      expect(() => resolveProvider({}, 4000)).toThrow(NoProviderError);
+      expect(statusForError(new NoProviderError())).toBe(400);
+    } finally {
+      envKeys.forEach((key) => {
+        if (saved[key] === undefined) delete process.env[key];
+        else process.env[key] = saved[key];
+      });
+    }
+  });
+
+  it('reports a connection failure as a fixable message, not "fetch failed"', async () => {
+    const refused: any = new TypeError('fetch failed');
+    refused.cause = { code: 'ECONNREFUSED' };
+    global.fetch = jest.fn().mockRejectedValue(refused) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      compatible: { endpoint: 'http://127.0.0.1:1234/v1', model: 'qwen3-8b' },
+      selectedProvider: 'compatible',
+    });
+
+    expect(res.statusCode).toBe(502);
+    expect((res.jsonBody as any).error).toContain('refused the connection');
+    expect((res.jsonBody as any).error).not.toContain('fetch failed');
+  });
+
+  /**
+   * 超时和「客户端自己走了」都是 AbortError，但两者的正确反应相反：
+   * 前者要告诉用户，后者只需安静收尾。混在一起的后果是等满两分钟之后
+   * 拿到一个空白气泡 —— 没内容、没报错，看不出发生了什么。
+   */
+  it('reports an upstream timeout as 504, not as a silent empty response', async () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn(
+      (_url: any, init: any) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => {
+            const error = new Error('The operation was aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        })
+    ) as any;
+
+    const res = createFakeRes();
+    const pending = streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+    jest.advanceTimersByTime(130_000);
+    await pending;
+    jest.useRealTimers();
+
+    expect(res.statusCode).toBe(504);
+    expect((res.jsonBody as any).error).toMatch(/No response from https:\/\/api\.openai\.com/);
+  });
+
+  it('stays quiet when it is the client that left', async () => {
+    const controller = new AbortController();
+    global.fetch = jest.fn(() => {
+      controller.abort();
+      const error = new Error('The operation was aborted');
+      error.name = 'AbortError';
+      return Promise.reject(error);
+    }) as any;
+
+    const res = createFakeRes();
+    await streamAI(
+      res as any,
+      [{ role: 'user', content: 'hi' }],
+      { openAI: { apiKey: 'k', model: 'gpt-4.1' }, selectedProvider: 'openai' },
+      { signal: controller.signal }
+    );
+
+    expect(res.statusCode).toBeUndefined();
+    expect(res.jsonBody).toBeFalsy();
+    expect(res.ended).toBe(true);
+  });
+
+  it('does not paste an HTML error page into the message', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => '<html><head><title>502 Bad Gateway</title></head><body>...</body></html>',
+    }) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect((res.jsonBody as any).error).not.toContain('<html>');
+    expect((res.jsonBody as any).error).toMatch(/HTML error page/);
   });
 
   it('reports a mid-stream failure as an error event, not a broken body', async () => {
@@ -639,6 +776,50 @@ describe('server streaming', () => {
       expect([kind, roles[0]]).toEqual([kind, 'system']);
       expect([kind, body.messages[0].content]).toEqual([kind, 'persona\n\nworkspace context']);
     }
+  });
+
+  /**
+   * buildRequest 有三个入口：callAI（非流式）、streamAI、streamStructured。
+   * 规整必须留在 buildRequest 里 —— 只在 streamAI 里做的话，生成类接口
+   * （出题、生成工程题、AI 评审）会在本地模型上重新踩回同一个 400。
+   */
+  it('normalises on the structured-stream path too, not just chat', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(fakeStreamResponse([])) as any;
+    global.fetch = fetchMock;
+
+    await streamStructured(createFakeRes() as any, [
+      { role: 'system', content: 'persona' },
+      { role: 'system', content: 'schema' },
+      { role: 'user', content: 'make one' },
+    ], {
+      compatible: { endpoint: 'http://localhost:1234/v1', model: 'qwen3-8b' },
+      selectedProvider: 'compatible',
+    }, { onComplete: async () => ({ ok: true }) });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.messages.filter((message: any) => message.role === 'system')).toHaveLength(1);
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'persona\n\nschema' });
+  });
+
+  it('normalises on the non-streaming path too', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'done' } }] }),
+    }) as any;
+    global.fetch = fetchMock;
+
+    await callAI(
+      [
+        { role: 'system', content: 'persona' },
+        { role: 'system', content: 'context' },
+        { role: 'user', content: 'hi' },
+      ],
+      { openAI: { apiKey: 'k', model: 'gpt-4.1' }, selectedProvider: 'openai' }
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.messages.filter((message: any) => message.role === 'system')).toHaveLength(1);
+    expect(body.stream).toBe(false);
   });
 
   it('keeps Claude on its separate system field', async () => {

--- a/tests/ai/streaming.test.ts
+++ b/tests/ai/streaming.test.ts
@@ -5,6 +5,7 @@
  * 客户端：SSE 事件 -> 文本，重点是任意位置切分的分块
  */
 import { createSseParser, parseSseLine } from '../../src/lib/chatStreamProtocol';
+import { EndpointPolicyError } from '../../src/lib/server/endpointPolicy';
 import {
   callAI,
   NoProviderError,
@@ -437,6 +438,12 @@ describe('server streaming', () => {
     expect((res.jsonBody as any).error).toBe('model is loading');
   });
 
+  it('classifies a blocked or malformed endpoint as 400, not 500', () => {
+    // 这句 message 本来就是写给用户看的（「不是合法的 URL」「指向了内网」），
+    // 包成 500 只会让人以为是应用坏了
+    expect(statusForError(new EndpointPolicyError('Not a valid URL: localhost;1234'))).toBe(400);
+  });
+
   it('classifies a missing provider as 400, not 500', () => {
     // 没配 provider 是「你还没设置」，不是「服务器坏了」。
     // resolveProvider 在写响应头之前就抛，由路由的 catch 统一映射状态码。
@@ -502,13 +509,17 @@ describe('server streaming', () => {
     ) as any;
 
     const res = createFakeRes();
-    const pending = streamAI(res as any, [{ role: 'user', content: 'hi' }], {
-      openAI: { apiKey: 'k', model: 'gpt-4.1' },
-      selectedProvider: 'openai',
-    });
-    jest.advanceTimersByTime(130_000);
-    await pending;
-    jest.useRealTimers();
+    try {
+      const pending = streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+        openAI: { apiKey: 'k', model: 'gpt-4.1' },
+        selectedProvider: 'openai',
+      });
+      jest.advanceTimersByTime(130_000);
+      await pending;
+    } finally {
+      // 不放 finally 的话，这个用例一失败，后面所有量时间的用例都会跟着挂
+      jest.useRealTimers();
+    }
 
     expect(res.statusCode).toBe(504);
     expect((res.jsonBody as any).error).toMatch(/No response from https:\/\/api\.openai\.com/);
@@ -518,9 +529,9 @@ describe('server streaming', () => {
     const controller = new AbortController();
     global.fetch = jest.fn(() => {
       controller.abort();
-      const error = new Error('The operation was aborted');
-      error.name = 'AbortError';
-      return Promise.reject(error);
+      // Node 真正抛的是 DOMException，它带着遗留的数字 code 20 ——
+      // 用 new Error 造一个假的，就测不出「有 code 就当成网络故障」这个错判
+      return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
     }) as any;
 
     const res = createFakeRes();
@@ -534,6 +545,68 @@ describe('server streaming', () => {
     expect(res.statusCode).toBeUndefined();
     expect(res.jsonBody).toBeFalsy();
     expect(res.ended).toBe(true);
+  });
+
+  /**
+   * 空回答不能算成功：界面上是一个空白气泡 —— 没内容、没报错，
+   * 连重试按钮都不亮，用户看不出发生了什么。
+   */
+  it('reports an empty upstream response instead of a blank answer', async () => {
+    global.fetch = jest.fn().mockResolvedValue(fakeStreamResponse(['data: [DONE]\n\n'])) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    const events = collectEvents(res);
+    const failure = events.find((event: any) => event.type === 'error');
+    expect(failure).toBeTruthy();
+    expect((failure as any).message).toMatch(/empty response/i);
+  });
+
+  it('refuses a conversation with nothing in it, before calling upstream', async () => {
+    const fetchMock = jest.fn() as any;
+    global.fetch = fetchMock;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: '   ' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect((res.jsonBody as any).error).toMatch(/nothing to send/i);
+  });
+
+  /**
+   * 正文读到一半断了（本地模型被 OOM 杀掉是最常见的原因）。
+   * 头已经发出去了，状态码改不动，但至少不能只丢给用户一个词：terminated。
+   */
+  it('translates a mid-stream disconnect into something actionable', async () => {
+    const broken: any = new TypeError('terminated');
+    broken.cause = { code: 'UND_ERR_SOCKET' };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: async () => {
+            throw broken;
+          },
+        }),
+      },
+    }) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      compatible: { endpoint: 'http://127.0.0.1:1234/v1', model: 'qwen3-8b' },
+      selectedProvider: 'compatible',
+    });
+
+    const failure = collectEvents(res).find((event: any) => event.type === 'error');
+    expect((failure as any).message).toMatch(/closed the connection unexpectedly/);
   });
 
   it('does not paste an HTML error page into the message', async () => {

--- a/tests/ai/streaming.test.ts
+++ b/tests/ai/streaming.test.ts
@@ -145,6 +145,19 @@ describe('message normalisation', () => {
     ).toEqual([{ role: 'user', content: 'first\n\nsecond' }]);
   });
 
+  it('drops messages with a role we do not recognise', () => {
+    // 转发一个上游不认识的 role，换回来的是一个看不懂的 400；
+    // 而两条都没有 role 的消息还会因为 undefined === undefined 被并成一条
+    expect(
+      normalizeMessages([
+        { role: 'tool', content: 'tool output' },
+        { content: 'no role at all' },
+        { content: 'also no role' },
+        { role: 'user', content: 'hi' },
+      ] as any)
+    ).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
   it('survives a malformed messages array instead of throwing', () => {
     const messages = [
       null,
@@ -607,6 +620,24 @@ describe('server streaming', () => {
 
     const failure = collectEvents(res).find((event: any) => event.type === 'error');
     expect((failure as any).message).toMatch(/closed the connection unexpectedly/);
+  });
+
+  it('keeps a long plain-text upstream error, truncated rather than dropped', async () => {
+    const long = `context length exceeded. ${'detail '.repeat(80)}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => long,
+    }) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect((res.jsonBody as any).error).toMatch(/^context length exceeded/);
+    expect(((res.jsonBody as any).error as string).length).toBeLessThan(long.length);
   });
 
   it('does not paste an HTML error page into the message', async () => {

--- a/tests/ai/streaming.test.ts
+++ b/tests/ai/streaming.test.ts
@@ -5,7 +5,14 @@
  * 客户端：SSE 事件 -> 文本，重点是任意位置切分的分块
  */
 import { createSseParser, parseSseLine } from '../../src/lib/chatStreamProtocol';
-import { streamAI, streamStructured } from '../../src/lib/server/aiProvider';
+import {
+  NoProviderError,
+  normalizeMessages,
+  resolveProvider,
+  statusForError,
+  streamAI,
+  streamStructured,
+} from '../../src/lib/server/aiProvider';
 
 /* ------------------------------------------------------------------ */
 /* 客户端解析                                                          */
@@ -63,6 +70,62 @@ describe('client SSE parsing', () => {
 
   it('treats non-JSON payloads as plain text for legacy endpoints', () => {
     expect(parseSseLine('data: raw text')).toEqual({ text: 'raw text' });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 消息规整                                                            */
+/* ------------------------------------------------------------------ */
+
+describe('message normalisation', () => {
+  /**
+   * 开放权重模型的 chat 模板（Qwen 等）在 Jinja 里写死了
+   * raise_exception('System message must be at the beginning.')，
+   * llama.cpp / LM Studio / Ollama 会把它变成一个 400。
+   * 托管 API 宽容，所以这个前提一直没被我们自己保证。
+   */
+  it('merges multiple system messages into one at the front', () => {
+    expect(
+      normalizeMessages([
+        { role: 'system', content: 'persona' },
+        { role: 'system', content: 'context' },
+        { role: 'user', content: 'hi' },
+      ])
+    ).toEqual([
+      { role: 'system', content: 'persona\n\ncontext' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('hoists a system message that arrived mid-conversation', () => {
+    expect(
+      normalizeMessages([
+        { role: 'user', content: 'hi' },
+        { role: 'system', content: 'late rule' },
+        { role: 'assistant', content: 'sure' },
+      ])
+    ).toEqual([
+      { role: 'system', content: 'late rule' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'sure' },
+    ]);
+  });
+
+  it('drops empty system messages instead of sending a blank one', () => {
+    expect(
+      normalizeMessages([
+        { role: 'system', content: '   ' },
+        { role: 'user', content: 'hi' },
+      ])
+    ).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
+  it('leaves a conversation without a system message alone', () => {
+    const messages = [
+      { role: 'user' as const, content: 'hi' },
+      { role: 'assistant' as const, content: 'hello' },
+    ];
+    expect(normalizeMessages(messages)).toEqual(messages);
   });
 });
 
@@ -286,7 +349,12 @@ describe('server streaming', () => {
     expect(body.temperature).toBeUndefined();
   });
 
-  it('reports upstream failure as JSON before headers are sent', async () => {
+  /**
+   * 上游拒绝了请求，是「这次请求不对」而不是「我们挂了」——
+   * 状态码要照传，消息要是人能读的那一句，否则用户只看到一个 500，
+   * 无从知道该去改 key、改模型名还是改端点。
+   */
+  it('passes an upstream 401 through as 401, with its message', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 401,
@@ -299,9 +367,53 @@ describe('server streaming', () => {
       selectedProvider: 'openai',
     });
 
-    expect(res.statusCode).toBe(500);
-    expect((res.jsonBody as any).error).toMatch(/401/);
+    expect(res.statusCode).toBe(401);
+    expect((res.jsonBody as any).error).toBe('invalid api key');
     expect(res.written).toHaveLength(0);
+  });
+
+  it('unwraps an OpenAI-style error body instead of quoting the raw JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () =>
+        JSON.stringify({
+          error: { message: 'system message must be at the beginning', code: 'template_error' },
+        }),
+    }) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      compatible: { endpoint: 'http://localhost:1234/v1', model: 'qwen3-8b' },
+      selectedProvider: 'compatible',
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect((res.jsonBody as any).error).toBe('system message must be at the beginning');
+  });
+
+  it('reports an upstream 5xx as 502, not as our own 500', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'model is loading',
+    }) as any;
+
+    const res = createFakeRes();
+    await streamAI(res as any, [{ role: 'user', content: 'hi' }], {
+      openAI: { apiKey: 'k', model: 'gpt-4.1' },
+      selectedProvider: 'openai',
+    });
+
+    expect(res.statusCode).toBe(502);
+    expect((res.jsonBody as any).error).toBe('model is loading');
+  });
+
+  it('classifies a missing provider as 400, not 500', () => {
+    // 没配 provider 是「你还没设置」，不是「服务器坏了」。
+    // resolveProvider 在写响应头之前就抛，由路由的 catch 统一映射状态码。
+    expect(() => resolveProvider({}, 4000)).toThrow(NoProviderError);
+    expect(statusForError(new NoProviderError())).toBe(400);
   });
 
   it('reports a mid-stream failure as an error event, not a broken body', async () => {
@@ -494,6 +606,58 @@ describe('server streaming', () => {
     expect(collectText(res)).toBe('real stream');
     // 它确实是流，所以不该被标成 non-incremental
     expect(collectEvents(res)).not.toContainEqual({ type: 'meta', incremental: false });
+  });
+
+  it('never sends more than one system message, and always first', async () => {
+    const configs: Array<[string, any]> = [
+      ['deepseek', { deepSeek: { apiKey: 'k', model: 'deepseek-chat' }, selectedProvider: 'deepseek' }],
+      ['openai', { openAI: { apiKey: 'k', model: 'gpt-4.1' }, selectedProvider: 'openai' }],
+      ['qwen', { qwen: { apiKey: 'k', model: 'qwen-plus' }, selectedProvider: 'qwen' }],
+      ['ollama', { ollama: { endpoint: 'http://localhost:11434', model: 'llama3.1' }, selectedProvider: 'ollama' }],
+      [
+        'compatible',
+        { compatible: { endpoint: 'http://localhost:1234/v1', model: 'qwen3-8b' }, selectedProvider: 'compatible' },
+      ],
+    ];
+
+    // 这正是 ai-chat / engineering-chat 以前发出去的形状：两条 system
+    const messages: any = [
+      { role: 'system', content: 'persona' },
+      { role: 'system', content: 'workspace context' },
+      { role: 'user', content: 'hi' },
+    ];
+
+    for (const [kind, config] of configs) {
+      const fetchMock = jest.fn().mockResolvedValue(fakeStreamResponse([])) as any;
+      global.fetch = fetchMock;
+
+      await streamAI(createFakeRes() as any, messages, config);
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const roles = body.messages.map((message: any) => message.role);
+      expect([kind, roles.filter((role: string) => role === 'system').length]).toEqual([kind, 1]);
+      expect([kind, roles[0]]).toEqual([kind, 'system']);
+      expect([kind, body.messages[0].content]).toEqual([kind, 'persona\n\nworkspace context']);
+    }
+  });
+
+  it('keeps Claude on its separate system field', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(fakeStreamResponse([])) as any;
+    global.fetch = fetchMock;
+
+    await streamAI(
+      createFakeRes() as any,
+      [
+        { role: 'system', content: 'persona' },
+        { role: 'system', content: 'context' },
+        { role: 'user', content: 'hi' },
+      ],
+      { claude: { apiKey: 'k', model: 'claude-sonnet-5' }, selectedProvider: 'claude' }
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.system).toBe('persona\n\ncontext');
+    expect(body.messages.every((message: any) => message.role !== 'system')).toBe(true);
   });
 
   it('streams raw text when format is text', async () => {

--- a/tests/ai/text-stream.test.ts
+++ b/tests/ai/text-stream.test.ts
@@ -1,0 +1,37 @@
+/**
+ * 纯文本流（AI 题解）的错误通道。
+ *
+ * 这条路径的正文就是代码本身，错误只能夹在正文里送 —— 分隔符必须是代码里
+ * 不可能出现的东西，否则一段正常的题解会被从中间截断、还报一个假错误。
+ */
+import { splitTextStreamError, TEXT_STREAM_ERROR_MARK } from '../../src/lib/textStreamProtocol';
+
+describe('text stream error channel', () => {
+  it('splits the error off the generated code', () => {
+    const body = `function solve() {}${TEXT_STREAM_ERROR_MARK}the endpoint refused the connection`;
+    expect(splitTextStreamError(body)).toEqual({
+      text: 'function solve() {}',
+      error: 'the endpoint refused the connection',
+    });
+  });
+
+  it('leaves a clean answer untouched', () => {
+    expect(splitTextStreamError('function solve() {}')).toEqual({
+      text: 'function solve() {}',
+      error: '',
+    });
+  });
+
+  it('does not mistake prose about errors for the error channel', () => {
+    // 旧的分隔符是可读的 `[error] `，模型完全写得出来 ——
+    // 后果是这段题解从这里被截断
+    const body = 'function solve() {}\n\n// prints\n\n[error] when the input is empty';
+    expect(splitTextStreamError(body).error).toBe('');
+    expect(splitTextStreamError(body).text).toBe(body);
+  });
+
+  it('takes the last mark, so an error is never swallowed by the answer', () => {
+    const body = `code${TEXT_STREAM_ERROR_MARK}first${TEXT_STREAM_ERROR_MARK}second`;
+    expect(splitTextStreamError(body).error).toBe('second');
+  });
+});


### PR DESCRIPTION
## 问题

用户报：LM Studio + Qwen3 下，**AI 对话**和**工程项目 AI 评审**都用不了，提示 `500 system message must be at the beginning`。

## 根因

`raise_exception('System message must be at the beginning.')` 写在**模型的 Jinja chat 模板**里（Qwen 系列等），llama.cpp / LM Studio / Ollama 渲染模板时原样抛出，变成 400。llama.cpp 把它当作模板的既定行为而非 bug（#20733，closed as not planned），也就是说保证这个前提是客户端的责任。

我们这边：

| 路径 | messages 形状 | 违反？ |
| --- | --- | --- |
| `pages/api/ai-chat.ts` | `system(人设)` + `system(题目上下文)` + … | ❌ 两条 system |
| `pages/api/engineering-chat.ts` | `system(人设)` + `system(工作区上下文)` + … | ❌ 两条 system |
| `pages/api/engineering-review.ts` | `system` + `user` | ✅ 合规 |
| 其余生成类接口 | `system` + `user` | ✅ 合规 |

托管 API（OpenAI / DeepSeek / Qwen 云端）接受多条 system，所以同一份代码在它们那儿一直是好的 —— 这是它只在本地模型暴露的原因。

**评审那条没有复现出这个根因**：它只发一条 system 且在 index 0，对着严格 mock 返回 200。它在用户环境里的失败另有原因（很可能是 8B 模型的上下文长度），而下面这半个改动正是为了让那个原因显示出来。

## 改动

1. `normalizeMessages()` 放进共用的 `buildRequest()` —— 所有 system 段按原顺序拼成一条放最前，语义不变。六个 provider × 三个入口（`callAI` / `streamAI` / `streamStructured`）一次覆盖；Claude 仍走它自己的 `system` 字段。**不是给 LM Studio 打补丁。**
2. `AIUpstreamError` + `statusForError()` + `describeUpstreamError()` —— 上游的 4xx 照传、5xx 归一成 502，消息用上游自己那句话。之前是一律 500 + 把整个 JSON 原文塞进 message。
3. `useChatStream` 不再把非 JSON 的错误体（代理的 HTML 错误页）原样贴进对话框。

## 验证

等价 mock（`system` 必须唯一且在最前，违反返回 400，与 LM Studio 行为一致）：

```
=== next start (:3402) ===
/api/ai-chat               status=200 firstByte=227ms total=1234ms deltas=6 gaps=[196,202,204,201,202]
/api/engineering-chat      status=200 firstByte=211ms total=1219ms deltas=6 gaps=[199,201,204,201,202]
/api/engineering-review    status=200 firstByte=212ms total=1222ms deltas=6 gaps=[201,200,203,202,203]

=== Electron 自定义服务器 (:3403) ===  三条同样 200，首块 207~229ms
```

mock 侧日志：修复前 `roles=system,system,user systems=2` → 400；修复后全部 `roles=system,user systems=1`。

错误暴露（上游回 400 + OpenAI 风格错误体）：

```
/api/ai-chat            {"error":"The model's maximum context length is 8192 tokens, however you requested 9500."} [HTTP 400]
/api/engineering-chat   同上 [HTTP 400]
/api/engineering-review 同上 [HTTP 400]
```

流式没有回退，12 个组合全部真流式（首块 ≈305ms / 上游 300ms 一块，间隔中位数 ≈302ms）。

`npx tsc --noEmit` clean，`npm test` 5/5，`npx jest tests/ai` 66/66。