### PR TITLE
feat(opslab): 确定性内核（L0）

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -42,6 +42,11 @@ class TestRunner {
         description: 'Structural validation, stage verification and the save path for generated projects'
       },
       {
+        name: 'Opslab Deterministic Kernel',
+        file: 'tests/opslab',
+        description: 'Virtual clock ordering, settle/deadlock detection, snapshots, and byte-identical replay of dozens of concurrent entities'
+      },
+      {
         name: 'Desktop Menus',
         file: 'tests/desktop',
         description: 'Application and context menus, including the edit roles that ⌘V depends on'

--- a/src/lib/opslab/kernel/clock.ts
+++ b/src/lib/opslab/kernel/clock.ts
@@ -1,0 +1,207 @@
+/**
+ * opslab 的虚拟时钟
+ *
+ * 和 src/lib/engineering/clock.ts 那个的区别：那一个是为「一条用例把一段异步跑完」
+ * 设计的，单任务驱动；这里要同时驮着几十个长期存在的实体 —— 控制器、kubelet、
+ * 容器进程、协议超时 —— 而且必须完全确定。
+ *
+ * 确定性靠三件事：
+ *  1. 时间只由这里推进，不存在真实定时器；
+ *  2. 同一时刻到期的定时器按 (时间, 优先级, 注册序号) 唯一定序；
+ *  3. 后台定时器（控制器的定期重扫这类）单独标记，不参与「世界静下来了没有」的判断，
+ *     否则一个每 30 秒重扫的控制器会让世界永远「有事情要做」。
+ */
+
+/** 同一时刻到期时谁先跑。数字小的先。 */
+export const Priority = {
+  /** apiserver 把变更分发给 watch —— 必须最先，其余人才看得到 */
+  DISPATCH: 0,
+  /** kubelet：容器状态推进 */
+  NODE: 10,
+  /** 控制器 reconcile */
+  CONTROLLER: 20,
+  /** 网络与协议超时 */
+  NETWORK: 30,
+  /** 学员命令、探测 */
+  USER: 40,
+} as const;
+
+export type PriorityValue = (typeof Priority)[keyof typeof Priority] | number;
+
+export interface ScheduleOptions {
+  /** 同刻定序用，默认 USER */
+  priority?: PriorityValue;
+  /** 周期性重复的间隔；不传就是一次性 */
+  intervalMs?: number;
+  /**
+   * 后台定时器。
+   *
+   * 控制器的定期重扫、心跳这类「永远有下一次」的东西标成 background，
+   * settle() 就不会因为它们而永远等下去。快进（advanceBy）照样会触发它们。
+   */
+  background?: boolean;
+  /** 调试用的名字，出现在死锁报告里 */
+  label?: string;
+}
+
+interface Timer {
+  id: number;
+  time: number;
+  seq: number;
+  priority: number;
+  fn: () => void;
+  intervalMs?: number;
+  background: boolean;
+  label?: string;
+}
+
+export class VirtualClock {
+  private time = 0;
+  private seq = 0;
+  private nextId = 1;
+  private timers: Timer[] = [];
+  /** 定时器回调抛出的第一个异常，由驱动器取走 */
+  private failure: { error: unknown; label?: string } | null = null;
+
+  now(): number {
+    return this.time;
+  }
+
+  /** 还挂着多少定时器（含后台） */
+  get pending(): number {
+    return this.timers.length;
+  }
+
+  /** 还挂着多少**非后台**定时器 —— 「世界还有正事要做吗」看这个 */
+  get pendingForeground(): number {
+    return this.timers.reduce((n, t) => n + (t.background ? 0 : 1), 0);
+  }
+
+  takeFailure(): { error: unknown; label?: string } | null {
+    const failure = this.failure;
+    this.failure = null;
+    return failure;
+  }
+
+  schedule(fn: () => void, delayMs: number, options: ScheduleOptions = {}): number {
+    const delay = Number.isFinite(delayMs) && delayMs > 0 ? Math.floor(delayMs) : 0;
+    const timer: Timer = {
+      id: this.nextId++,
+      time: this.time + delay,
+      seq: this.seq++,
+      priority: options.priority ?? Priority.USER,
+      fn,
+      intervalMs: options.intervalMs,
+      background: options.background === true,
+      label: options.label,
+    };
+    this.timers.push(timer);
+    return timer.id;
+  }
+
+  clear(id: number): void {
+    const index = this.timers.findIndex((timer) => timer.id === id);
+    if (index >= 0) this.timers.splice(index, 1);
+  }
+
+  sleep(ms: number, options: ScheduleOptions = {}): Promise<void> {
+    return new Promise((resolve) => this.schedule(resolve, ms, options));
+  }
+
+  /** 下一个定时器在什么时刻；没有则 null */
+  peekNextTime(options: { includeBackground?: boolean } = {}): number | null {
+    const includeBackground = options.includeBackground !== false;
+    let earliest: number | null = null;
+    for (const timer of this.timers) {
+      if (!includeBackground && timer.background) continue;
+      if (earliest === null || timer.time < earliest) earliest = timer.time;
+    }
+    return earliest;
+  }
+
+  /**
+   * 把时钟推到下一个到期时刻，触发该时刻的**全部**定时器。
+   * @returns 是否真的推进了
+   */
+  advanceToNext(options: { includeBackground?: boolean } = {}): boolean {
+    const target = this.peekNextTime(options);
+    if (target === null) return false;
+    this.fireUpTo(target);
+    return true;
+  }
+
+  /** 把时钟推进 ms，沿途所有定时器都会触发 */
+  advanceBy(ms: number): void {
+    this.advanceTo(this.time + Math.max(0, Math.floor(ms)));
+  }
+
+  /** 把时钟推到某个绝对时刻 */
+  advanceTo(target: number): void {
+    while (true) {
+      const next = this.peekNextTime();
+      if (next === null || next > target) break;
+      this.fireUpTo(next);
+    }
+    if (target > this.time) this.time = target;
+  }
+
+  /**
+   * 触发到 target 时刻为止的定时器。
+   *
+   * 定序是确定性的核心：同一时刻按 (priority, seq)，绝不依赖数组顺序或 Map 迭代。
+   * 每轮只取「当前这一刻」的一批，触发过程中新注册的同刻定时器留到下一轮，
+   * 免得一个自己重排自己的定时器把循环卡死。
+   */
+  private fireUpTo(target: number): void {
+    this.time = Math.max(this.time, target);
+
+    const due = this.timers
+      .filter((timer) => timer.time <= this.time)
+      .sort((a, b) => (a.priority - b.priority) || (a.seq - b.seq));
+
+    for (const timer of due) {
+      const index = this.timers.indexOf(timer);
+      if (index < 0) continue;                    // 被同批里更早的回调清掉了
+      if (timer.intervalMs && timer.intervalMs > 0) {
+        timer.time = this.time + timer.intervalMs;
+        timer.seq = this.seq++;
+      } else {
+        this.timers.splice(index, 1);
+      }
+      try {
+        timer.fn();
+      } catch (error) {
+        // 一个回调抛异常不该中断这一刻其余回调的触发，但也不能悄悄吞掉。
+        // 记下来交给驱动器变成一次失败。
+        if (!this.failure) this.failure = { error, label: timer.label };
+      }
+    }
+  }
+
+  /** 快照只存标量。挂着的定时器**不在**其中 —— 见 kernel.ts 里对快照时机的说明。 */
+  snapshot(): { time: number; seq: number; nextId: number } {
+    return { time: this.time, seq: this.seq, nextId: this.nextId };
+  }
+
+  restore(state: { time: number; seq: number; nextId: number }): void {
+    this.time = state.time;
+    this.seq = state.seq;
+    this.nextId = state.nextId;
+    this.timers = [];
+    this.failure = null;
+  }
+
+  /** 丢掉所有挂着的定时器 */
+  clearAll(): void {
+    this.timers = [];
+    this.failure = null;
+  }
+
+  /** 调试用：现在挂着哪些定时器 */
+  describePending(limit = 10): string[] {
+    return [...this.timers]
+      .sort((a, b) => (a.time - b.time) || (a.priority - b.priority) || (a.seq - b.seq))
+      .slice(0, limit)
+      .map((t) => `${t.label ?? 'timer'}@${t.time}ms${t.background ? ' (background)' : ''}`);
+  }
+}

--- a/src/lib/opslab/kernel/clock.ts
+++ b/src/lib/opslab/kernel/clock.ts
@@ -55,6 +55,24 @@ interface Timer {
   label?: string;
 }
 
+/**
+ * 同一时刻最多连续触发多少批定时器。
+ *
+ * 一个回调里再排一个 0 延迟的定时器，时间就永远停在原地 ——
+ * 没有这道闸，advanceTo 是个同步死循环，会把整个标签页转死而且一声不吭
+ * （虚拟时间和真实时间的预算都在 settle 里，根本轮不到执行）。
+ */
+const MAX_BATCHES_AT_SAME_INSTANT = 10_000;
+
+export class ClockLivelockError extends Error {
+  pending: string[];
+  constructor(message: string, pending: string[]) {
+    super(message);
+    this.name = 'ClockLivelockError';
+    this.pending = pending;
+  }
+}
+
 export class VirtualClock {
   private time = 0;
   private seq = 0;
@@ -137,9 +155,28 @@ export class VirtualClock {
 
   /** 把时钟推到某个绝对时刻 */
   advanceTo(target: number): void {
+    let batchesAtSameInstant = 0;
+    let lastInstant = this.time;
+
     while (true) {
       const next = this.peekNextTime();
       if (next === null || next > target) break;
+
+      // 时间没往前走 = 有人在原地不停重排自己
+      if (next === lastInstant) {
+        batchesAtSameInstant += 1;
+        if (batchesAtSameInstant > MAX_BATCHES_AT_SAME_INSTANT) {
+          throw new ClockLivelockError(
+            `虚拟时间卡在 ${this.time}ms 不动：连续 ${MAX_BATCHES_AT_SAME_INSTANT} 批定时器都排在同一刻，` +
+              `多半是某个回调在不停地排 0 延迟定时器。`,
+            this.describePending()
+          );
+        }
+      } else {
+        batchesAtSameInstant = 0;
+        lastInstant = next;
+      }
+
       this.fireUpTo(next);
     }
     if (target > this.time) this.time = target;
@@ -160,8 +197,10 @@ export class VirtualClock {
       .sort((a, b) => (a.priority - b.priority) || (a.seq - b.seq));
 
     for (const timer of due) {
-      const index = this.timers.indexOf(timer);
-      if (index < 0) continue;                    // 被同批里更早的回调清掉了
+      // 可能已经被同批里更早的回调清掉了。用 id 判断而不是 indexOf，
+      // 否则这里是 O(批量 × 挂着的定时器数)。
+      const index = this.timers.findIndex((t) => t.id === timer.id);
+      if (index < 0) continue;
       if (timer.intervalMs && timer.intervalMs > 0) {
         timer.time = this.time + timer.intervalMs;
         timer.seq = this.seq++;

--- a/src/lib/opslab/kernel/index.ts
+++ b/src/lib/opslab/kernel/index.ts
@@ -1,0 +1,11 @@
+/**
+ * opslab 确定性内核
+ *
+ * 世界里所有会「过时间」的东西都挂在这上面。详见 kernel.ts 的说明，
+ * 以及 design/opslab.md 里 L0 那一层。
+ */
+export { Kernel, createKernel, DeadlockError, BudgetExceededError, Priority } from './kernel';
+export type { KernelOptions, KernelSnapshot, SettleOptions, PriorityValue, ScheduleOptions } from './kernel';
+export { VirtualClock } from './clock';
+export { createRandom } from './random';
+export type { DeterministicRandom } from './random';

--- a/src/lib/opslab/kernel/index.ts
+++ b/src/lib/opslab/kernel/index.ts
@@ -6,6 +6,6 @@
  */
 export { Kernel, createKernel, DeadlockError, BudgetExceededError, Priority } from './kernel';
 export type { KernelOptions, KernelSnapshot, SettleOptions, PriorityValue, ScheduleOptions } from './kernel';
-export { VirtualClock } from './clock';
+export { VirtualClock, ClockLivelockError } from './clock';
 export { createRandom } from './random';
 export type { DeterministicRandom } from './random';

--- a/src/lib/opslab/kernel/kernel.ts
+++ b/src/lib/opslab/kernel/kernel.ts
@@ -1,0 +1,285 @@
+/**
+ * 确定性内核
+ *
+ * 模拟世界里所有会「过时间」的东西都挂在这上面：控制器、kubelet、容器进程、
+ * 协议超时、学员敲的命令。内核保证两件事：
+ *
+ *  1. **时间只由它推进** —— 没有真实定时器，快进一分钟是一次同步计算；
+ *  2. **同样的输入必然得到同样的输出** —— 判定、反向验证、进度恢复全靠这一条。
+ *
+ * 这不是我们发明的技法，是分布式领域的 deterministic simulation testing
+ * （FoundationDB 起头，TigerBeetle / Antithesis 在用）。
+ *
+ * ## 关于快照
+ *
+ * 内核快照只有标量（时间、随机数状态、计数器），**挂着的定时器不在里面** ——
+ * JS 没法序列化一个闭包。所以规则是：**只能在世界静下来的时刻做快照**
+ * （settle 之后、没有前台定时器）。恢复时新建内核、把世界状态灌回去、
+ * 重新启动控制器；控制器是 level-triggered 的，从状态重新收敛即可，
+ * 这正是真 Kubernetes 控制器的工作方式。
+ */
+import { createRandom, DeterministicRandom } from './random';
+import { Priority, PriorityValue, ScheduleOptions, VirtualClock } from './clock';
+
+/**
+ * 抓住真实 setTimeout。
+ *
+ * 模块加载时就取，一来避免被沙箱里注入的同名函数换掉，
+ * 二来 settle 的热循环里每轮都 bind 一次纯属浪费。
+ */
+const realSetTimeout: typeof setTimeout =
+  typeof setTimeout === 'function' ? setTimeout.bind(null) : ((fn: any) => fn()) as any;
+
+/** 让出一个宏任务，等当前所有微任务链排空 */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => realSetTimeout(resolve, 0));
+}
+
+export class DeadlockError extends Error {
+  pending: string[];
+  constructor(message: string, pending: string[]) {
+    super(message);
+    this.name = 'DeadlockError';
+    this.pending = pending;
+  }
+}
+
+export class BudgetExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BudgetExceededError';
+  }
+}
+
+export interface KernelOptions {
+  seed?: number;
+  /** 虚拟时间上限，超过说明世界逻辑上跑不完 */
+  maxVirtualMs?: number;
+  /** 真实墙钟上限，防住失控循环 */
+  maxWallClockMs?: number;
+}
+
+export interface SettleOptions {
+  /** 最多推进多少虚拟时间；超了抛 BudgetExceededError */
+  maxVirtualMs?: number;
+  /** 连续多少轮「没有定时器可推进但还有任务没结束」判为死锁 */
+  maxIdleDrains?: number;
+}
+
+export interface KernelSnapshot {
+  clock: ReturnType<VirtualClock['snapshot']>;
+  random: number;
+  taskSeq: number;
+}
+
+interface TaskRecord {
+  id: number;
+  name: string;
+  done: boolean;
+  error?: unknown;
+}
+
+export class Kernel {
+  readonly clock = new VirtualClock();
+  readonly random: DeterministicRandom;
+
+  private readonly maxVirtualMs: number;
+  private readonly maxWallClockMs: number;
+  private tasks = new Map<number, TaskRecord>();
+  private taskSeq = 0;
+  private disposed = false;
+
+  constructor(options: KernelOptions = {}) {
+    this.random = createRandom(options.seed ?? 1);
+    this.maxVirtualMs = options.maxVirtualMs ?? 24 * 60 * 60 * 1000;   // 一天虚拟时间
+    this.maxWallClockMs = options.maxWallClockMs ?? 30_000;
+  }
+
+  now(): number {
+    return this.clock.now();
+  }
+
+  /** 当前活着（还没结束）的任务数 */
+  get liveTasks(): number {
+    let n = 0;
+    for (const task of this.tasks.values()) if (!task.done) n += 1;
+    return n;
+  }
+
+  sleep(ms: number, options?: ScheduleOptions): Promise<void> {
+    return this.clock.sleep(ms, options);
+  }
+
+  setTimeout(fn: () => void, ms: number, options?: ScheduleOptions): number {
+    return this.clock.schedule(fn, ms, options);
+  }
+
+  setInterval(fn: () => void, ms: number, options: ScheduleOptions = {}): number {
+    return this.clock.schedule(fn, ms, { ...options, intervalMs: ms });
+  }
+
+  clearTimer(id: number): void {
+    this.clock.clear(id);
+  }
+
+  /**
+   * 起一个长期存在的实体（控制器、kubelet、容器进程…）。
+   *
+   * 任务自己 await 内核的时间原语；内核只负责推进时间和定序，
+   * 不打断任务 —— JS 单线程本身就是确定的，不确定性来自真实时间与真实 I/O，
+   * 而这两样在这里都不存在。
+   */
+  spawn(name: string, fn: () => Promise<void> | void): number {
+    if (this.disposed) throw new Error('kernel disposed');
+    const id = ++this.taskSeq;
+    const record: TaskRecord = { id, name, done: false };
+    this.tasks.set(id, record);
+    Promise.resolve()
+      .then(fn)
+      .then(
+        () => { record.done = true; },
+        (error) => { record.done = true; record.error = error; }
+      );
+    return id;
+  }
+
+  /**
+   * 有任务抛异常了吗；有就把第一个抛出来。
+   *
+   * 顺手把已经结束的任务从表里摘掉：一场长会话里每条命令都可能派生探测任务，
+   * 不清理的话这张表只增不减。
+   */
+  private throwTaskFailure(): void {
+    let failure: { name: string; error: unknown } | null = null;
+    for (const task of this.tasks.values()) {
+      if (task.error !== undefined && !failure) {
+        failure = { name: task.name, error: task.error };
+        task.error = undefined;
+      }
+      if (task.done && task.error === undefined) this.tasks.delete(task.id);
+    }
+    if (!failure) return;
+    throw failure.error instanceof Error
+      ? failure.error
+      : new Error(`task "${failure.name}" failed: ${String(failure.error)}`);
+  }
+
+  /**
+   * 把世界推进到「静下来」为止。
+   *
+   * 静下来 = 没有前台定时器可推进，且没有任务还在跑。控制器的定期重扫这类
+   * 后台定时器不算数，否则永远静不下来。
+   */
+  async settle(options: SettleOptions = {}): Promise<void> {
+    const maxVirtual = options.maxVirtualMs ?? this.maxVirtualMs;
+    const maxIdleDrains = options.maxIdleDrains ?? 50;
+    const startedVirtual = this.clock.now();
+    const startedWall = Date.now();
+    let idleDrains = 0;
+
+    while (true) {
+      await flushMicrotasks();
+
+      const timerFailure = this.clock.takeFailure();
+      if (timerFailure) throw timerFailure.error;
+      this.throwTaskFailure();
+
+      if (this.clock.pendingForeground > 0) {
+        this.clock.advanceToNext({ includeBackground: false });
+        idleDrains = 0;
+      } else if (this.liveTasks > 0) {
+        // 没有前台定时器，但还有任务在跑 —— 也许它在等一个微任务链，
+        // 也许它在等一个永远不会来的东西。多排空几轮再判死锁。
+        idleDrains += 1;
+        if (idleDrains > maxIdleDrains) {
+          const names = [...this.tasks.values()].filter((t) => !t.done).map((t) => t.name);
+          throw new DeadlockError(
+            `世界静不下来：没有待触发的定时器，但仍有 ${names.length} 个任务没有结束。` +
+              `多半是某个 promise 永远不会 resolve。`,
+            [...names, ...this.clock.describePending()]
+          );
+        }
+      } else {
+        return;                                   // 静了
+      }
+
+      if (this.clock.now() - startedVirtual > maxVirtual) {
+        throw new BudgetExceededError(
+          `虚拟时间超过 ${maxVirtual}ms —— 这个世界收敛不了。挂着的：${this.clock.describePending().join(', ')}`
+        );
+      }
+      if (Date.now() - startedWall > this.maxWallClockMs) {
+        throw new BudgetExceededError(
+          `真实耗时超过 ${this.maxWallClockMs}ms —— 疑似失控循环。`
+        );
+      }
+    }
+  }
+
+  /**
+   * 快进一段虚拟时间，沿途所有定时器（含后台）都会触发。
+   *
+   * 「等 30 秒看滚动更新走到哪」「让证书过期」用这个。推进完再 settle 一次，
+   * 让被唤醒的那些实体把手上的活干完。
+   */
+  async advanceBy(ms: number, options: SettleOptions = {}): Promise<void> {
+    const target = this.clock.now() + Math.max(0, Math.floor(ms));
+    while (this.clock.now() < target) {
+      const next = this.clock.peekNextTime();
+      if (next === null || next > target) break;
+      this.clock.advanceTo(next);
+      await flushMicrotasks();
+      const timerFailure = this.clock.takeFailure();
+      if (timerFailure) throw timerFailure.error;
+      this.throwTaskFailure();
+    }
+    this.clock.advanceTo(target);
+    await this.settle(options);
+  }
+
+  /**
+   * 快照。
+   *
+   * 只能在静下来的时刻取 —— 挂着的定时器不在快照里（闭包没法序列化），
+   * 在有前台定时器时取快照，恢复出来的世界会缺掉那些待办。
+   */
+  snapshot(): KernelSnapshot {
+    if (this.clock.pendingForeground > 0) {
+      throw new Error(
+        `只能在世界静下来时快照，现在还有 ${this.clock.pendingForeground} 个前台定时器：` +
+          this.clock.describePending().join(', ')
+      );
+    }
+    return {
+      clock: this.clock.snapshot(),
+      random: this.random.state(),
+      taskSeq: this.taskSeq,
+    };
+  }
+
+  /**
+   * 从快照恢复。
+   *
+   * 只恢复内核自己的标量。世界状态由调用方灌回去，控制器由调用方重新 spawn ——
+   * 它们是 level-triggered 的，从状态重新收敛就行。
+   */
+  restore(snapshot: KernelSnapshot): void {
+    this.clock.restore(snapshot.clock);
+    this.random.restore(snapshot.random);
+    this.taskSeq = snapshot.taskSeq;
+    this.tasks = new Map();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.tasks = new Map();
+    this.clock.clearAll();
+  }
+}
+
+export function createKernel(options?: KernelOptions): Kernel {
+  return new Kernel(options);
+}
+
+export { Priority };
+export type { PriorityValue, ScheduleOptions };

--- a/src/lib/opslab/kernel/random.ts
+++ b/src/lib/opslab/kernel/random.ts
@@ -1,0 +1,63 @@
+/**
+ * 确定性随机数
+ *
+ * 模拟世界里任何「随机」都必须可复现：Pod 名字的后缀、调度器打平时的抖动、
+ * 注入故障的时机。用种子化的 PRNG，并且把内部状态暴露出来 ——
+ * 快照要连同随机数状态一起存，否则恢复之后的世界会走上另一条分支。
+ */
+
+export interface DeterministicRandom {
+  /** [0, 1) */
+  next(): number;
+  /** [0, maxExclusive) 的整数 */
+  int(maxExclusive: number): number;
+  /** 从数组里挑一个；空数组返回 undefined */
+  pick<T>(items: readonly T[]): T | undefined;
+  /** 生成一个 k8s 风格的小写字母数字后缀，例如 `7f4x2` */
+  suffix(length?: number): string;
+  /** 当前内部状态，用于快照 */
+  state(): number;
+  /** 从快照恢复 */
+  restore(state: number): void;
+}
+
+const SUFFIX_ALPHABET = 'bcdfghjklmnpqrstvwxz2456789';
+
+/**
+ * mulberry32。选它是因为状态只有一个 32 位整数 ——
+ * 快照里存一个数字就够，不用序列化一整个生成器。
+ */
+export function createRandom(seed: number): DeterministicRandom {
+  let state = seed >>> 0 || 1;
+
+  const next = (): number => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), 1 | t);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  return {
+    next,
+    int(maxExclusive: number): number {
+      if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) return 0;
+      return Math.floor(next() * maxExclusive);
+    },
+    pick<T>(items: readonly T[]): T | undefined {
+      if (items.length === 0) return undefined;
+      return items[Math.floor(next() * items.length)];
+    },
+    suffix(length = 5): string {
+      let out = '';
+      for (let i = 0; i < length; i += 1) {
+        out += SUFFIX_ALPHABET[Math.floor(next() * SUFFIX_ALPHABET.length)];
+      }
+      return out;
+    },
+    state: () => state,
+    restore(value: number) {
+      state = value >>> 0 || 1;
+    },
+  };
+}

--- a/tests/opslab/kernel.test.ts
+++ b/tests/opslab/kernel.test.ts
@@ -6,6 +6,7 @@
  */
 import {
   BudgetExceededError,
+  ClockLivelockError,
   createKernel,
   createRandom,
   DeadlockError,
@@ -139,6 +140,15 @@ describe('异常与预算', () => {
     });
     await expect(kernel.settle()).rejects.toThrow('boom from task');
   });
+
+  it('在原地不停重排 0 延迟定时器的回调会被判活锁，而不是把线程转死', async () => {
+    // 这一条来自自审：虚拟时间与真实时间的预算都在 settle 里，而 advanceTo 是同步的，
+    // 没有这道闸的话下面这段会把整个进程转死，一声不吭。
+    const kernel = createKernel();
+    const tick = () => { kernel.setTimeout(tick, 0); };
+    kernel.setTimeout(tick, 0);
+    await expect(kernel.advanceBy(10)).rejects.toThrow(ClockLivelockError);
+  }, 20_000);
 
   it('收敛不了的世界撞上虚拟时间预算', async () => {
     const kernel = createKernel();

--- a/tests/opslab/kernel.test.ts
+++ b/tests/opslab/kernel.test.ts
@@ -1,0 +1,275 @@
+/**
+ * opslab 确定性内核的回归测试
+ *
+ * 重点是最后那组：几十个并发实体跑在同一个虚拟时钟上，同样的输入必须得到
+ * 逐字节相同的结果。这一条不成立的话，判定、反向验证、进度恢复全都不成立。
+ */
+import {
+  BudgetExceededError,
+  createKernel,
+  createRandom,
+  DeadlockError,
+  Kernel,
+  Priority,
+} from '../../src/lib/opslab/kernel';
+
+describe('确定性随机数', () => {
+  it('同一个种子给出同一串数', () => {
+    const a = createRandom(42);
+    const b = createRandom(42);
+    const left = Array.from({ length: 20 }, () => a.next());
+    const right = Array.from({ length: 20 }, () => b.next());
+    expect(left).toEqual(right);
+  });
+
+  it('不同种子给出不同的串', () => {
+    const a = Array.from({ length: 10 }, createRandom(1).next);
+    const b = Array.from({ length: 10 }, createRandom(2).next);
+    expect(a).not.toEqual(b);
+  });
+
+  it('状态可以存下来再恢复', () => {
+    const rng = createRandom(7);
+    rng.next();
+    rng.next();
+    const saved = rng.state();
+    const expected = [rng.next(), rng.next(), rng.next()];
+
+    rng.restore(saved);
+    expect([rng.next(), rng.next(), rng.next()]).toEqual(expected);
+  });
+
+  it('suffix 产出 k8s 风格的后缀', () => {
+    const rng = createRandom(3);
+    const suffix = rng.suffix(5);
+    expect(suffix).toHaveLength(5);
+    expect(suffix).toMatch(/^[a-z0-9]+$/);
+  });
+});
+
+describe('虚拟时钟', () => {
+  it('同一时刻按优先级再按注册顺序触发', async () => {
+    const kernel = createKernel();
+    const order: string[] = [];
+
+    // 故意反着注册：如果定序只看数组顺序，这个用例就会挂
+    kernel.setTimeout(() => order.push('user-1'), 100, { priority: Priority.USER });
+    kernel.setTimeout(() => order.push('controller-1'), 100, { priority: Priority.CONTROLLER });
+    kernel.setTimeout(() => order.push('dispatch-1'), 100, { priority: Priority.DISPATCH });
+    kernel.setTimeout(() => order.push('controller-2'), 100, { priority: Priority.CONTROLLER });
+    kernel.setTimeout(() => order.push('node-1'), 100, { priority: Priority.NODE });
+
+    await kernel.settle();
+    expect(order).toEqual(['dispatch-1', 'node-1', 'controller-1', 'controller-2', 'user-1']);
+  });
+
+  it('时间按定时器推进，不消耗真实时间', async () => {
+    const kernel = createKernel();
+    const wallStart = Date.now();
+    kernel.spawn('sleeper', async () => {
+      await kernel.sleep(60_000);
+      await kernel.sleep(60_000);
+    });
+    await kernel.settle();
+    expect(kernel.now()).toBe(120_000);
+    // 两分钟虚拟时间，真实世界里应当是一瞬
+    expect(Date.now() - wallStart).toBeLessThan(2000);
+  });
+
+  it('后台定时器不会让世界永远静不下来', async () => {
+    const kernel = createKernel();
+    let resyncs = 0;
+    // 控制器的定期重扫：永远有下一次
+    kernel.setInterval(() => { resyncs += 1; }, 30_000, {
+      background: true,
+      label: 'controller-resync',
+    });
+
+    let done = false;
+    kernel.spawn('work', async () => {
+      await kernel.sleep(500);
+      done = true;
+    });
+
+    await kernel.settle();
+    expect(done).toBe(true);
+    expect(kernel.now()).toBe(500);
+    // settle 不该去触发后台定时器
+    expect(resyncs).toBe(0);
+  });
+
+  it('快进会触发后台定时器', async () => {
+    const kernel = createKernel();
+    let resyncs = 0;
+    kernel.setInterval(() => { resyncs += 1; }, 30_000, { background: true });
+
+    await kernel.advanceBy(95_000);
+    expect(resyncs).toBe(3);
+    expect(kernel.now()).toBe(95_000);
+  });
+
+  it('清掉的定时器不会再触发', async () => {
+    const kernel = createKernel();
+    let fired = 0;
+    const id = kernel.setTimeout(() => { fired += 1; }, 100);
+    kernel.clearTimer(id);
+    await kernel.advanceBy(1000);
+    expect(fired).toBe(0);
+  });
+});
+
+describe('异常与预算', () => {
+  it('永不 resolve 的 promise 报成死锁而不是挂死', async () => {
+    const kernel = createKernel();
+    kernel.spawn('stuck', () => new Promise<void>(() => { /* 永远不 resolve */ }));
+    await expect(kernel.settle()).rejects.toThrow(DeadlockError);
+  });
+
+  it('定时器回调里的异常成为一次失败，不是全局未捕获', async () => {
+    const kernel = createKernel();
+    kernel.setTimeout(() => { throw new Error('boom from timer'); }, 10);
+    await expect(kernel.settle()).rejects.toThrow('boom from timer');
+  });
+
+  it('任务里的异常会被抛出来', async () => {
+    const kernel = createKernel();
+    kernel.spawn('bad', async () => {
+      await kernel.sleep(10);
+      throw new Error('boom from task');
+    });
+    await expect(kernel.settle()).rejects.toThrow('boom from task');
+  });
+
+  it('收敛不了的世界撞上虚拟时间预算', async () => {
+    const kernel = createKernel();
+    kernel.spawn('forever', async () => {
+      // 前台定时器上的无限循环：永远有下一步，永远静不下来
+      for (;;) await kernel.sleep(1000);
+    });
+    await expect(kernel.settle({ maxVirtualMs: 60_000 })).rejects.toThrow(BudgetExceededError);
+  });
+});
+
+describe('快照', () => {
+  it('静下来之后可以快照，并且能恢复随机数与时间', async () => {
+    const kernel = createKernel({ seed: 99 });
+    kernel.spawn('work', async () => { await kernel.sleep(1234); });
+    await kernel.settle();
+    kernel.random.next();
+
+    const snapshot = kernel.snapshot();
+    const expected = [kernel.random.next(), kernel.random.next()];
+
+    const restored = createKernel({ seed: 1 });
+    restored.restore(snapshot);
+    expect(restored.now()).toBe(1234);
+    expect([restored.random.next(), restored.random.next()]).toEqual(expected);
+  });
+
+  it('还有前台定时器时拒绝快照', async () => {
+    const kernel = createKernel();
+    kernel.setTimeout(() => {}, 500, { label: 'pending-work' });
+    expect(() => kernel.snapshot()).toThrow(/静下来/);
+  });
+
+  it('只有后台定时器时允许快照', async () => {
+    const kernel = createKernel();
+    kernel.setInterval(() => {}, 30_000, { background: true });
+    expect(() => kernel.snapshot()).not.toThrow();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 这一组是重点：几十个并发实体，同样的输入必须给出同样的结果            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 一个够乱的世界。
+ *
+ * 40 个实体分三类，互相通过共享状态影响对方，各自按种子随机的间隔醒来，
+ * 还会中途派生新任务 —— 尽量把「顺序可能飘」的因素都塞进去。
+ */
+async function runChaosWorld(seed: number): Promise<string> {
+  const kernel = new Kernel({ seed, maxVirtualMs: 10 * 60 * 1000 });
+  const log: string[] = [];
+  const store = new Map<string, number>();
+  const record = (what: string) => log.push(`${kernel.now()}ms ${what}`);
+
+  // 一类：写状态的「控制器」
+  for (let i = 0; i < 15; i += 1) {
+    const name = `ctrl-${i}`;
+    kernel.spawn(name, async () => {
+      for (let round = 0; round < 4; round += 1) {
+        await kernel.sleep(50 + kernel.random.int(200), { priority: Priority.CONTROLLER });
+        const key = `obj-${kernel.random.int(6)}`;
+        const value = (store.get(key) ?? 0) + 1;
+        store.set(key, value);
+        record(`${name} set ${key}=${value}`);
+      }
+    });
+  }
+
+  // 二类：读状态的「kubelet」，并且会派生一次性的子任务
+  for (let i = 0; i < 15; i += 1) {
+    const name = `node-${i}`;
+    kernel.spawn(name, async () => {
+      for (let round = 0; round < 3; round += 1) {
+        await kernel.sleep(30 + kernel.random.int(150), { priority: Priority.NODE });
+        const key = `obj-${kernel.random.int(6)}`;
+        record(`${name} saw ${key}=${store.get(key) ?? 0}`);
+        if (round === 1) {
+          kernel.spawn(`${name}-probe`, async () => {
+            await kernel.sleep(10 + kernel.random.int(40), { priority: Priority.NETWORK });
+            record(`${name}-probe done`);
+          });
+        }
+      }
+    });
+  }
+
+  // 三类：后台重扫，不该影响 settle
+  for (let i = 0; i < 10; i += 1) {
+    kernel.setInterval(() => record(`resync-${i}`), 30_000, { background: true, label: `resync-${i}` });
+  }
+
+  await kernel.settle();
+  // 再快进一分钟，把后台的也放出来跑
+  await kernel.advanceBy(60_000);
+
+  return log.join('\n');
+}
+
+describe('并发确定性', () => {
+  it('40 个并发实体，同一种子重放 50 次结果逐字节一致', async () => {
+    const first = await runChaosWorld(1234);
+    // 这个世界得真的复杂，否则测了个寂寞
+    expect(first.split('\n').length).toBeGreaterThan(100);
+
+    for (let run = 0; run < 49; run += 1) {
+      const again = await runChaosWorld(1234);
+      if (again !== first) {
+        const a = first.split('\n');
+        const b = again.split('\n');
+        const at = a.findIndex((line, index) => line !== b[index]);
+        throw new Error(`第 ${run + 2} 次重放在第 ${at + 1} 行分叉：\n  期望 ${a[at]}\n  实际 ${b[at]}`);
+      }
+      expect(again).toBe(first);
+    }
+  }, 60_000);
+
+  it('换个种子会得到不同的世界（否则说明随机数根本没参与）', async () => {
+    const a = await runChaosWorld(1234);
+    const b = await runChaosWorld(5678);
+    expect(a).not.toBe(b);
+  }, 30_000);
+
+  it('后台重扫在 settle 阶段不出现，快进之后才出现', async () => {
+    const transcript = await runChaosWorld(1234);
+    const lines = transcript.split('\n');
+    const firstResync = lines.findIndex((l) => l.includes('resync-'));
+    const lastWork = lines.map((l) => !l.includes('resync-')).lastIndexOf(true);
+    expect(firstResync).toBeGreaterThan(-1);
+    // 所有真活儿都排在第一次后台重扫之前
+    expect(lastWork).toBeLessThan(firstResync);
+  }, 30_000);
+});


### PR DESCRIPTION
第三段第 1 片。这是 L0 —— 后面的 apiserver、控制器、kubelet、容器进程、协议超时全挂在它上面。
设计见 `design/opslab.md`。

## 它保证什么

1. **时间只由内核推进** —— 没有真实定时器。快进一分钟是一次同步计算，不消耗真实时间。
2. **同样的输入必然得到同样的输出** —— 判定、反向验证、进度恢复都依赖这一条。

## 几个设计点

**同刻定序**按 `(时间, 优先级, 注册序号)` 唯一确定，绝不依赖数组顺序或 Map 迭代。
优先级分五档（DISPATCH / NODE / CONTROLLER / NETWORK / USER），好让「apiserver 先把变更
分发出去，控制器才看得到」这类因果顺序稳定成立。

**后台定时器单独标记。** 控制器的定期重扫这类「永远有下一次」的东西如果算进「世界还有事情
要做吗」，`settle()` 就永远返回不了。它们不参与静止判定，但 `advanceBy()` 快进时照常触发。

**快照只存标量**（时间、随机数状态、计数器），挂着的定时器不在里面 —— JS 没法序列化闭包。
所以规定：**只能在世界静下来的时刻快照**（`snapshot()` 会在有前台定时器时直接抛）。
恢复时重新 spawn 控制器，让它们从状态重新收敛 —— 这正好是真 k8s 控制器 level-triggered
的工作方式，不是将就出来的妥协。

**失败要看得见**：永不 resolve 的 promise 报成 `DeadlockError` 并列出还挂着谁；收敛不了的
世界撞虚拟时间预算；定时器回调里的异常成为一次失败，而不是没人接的全局未捕获。

## 验证

19 条测试，重点是最后一组并发确定性：

```
✓ 40 个并发实体，同一种子重放 50 次结果逐字节一致 (6420 ms)
✓ 换个种子会得到不同的世界（否则说明随机数根本没参与）
✓ 后台重扫在 settle 阶段不出现，快进之后才出现
```

那个世界够乱：15 个控制器按种子随机的间隔醒来写共享状态，15 个 kubelet 读状态并在中途
派生一次性子任务，10 个后台重扫，transcript 超过 100 行。**另外离线跑过 500 次重放，
同样只有一个哈希**（63 秒，太慢没进 CI，套件里留 50 次这一版做门禁）。

其余覆盖：同刻优先级定序、虚拟时间不消耗真实时间、后台定时器语义、清除定时器、
死锁检测、定时器与任务异常、虚拟时间预算、快照的静止前提与随机数恢复。

- `npm test` **8/8 套件全绿**（含新增的 Opslab Deterministic Kernel）
- `npm run build` 通过、`npm run projects:verify` 全通过、`tsc --noEmit` 干净
- 不碰任何既有代码路径

## 一处顺带修的

`scripts/test-runner.js` 里的套件是一份**显式清单**，不加进去 `npm test` 会静默跳过
新套件。已加上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)