### PR TITLE
fix(desktop): restore the Edit menu so ⌘V works again

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -37,6 +37,7 @@ module.exports = {
   // 打包文件
   files: [
     'electron-main.js',
+    'electron-menu.js',
     'electron-preload.js',
     'next.config.js',
     'package.json',

--- a/electron-main.js
+++ b/electron-main.js
@@ -5,6 +5,7 @@ const os = require('os');
 const { createServer } = require('http');
 // electron 的 net 已经占用了这个名字，Node 的 net 只能另起一个
 const nodeNet = require('node:net');
+const { labelsFor, buildAppMenuTemplate, buildContextMenuTemplate } = require('./electron-menu');
 
 // Global error handlers
 process.on('uncaughtException', (error) => {
@@ -33,80 +34,28 @@ let mainWindow;
 let server;
 let nextApp;
 
+/** 当前菜单用的那套文案，右键菜单跟着应用语言走 */
+let currentMenuLabels = labelsFor('en');
+
 // Function to update the application menu
 function updateApplicationMenu(language = 'en') {
-  const menuLabels = {
-    en: {
-      navigation: 'Navigation',
-      home: 'Home',
-      settings: 'Settings',
-      aiGenerator: 'AI Generator',
-      addProblem: 'Add Problem',
-      view: 'View',
-      help: 'Help',
-      documentation: 'Documentation'
-    },
-    zh: {
-      navigation: '导航',
-      home: '首页',
-      settings: '设置',
-      aiGenerator: 'AI 生成器',
-      addProblem: '添加题目',
-      view: '视图',
-      help: '帮助',
-      documentation: '文档'
-    }
-  };
-  
-  const labels = menuLabels[language] || menuLabels.en;
-  
-  const menu = Menu.buildFromTemplate([
-    {
-      label: labels.navigation,
-      submenu: [
-        {
-          label: labels.home,
-          click: () => mainWindow && mainWindow.loadURL(`http://localhost:${port}`)
-        },
-        {
-          label: labels.settings,
-          click: () => mainWindow && mainWindow.loadURL(`http://localhost:${port}/settings`)
-        },
-        {
-          label: labels.aiGenerator,
-          click: () => mainWindow && mainWindow.loadURL(`http://localhost:${port}/generator`)
-        },
-        {
-          label: labels.addProblem,
-          click: () => mainWindow && mainWindow.loadURL(`http://localhost:${port}/add-problem`)
-        }
-      ]
-    },
-    {
-      label: labels.view,
-      submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
-        { role: 'toggleDevTools' },
-        { type: 'separator' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' }
-      ]
-    },
-    {
-      label: labels.help,
-      submenu: [
-        {
-          label: labels.documentation,
-          click: () => shell.openExternal('https://github.com/zxypro1/OfflineLeetPractice')
-        }
-      ]
-    }
-  ]);
-  Menu.setApplicationMenu(menu);
+  currentMenuLabels = labelsFor(language);
+  const template = buildAppMenuTemplate({
+    language,
+    platform: process.platform,
+    navigate: (routePath) => mainWindow && mainWindow.loadURL(`http://${hostname}:${port}${routePath}`),
+    openDocumentation: () => shell.openExternal('https://github.com/zxypro1/OfflineLeetPractice')
+  });
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+/** 装上右键菜单：键盘快捷键之外的另一条剪切/复制/粘贴路径 */
+function attachContextMenu(webContents) {
+  webContents.on('context-menu', (_event, params) => {
+    const template = buildContextMenuTemplate(params, currentMenuLabels);
+    if (template.length === 0) return;
+    Menu.buildFromTemplate(template).popup({ window: BrowserWindow.fromWebContents(webContents) });
+  });
 }
 
 // Load saved configuration
@@ -308,6 +257,9 @@ function createWindow() {
   
   // Update the application menu with the saved language
   updateApplicationMenu(savedLanguage);
+
+  // 右键菜单：键盘快捷键之外的另一条剪切/复制/粘贴路径
+  attachContextMenu(mainWindow.webContents);
 
   // Open external links in the default browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {

--- a/electron-main.js
+++ b/electron-main.js
@@ -54,7 +54,10 @@ function attachContextMenu(webContents) {
   webContents.on('context-menu', (_event, params) => {
     const template = buildContextMenuTemplate(params, currentMenuLabels);
     if (template.length === 0) return;
-    Menu.buildFromTemplate(template).popup({ window: BrowserWindow.fromWebContents(webContents) });
+    // 窗口可能在右键和弹出之间被关掉，fromWebContents 这时返回 null
+    const window = BrowserWindow.fromWebContents(webContents);
+    if (!window) return;
+    Menu.buildFromTemplate(template).popup({ window });
   });
 }
 

--- a/electron-menu.js
+++ b/electron-menu.js
@@ -1,0 +1,148 @@
+/**
+ * 菜单模板
+ *
+ * 单独成一个模块是为了能被测试直接 require —— 它不碰 electron，
+ * 只产出模板数据，由 electron-main.js 交给 Menu.buildFromTemplate。
+ *
+ * 这里最要紧的是 Edit 菜单：macOS 通过菜单项的 key equivalent 派发
+ * ⌘V / ⌘C / ⌘X / ⌘A / ⌘Z，菜单里没有对应 role 的话，这些快捷键在渲染进程里
+ * 就完全不生效。设置页粘不了 API key 就是这么来的，所以 tests/desktop 里
+ * 有一条用例专门盯着它别再掉。
+ */
+
+const MENU_LABELS = {
+  en: {
+    navigation: 'Navigation',
+    home: 'Home',
+    settings: 'Settings',
+    aiGenerator: 'AI Generator',
+    addProblem: 'Add Problem',
+    edit: 'Edit',
+    undo: 'Undo',
+    redo: 'Redo',
+    cut: 'Cut',
+    copy: 'Copy',
+    paste: 'Paste',
+    selectAll: 'Select All',
+    view: 'View',
+    help: 'Help',
+    documentation: 'Documentation'
+  },
+  zh: {
+    navigation: '导航',
+    home: '首页',
+    settings: '设置',
+    aiGenerator: 'AI 生成器',
+    addProblem: '添加题目',
+    edit: '编辑',
+    undo: '撤销',
+    redo: '重做',
+    cut: '剪切',
+    copy: '复制',
+    paste: '粘贴',
+    selectAll: '全选',
+    view: '视图',
+    help: '帮助',
+    documentation: '文档'
+  }
+};
+
+/** 未知语言一律回落到英文，而不是抛错 */
+function labelsFor(language) {
+  return MENU_LABELS[language] || MENU_LABELS.en;
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.language
+ * @param {string} options.platform          process.platform
+ * @param {(path: string) => void} options.navigate
+ * @param {() => void} options.openDocumentation
+ */
+function buildAppMenuTemplate({ language, platform, navigate, openDocumentation }) {
+  const labels = labelsFor(language);
+  const isMac = platform === 'darwin';
+
+  return [
+    // macOS 的第一个子菜单永远被当成应用菜单。不显式给出 appMenu 的话，
+    // 我们的第一项（导航）会被系统顶上这个位置：标题变成进程名，
+    // 而「关于 / 隐藏 / 退出」这些标准项整个消失。
+    ...(isMac ? [{ role: 'appMenu' }] : []),
+    {
+      label: labels.navigation,
+      submenu: [
+        { label: labels.home, click: () => navigate('/') },
+        { label: labels.settings, click: () => navigate('/settings') },
+        { label: labels.aiGenerator, click: () => navigate('/generator') },
+        { label: labels.addProblem, click: () => navigate('/add-problem') }
+      ]
+    },
+    {
+      // 少了这一整块，⌘V / ⌘C / ⌘X / ⌘A / ⌘Z 在 macOS 上全部失效。
+      label: labels.edit,
+      submenu: [
+        { role: 'undo', label: labels.undo },
+        { role: 'redo', label: labels.redo },
+        { type: 'separator' },
+        { role: 'cut', label: labels.cut },
+        { role: 'copy', label: labels.copy },
+        { role: 'paste', label: labels.paste },
+        { role: 'selectAll', label: labels.selectAll }
+      ]
+    },
+    {
+      label: labels.view,
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    {
+      label: labels.help,
+      submenu: [{ label: labels.documentation, click: () => openDocumentation() }]
+    }
+  ];
+}
+
+/**
+ * 右键菜单的模板。
+ *
+ * Electron 不带默认上下文菜单，不自己装一个的话，输入框上右键什么都不弹——
+ * 键盘快捷键之外的另一条粘贴路径同样是断的。
+ *
+ * @param {object} params  Electron context-menu 事件的 params
+ * @param {object} labels  labelsFor() 的结果
+ * @returns {Array} 模板；返回空数组表示这里不该弹菜单
+ */
+function buildContextMenuTemplate(params, labels) {
+  const { isEditable = false, editFlags = {}, selectionText = '' } = params || {};
+  const hasSelection = selectionText.trim().length > 0;
+
+  // 只在有意义的地方弹：可编辑区域，或者选中了文本想复制
+  if (!isEditable && !hasSelection) return [];
+
+  const template = [];
+  if (isEditable) {
+    template.push({ role: 'cut', label: labels.cut, enabled: Boolean(editFlags.canCut) });
+  }
+  template.push({ role: 'copy', label: labels.copy, enabled: Boolean(editFlags.canCopy) });
+  if (isEditable) {
+    template.push({ role: 'paste', label: labels.paste, enabled: Boolean(editFlags.canPaste) });
+    template.push({ type: 'separator' });
+    template.push({
+      role: 'selectAll',
+      label: labels.selectAll,
+      enabled: Boolean(editFlags.canSelectAll)
+    });
+  }
+  return template;
+}
+
+module.exports = { MENU_LABELS, labelsFor, buildAppMenuTemplate, buildContextMenuTemplate };

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -35,6 +35,11 @@ class TestRunner {
         name: 'Engineering Practice Runtime',
         file: 'tests/engineering/runtime.test.ts',
         description: 'Virtual clock, module runtime, metric gates and preset project solvability'
+      },
+      {
+        name: 'Desktop Menus',
+        file: 'tests/desktop',
+        description: 'Application and context menus, including the edit roles that ⌘V depends on'
       }
     ];
   }

--- a/tests/desktop/menu.test.js
+++ b/tests/desktop/menu.test.js
@@ -1,0 +1,157 @@
+/**
+ * 桌面端菜单
+ *
+ * 这些用例的由来：应用菜单里一直没有 Edit 菜单，于是 macOS 上 ⌘V 在渲染进程里
+ * 完全不生效（系统是靠菜单项的 key equivalent 派发它的），用户在设置页粘不了
+ * API key。Electron 也不带默认右键菜单，所以「右键 → 粘贴」这条后备路径同样是断的。
+ *
+ * 两条路径各自都有用例盯着，掉了要红。
+ */
+
+const {
+  labelsFor,
+  buildAppMenuTemplate,
+  buildContextMenuTemplate
+} = require('../../electron-menu');
+
+const baseOptions = {
+  language: 'en',
+  platform: 'darwin',
+  navigate: () => {},
+  openDocumentation: () => {}
+};
+
+/** 把模板拍平成 role 列表，方便断言 */
+function rolesIn(submenu) {
+  return (submenu || []).map((item) => item.role).filter(Boolean);
+}
+
+function menuNamed(template, label) {
+  return template.find((entry) => entry.label === label);
+}
+
+describe('application menu', () => {
+  it('has an Edit menu carrying the standard editing roles', () => {
+    const template = buildAppMenuTemplate(baseOptions);
+    const edit = menuNamed(template, 'Edit');
+
+    expect(edit).toBeDefined();
+    // 这些 role 就是 ⌘Z / ⇧⌘Z / ⌘X / ⌘C / ⌘V / ⌘A 的归属
+    expect(rolesIn(edit.submenu)).toEqual([
+      'undo',
+      'redo',
+      'cut',
+      'copy',
+      'paste',
+      'selectAll'
+    ]);
+  });
+
+  it('binds paste through a role rather than a hand-rolled click handler', () => {
+    const edit = menuNamed(buildAppMenuTemplate(baseOptions), 'Edit');
+    const paste = edit.submenu.find((item) => item.role === 'paste');
+
+    // role 自带 accelerator 与原生行为；换成 click 就等于把 ⌘V 重新丢掉
+    expect(paste).toBeDefined();
+    expect(paste.click).toBeUndefined();
+  });
+
+  it('puts the macOS app menu first so Navigation keeps its own slot', () => {
+    const template = buildAppMenuTemplate(baseOptions);
+
+    // 不占住第一格的话，导航菜单会被系统顶成应用菜单：
+    // 标题变进程名，「关于 / 隐藏 / 退出」一并消失
+    expect(template[0]).toEqual({ role: 'appMenu' });
+    expect(menuNamed(template, 'Navigation')).toBeDefined();
+  });
+
+  it('omits the macOS-only app menu on other platforms', () => {
+    const template = buildAppMenuTemplate({ ...baseOptions, platform: 'win32' });
+
+    expect(template.some((entry) => entry.role === 'appMenu')).toBe(false);
+    expect(template[0].label).toBe('Navigation');
+    expect(menuNamed(template, 'Edit')).toBeDefined();
+  });
+
+  it('localises the Edit menu with the rest of the UI', () => {
+    const edit = menuNamed(buildAppMenuTemplate({ ...baseOptions, language: 'zh' }), '编辑');
+
+    expect(edit).toBeDefined();
+    expect(edit.submenu.find((item) => item.role === 'paste').label).toBe('粘贴');
+    // 换了语言也不能把 role 丢了，否则中文界面下 ⌘V 又会失效
+    expect(rolesIn(edit.submenu)).toContain('paste');
+  });
+
+  it('falls back to English for an unknown language', () => {
+    expect(labelsFor('fr')).toBe(labelsFor('en'));
+    expect(menuNamed(buildAppMenuTemplate({ ...baseOptions, language: 'fr' }), 'Edit')).toBeDefined();
+  });
+
+  it('keeps every navigation entry wired to a route', () => {
+    const visited = [];
+    const template = buildAppMenuTemplate({ ...baseOptions, navigate: (p) => visited.push(p) });
+    menuNamed(template, 'Navigation').submenu.forEach((item) => item.click());
+
+    expect(visited).toEqual(['/', '/settings', '/generator', '/add-problem']);
+  });
+});
+
+describe('context menu', () => {
+  const labels = labelsFor('en');
+  const allFlags = { canCut: true, canCopy: true, canPaste: true, canSelectAll: true };
+
+  it('offers paste on an editable field', () => {
+    const template = buildContextMenuTemplate(
+      { isEditable: true, editFlags: allFlags, selectionText: '' },
+      labels
+    );
+
+    expect(rolesIn(template)).toEqual(['cut', 'copy', 'paste', 'selectAll']);
+    expect(template.find((item) => item.role === 'paste').enabled).toBe(true);
+  });
+
+  it('mirrors the editFlags so unavailable actions render greyed out', () => {
+    const template = buildContextMenuTemplate(
+      {
+        isEditable: true,
+        editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: false },
+        selectionText: ''
+      },
+      labels
+    );
+
+    expect(template.find((item) => item.role === 'paste').enabled).toBe(true);
+    expect(template.find((item) => item.role === 'cut').enabled).toBe(false);
+    expect(template.find((item) => item.role === 'selectAll').enabled).toBe(false);
+  });
+
+  it('offers copy only when read-only text is selected', () => {
+    const template = buildContextMenuTemplate(
+      { isEditable: false, editFlags: { canCopy: true }, selectionText: 'hello' },
+      labels
+    );
+
+    // 不可编辑的地方给 paste 是没有意义的
+    expect(rolesIn(template)).toEqual(['copy']);
+  });
+
+  it('stays closed on a plain right-click with nothing to act on', () => {
+    expect(
+      buildContextMenuTemplate({ isEditable: false, editFlags: {}, selectionText: '   ' }, labels)
+    ).toEqual([]);
+  });
+
+  it('localises alongside the application menu', () => {
+    const template = buildContextMenuTemplate(
+      { isEditable: true, editFlags: allFlags, selectionText: '' },
+      labelsFor('zh')
+    );
+
+    expect(template.find((item) => item.role === 'paste').label).toBe('粘贴');
+  });
+
+  it('survives a params object with fields missing', () => {
+    expect(() => buildContextMenuTemplate({}, labels)).not.toThrow();
+    expect(buildContextMenuTemplate({}, labels)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Scope

Not just the settings page, and not the React components — **every input in the desktop app** was affected. The browser is fine.

| Question | Answer |
| --- | --- |
| Settings only, or all inputs? | **All inputs.** The cause is the application menu, which is global. |
| Desktop only, or browser too? | **Desktop only.** Chrome supplies its own Edit menu. |
| ⌘V, right-click, or both? | **Both.** Two independent gaps, below. |
| No reaction, or pasted-then-cleared? | **No reaction** — the keystroke never reaches the renderer. |
| Regression? | **No.** See below. |

## Root cause

Two separate holes, both in the Electron layer:

1. **The application menu had no Edit submenu.** macOS delivers ⌘V / ⌘C / ⌘X / ⌘A / ⌘Z through the *key equivalents of menu items*. With no item claiming those keys, the renderer never sees them.
2. **Electron ships no default context menu**, so right-click → Paste did not exist either.

Verified by enumerating the accessibility tree of the **shipped v0.13.0 build**:

```
menu bar: Apple, next-router-worker, View, Help

[next-router-worker] Home, Settings, AI Generator, Add Problem
[View]               Reload, Force Reload, Toggle Developer Tools, …
[Help]               Documentation
```

No Edit menu, and no paste/copy/cut/selectAll/undo anywhere.

That listing also exposes a second symptom of the same defect: macOS commandeers the **first** submenu as the application menu. `Navigation` got pulled into that slot, so it lost its label (the bar shows the process name) and About/Hide/**Quit** never existed.

## Suspects ruled out

- **Component interception** — the settings inputs are plain controlled Mantine fields: no `onPaste`, no `onKeyDown`, no `readOnly`. In the browser a dispatched paste is not `defaultPrevented` and the value sticks.
- **Global keydown capture** — the handlers in `CodeRunner` and `WorkspaceEditor` bail out early for `INPUT`/`TEXTAREA`/`contentEditable` and only claim Enter/s/p/b. Neither is even mounted on the settings page.
- **webContents interception** — no `before-input-event`, no `globalShortcut`; the preload only exposes four IPC methods.

## Not a regression

`paste` has **never** appeared in `electron-main.js` in this repo's history (`git log -S`). The recent port-fallback commit touched only the `require` line, adding `dialog`. The Edit menu was missing from the first desktop commit onwards — the settings page is simply the first place a user needed to paste something.

## Fix

- **Edit menu** with `undo`/`redo`/`cut`/`copy`/`paste`/`selectAll` as **roles** (not hand-rolled click handlers — roles carry the native accelerator and behaviour), localised alongside the rest of the UI.
- **Context menu** on the window, built from the event's `editFlags` so unavailable actions render greyed out instead of misleadingly enabled. It stays closed on a right-click with nothing to act on.
- **`role: 'appMenu'` first on macOS**, guarded by platform, so Navigation keeps its own slot and About/Hide/Quit come back.
- Templates extracted to `electron-menu.js`, which touches no Electron API and is therefore directly testable.
- **`electron-menu.js` added to the electron-builder `files` list** — without that the packaged app would fail to require it.

## Verification

**In the real desktop app** (locally built, driven through the macOS accessibility API):

```
before: Apple, next-router-worker, View, Help
after:  Apple, [appMenu], Navigation, Edit, View, Help

Edit: Undo, Redo, Cut, Copy, Paste, Select All
  Paste      -> Cmd+V
  Cut        -> Cmd+X
  Copy       -> Cmd+C
  Select All -> Cmd+A
  Undo       -> Cmd+Z    Redo -> Shift+Cmd+Z
```

The OS reporting `Paste → ⌘V` is exactly the binding that was missing.

**In the renderer**, dispatching the paste editor command into the DeepSeek API key field inserts the clipboard text and React retains it — confirming the component side was always healthy.

**Automated:** 13 new tests in `tests/desktop/menu.test.js`, registered with the repo's runner. Reverting the fix turns **6 of them red**, so they genuinely pin the behaviour.

`npm test` 6/6 suites · `npx tsc --noEmit` clean · `npm run projects:verify` all 70 stages green.

### What I could not verify live

I could not press a physical ⌘V or right-click. Computer-use approval is unavailable in this session, and `osascript` lacks the Accessibility grant to post synthetic events — it fails silently. I confirmed this with a control test: a plain keystroke did not reach the app either, so an inconclusive ⌘V attempt proves nothing in either direction.

So the keyboard path is verified up to the OS binding (`Paste → ⌘V`) plus the renderer accepting a paste command, with Electron's own `role: 'paste'` → `webContents.paste()` in between. The context-menu path is covered by unit tests over the template plus the three-line handler wiring, not by an observed popup.

**Worth a 10-second manual check before release:** open Settings, ⌘V into an API key field, and right-click one to confirm Paste appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)