### PR TITLE
feat(opslab): etcd 语义的键值存储

### DIFF
--- a/src/lib/opslab/store/index.ts
+++ b/src/lib/opslab/store/index.ts
@@ -1,0 +1,18 @@
+/**
+ * etcd 语义的键值存储 —— apiserver 的地基。
+ * 详见 store.ts 的说明，以及 design/opslab.md 里 L2 那一层。
+ */
+export { Store, createStore, CompactedError, FutureRevisionError } from './store';
+export type {
+  Compare,
+  EventType,
+  KeyValue,
+  RangeOptions,
+  RangeResult,
+  StoreSnapshot,
+  TxnOp,
+  TxnResult,
+  WatchEvent,
+  Watcher,
+  WatchOptions,
+} from './store';

--- a/src/lib/opslab/store/store.ts
+++ b/src/lib/opslab/store/store.ts
@@ -1,0 +1,468 @@
+/**
+ * etcd 语义的键值存储
+ *
+ * apiserver 的每一条对外行为都建立在 etcd 的这几条语义上，所以这一层要先做对：
+ *
+ *  - **单调 revision**：每次写让全局 revision +1，对象记下自己是在哪一版被改的。
+ *    apiserver 的 `resourceVersion` 就是它，乐观并发（409 Conflict）也靠它。
+ *  - **watch from revision**：从某一版开始订阅，先补齐这之后发生过的事件再接着推。
+ *    「informer 先 list 再 watch，中间不能漏事件」全靠这个。
+ *  - **CAS 事务**：比较再写，是 apiserver 实现「改的是我读到的那一版」的底座。
+ *  - **compaction**：历史不能无限留。压缩之后从太老的 revision 起 watch 要明确报错
+ *    （对应 k8s 的 `too old resource version`），而不是悄悄少给几个事件。
+ *
+ * 键的形状照抄 k8s：`/registry/<resource>/<namespace>/<name>`。
+ */
+
+export type EventType = 'PUT' | 'DELETE';
+
+export interface KeyValue {
+  key: string;
+  /** 存的是解析好的对象，不是字节 —— 我们不需要真的编解码 */
+  value: unknown;
+  /** 这个键被创建时的 revision */
+  createRevision: number;
+  /** 这个键最后一次被修改时的 revision */
+  modRevision: number;
+  /** 从创建以来被改过多少次，第一次写是 1 */
+  version: number;
+}
+
+export interface WatchEvent {
+  type: EventType;
+  kv: KeyValue;
+  /** DELETE 时带上被删掉之前的那一版，控制器要靠它知道删的是什么 */
+  prevKv?: KeyValue;
+}
+
+export interface RangeOptions {
+  /** 前缀匹配；不传就是精确取一个键 */
+  prefix?: boolean;
+  /** 从这个键之后开始（分页用），不含它本身 */
+  startAfter?: string;
+  limit?: number;
+  /** 读某个历史版本；不传读最新 */
+  revision?: number;
+}
+
+export interface RangeResult {
+  kvs: KeyValue[];
+  /** 这次读对应的 revision，informer 拿它作为 watch 的起点 */
+  revision: number;
+  /** 还有更多没返回（被 limit 截断了） */
+  more: boolean;
+  /** 满足条件的总数 */
+  count: number;
+}
+
+/** 事务里的比较条件 */
+export type Compare =
+  | { key: string; target: 'MOD_REVISION'; op: '=' | '!=' | '<' | '>'; value: number }
+  | { key: string; target: 'CREATE_REVISION'; op: '=' | '!='; value: number }
+  | { key: string; target: 'VERSION'; op: '=' | '!='; value: number }
+  | { key: string; target: 'EXISTS'; value: boolean };
+
+export type TxnOp =
+  | { type: 'put'; key: string; value: unknown }
+  | { type: 'delete'; key: string }
+  | { type: 'get'; key: string; options?: RangeOptions };
+
+export interface TxnResult {
+  succeeded: boolean;
+  revision: number;
+  /** 与执行的那一支 ops 一一对应；put/delete 返回受影响的 kv，get 返回 RangeResult */
+  results: Array<KeyValue | RangeResult | null>;
+}
+
+export class CompactedError extends Error {
+  requiredRevision: number;
+  compactRevision: number;
+  constructor(requiredRevision: number, compactRevision: number) {
+    super(
+      `required revision ${requiredRevision} has been compacted, ` +
+        `the earliest available revision is ${compactRevision}`
+    );
+    this.name = 'CompactedError';
+    this.requiredRevision = requiredRevision;
+    this.compactRevision = compactRevision;
+  }
+}
+
+export class FutureRevisionError extends Error {
+  constructor(requested: number, current: number) {
+    super(`required revision ${requested} is greater than the current revision ${current}`);
+    this.name = 'FutureRevisionError';
+  }
+}
+
+export interface WatchOptions {
+  /** 从哪一版之后开始收事件；不传就是「只收将来的」 */
+  startRevision?: number;
+  prefix?: boolean;
+}
+
+export interface Watcher {
+  cancel(): void;
+}
+
+interface HistoryEntry {
+  revision: number;
+  events: WatchEvent[];
+}
+
+interface WatcherRecord {
+  id: number;
+  key: string;
+  prefix: boolean;
+  onEvent: (event: WatchEvent) => void;
+  cancelled: boolean;
+}
+
+export interface StoreSnapshot {
+  revision: number;
+  compactRevision: number;
+  kvs: KeyValue[];
+}
+
+/** 深拷贝。存进来和读出去都要拷，免得调用方手上的引用把库里的对象改了。 */
+function clone<T>(value: T): T {
+  return value === undefined ? value : (JSON.parse(JSON.stringify(value)) as T);
+}
+
+export class Store {
+  private data = new Map<string, KeyValue>();
+  private revisionCounter = 0;
+  private compactRevision = 0;
+  /** 事件历史，供 watch 补齐与历史读用。compaction 会砍掉前面的部分。 */
+  private history: HistoryEntry[] = [];
+  /**
+   * compactRevision 那一刻的完整状态。
+   *
+   * 历史读是「从某个已知状态往后重放事件」。压缩把前面的历史丢掉之后，
+   * 光靠剩下的事件重放不出完整世界 —— 压缩点之前创建、之后没再动过的对象会凭空消失。
+   * 所以压缩时把那一刻的状态物化下来当底座。恢复快照同理：底座就是快照本身。
+   */
+  private baseState = new Map<string, KeyValue>();
+  private watchers = new Map<number, WatcherRecord>();
+  private watcherSeq = 0;
+  /** 历史最多留多少个 revision，超了自动压缩 —— 一场长会话不能无限吃内存 */
+  private readonly maxHistory: number;
+
+  constructor(options: { maxHistory?: number } = {}) {
+    this.maxHistory = options.maxHistory ?? 5000;
+  }
+
+  get revision(): number {
+    return this.revisionCounter;
+  }
+
+  get compactedAt(): number {
+    return this.compactRevision;
+  }
+
+  /* ---------------- 读 ---------------- */
+
+  /**
+   * 读一个键或一段前缀。
+   *
+   * 结果按键名排序 —— 顺序稳定是确定性的前提，别依赖 Map 的插入序。
+   */
+  range(key: string, options: RangeOptions = {}): RangeResult {
+    if (options.revision !== undefined) {
+      return this.rangeAtRevision(key, options, options.revision);
+    }
+
+    let kvs = [...this.data.values()]
+      .filter((kv) => (options.prefix ? kv.key.startsWith(key) : kv.key === key))
+      .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+
+    if (options.startAfter) {
+      kvs = kvs.filter((kv) => kv.key > options.startAfter!);
+    }
+    const count = kvs.length;
+    let more = false;
+    if (options.limit !== undefined && options.limit > 0 && kvs.length > options.limit) {
+      kvs = kvs.slice(0, options.limit);
+      more = true;
+    }
+    return { kvs: kvs.map(clone), revision: this.revisionCounter, more, count };
+  }
+
+  /**
+   * 读某个历史版本。
+   *
+   * 从当前状态往回放历史事件复原 —— 数据量小，不值得为它维护多版本索引。
+   */
+  private rangeAtRevision(key: string, options: RangeOptions, revision: number): RangeResult {
+    this.assertRevisionAvailable(revision);
+
+    const state = this.materializeAt(revision);
+
+    let kvs = [...state.values()]
+      .filter((kv) => (options.prefix ? kv.key.startsWith(key) : kv.key === key))
+      .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+    if (options.startAfter) kvs = kvs.filter((kv) => kv.key > options.startAfter!);
+
+    const count = kvs.length;
+    let more = false;
+    if (options.limit !== undefined && options.limit > 0 && kvs.length > options.limit) {
+      kvs = kvs.slice(0, options.limit);
+      more = true;
+    }
+    return { kvs: kvs.map(clone), revision, more, count };
+  }
+
+  /** 从底座出发重放到 revision 为止，得到那一刻的完整状态 */
+  private materializeAt(revision: number): Map<string, KeyValue> {
+    const state = new Map(this.baseState);
+    for (const entry of this.history) {
+      if (entry.revision > revision) break;
+      for (const event of entry.events) {
+        if (event.type === 'PUT') state.set(event.kv.key, event.kv);
+        else state.delete(event.kv.key);
+      }
+    }
+    return state;
+  }
+
+  get(key: string): KeyValue | undefined {
+    const kv = this.data.get(key);
+    return kv ? clone(kv) : undefined;
+  }
+
+  /* ---------------- 写 ---------------- */
+
+  put(key: string, value: unknown): KeyValue {
+    const revision = ++this.revisionCounter;
+    const existing = this.data.get(key);
+    const kv: KeyValue = {
+      key,
+      value: clone(value),
+      createRevision: existing ? existing.createRevision : revision,
+      modRevision: revision,
+      version: existing ? existing.version + 1 : 1,
+    };
+    this.data.set(key, kv);
+    this.commit(revision, [{ type: 'PUT', kv: clone(kv), prevKv: existing ? clone(existing) : undefined }]);
+    return clone(kv);
+  }
+
+  delete(key: string): KeyValue | undefined {
+    const existing = this.data.get(key);
+    if (!existing) return undefined;
+    const revision = ++this.revisionCounter;
+    this.data.delete(key);
+    this.commit(revision, [{ type: 'DELETE', kv: { ...clone(existing), modRevision: revision }, prevKv: clone(existing) }]);
+    return clone(existing);
+  }
+
+  /** 删掉一整段前缀，返回删了几个。整段算一个 revision。 */
+  deletePrefix(prefix: string): number {
+    const victims = [...this.data.values()]
+      .filter((kv) => kv.key.startsWith(prefix))
+      .sort((a, b) => (a.key < b.key ? -1 : 1));
+    if (victims.length === 0) return 0;
+
+    const revision = ++this.revisionCounter;
+    const events: WatchEvent[] = [];
+    for (const kv of victims) {
+      this.data.delete(kv.key);
+      events.push({ type: 'DELETE', kv: { ...clone(kv), modRevision: revision }, prevKv: clone(kv) });
+    }
+    this.commit(revision, events);
+    return victims.length;
+  }
+
+  /**
+   * 事务：先比较，全部成立走 onSuccess，否则走 onFailure。
+   *
+   * apiserver 的乐观并发就架在这上面：读到 modRevision=N 的对象，
+   * 写回时要求它仍然是 N，不是就 409。
+   */
+  txn(compares: Compare[], onSuccess: TxnOp[], onFailure: TxnOp[] = []): TxnResult {
+    const succeeded = compares.every((compare) => this.evaluate(compare));
+    const ops = succeeded ? onSuccess : onFailure;
+
+    // 整个事务是一个 revision：一次 apply 里改了几样东西，watch 应当看到它们同时发生
+    const writes = ops.filter((op) => op.type !== 'get');
+    const revision = writes.length > 0 ? ++this.revisionCounter : this.revisionCounter;
+    const events: WatchEvent[] = [];
+    const results: Array<KeyValue | RangeResult | null> = [];
+
+    for (const op of ops) {
+      if (op.type === 'get') {
+        results.push(this.range(op.key, op.options));
+        continue;
+      }
+      if (op.type === 'put') {
+        const existing = this.data.get(op.key);
+        const kv: KeyValue = {
+          key: op.key,
+          value: clone(op.value),
+          createRevision: existing ? existing.createRevision : revision,
+          modRevision: revision,
+          version: existing ? existing.version + 1 : 1,
+        };
+        this.data.set(op.key, kv);
+        events.push({ type: 'PUT', kv: clone(kv), prevKv: existing ? clone(existing) : undefined });
+        results.push(clone(kv));
+        continue;
+      }
+      const existing = this.data.get(op.key);
+      if (!existing) { results.push(null); continue; }
+      this.data.delete(op.key);
+      events.push({ type: 'DELETE', kv: { ...clone(existing), modRevision: revision }, prevKv: clone(existing) });
+      results.push(clone(existing));
+    }
+
+    if (events.length > 0) this.commit(revision, events);
+    return { succeeded, revision, results };
+  }
+
+  private evaluate(compare: Compare): boolean {
+    const kv = this.data.get(compare.key);
+    if (compare.target === 'EXISTS') return (kv !== undefined) === compare.value;
+    if (!kv) return false;
+    const actual =
+      compare.target === 'MOD_REVISION' ? kv.modRevision
+      : compare.target === 'CREATE_REVISION' ? kv.createRevision
+      : kv.version;
+    switch (compare.op) {
+      case '=': return actual === compare.value;
+      case '!=': return actual !== compare.value;
+      case '<': return actual < compare.value;
+      case '>': return actual > compare.value;
+      default: return false;
+    }
+  }
+
+  /* ---------------- watch ---------------- */
+
+  /**
+   * 订阅变更。
+   *
+   * 传了 startRevision 就先把这之后已经发生过的事件补齐再接着推 ——
+   * informer「先 list 拿到 revision，再从那一版 watch」这条路径不能漏事件，
+   * 否则控制器会基于过时的世界做决定。
+   */
+  watch(key: string, options: WatchOptions = {}, onEvent: (event: WatchEvent) => void): Watcher {
+    const id = ++this.watcherSeq;
+    const record: WatcherRecord = {
+      id,
+      key,
+      prefix: options.prefix === true,
+      onEvent,
+      cancelled: false,
+    };
+
+    if (options.startRevision !== undefined) {
+      this.assertRevisionAvailable(options.startRevision);
+      for (const entry of this.history) {
+        if (entry.revision <= options.startRevision) continue;
+        for (const event of entry.events) {
+          if (!this.matches(record, event.kv.key)) continue;
+          record.onEvent(clone(event));
+        }
+      }
+    }
+
+    this.watchers.set(id, record);
+    return {
+      cancel: () => {
+        record.cancelled = true;
+        this.watchers.delete(id);
+      },
+    };
+  }
+
+  private matches(record: WatcherRecord, key: string): boolean {
+    return record.prefix ? key.startsWith(record.key) : key === record.key;
+  }
+
+  /**
+   * 落一次变更：记历史、通知订阅者。
+   *
+   * 订阅者按注册顺序通知（Map 的插入序是稳定的），这是确定性的一部分。
+   * 通知期间新注册的订阅者不会收到这一批 —— 遍历的是快照，
+   * 否则「在回调里 watch」会拿到半截事件流。
+   */
+  private commit(revision: number, events: WatchEvent[]): void {
+    this.history.push({ revision, events: events.map(clone) });
+    this.trimHistory();
+
+    for (const record of [...this.watchers.values()]) {
+      if (record.cancelled) continue;
+      for (const event of events) {
+        if (!this.matches(record, event.kv.key)) continue;
+        record.onEvent(clone(event));
+      }
+    }
+  }
+
+  /* ---------------- compaction ---------------- */
+
+  /**
+   * 砍掉 revision 之前的历史。之后从更早的版本 watch 会明确报 CompactedError。
+   *
+   * 丢历史之前先把那一刻的状态物化成新底座，否则历史读会漏掉
+   * 「压缩点之前创建、之后没再动过」的对象。
+   */
+  compact(revision: number): void {
+    if (revision <= this.compactRevision) return;
+    const target = Math.min(revision, this.revisionCounter);
+    this.baseState = this.materializeAt(target);
+    this.compactRevision = target;
+    this.history = this.history.filter((entry) => entry.revision > this.compactRevision);
+  }
+
+  private trimHistory(): void {
+    if (this.history.length <= this.maxHistory) return;
+    const dropTo = this.history[this.history.length - this.maxHistory].revision - 1;
+    this.compact(dropTo);
+  }
+
+  private assertRevisionAvailable(revision: number): void {
+    if (revision > this.revisionCounter) {
+      throw new FutureRevisionError(revision, this.revisionCounter);
+    }
+    // 压缩点本身还能用作起点：它之后的事件都还在
+    if (revision < this.compactRevision) {
+      throw new CompactedError(revision, this.compactRevision);
+    }
+  }
+
+  /* ---------------- 快照 ---------------- */
+
+  /**
+   * 快照。
+   *
+   * 只存当前状态与 revision，**不存历史** —— 历史是给 watch 补事件用的，
+   * 恢复之后所有 informer 都要重新 list + watch，补不补得上旧事件没有意义。
+   * 恢复后 compactRevision 抬到当前 revision，从更早的版本 watch 会正确报错。
+   */
+  snapshot(): StoreSnapshot {
+    return {
+      revision: this.revisionCounter,
+      compactRevision: this.compactRevision,
+      kvs: [...this.data.values()]
+        .sort((a, b) => (a.key < b.key ? -1 : 1))
+        .map(clone),
+    };
+  }
+
+  restore(snapshot: StoreSnapshot): void {
+    this.data = new Map(snapshot.kvs.map((kv) => [kv.key, clone(kv)]));
+    this.revisionCounter = snapshot.revision;
+    // 快照里没有历史，所以恢复之后的压缩点就是快照那一版；
+    // 底座是快照本身，这样「读当前 revision」才能读到东西。
+    this.compactRevision = Math.max(snapshot.compactRevision, snapshot.revision);
+    this.baseState = new Map(snapshot.kvs.map((kv) => [kv.key, clone(kv)]));
+    this.history = [];
+    for (const record of this.watchers.values()) record.cancelled = true;
+    this.watchers = new Map();
+  }
+}
+
+export function createStore(options?: { maxHistory?: number }): Store {
+  return new Store(options);
+}

--- a/tests/opslab/store.test.ts
+++ b/tests/opslab/store.test.ts
@@ -1,0 +1,379 @@
+/**
+ * etcd 语义存储的回归测试
+ *
+ * 这一层的每条语义都会被 apiserver 直接拿去用：
+ * revision 就是 resourceVersion，CAS 就是乐观并发（409），
+ * watch-from-revision 就是 informer 的「先 list 再 watch 不漏事件」，
+ * compaction 就是 `too old resource version`。所以这里挨条钉死。
+ */
+import {
+  CompactedError,
+  createStore,
+  FutureRevisionError,
+  Store,
+  WatchEvent,
+} from '../../src/lib/opslab/store';
+
+const K = (name: string, ns = 'default') => `/registry/pods/${ns}/${name}`;
+
+describe('revision 语义', () => {
+  it('每次写让 revision 单调 +1', () => {
+    const store = createStore();
+    expect(store.revision).toBe(0);
+    store.put(K('a'), { x: 1 });
+    expect(store.revision).toBe(1);
+    store.put(K('b'), { x: 2 });
+    expect(store.revision).toBe(2);
+    store.put(K('a'), { x: 3 });
+    expect(store.revision).toBe(3);
+  });
+
+  it('createRevision 不变、modRevision 跟着改、version 累加', () => {
+    const store = createStore();
+    const first = store.put(K('a'), { x: 1 });
+    expect(first).toMatchObject({ createRevision: 1, modRevision: 1, version: 1 });
+
+    store.put(K('other'), {});
+    const second = store.put(K('a'), { x: 2 });
+    expect(second).toMatchObject({ createRevision: 1, modRevision: 3, version: 2 });
+  });
+
+  it('删掉再建，createRevision 重新算', () => {
+    const store = createStore();
+    store.put(K('a'), { x: 1 });
+    store.delete(K('a'));
+    const again = store.put(K('a'), { x: 2 });
+    expect(again).toMatchObject({ createRevision: 3, modRevision: 3, version: 1 });
+  });
+});
+
+describe('读', () => {
+  it('前缀读按键名排序，不看插入顺序', () => {
+    const store = createStore();
+    // 故意乱序写入
+    store.put(K('zeta'), {});
+    store.put(K('alpha'), {});
+    store.put(K('mid'), {});
+    const result = store.range('/registry/pods/', { prefix: true });
+    expect(result.kvs.map((kv) => kv.key)).toEqual([K('alpha'), K('mid'), K('zeta')]);
+  });
+
+  it('分页：limit 截断并给出 more 与总数', () => {
+    const store = createStore();
+    for (const name of ['a', 'b', 'c', 'd', 'e']) store.put(K(name), {});
+
+    const page1 = store.range('/registry/pods/', { prefix: true, limit: 2 });
+    expect(page1.kvs.map((kv) => kv.key)).toEqual([K('a'), K('b')]);
+    expect(page1.more).toBe(true);
+    expect(page1.count).toBe(5);
+
+    const page2 = store.range('/registry/pods/', { prefix: true, limit: 2, startAfter: K('b') });
+    expect(page2.kvs.map((kv) => kv.key)).toEqual([K('c'), K('d')]);
+
+    const page3 = store.range('/registry/pods/', { prefix: true, limit: 2, startAfter: K('d') });
+    expect(page3.kvs.map((kv) => kv.key)).toEqual([K('e')]);
+    expect(page3.more).toBe(false);
+  });
+
+  it('读历史版本看到的是那一刻的世界', () => {
+    const store = createStore();
+    store.put(K('a'), { v: 1 });          // rev 1
+    store.put(K('b'), { v: 1 });          // rev 2
+    store.put(K('a'), { v: 2 });          // rev 3
+    store.delete(K('b'));                 // rev 4
+
+    const atTwo = store.range('/registry/pods/', { prefix: true, revision: 2 });
+    expect(atTwo.kvs.map((kv) => kv.key)).toEqual([K('a'), K('b')]);
+    expect(atTwo.kvs[0].value).toEqual({ v: 1 });
+
+    const now = store.range('/registry/pods/', { prefix: true });
+    expect(now.kvs.map((kv) => kv.key)).toEqual([K('a')]);
+    expect(now.kvs[0].value).toEqual({ v: 2 });
+  });
+
+  it('读未来的 revision 直接报错', () => {
+    const store = createStore();
+    store.put(K('a'), {});
+    expect(() => store.range(K('a'), { revision: 99 })).toThrow(FutureRevisionError);
+  });
+
+  it('读出来的是拷贝，改它不会污染库里的对象', () => {
+    const store = createStore();
+    store.put(K('a'), { nested: { n: 1 } });
+    const read = store.get(K('a')) as any;
+    read.value.nested.n = 999;
+    expect((store.get(K('a')) as any).value.nested.n).toBe(1);
+  });
+
+  it('写进去的也是拷贝，之后改原对象不影响库里的', () => {
+    const store = createStore();
+    const original = { nested: { n: 1 } };
+    store.put(K('a'), original);
+    original.nested.n = 999;
+    expect((store.get(K('a')) as any).value.nested.n).toBe(1);
+  });
+});
+
+describe('事务与乐观并发', () => {
+  it('modRevision 对得上就写成功', () => {
+    const store = createStore();
+    const kv = store.put(K('a'), { v: 1 });
+    const result = store.txn(
+      [{ key: K('a'), target: 'MOD_REVISION', op: '=', value: kv.modRevision }],
+      [{ type: 'put', key: K('a'), value: { v: 2 } }]
+    );
+    expect(result.succeeded).toBe(true);
+    expect((store.get(K('a')) as any).value).toEqual({ v: 2 });
+  });
+
+  it('中间被别人改过就失败 —— apiserver 的 409 靠这个', () => {
+    const store = createStore();
+    const kv = store.put(K('a'), { v: 1 });
+    store.put(K('a'), { v: 'someone else' });          // 并发写
+
+    const result = store.txn(
+      [{ key: K('a'), target: 'MOD_REVISION', op: '=', value: kv.modRevision }],
+      [{ type: 'put', key: K('a'), value: { v: 2 } }]
+    );
+    expect(result.succeeded).toBe(false);
+    expect((store.get(K('a')) as any).value).toEqual({ v: 'someone else' });
+  });
+
+  it('EXISTS 比较可以实现「只在不存在时创建」', () => {
+    const store = createStore();
+    const create = () =>
+      store.txn(
+        [{ key: K('a'), target: 'EXISTS', value: false }],
+        [{ type: 'put', key: K('a'), value: { v: 1 } }]
+      );
+    expect(create().succeeded).toBe(true);
+    expect(create().succeeded).toBe(false);            // 第二次是 AlreadyExists
+  });
+
+  it('一个事务里的多次写共用一个 revision', () => {
+    const store = createStore();
+    const result = store.txn(
+      [],
+      [
+        { type: 'put', key: K('a'), value: {} },
+        { type: 'put', key: K('b'), value: {} },
+        { type: 'put', key: K('c'), value: {} },
+      ]
+    );
+    expect(store.revision).toBe(1);
+    const kvs = (result.results as any[]).map((r) => r.modRevision);
+    expect(kvs).toEqual([1, 1, 1]);
+  });
+
+  it('比较不成立时走 onFailure 那一支', () => {
+    const store = createStore();
+    const result = store.txn(
+      [{ key: K('missing'), target: 'EXISTS', value: true }],
+      [{ type: 'put', key: K('yes'), value: {} }],
+      [{ type: 'put', key: K('no'), value: {} }]
+    );
+    expect(result.succeeded).toBe(false);
+    expect(store.get(K('yes'))).toBeUndefined();
+    expect(store.get(K('no'))).toBeDefined();
+  });
+});
+
+describe('watch', () => {
+  const collect = (store: Store, key: string, opts = {}) => {
+    const seen: string[] = [];
+    const watcher = store.watch(key, { prefix: true, ...opts }, (e: WatchEvent) => {
+      seen.push(`${e.type} ${e.kv.key}@${e.kv.modRevision}`);
+    });
+    return { seen, watcher };
+  };
+
+  it('收到之后发生的 PUT 与 DELETE', () => {
+    const store = createStore();
+    const { seen } = collect(store, '/registry/pods/');
+    store.put(K('a'), {});
+    store.delete(K('a'));
+    expect(seen).toEqual([`PUT ${K('a')}@1`, `DELETE ${K('a')}@2`]);
+  });
+
+  it('DELETE 事件带上 prevKv，控制器才知道删的是什么', () => {
+    const store = createStore();
+    store.put(K('a'), { important: true });
+    let deleted: WatchEvent | null = null;
+    store.watch('/registry/pods/', { prefix: true }, (e) => { if (e.type === 'DELETE') deleted = e; });
+    store.delete(K('a'));
+    expect((deleted as any).prevKv.value).toEqual({ important: true });
+  });
+
+  it('只收自己前缀下的事件', () => {
+    const store = createStore();
+    const { seen } = collect(store, '/registry/pods/kube-system/');
+    store.put(K('mine', 'kube-system'), {});
+    store.put(K('theirs', 'default'), {});
+    expect(seen).toEqual([`PUT ${K('mine', 'kube-system')}@1`]);
+  });
+
+  it('从历史 revision 起 watch 会先补齐错过的事件', () => {
+    const store = createStore();
+    store.put(K('a'), {});                       // rev 1
+    store.put(K('b'), {});                       // rev 2
+    const listRevision = store.revision;         // informer 在这里完成了 list
+    store.put(K('c'), {});                       // rev 3，watch 建立之前发生
+
+    const { seen } = collect(store, '/registry/pods/', { startRevision: listRevision });
+    // 补齐的那条要在，之前的不该重放
+    expect(seen).toEqual([`PUT ${K('c')}@3`]);
+
+    store.put(K('d'), {});
+    expect(seen).toEqual([`PUT ${K('c')}@3`, `PUT ${K('d')}@4`]);
+  });
+
+  it('取消之后不再收事件', () => {
+    const store = createStore();
+    const { seen, watcher } = collect(store, '/registry/pods/');
+    store.put(K('a'), {});
+    watcher.cancel();
+    store.put(K('b'), {});
+    expect(seen).toEqual([`PUT ${K('a')}@1`]);
+  });
+
+  it('多个订阅者按注册顺序收到通知', () => {
+    const store = createStore();
+    const order: string[] = [];
+    store.watch('/registry/', { prefix: true }, () => order.push('first'));
+    store.watch('/registry/', { prefix: true }, () => order.push('second'));
+    store.watch('/registry/', { prefix: true }, () => order.push('third'));
+    store.put(K('a'), {});
+    expect(order).toEqual(['first', 'second', 'third']);
+  });
+
+  it('在回调里新建的订阅者不会收到这一批事件', () => {
+    const store = createStore();
+    const late: string[] = [];
+    store.watch('/registry/', { prefix: true }, () => {
+      store.watch('/registry/', { prefix: true }, () => late.push('late'));
+    });
+    store.put(K('a'), {});
+    expect(late).toEqual([]);
+    store.put(K('b'), {});
+    expect(late.length).toBeGreaterThan(0);
+  });
+});
+
+describe('compaction', () => {
+  it('压缩之后从更早的 revision 起 watch 会明确报错', () => {
+    const store = createStore();
+    store.put(K('a'), {});          // 1
+    store.put(K('b'), {});          // 2
+    store.put(K('c'), {});          // 3
+    store.compact(2);
+
+    expect(() => store.watch('/registry/', { prefix: true, startRevision: 1 }, () => {}))
+      .toThrow(CompactedError);
+    // 压缩点本身还能用
+    expect(() => store.watch('/registry/', { prefix: true, startRevision: 2 }, () => {}))
+      .not.toThrow();
+  });
+
+  it('压缩之后读历史版本仍然完整 —— 压缩点之前建的对象不能凭空消失', () => {
+    // 自审时抓到的：历史读原先是从空状态重放全部历史，压缩把前面的事件丢掉之后，
+    // 「压缩点之前创建、之后没再动过」的对象就读不出来了。
+    const store = createStore();
+    store.put(K('a'), { v: 1 });   // rev 1
+    store.put(K('b'), { v: 1 });   // rev 2
+    store.put(K('c'), { v: 1 });   // rev 3
+    store.compact(2);
+
+    const at3 = store.range('/registry/pods/', { prefix: true, revision: 3 });
+    expect(at3.kvs.map((kv) => kv.key)).toEqual([K('a'), K('b'), K('c')]);
+
+    const at2 = store.range('/registry/pods/', { prefix: true, revision: 2 });
+    expect(at2.kvs.map((kv) => kv.key)).toEqual([K('a'), K('b')]);
+  });
+
+  it('历史超过上限会自动压缩，不会无限吃内存', () => {
+    const store = createStore({ maxHistory: 10 });
+    for (let i = 0; i < 100; i += 1) store.put(K(`n${i}`), { i });
+    expect(store.compactedAt).toBeGreaterThan(0);
+    expect(() => store.range(K('n0'), { revision: 1 })).toThrow(CompactedError);
+    // 当前状态不受影响
+    expect(store.range('/registry/pods/', { prefix: true }).count).toBe(100);
+  });
+});
+
+describe('快照', () => {
+  it('存下来再恢复，状态与 revision 都对得上', () => {
+    const store = createStore();
+    store.put(K('a'), { v: 1 });
+    store.put(K('b'), { v: 2 });
+    const snapshot = store.snapshot();
+
+    const restored = createStore();
+    restored.restore(snapshot);
+    expect(restored.revision).toBe(store.revision);
+    expect(restored.range('/registry/pods/', { prefix: true }).kvs.map((kv) => kv.key))
+      .toEqual([K('a'), K('b')]);
+    // 接着写要从恢复的 revision 继续，不能倒退
+    expect(restored.put(K('c'), {}).modRevision).toBe(3);
+  });
+
+  it('恢复之后从旧 revision 起 watch 会报 compacted —— 历史没有跟着快照走', () => {
+    const store = createStore();
+    store.put(K('a'), {});
+    store.put(K('b'), {});
+    const restored = createStore();
+    restored.restore(store.snapshot());
+    expect(() => restored.watch('/registry/', { prefix: true, startRevision: 1 }, () => {}))
+      .toThrow(CompactedError);
+  });
+
+  it('恢复之后读当前 revision 能读到东西 —— 底座就是快照本身', () => {
+    // 同一个自审发现的另一面：快照里没有历史，恢复后重放不出任何东西，
+    // 「读当前 revision」会返回空。
+    const store = createStore();
+    store.put(K('a'), {});
+    store.put(K('b'), {});
+    const restored = createStore();
+    restored.restore(store.snapshot());
+
+    const now = restored.range('/registry/pods/', { prefix: true, revision: restored.revision });
+    expect(now.kvs.map((kv) => kv.key)).toEqual([K('a'), K('b')]);
+  });
+
+  it('快照是深拷贝，之后改原库不影响它', () => {
+    const store = createStore();
+    store.put(K('a'), { nested: { n: 1 } });
+    const snapshot = store.snapshot();
+    store.put(K('a'), { nested: { n: 2 } });
+
+    const restored = createStore();
+    restored.restore(snapshot);
+    expect((restored.get(K('a')) as any).value.nested.n).toBe(1);
+  });
+});
+
+describe('确定性', () => {
+  it('同一串操作重放 200 次，事件流逐字节一致', () => {
+    const run = () => {
+      const store = createStore();
+      const log: string[] = [];
+      store.watch('/registry/', { prefix: true }, (e) => {
+        log.push(`${e.type} ${e.kv.key} rev=${e.kv.modRevision} v=${JSON.stringify(e.kv.value)}`);
+      });
+      // 故意乱序、混着事务与前缀删除
+      for (const name of ['delta', 'alpha', 'charlie', 'bravo']) store.put(K(name), { name });
+      store.txn(
+        [{ key: K('alpha'), target: 'EXISTS', value: true }],
+        [
+          { type: 'put', key: K('alpha'), value: { name: 'alpha', updated: true } },
+          { type: 'delete', key: K('bravo') },
+        ]
+      );
+      store.deletePrefix('/registry/pods/default/c');
+      log.push(JSON.stringify(store.range('/registry/pods/', { prefix: true }).kvs.map((kv) => kv.key)));
+      return log.join('\n');
+    };
+
+    const first = run();
+    for (let i = 0; i < 199; i += 1) expect(run()).toBe(first);
+  });
+});


### PR DESCRIPTION
第三段第 2 片的第一块 —— apiserver 的地基。

## 为什么先做这一层

apiserver 对外的每条行为都架在 etcd 的这几条语义上，先把它做对，上面那层才不用打补丁：

| etcd 语义 | apiserver 里对应什么 |
| --- | --- |
| 单调 revision | `resourceVersion` |
| CAS 事务 | 乐观并发，写冲突返回 409 |
| watch from revision | informer「先 list 拿到 revision，再从那一版 watch」，中间不能漏事件 |
| compaction | `too old resource version` |

## 实现了什么

单调 revision（`createRevision` / `modRevision` / `version` 三者语义分清：删掉再建
createRevision 要重新算）、前缀读与分页（`limit` + `startAfter` + `more` + 总数）、
历史版本读、CAS 事务（一个事务里的多次写共用一个 revision，watch 看到它们同时发生）、
watch（`prevKv`、补齐错过的事件、订阅者按注册顺序通知、回调里新建的订阅者不收当批）、
compaction（含历史上限自动压缩）与快照。

确定性上的两条硬规矩：**读取结果一律按键名排序**（不依赖 Map 插入序），
**存取都做深拷贝**（调用方手上的引用不能反过来改到库里的对象）。

## 自审抓到两个 bug，都补了回归

**1. 压缩之后历史读会丢对象。** 历史读原先是从空状态重放全部历史；压缩把前面的事件丢掉
之后，「压缩点之前创建、之后没再动过」的对象就重放不出来了。实测写 3 个对象、压缩到 rev 2，
再读 rev 3 只剩 1 个。

**2. 同一成因的另一面**：快照里不带历史，恢复之后读当前 revision 返回空。

改法是同一个：压缩时把那一刻的状态物化成底座，重放叠在底座上；恢复快照时底座就是快照本身。

## 验证

- 27 条 store 测试全绿，含「同一串操作重放 200 次事件流逐字节一致」
- `npm test` **8/8 套件**（opslab 套件现在 49 条：内核 20 + 存储 27 + 2 条新回归）
- `npm run build` 通过、`projects:verify` 全通过、`tsc --noEmit` 干净
- 不碰任何既有代码路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)