### PR TITLE
fix(desktop): close the rest of the browser-parity gaps

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -38,6 +38,7 @@ module.exports = {
   files: [
     'electron-main.js',
     'electron-menu.js',
+    'electron-urls.js',
     'electron-preload.js',
     'next.config.js',
     'package.json',

--- a/electron-main.js
+++ b/electron-main.js
@@ -86,9 +86,11 @@ function attachContextMenu(webContents) {
  * downloadURL 触发 will-download，默认行为是直接落到下载目录、不问用户。
  * 这里给这一次下载挂上保存对话框，走完就把标记清掉。
  */
-let pendingSaveAs = false;
+// 按地址记，而不是一个全局布尔：万一同时有别的下载在跑，
+// 布尔会被那一次消费掉，对话框就弹到错误的文件上了。
+const pendingSaveAs = new Set();
 function saveImageAs(webContents, url) {
-  pendingSaveAs = true;
+  pendingSaveAs.add(url);
   webContents.downloadURL(url);
 }
 
@@ -98,10 +100,16 @@ function saveImageAs(webContents, url) {
  * 浏览器里点下载会弹「保存到哪里」，Electron 不接这个事件的话会静默存到
  * 默认目录，用户完全不知道文件去哪了。
  */
+let downloadHandlerAttached = false;
 function attachDownloadHandler(session) {
+  // session 是全局共享的；createWindow 可能再跑一次（macOS 上关窗后重新激活），
+  // 重复注册会让同一次下载弹两个对话框。
+  if (downloadHandlerAttached) return;
+  downloadHandlerAttached = true;
+
   session.on('will-download', (_event, item) => {
-    if (pendingSaveAs) {
-      pendingSaveAs = false;
+    if (pendingSaveAs.has(item.getURL())) {
+      pendingSaveAs.delete(item.getURL());
       const suggested = item.getFilename();
       const target = dialog.showSaveDialogSync(mainWindow, { defaultPath: suggested });
       if (!target) {

--- a/electron-main.js
+++ b/electron-main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, shell, Menu, ipcMain, protocol, net, dialog } = require('electron');
+const { app, BrowserWindow, shell, Menu, ipcMain, protocol, net, dialog, clipboard, screen } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -6,6 +6,7 @@ const { createServer } = require('http');
 // electron 的 net 已经占用了这个名字，Node 的 net 只能另起一个
 const nodeNet = require('node:net');
 const { labelsFor, buildAppMenuTemplate, buildContextMenuTemplate } = require('./electron-menu');
+const { isInternalUrl, isSafeExternalUrl } = require('./electron-urls');
 
 // Global error handlers
 process.on('uncaughtException', (error) => {
@@ -37,6 +38,16 @@ let nextApp;
 /** 当前菜单用的那套文案，右键菜单跟着应用语言走 */
 let currentMenuLabels = labelsFor('en');
 
+/** 应用自己的页面地址（判定逻辑与用例都在 electron-urls.js） */
+function isAppUrl(candidate) {
+  return isInternalUrl(candidate, { hostname, port });
+}
+
+/** 只把 http(s) 交给系统浏览器；file:// javascript: 这类一律不碰 */
+function openExternalSafely(candidate) {
+  if (isSafeExternalUrl(candidate)) shell.openExternal(candidate);
+}
+
 // Function to update the application menu
 function updateApplicationMenu(language = 'en') {
   currentMenuLabels = labelsFor(language);
@@ -44,7 +55,9 @@ function updateApplicationMenu(language = 'en') {
     language,
     platform: process.platform,
     navigate: (routePath) => mainWindow && mainWindow.loadURL(`http://${hostname}:${port}${routePath}`),
-    openDocumentation: () => shell.openExternal('https://github.com/zxypro1/OfflineLeetPractice')
+    openDocumentation: () => openExternalSafely('https://github.com/zxypro1/OfflineLeetPractice'),
+    openFind: () => mainWindow && mainWindow.webContents.send('find:open'),
+    findAgain: (forward) => mainWindow && mainWindow.webContents.send('find:again', forward)
   });
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
@@ -52,12 +65,77 @@ function updateApplicationMenu(language = 'en') {
 /** 装上右键菜单：键盘快捷键之外的另一条剪切/复制/粘贴路径 */
 function attachContextMenu(webContents) {
   webContents.on('context-menu', (_event, params) => {
-    const template = buildContextMenuTemplate(params, currentMenuLabels);
+    const template = buildContextMenuTemplate(params, currentMenuLabels, {
+      copyLink: (url) => clipboard.writeText(url),
+      openLink: (url) => openExternalSafely(url),
+      copyImage: (p) => webContents.copyImageAt(p.x, p.y),
+      saveImageAs: (url) => saveImageAs(webContents, url),
+      replaceMisspelling: (word) => webContents.replaceMisspelling(word)
+    });
     if (template.length === 0) return;
     // 窗口可能在右键和弹出之间被关掉，fromWebContents 这时返回 null
     const window = BrowserWindow.fromWebContents(webContents);
     if (!window) return;
     Menu.buildFromTemplate(template).popup({ window });
+  });
+}
+
+/**
+ * 「图片另存为」。
+ *
+ * downloadURL 触发 will-download，默认行为是直接落到下载目录、不问用户。
+ * 这里给这一次下载挂上保存对话框，走完就把标记清掉。
+ */
+let pendingSaveAs = false;
+function saveImageAs(webContents, url) {
+  pendingSaveAs = true;
+  webContents.downloadURL(url);
+}
+
+/**
+ * 下载行为。
+ *
+ * 浏览器里点下载会弹「保存到哪里」，Electron 不接这个事件的话会静默存到
+ * 默认目录，用户完全不知道文件去哪了。
+ */
+function attachDownloadHandler(session) {
+  session.on('will-download', (_event, item) => {
+    if (pendingSaveAs) {
+      pendingSaveAs = false;
+      const suggested = item.getFilename();
+      const target = dialog.showSaveDialogSync(mainWindow, { defaultPath: suggested });
+      if (!target) {
+        item.cancel();
+        return;
+      }
+      item.setSavePath(target);
+    }
+    item.once('done', (_e, state) => {
+      if (state === 'completed') {
+        shell.showItemInFolder(item.getSavePath());
+      }
+    });
+  });
+}
+
+/**
+ * 导航守卫。
+ *
+ * setWindowOpenHandler 只管 window.open / target=_blank；普通 <a href> 点击走的是
+ * will-navigate。不拦的话，AI 回答或题解 markdown 里的外链会把整个应用窗口导航走，
+ * 而这个窗口没有地址栏也没有后退键，用户就出不来了。
+ */
+function attachNavigationGuards(webContents) {
+  webContents.on('will-navigate', (event, url) => {
+    if (isAppUrl(url)) return;
+    event.preventDefault();
+    openExternalSafely(url);
+  });
+
+  webContents.setWindowOpenHandler(({ url }) => {
+    if (isAppUrl(url)) return { action: 'allow' };
+    openExternalSafely(url);
+    return { action: 'deny' };
   });
 }
 
@@ -208,6 +286,52 @@ async function startNextServer() {
   }
 }
 
+const CONFIG_PATH = path.join(os.homedir(), '.offline-leet-practice', 'config.json');
+
+function readConfig() {
+  try {
+    if (fs.existsSync(CONFIG_PATH)) return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+  } catch (error) {
+    console.error('Error reading config:', error);
+  }
+  return {};
+}
+
+/**
+ * 记住窗口大小和位置。
+ *
+ * 浏览器会替你记住窗口几何，Electron 每次都从默认值重开。
+ * 存之前先跟当前显示器比一下：外接屏拔掉之后，旧坐标会把窗口开到屏幕外。
+ */
+function persistWindowBounds() {
+  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.isMinimized()) return;
+  try {
+    const config = readConfig();
+    config.windowBounds = { ...mainWindow.getNormalBounds(), maximized: mainWindow.isMaximized() };
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+  } catch (error) {
+    console.error('Error saving window bounds:', error);
+  }
+}
+
+/** 落在任何一块屏幕里才用，否则回落到默认居中 */
+function restoredWindowBounds() {
+  const saved = readConfig().windowBounds;
+  if (!saved || typeof saved.width !== 'number' || typeof saved.height !== 'number') return null;
+
+  const visible = screen.getAllDisplays().some((display) => {
+    const area = display.workArea;
+    return (
+      saved.x >= area.x - 50 &&
+      saved.y >= area.y - 50 &&
+      saved.x + saved.width <= area.x + area.width + 50 &&
+      saved.y + saved.height <= area.y + area.height + 50
+    );
+  });
+  return visible ? saved : null;
+}
+
 let savedThemePref = 'light';
 
 function createWindow() {
@@ -224,9 +348,12 @@ function createWindow() {
     console.error('Error loading theme preference:', error);
   }
   
+  const restored = restoredWindowBounds();
+
   mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
+    width: restored?.width ?? 1400,
+    height: restored?.height ?? 900,
+    ...(restored && typeof restored.x === 'number' ? { x: restored.x, y: restored.y } : {}),
     minWidth: 1000,
     minHeight: 700,
     title: 'AlgoLocal',
@@ -238,7 +365,8 @@ function createWindow() {
       contextIsolation: true,
       preload: path.join(__dirname, 'electron-preload.js'),
       webSecurity: true,
-      spellcheck: false
+      // 浏览器里输入框天然有拼写检查，关掉等于桌面端平白少一项
+      spellcheck: true
     },
     icon: path.join(__dirname, 'public', 'icon.png'),
     show: false // Don't show until ready
@@ -264,18 +392,39 @@ function createWindow() {
   // 右键菜单：键盘快捷键之外的另一条剪切/复制/粘贴路径
   attachContextMenu(mainWindow.webContents);
 
-  // Open external links in the default browser
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith('http') && !url.includes('localhost')) {
-      shell.openExternal(url);
-      return { action: 'deny' };
+  // 外链走系统浏览器，不在应用窗口里导航
+  attachNavigationGuards(mainWindow.webContents);
+
+  // 下载要弹保存对话框，而不是静默落盘
+  attachDownloadHandler(mainWindow.webContents.session);
+
+  // 查找命中数回传给查找栏
+  mainWindow.webContents.on('found-in-page', (_event, result) => {
+    if (mainWindow) {
+      mainWindow.webContents.send('find:result', {
+        activeMatchOrdinal: result.activeMatchOrdinal,
+        matches: result.matches
+      });
     }
-    return { action: 'allow' };
   });
 
   // Show window when ready
   mainWindow.once('ready-to-show', () => {
+    if (restored?.maximized) mainWindow.maximize();
     mainWindow.show();
+  });
+
+  // 拖动/缩放停下来之后再写盘，别每一帧都写
+  let boundsTimer = null;
+  const scheduleBoundsSave = () => {
+    if (boundsTimer) clearTimeout(boundsTimer);
+    boundsTimer = setTimeout(persistWindowBounds, 400);
+  };
+  mainWindow.on('resize', scheduleBoundsSave);
+  mainWindow.on('move', scheduleBoundsSave);
+  mainWindow.on('close', () => {
+    if (boundsTimer) clearTimeout(boundsTimer);
+    persistWindowBounds();
   });
 
   // Load the app
@@ -329,6 +478,18 @@ function cleanup() {
     });
   }
 }
+
+// 页内查找：菜单发 find:open 给渲染进程，渲染进程把关键词回传到这里
+ipcMain.handle('find:query', (_event, text, options) => {
+  if (!mainWindow || !text) return false;
+  mainWindow.webContents.findInPage(text, options || {});
+  return true;
+});
+
+ipcMain.handle('find:stop', () => {
+  if (mainWindow) mainWindow.webContents.stopFindInPage('clearSelection');
+  return true;
+});
 
 // IPC event handlers for configuration management
 ipcMain.handle('save-config', async (event, configData) => {

--- a/electron-menu.js
+++ b/electron-menu.js
@@ -7,7 +7,7 @@
  * 这里最要紧的是 Edit 菜单：macOS 通过菜单项的 key equivalent 派发
  * ⌘V / ⌘C / ⌘X / ⌘A / ⌘Z，菜单里没有对应 role 的话，这些快捷键在渲染进程里
  * 就完全不生效。设置页粘不了 API key 就是这么来的，所以 tests/desktop 里
- * 有一条用例专门盯着它别再掉。
+ * 有一整组用例专门盯着这些 role 别再掉。
  */
 
 const MENU_LABELS = {
@@ -23,10 +23,21 @@ const MENU_LABELS = {
     cut: 'Cut',
     copy: 'Copy',
     paste: 'Paste',
+    pasteAndMatchStyle: 'Paste and Match Style',
+    delete: 'Delete',
     selectAll: 'Select All',
+    find: 'Find…',
+    findNext: 'Find Next',
+    findPrevious: 'Find Previous',
     view: 'View',
+    window: 'Window',
     help: 'Help',
-    documentation: 'Documentation'
+    documentation: 'Documentation',
+    copyLink: 'Copy Link Address',
+    openLink: 'Open Link in Browser',
+    copyImage: 'Copy Image',
+    saveImageAs: 'Save Image As…',
+    noSuggestions: 'No spelling suggestions'
   },
   zh: {
     navigation: '导航',
@@ -40,10 +51,21 @@ const MENU_LABELS = {
     cut: '剪切',
     copy: '复制',
     paste: '粘贴',
+    pasteAndMatchStyle: '粘贴并匹配样式',
+    delete: '删除',
     selectAll: '全选',
+    find: '查找…',
+    findNext: '查找下一个',
+    findPrevious: '查找上一个',
     view: '视图',
+    window: '窗口',
     help: '帮助',
-    documentation: '文档'
+    documentation: '文档',
+    copyLink: '复制链接地址',
+    openLink: '在浏览器中打开链接',
+    copyImage: '复制图片',
+    saveImageAs: '图片另存为…',
+    noSuggestions: '没有拼写建议'
   }
 };
 
@@ -55,18 +77,27 @@ function labelsFor(language) {
 /**
  * @param {object} options
  * @param {string} options.language
- * @param {string} options.platform          process.platform
+ * @param {string} options.platform            process.platform
  * @param {(path: string) => void} options.navigate
  * @param {() => void} options.openDocumentation
+ * @param {() => void} options.openFind
+ * @param {(forward: boolean) => void} options.findAgain
  */
-function buildAppMenuTemplate({ language, platform, navigate, openDocumentation }) {
+function buildAppMenuTemplate({
+  language,
+  platform,
+  navigate,
+  openDocumentation,
+  openFind,
+  findAgain
+}) {
   const labels = labelsFor(language);
   const isMac = platform === 'darwin';
 
   return [
     // macOS 的第一个子菜单永远被当成应用菜单。不显式给出 appMenu 的话，
     // 我们的第一项（导航）会被系统顶上这个位置：标题变成进程名，
-    // 而「关于 / 隐藏 / 退出」这些标准项整个消失。
+    // 而「关于 / 隐藏 / 退出」这些标准项整个消失（⌘Q 也跟着没了）。
     ...(isMac ? [{ role: 'appMenu' }] : []),
     {
       label: labels.navigation,
@@ -74,7 +105,9 @@ function buildAppMenuTemplate({ language, platform, navigate, openDocumentation 
         { label: labels.home, click: () => navigate('/') },
         { label: labels.settings, click: () => navigate('/settings') },
         { label: labels.aiGenerator, click: () => navigate('/generator') },
-        { label: labels.addProblem, click: () => navigate('/add-problem') }
+        { label: labels.addProblem, click: () => navigate('/add-problem') },
+        // 非 macOS 上应用菜单不存在，退出得挂在这儿
+        ...(isMac ? [] : [{ type: 'separator' }, { role: 'quit' }])
       ]
     },
     {
@@ -87,7 +120,14 @@ function buildAppMenuTemplate({ language, platform, navigate, openDocumentation 
         { role: 'cut', label: labels.cut },
         { role: 'copy', label: labels.copy },
         { role: 'paste', label: labels.paste },
-        { role: 'selectAll', label: labels.selectAll }
+        { role: 'pasteAndMatchStyle', label: labels.pasteAndMatchStyle },
+        { role: 'delete', label: labels.delete },
+        { role: 'selectAll', label: labels.selectAll },
+        { type: 'separator' },
+        // 浏览器里 ⌘F 是白送的，Electron 里得自己接 findInPage
+        { label: labels.find, accelerator: 'CmdOrCtrl+F', click: () => openFind() },
+        { label: labels.findNext, accelerator: 'CmdOrCtrl+G', click: () => findAgain(true) },
+        { label: labels.findPrevious, accelerator: 'Shift+CmdOrCtrl+G', click: () => findAgain(false) }
       ]
     },
     {
@@ -105,7 +145,18 @@ function buildAppMenuTemplate({ language, platform, navigate, openDocumentation 
       ]
     },
     {
+      // ⌘M / ⌘W 同样是靠菜单项派发的
+      label: labels.window,
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        { role: 'close' },
+        ...(isMac ? [{ type: 'separator' }, { role: 'front' }] : [])
+      ]
+    },
+    {
       label: labels.help,
+      role: 'help',
       submenu: [{ label: labels.documentation, click: () => openDocumentation() }]
     }
   ];
@@ -117,22 +168,49 @@ function buildAppMenuTemplate({ language, platform, navigate, openDocumentation 
  * Electron 不带默认上下文菜单，不自己装一个的话，输入框上右键什么都不弹——
  * 键盘快捷键之外的另一条粘贴路径同样是断的。
  *
- * @param {object} params  Electron context-menu 事件的 params
- * @param {object} labels  labelsFor() 的结果
+ * @param {object} params    Electron context-menu 事件的 params
+ * @param {object} labels    labelsFor() 的结果
+ * @param {object} actions   { copyLink, openLink, copyImage, saveImageAs, replaceMisspelling }
  * @returns {Array} 模板；返回空数组表示这里不该弹菜单
  */
-function buildContextMenuTemplate(params, labels) {
-  const { isEditable = false, editFlags = {}, selectionText = '' } = params || {};
+function buildContextMenuTemplate(params, labels, actions = {}) {
+  const {
+    isEditable = false,
+    editFlags = {},
+    selectionText = '',
+    linkURL = '',
+    mediaType = 'none',
+    srcURL = '',
+    misspelledWord = '',
+    dictionarySuggestions = []
+  } = params || {};
+
   const hasSelection = selectionText.trim().length > 0;
-
-  // 只在有意义的地方弹：可编辑区域，或者选中了文本想复制
-  if (!isEditable && !hasSelection) return [];
-
+  const isImage = mediaType === 'image' && Boolean(srcURL);
   const template = [];
+
+  // 拼写建议排在最前面，和浏览器一致。开了拼写检查却不给改正入口，
+  // 等于只画红波浪线不让修。
+  if (misspelledWord) {
+    if (dictionarySuggestions.length === 0) {
+      template.push({ label: labels.noSuggestions, enabled: false });
+    } else {
+      dictionarySuggestions.slice(0, 5).forEach((suggestion) => {
+        template.push({
+          label: suggestion,
+          click: () => actions.replaceMisspelling && actions.replaceMisspelling(suggestion)
+        });
+      });
+    }
+    template.push({ type: 'separator' });
+  }
+
   if (isEditable) {
     template.push({ role: 'cut', label: labels.cut, enabled: Boolean(editFlags.canCut) });
   }
-  template.push({ role: 'copy', label: labels.copy, enabled: Boolean(editFlags.canCopy) });
+  if (isEditable || hasSelection) {
+    template.push({ role: 'copy', label: labels.copy, enabled: Boolean(editFlags.canCopy) });
+  }
   if (isEditable) {
     template.push({ role: 'paste', label: labels.paste, enabled: Boolean(editFlags.canPaste) });
     template.push({ type: 'separator' });
@@ -142,6 +220,20 @@ function buildContextMenuTemplate(params, labels) {
       enabled: Boolean(editFlags.canSelectAll)
     });
   }
+
+  if (linkURL) {
+    if (template.length) template.push({ type: 'separator' });
+    template.push({ label: labels.copyLink, click: () => actions.copyLink && actions.copyLink(linkURL) });
+    // 外链一律交给系统浏览器，绝不在应用窗口里导航过去
+    template.push({ label: labels.openLink, click: () => actions.openLink && actions.openLink(linkURL) });
+  }
+
+  if (isImage) {
+    if (template.length) template.push({ type: 'separator' });
+    template.push({ label: labels.copyImage, click: () => actions.copyImage && actions.copyImage(params) });
+    template.push({ label: labels.saveImageAs, click: () => actions.saveImageAs && actions.saveImageAs(srcURL) });
+  }
+
   return template;
 }
 

--- a/electron-preload.js
+++ b/electron-preload.js
@@ -8,5 +8,25 @@ contextBridge.exposeInMainWorld('electronAPI', {
   loadConfiguration: () => ipcRenderer.invoke('load-config'),
   setLanguage: (language) => ipcRenderer.invoke('set-language', language),
   setTheme: (theme) => ipcRenderer.invoke('set-theme', theme),
-  // Add other IPC methods as needed
+
+  // 页内查找。浏览器里 ⌘F 是白送的，Electron 得自己把
+  // 菜单 -> 渲染进程 -> findInPage 这条链接起来。
+  // 每个 on* 都返回取消订阅函数，组件卸载时要调用，否则热重载会越堆越多。
+  onFindOpen: (callback) => {
+    const handler = () => callback();
+    ipcRenderer.on('find:open', handler);
+    return () => ipcRenderer.removeListener('find:open', handler);
+  },
+  onFindAgain: (callback) => {
+    const handler = (_event, forward) => callback(forward);
+    ipcRenderer.on('find:again', handler);
+    return () => ipcRenderer.removeListener('find:again', handler);
+  },
+  onFindResult: (callback) => {
+    const handler = (_event, result) => callback(result);
+    ipcRenderer.on('find:result', handler);
+    return () => ipcRenderer.removeListener('find:result', handler);
+  },
+  findInPage: (text, options) => ipcRenderer.invoke('find:query', text, options),
+  stopFindInPage: () => ipcRenderer.invoke('find:stop')
 });

--- a/electron-urls.js
+++ b/electron-urls.js
@@ -1,0 +1,37 @@
+/**
+ * 导航地址判定
+ *
+ * 单独成模块是为了能被测试直接 require（不碰 electron），也因为这段是安全相关的：
+ * 原来的写法是 `url.includes('localhost')`，`https://evil.example/?x=localhost`
+ * 就能骗过去。Electron 安全文档明确要求按解析出来的 origin 判断，不要做字符串包含。
+ */
+
+/** 是不是应用自己的页面 */
+function isInternalUrl(candidate, { hostname, port }) {
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    if (parsed.hostname !== hostname) return false;
+    // 端口不同就是另一个服务，哪怕主机名一样
+    return parsed.port === String(port);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 能不能交给系统浏览器打开。
+ *
+ * 只放行 http(s)：file:// 会用默认程序打开本地文件，javascript: / data: 更不该
+ * 经由 shell.openExternal 出去。
+ */
+function isSafeExternalUrl(candidate) {
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { isInternalUrl, isSafeExternalUrl };

--- a/locales/en.json
+++ b/locales/en.json
@@ -634,5 +634,12 @@
     "savedJustNow": "Saved just now",
     "savedMinutes": "Saved {{minutes}}m ago",
     "autosaveOn": "Autosave on"
+  },
+  "find": {
+    "placeholder": "Find in page",
+    "none": "No results",
+    "next": "Next match",
+    "previous": "Previous match",
+    "close": "Close find bar"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -634,5 +634,12 @@
     "savedJustNow": "已保存 · 刚刚",
     "savedMinutes": "已保存 · {{minutes}} 分钟前",
     "autosaveOn": "自动保存已开启"
+  },
+  "find": {
+    "placeholder": "在页面中查找",
+    "none": "无结果",
+    "next": "下一个",
+    "previous": "上一个",
+    "close": "关闭查找栏"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import '@mantine/core/styles.css';
 import '../styles/globals.css';
 import { I18nProvider, useI18n } from '../src/contexts/I18nContext';
 import { ThemeProvider, useTheme } from '../src/contexts/ThemeContext';
+import FindBar from '../src/components/FindBar';
 
 // AlgoLocal 品牌青色：与新的本地执行回路标志保持一致
 const brand: MantineColorsTuple = [
@@ -97,6 +98,8 @@ function AppContent({ Component, pageProps }: AppProps) {
   return (
     <MantineProvider theme={theme} defaultColorScheme={forceScheme} forceColorScheme={forceScheme}>
       <Component {...pageProps} />
+      {/* 桌面端的 ⌘F 查找栏；浏览器里它自己不渲染 */}
+      <FindBar />
     </MantineProvider>
   );
 }

--- a/src/components/FindBar.tsx
+++ b/src/components/FindBar.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { ActionIcon, Group, Paper, Text, TextInput } from '@mantine/core';
+import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
+import { useI18n } from '../contexts/I18nContext';
+
+/**
+ * 页内查找栏（仅桌面端）
+ *
+ * 浏览器里 ⌘F 是白送的，Electron 里没有。菜单里的「查找」把 find:open 发过来，
+ * 这里收关键词交给主进程的 findInPage，命中数再从 find:result 回来。
+ *
+ * 浏览器环境下 window.electronAPI 不存在，组件直接不渲染——Chrome 自己的
+ * 查找栏比这个好用，不要抢它。
+ */
+export default function FindBar() {
+  const { t } = useI18n();
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [result, setResult] = React.useState({ activeMatchOrdinal: 0, matches: 0 });
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  // 事件回调里要读到最新的关键词，用 ref 免得每次都重订阅
+  const queryRef = React.useRef('');
+  queryRef.current = query;
+
+  const api = () => (typeof window !== 'undefined' ? (window as any).electronAPI : undefined);
+
+  const search = React.useCallback((text: string, forward = true, findNext = false) => {
+    const bridge = api();
+    if (!bridge) return;
+    if (!text) {
+      bridge.stopFindInPage();
+      setResult({ activeMatchOrdinal: 0, matches: 0 });
+      return;
+    }
+    bridge.findInPage(text, { forward, findNext });
+  }, []);
+
+  const close = React.useCallback(() => {
+    setOpen(false);
+    setResult({ activeMatchOrdinal: 0, matches: 0 });
+    api()?.stopFindInPage();
+  }, []);
+
+  React.useEffect(() => {
+    const bridge = api();
+    if (!bridge?.onFindOpen) return;
+
+    const offOpen = bridge.onFindOpen(() => {
+      setOpen(true);
+      // 已经开着的时候再按 ⌘F，是「重新选中输入框」而不是关掉
+      requestAnimationFrame(() => inputRef.current?.select());
+    });
+    const offAgain = bridge.onFindAgain((forward: boolean) => {
+      if (queryRef.current) search(queryRef.current, forward, true);
+    });
+    const offResult = bridge.onFindResult((r: any) => setResult(r));
+
+    return () => {
+      offOpen?.();
+      offAgain?.();
+      offResult?.();
+    };
+  }, [search]);
+
+  if (!open) return null;
+
+  const matches = result.matches || 0;
+
+  return (
+    <Paper
+      withBorder
+      shadow="md"
+      radius="md"
+      p={6}
+      style={{ position: 'fixed', top: 12, right: 16, zIndex: 4000, minWidth: 300 }}
+    >
+      <Group gap={4} wrap="nowrap">
+        <TextInput
+          ref={inputRef}
+          size="xs"
+          autoFocus
+          placeholder={t('find.placeholder')}
+          value={query}
+          onChange={(event) => {
+            const next = event.currentTarget.value;
+            setQuery(next);
+            search(next);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              // Shift+Enter 往回找，和浏览器一致
+              search(query, !event.shiftKey, true);
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              close();
+            }
+          }}
+          style={{ flex: 1 }}
+        />
+        <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap', minWidth: 44, textAlign: 'center' }}>
+          {matches ? `${result.activeMatchOrdinal}/${matches}` : t('find.none')}
+        </Text>
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          aria-label={t('find.previous')}
+          disabled={!matches}
+          onClick={() => search(query, false, true)}
+        >
+          <IconChevronUp size={14} />
+        </ActionIcon>
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          aria-label={t('find.next')}
+          disabled={!matches}
+          onClick={() => search(query, true, true)}
+        >
+          <IconChevronDown size={14} />
+        </ActionIcon>
+        <ActionIcon size="sm" variant="subtle" aria-label={t('find.close')} onClick={close}>
+          <IconX size={14} />
+        </ActionIcon>
+      </Group>
+    </Paper>
+  );
+}

--- a/tests/desktop/menu.test.js
+++ b/tests/desktop/menu.test.js
@@ -1,11 +1,12 @@
 /**
- * 桌面端菜单
+ * 桌面端菜单与右键菜单
  *
  * 这些用例的由来：应用菜单里一直没有 Edit 菜单，于是 macOS 上 ⌘V 在渲染进程里
  * 完全不生效（系统是靠菜单项的 key equivalent 派发它的），用户在设置页粘不了
- * API key。Electron 也不带默认右键菜单，所以「右键 → 粘贴」这条后备路径同样是断的。
+ * API key。同一类问题还牵出 Window 菜单缺失（⌘M / ⌘W 失效）、应用菜单被顶掉
+ * （⌘Q 失效），以及 Electron 根本不带默认右键菜单。
  *
- * 两条路径各自都有用例盯着，掉了要红。
+ * 每一项都有用例盯着，掉了要红。
  */
 
 const {
@@ -18,7 +19,9 @@ const baseOptions = {
   language: 'en',
   platform: 'darwin',
   navigate: () => {},
-  openDocumentation: () => {}
+  openDocumentation: () => {},
+  openFind: () => {},
+  findAgain: () => {}
 };
 
 /** 把模板拍平成 role 列表，方便断言 */
@@ -30,10 +33,13 @@ function menuNamed(template, label) {
   return template.find((entry) => entry.label === label);
 }
 
+function itemWithAccelerator(submenu, accelerator) {
+  return submenu.find((item) => item.accelerator === accelerator);
+}
+
 describe('application menu', () => {
-  it('has an Edit menu carrying the standard editing roles', () => {
-    const template = buildAppMenuTemplate(baseOptions);
-    const edit = menuNamed(template, 'Edit');
+  it('has an Edit menu carrying every standard editing role', () => {
+    const edit = menuNamed(buildAppMenuTemplate(baseOptions), 'Edit');
 
     expect(edit).toBeDefined();
     // 这些 role 就是 ⌘Z / ⇧⌘Z / ⌘X / ⌘C / ⌘V / ⌘A 的归属
@@ -43,6 +49,8 @@ describe('application menu', () => {
       'cut',
       'copy',
       'paste',
+      'pasteAndMatchStyle',
+      'delete',
       'selectAll'
     ]);
   });
@@ -60,7 +68,7 @@ describe('application menu', () => {
     const template = buildAppMenuTemplate(baseOptions);
 
     // 不占住第一格的话，导航菜单会被系统顶成应用菜单：
-    // 标题变进程名，「关于 / 隐藏 / 退出」一并消失
+    // 标题变进程名，「关于 / 隐藏 / 退出」（含 ⌘Q）一并消失
     expect(template[0]).toEqual({ role: 'appMenu' });
     expect(menuNamed(template, 'Navigation')).toBeDefined();
   });
@@ -71,6 +79,42 @@ describe('application menu', () => {
     expect(template.some((entry) => entry.role === 'appMenu')).toBe(false);
     expect(template[0].label).toBe('Navigation');
     expect(menuNamed(template, 'Edit')).toBeDefined();
+  });
+
+  it('gives non-mac platforms a Quit item, since they have no app menu', () => {
+    const nav = menuNamed(buildAppMenuTemplate({ ...baseOptions, platform: 'win32' }), 'Navigation');
+
+    expect(rolesIn(nav.submenu)).toContain('quit');
+  });
+
+  it('has a Window menu so the window shortcuts reach the window', () => {
+    const windowMenu = menuNamed(buildAppMenuTemplate(baseOptions), 'Window');
+
+    expect(windowMenu).toBeDefined();
+    expect(rolesIn(windowMenu.submenu)).toEqual(['minimize', 'zoom', 'close', 'front']);
+  });
+
+  it('drops the macOS-only front role off mac', () => {
+    const windowMenu = menuNamed(
+      buildAppMenuTemplate({ ...baseOptions, platform: 'linux' }),
+      'Window'
+    );
+
+    expect(rolesIn(windowMenu.submenu)).toEqual(['minimize', 'zoom', 'close']);
+  });
+
+  it('keeps the full View menu', () => {
+    const view = menuNamed(buildAppMenuTemplate(baseOptions), 'View');
+
+    expect(rolesIn(view.submenu)).toEqual([
+      'reload',
+      'forceReload',
+      'toggleDevTools',
+      'resetZoom',
+      'zoomIn',
+      'zoomOut',
+      'togglefullscreen'
+    ]);
   });
 
   it('localises the Edit menu with the rest of the UI', () => {
@@ -89,10 +133,46 @@ describe('application menu', () => {
 
   it('keeps every navigation entry wired to a route', () => {
     const visited = [];
-    const template = buildAppMenuTemplate({ ...baseOptions, navigate: (p) => visited.push(p) });
-    menuNamed(template, 'Navigation').submenu.forEach((item) => item.click());
+    const nav = menuNamed(
+      buildAppMenuTemplate({ ...baseOptions, navigate: (p) => visited.push(p) }),
+      'Navigation'
+    );
+    nav.submenu.filter((item) => item.click).forEach((item) => item.click());
 
     expect(visited).toEqual(['/', '/settings', '/generator', '/add-problem']);
+  });
+});
+
+describe('find in page', () => {
+  it('wires the find accelerators, since Electron gives no find for free', () => {
+    const edit = menuNamed(buildAppMenuTemplate(baseOptions), 'Edit');
+
+    expect(itemWithAccelerator(edit.submenu, 'CmdOrCtrl+F')).toBeDefined();
+    expect(itemWithAccelerator(edit.submenu, 'CmdOrCtrl+G')).toBeDefined();
+    expect(itemWithAccelerator(edit.submenu, 'Shift+CmdOrCtrl+G')).toBeDefined();
+  });
+
+  it('calls openFind when Find is picked', () => {
+    let opened = 0;
+    const edit = menuNamed(
+      buildAppMenuTemplate({ ...baseOptions, openFind: () => (opened += 1) }),
+      'Edit'
+    );
+    itemWithAccelerator(edit.submenu, 'CmdOrCtrl+F').click();
+
+    expect(opened).toBe(1);
+  });
+
+  it('passes the search direction through to findAgain', () => {
+    const directions = [];
+    const edit = menuNamed(
+      buildAppMenuTemplate({ ...baseOptions, findAgain: (forward) => directions.push(forward) }),
+      'Edit'
+    );
+    itemWithAccelerator(edit.submenu, 'CmdOrCtrl+G').click();
+    itemWithAccelerator(edit.submenu, 'Shift+CmdOrCtrl+G').click();
+
+    expect(directions).toEqual([true, false]);
   });
 });
 
@@ -141,6 +221,51 @@ describe('context menu', () => {
     ).toEqual([]);
   });
 
+  it('offers link actions on a link', () => {
+    const copied = [];
+    const opened = [];
+    const template = buildContextMenuTemplate(
+      { isEditable: false, editFlags: {}, selectionText: '', linkURL: 'https://example.com/x' },
+      labels,
+      { copyLink: (u) => copied.push(u), openLink: (u) => opened.push(u) }
+    );
+    template.filter((item) => item.click).forEach((item) => item.click());
+
+    expect(template.map((item) => item.label).filter(Boolean)).toEqual([
+      'Copy Link Address',
+      'Open Link in Browser'
+    ]);
+    expect(copied).toEqual(['https://example.com/x']);
+    expect(opened).toEqual(['https://example.com/x']);
+  });
+
+  it('offers image actions on an image', () => {
+    const saved = [];
+    const template = buildContextMenuTemplate(
+      { mediaType: 'image', srcURL: 'https://example.com/a.png', editFlags: {}, selectionText: '' },
+      labels,
+      { copyImage: () => {}, saveImageAs: (u) => saved.push(u) }
+    );
+    template.find((item) => item.label === 'Save Image As…').click();
+
+    expect(template.map((item) => item.label).filter(Boolean)).toEqual([
+      'Copy Image',
+      'Save Image As…'
+    ]);
+    expect(saved).toEqual(['https://example.com/a.png']);
+  });
+
+  it('combines editable and link entries when a link sits in a text field', () => {
+    const template = buildContextMenuTemplate(
+      { isEditable: true, editFlags: allFlags, selectionText: '', linkURL: 'https://example.com' },
+      labels,
+      {}
+    );
+
+    expect(rolesIn(template)).toEqual(['cut', 'copy', 'paste', 'selectAll']);
+    expect(template.some((item) => item.label === 'Copy Link Address')).toBe(true);
+  });
+
   it('localises alongside the application menu', () => {
     const template = buildContextMenuTemplate(
       { isEditable: true, editFlags: allFlags, selectionText: '' },
@@ -153,5 +278,59 @@ describe('context menu', () => {
   it('survives a params object with fields missing', () => {
     expect(() => buildContextMenuTemplate({}, labels)).not.toThrow();
     expect(buildContextMenuTemplate({}, labels)).toEqual([]);
+  });
+
+  it('offers spelling corrections on a misspelled word', () => {
+    const replaced = [];
+    const template = buildContextMenuTemplate(
+      {
+        isEditable: true,
+        editFlags: allFlags,
+        selectionText: '',
+        misspelledWord: 'teh',
+        dictionarySuggestions: ['the', 'ten', 'tea']
+      },
+      labels,
+      { replaceMisspelling: (w) => replaced.push(w) }
+    );
+    template[0].click();
+
+    // 建议排在最前，紧跟一条分隔线，然后才是常规编辑项
+    expect(template.slice(0, 3).map((item) => item.label)).toEqual(['the', 'ten', 'tea']);
+    expect(template[3]).toEqual({ type: 'separator' });
+    expect(replaced).toEqual(['the']);
+    expect(rolesIn(template)).toEqual(['cut', 'copy', 'paste', 'selectAll']);
+  });
+
+  it('says so when a misspelling has no suggestions', () => {
+    const template = buildContextMenuTemplate(
+      { isEditable: true, editFlags: allFlags, misspelledWord: 'zzxq', dictionarySuggestions: [] },
+      labels
+    );
+
+    expect(template[0]).toEqual({ label: 'No spelling suggestions', enabled: false });
+  });
+
+  it('caps the suggestion list so the menu stays usable', () => {
+    const template = buildContextMenuTemplate(
+      {
+        isEditable: true,
+        editFlags: allFlags,
+        misspelledWord: 'x',
+        dictionarySuggestions: ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+      },
+      labels
+    );
+
+    expect(template.filter((item) => /^[a-g]$/.test(item.label || '')).length).toBe(5);
+  });
+
+  it('does not blow up when no action handlers are supplied', () => {
+    const template = buildContextMenuTemplate(
+      { linkURL: 'https://example.com', editFlags: {}, selectionText: '' },
+      labels
+    );
+
+    expect(() => template.forEach((item) => item.click && item.click())).not.toThrow();
   });
 });

--- a/tests/desktop/urls.test.js
+++ b/tests/desktop/urls.test.js
@@ -1,0 +1,66 @@
+/**
+ * 导航地址判定
+ *
+ * 原来的判断是 `url.startsWith('http') && !url.includes('localhost')`，
+ * 也就是说带上 `?x=localhost` 的外部地址会被当成「自己人」放进应用窗口。
+ * 这一组用例就是钉住那个绕过。
+ */
+
+const { isInternalUrl, isSafeExternalUrl } = require('../../electron-urls');
+
+const app = { hostname: 'localhost', port: 3000 };
+
+describe('isInternalUrl', () => {
+  it('accepts the app on its own host and port', () => {
+    expect(isInternalUrl('http://localhost:3000/', app)).toBe(true);
+    expect(isInternalUrl('http://localhost:3000/settings', app)).toBe(true);
+    expect(isInternalUrl('http://localhost:3000/problems/two-sum?x=1#frag', app)).toBe(true);
+  });
+
+  it('rejects an external host that merely mentions localhost', () => {
+    // 老的字符串判断正是栽在这里
+    expect(isInternalUrl('https://evil.example/?next=localhost', app)).toBe(false);
+    expect(isInternalUrl('https://localhost.evil.example/', app)).toBe(false);
+    expect(isInternalUrl('https://evil.example/localhost:3000', app)).toBe(false);
+  });
+
+  it('rejects another port on the same host', () => {
+    expect(isInternalUrl('http://localhost:3001/', app)).toBe(false);
+    expect(isInternalUrl('http://localhost/', app)).toBe(false);
+  });
+
+  it('tracks the port the server actually landed on', () => {
+    // 3000 被占用时会往后找，判定要跟着走
+    expect(isInternalUrl('http://localhost:3003/', { hostname: 'localhost', port: 3003 })).toBe(true);
+    expect(isInternalUrl('http://localhost:3000/', { hostname: 'localhost', port: 3003 })).toBe(false);
+  });
+
+  it('rejects non-http schemes and junk', () => {
+    expect(isInternalUrl('file:///etc/passwd', app)).toBe(false);
+    expect(isInternalUrl('javascript:alert(1)', app)).toBe(false);
+    expect(isInternalUrl('not a url', app)).toBe(false);
+    expect(isInternalUrl('', app)).toBe(false);
+    expect(isInternalUrl(undefined, app)).toBe(false);
+  });
+});
+
+describe('isSafeExternalUrl', () => {
+  it('allows http and https', () => {
+    expect(isSafeExternalUrl('https://example.com')).toBe(true);
+    expect(isSafeExternalUrl('http://example.com')).toBe(true);
+  });
+
+  it('refuses schemes that shell.openExternal should never receive', () => {
+    // file:// 会用默认程序打开本地文件，其余几个更不该出去
+    expect(isSafeExternalUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeExternalUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeExternalUrl('smb://share/x')).toBe(false);
+  });
+
+  it('refuses unparseable input', () => {
+    expect(isSafeExternalUrl('')).toBe(false);
+    expect(isSafeExternalUrl('nonsense')).toBe(false);
+    expect(isSafeExternalUrl(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up sweep after the missing Edit menu. Same class of bug throughout: capabilities a browser provides for free that an Electron shell has to opt into, and this one had not.

## Audit

Everything checked, against `electron-main.js` and Electron's own docs rather than by guesswork.

### 1. Application menu

| Item | Before | Now |
| --- | --- | --- |
| Undo / Redo | ❌ missing | ✅ ⌘Z / ⇧⌘Z |
| Cut / Copy / Paste | ❌ missing | ✅ ⌘X / ⌘C / ⌘V |
| Paste and Match Style | ❌ missing | ✅ ⌥⇧⌘V |
| Delete | ❌ missing | ✅ |
| Select All | ❌ missing | ✅ ⌘A |
| App menu (About/Services/Hide/Quit) | ❌ absent — **⌘Q did not work** | ✅ via `role: 'appMenu'` |
| Window (minimize/zoom/close/front) | ❌ menu did not exist — **⌘M / ⌘W dead** | ✅ |
| View (reload/force reload/devtools/zoom/fullscreen) | ✅ already complete | unchanged |
| Help | ✅ present | now `role: 'help'` |

The first three rows shipped in the previous PR; the rest are new here.

### 2. Context menu

| Item | Before | Now |
| --- | --- | --- |
| Input: cut/copy/paste/select all | ✅ previous PR | unchanged |
| Plain text: copy | ✅ previous PR | unchanged |
| Link: copy address | ❌ | ✅ |
| Link: open in system browser | ❌ | ✅ (never in-app) |
| Image: copy | ❌ | ✅ |
| Image: save as | ❌ | ✅ with a save dialog |
| Spelling corrections | ❌ | ✅ wired to `replaceMisspelling` |

### 3. Other browser-native capabilities

| Item | Finding | Fix |
| --- | --- | --- |
| ⌘A/C/V/X/Z/⇧Z | dead (no Edit menu) | fixed above |
| ⌘R reload, ⌘= / ⌘- zoom | ✅ already worked | — |
| ⌘W / ⌘Q | **dead** — no Window menu, no app menu | fixed above |
| ⌘F find | **dead** — Electron ships no find | find bar over `findInPage`, with ⌘G / ⇧⌘G and a match counter |
| Spellcheck | **explicitly disabled** (`spellcheck: false`) | enabled, plus correction suggestions |
| External links | **`will-navigate` unhandled** — a plain `<a href>` navigated the whole window away | routed to the system browser, window stays put |
| `setWindowOpenHandler` | `url.includes('localhost')` — bypassable | origin comparison via the URL parser |
| Downloads | no `will-download` — silent save to the default folder | save dialog, then reveal in folder |
| File drag/drop, uploads | no such feature in the app (no file inputs, no `createObjectURL`, no download anchors) | nothing to fix |
| Window state memory | absent | persisted, validated against current displays |

### 4. Reverse check — desktop-only silent failures

- **`navigator.clipboard.writeText`** in `CodeWithCopy` — works; localhost is a secure context.
- **Import features** (`import-problems`, `import-from-folder`) are server-side API routes reading paths, not browser file pickers — no desktop gap.
- **Global keydown handlers** in `CodeRunner` / `WorkspaceEditor` correctly bail out inside inputs; they claim only Enter/s/p/b.
- **Monaco's own ⌘F** keeps working — it handles keydown internally and never needed a menu item.

## Notable finding: a bypassable origin check

```js
// before — https://evil.example/?x=localhost passes as "internal"
if (url.startsWith('http') && !url.includes('localhost')) { … }
```

Electron's security guide explicitly calls out string comparison here. Now parsed and compared by hostname + port, with `tests/desktop/urls.test.js` pinning the bypass shut.

## Verification

**In a running build**, via the macOS accessibility API and CDP:

- Menu bar reads `Apple / app / Navigation / Edit / View / Window / Help`, and every accelerator is bound: ⌘Z ⇧⌘Z ⌘X ⌘C ⌘V ⌥⇧⌘V ⌘A ⌘F ⌘G ⇧⌘G ⌘R ⇧⌘R ⌥⌘I ⌘0 ⌘+ ⌘- ⌃⌘F ⌘M ⌘W ⌘H ⌘Q.
- **Find**: picking Edit → Find… opened the bar (localised: 在页面中查找); typing 密码 reported **17 matches** and displayed `2/17`.
- **External navigation**: `location.href = 'https://example.com/'` left the app on `localhost:3002/…` and opened the URL in the default browser instead. `window.open` likewise created no in-app window. `file:///etc/passwd` was blocked and *not* handed to the OS.
- **Window bounds**: resizing to 1180×820 wrote `{x:56,y:33,width:1180,height:820}` to config; after a restart the window came back at exactly 1180×820.

**Automated**: 35 tests in `tests/desktop`. `npm test` 6/6 · `tsc --noEmit` clean · `projects:verify` all 70 stages green.

### Not verified live

- **Spellchecking itself.** The flag is flipped and the suggestion path is unit-tested, but I could not observe Chromium's squiggles or capture `dictionarySuggestions` from a real right-click — it needs main-process instrumentation, and password fields (where the original bug was reported) never spellcheck in Chromium by design.
- **Physical key presses and real right-clicks.** Unchanged from the last PR: computer-use approval is unavailable in this session and `osascript` lacks the Accessibility grant to post synthetic events. Menu bindings are verified through what the OS reports, not by pressing the keys.
- **Image copy / save-as and the download dialog** are covered by unit tests over the template and handler wiring; I did not exercise a real download.

Worth a minute of manual checking before release: ⌘F, ⌘W, right-click on a link in an AI answer, and pasting into a settings field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)