### PR TITLE
feat(opslab): apiserver 的 REST 语义层

### DIFF
--- a/src/lib/opslab/apiserver/errors.ts
+++ b/src/lib/opslab/apiserver/errors.ts
@@ -1,0 +1,179 @@
+/**
+ * apiserver 的错误 —— 报错文本要和真集群一字不差
+ *
+ * 学员看到的报错就是他们排查问题的全部线索，所以这里不自己发挥措辞，
+ * 一律照抄 k8s 的 `staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go`。
+ * 比如「改的东西被别人动过」在真集群里是这一句：
+ *
+ *   Operation cannot be fulfilled on pods "web": the object has been modified;
+ *   please apply your changes to the latest version and try again
+ *
+ * 不是「conflict detected」之类看着合理但学员搜不到的自创说法。
+ */
+
+export type StatusReason =
+  | 'NotFound'
+  | 'AlreadyExists'
+  | 'Conflict'
+  | 'Invalid'
+  | 'BadRequest'
+  | 'Forbidden'
+  | 'MethodNotAllowed'
+  | 'Gone'
+  | 'UnsupportedMediaType'
+  | 'InternalError';
+
+export interface StatusCause {
+  reason: string;
+  message: string;
+  field: string;
+}
+
+export interface StatusDetails {
+  name?: string;
+  group?: string;
+  kind?: string;
+  uid?: string;
+  causes?: StatusCause[];
+  retryAfterSeconds?: number;
+}
+
+export interface Status {
+  kind: 'Status';
+  apiVersion: 'v1';
+  metadata: Record<string, never>;
+  status: 'Failure';
+  message: string;
+  reason: StatusReason;
+  details?: StatusDetails;
+  code: number;
+}
+
+/**
+ * apiserver 抛出来的错误。
+ *
+ * 带着完整的 Status —— HTTP 层直接把它序列化成响应体，
+ * kubectl 那边靠 reason 与 details 决定怎么显示。
+ */
+export class ApiError extends Error {
+  readonly status: Status;
+
+  constructor(status: Status) {
+    super(status.message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+
+  get code(): number {
+    return this.status.code;
+  }
+
+  get reason(): StatusReason {
+    return this.status.reason;
+  }
+}
+
+function makeStatus(
+  code: number,
+  reason: StatusReason,
+  message: string,
+  details?: StatusDetails
+): Status {
+  return {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Failure',
+    message,
+    reason,
+    ...(details ? { details } : {}),
+    code,
+  };
+}
+
+/** `pods "web" not found` */
+export function notFound(resource: string, name: string, group = ''): ApiError {
+  return new ApiError(
+    makeStatus(404, 'NotFound', `${resource} "${name}" not found`, { name, group, kind: resource })
+  );
+}
+
+/** `pods "web" already exists` */
+export function alreadyExists(resource: string, name: string, group = ''): ApiError {
+  return new ApiError(
+    makeStatus(409, 'AlreadyExists', `${resource} "${name}" already exists`, {
+      name,
+      group,
+      kind: resource,
+    })
+  );
+}
+
+/**
+ * `Operation cannot be fulfilled on pods "web": the object has been modified;
+ *  please apply your changes to the latest version and try again`
+ */
+export function conflict(resource: string, name: string, detail?: string, group = ''): ApiError {
+  const because =
+    detail ??
+    'the object has been modified; please apply your changes to the latest version and try again';
+  return new ApiError(
+    makeStatus(409, 'Conflict', `Operation cannot be fulfilled on ${resource} "${name}": ${because}`, {
+      name,
+      group,
+      kind: resource,
+    })
+  );
+}
+
+/** `Pod "web" is invalid: spec.replicas: Invalid value: -1: must be greater than or equal to 0` */
+export function invalid(kind: string, name: string, causes: StatusCause[], group = ''): ApiError {
+  const summary = causes
+    .map((cause) => `${cause.field}: ${cause.message}`)
+    .join(', ');
+  return new ApiError(
+    makeStatus(422, 'Invalid', `${kind} "${name}" is invalid: ${summary}`, {
+      name,
+      group,
+      kind,
+      causes,
+    })
+  );
+}
+
+export function badRequest(message: string): ApiError {
+  return new ApiError(makeStatus(400, 'BadRequest', message));
+}
+
+export function forbidden(message: string): ApiError {
+  return new ApiError(makeStatus(403, 'Forbidden', message));
+}
+
+export function methodNotAllowed(verb: string, resource: string): ApiError {
+  return new ApiError(
+    makeStatus(405, 'MethodNotAllowed', `${verb} is not supported on resource "${resource}"`)
+  );
+}
+
+/**
+ * `too old resource version: 12 (34)`
+ *
+ * informer 从一个已经被压缩掉的版本起 watch 时收到它，
+ * 正确的反应是丢掉本地缓存重新 list —— 这是 k8s 里很常见的一条日志。
+ */
+export function tooOldResourceVersion(requested: number, oldest: number): ApiError {
+  return new ApiError(
+    makeStatus(410, 'Gone', `too old resource version: ${requested} (${oldest})`)
+  );
+}
+
+export function internalError(message: string): ApiError {
+  return new ApiError(makeStatus(500, 'InternalError', `Internal error occurred: ${message}`));
+}
+
+/** 把任意异常规整成 Status，HTTP 层用它兜底 */
+export function toStatus(error: unknown): Status {
+  if (error instanceof ApiError) return error.status;
+  const message = error instanceof Error ? error.message : String(error);
+  return makeStatus(500, 'InternalError', `Internal error occurred: ${message}`);
+}

--- a/src/lib/opslab/apiserver/index.ts
+++ b/src/lib/opslab/apiserver/index.ts
@@ -1,0 +1,46 @@
+/**
+ * apiserver 的 REST 语义层
+ *
+ * 对象生命周期（默认值、resourceVersion 与乐观并发、generation、
+ * finalizer 与级联删除、分页、watch）都在这里；字段合法性校验是下一层的事。
+ * 详见 design/opslab.md 里 L2 那一节。
+ */
+export {
+  Registry,
+  FOREGROUND_DELETION,
+  ORPHAN_DEPENDENTS,
+  formatTimestamp,
+  parseFieldSelector,
+  parseLabelSelector,
+} from './registry';
+export type { RegistryDeps } from './registry';
+export { Scheme, createScheme, storageKey, storagePrefix } from './scheme';
+export type { GVR, ResourceDefinition } from './scheme';
+export {
+  ApiError,
+  alreadyExists,
+  badRequest,
+  conflict,
+  forbidden,
+  internalError,
+  invalid,
+  methodNotAllowed,
+  notFound,
+  tooOldResourceVersion,
+  toStatus,
+} from './errors';
+export type { Status, StatusCause, StatusDetails, StatusReason } from './errors';
+export type {
+  CreateOptions,
+  DeleteOptions,
+  KubeList,
+  KubeObject,
+  ListMeta,
+  ListOptions,
+  ObjectMeta,
+  OwnerReference,
+  PatchType,
+  PropagationPolicy,
+  UpdateOptions,
+  WatchEventOut,
+} from './types';

--- a/src/lib/opslab/apiserver/registry.ts
+++ b/src/lib/opslab/apiserver/registry.ts
@@ -1,0 +1,531 @@
+/**
+ * REST 语义层
+ *
+ * 架在 etcd 语义存储上，负责 k8s 对象真正的那些规矩：默认值、uid、
+ * resourceVersion 与乐观并发、generation 与 observedGeneration、
+ * finalizer 与 deletionTimestamp、ownerReferences、分页、watch。
+ *
+ * 这一层刻意不碰「这个字段合不合法」——schema 校验是下一片的事，
+ * 会接官方 OpenAPI + ajv。这里管的是**对象生命周期**，两者边界分清。
+ */
+import { Store, WatchEvent } from '../store';
+import {
+  alreadyExists,
+  badRequest,
+  conflict,
+  invalid,
+  notFound,
+  tooOldResourceVersion,
+} from './errors';
+import { CompactedError } from '../store';
+import { ResourceDefinition, Scheme, storageKey, storagePrefix } from './scheme';
+import type {
+  CreateOptions,
+  DeleteOptions,
+  KubeList,
+  KubeObject,
+  ListOptions,
+  ObjectMeta,
+  UpdateOptions,
+  WatchEventOut,
+} from './types';
+
+/** k8s 用这两个 finalizer 表达级联删除的意图，GC 控制器认它们 */
+export const FOREGROUND_DELETION = 'foregroundDeletion';
+export const ORPHAN_DEPENDENTS = 'orphan';
+
+export interface RegistryDeps {
+  store: Store;
+  scheme: Scheme;
+  /** 当前时间，来自虚拟时钟 —— 不能用 Date.now，否则输出不可复现 */
+  now: () => number;
+  /** 生成 uid，来自确定性随机数 */
+  uid: () => string;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : (JSON.parse(JSON.stringify(value)) as T);
+}
+
+/** k8s 的时间戳格式：RFC3339，秒级，不带毫秒 */
+export function formatTimestamp(epochMs: number): string {
+  return new Date(epochMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * 按逗号切分，但括号里的逗号不算。
+ *
+ * `env in (prod,staging)` 是合法选择器，直接 split(',') 会把它切成
+ * `env in (prod` 和 `staging)` 两半。
+ */
+function splitClauses(selector: string): string[] {
+  const clauses: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of selector) {
+    if (ch === '(') depth += 1;
+    if (ch === ')') depth = Math.max(0, depth - 1);
+    if (ch === ',' && depth === 0) {
+      clauses.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  clauses.push(current);
+  return clauses.map((c) => c.trim()).filter(Boolean);
+}
+
+/** `app=web,tier!=db,env in (prod,staging)` */
+export function parseLabelSelector(selector: string): (labels: Record<string, string>) => boolean {
+  const clauses = splitClauses(selector);
+  const matchers = clauses.map((clause) => {
+    let match = /^(.+?)\s+notin\s+\((.*)\)$/.exec(clause);
+    if (match) {
+      const values = match[2].split(',').map((v) => v.trim());
+      return (labels: Record<string, string>) => !values.includes(labels[match![1].trim()]);
+    }
+    match = /^(.+?)\s+in\s+\((.*)\)$/.exec(clause);
+    if (match) {
+      const values = match[2].split(',').map((v) => v.trim());
+      return (labels: Record<string, string>) => values.includes(labels[match![1].trim()]);
+    }
+    match = /^(.+?)!=(.*)$/.exec(clause);
+    if (match) return (labels: Record<string, string>) => labels[match![1].trim()] !== match![2].trim();
+    // k8s 里 `a==b` 和 `a=b` 等价，先试双等号免得被单等号切错
+    match = /^(.+?)==(.*)$/.exec(clause);
+    if (match) return (labels: Record<string, string>) => labels[match![1].trim()] === match![2].trim();
+    match = /^(.+?)=(.*)$/.exec(clause);
+    if (match) return (labels: Record<string, string>) => labels[match![1].trim()] === match![2].trim();
+    if (clause.startsWith('!')) {
+      const key = clause.slice(1).trim();
+      return (labels: Record<string, string>) => labels[key] === undefined;
+    }
+    return (labels: Record<string, string>) => labels[clause] !== undefined;
+  });
+  return (labels) => matchers.every((m) => m(labels ?? {}));
+}
+
+/** `metadata.name=web,spec.nodeName=node-1` */
+export function parseFieldSelector(selector: string): (object: KubeObject) => boolean {
+  const clauses = splitClauses(selector);
+  const matchers = clauses.map((clause) => {
+    const negate = /^(.+?)!=(.*)$/.exec(clause);
+    const equal = /^(.+?)=(.*)$/.exec(clause);
+    const [path, expected, wantEqual] = negate
+      ? [negate[1].trim(), negate[2].trim(), false]
+      : equal
+        ? [equal[1].trim(), equal[2].trim(), true]
+        : [clause, '', true];
+    return (object: KubeObject) => {
+      const actual = path.split('.').reduce<any>((acc, part) => (acc == null ? acc : acc[part]), object);
+      return wantEqual ? String(actual) === expected : String(actual) !== expected;
+    };
+  });
+  return (object) => matchers.every((m) => m(object));
+}
+
+/** continue token 与真 apiserver 同形：base64 的 JSON，带上起始键与读的那一版 */
+function encodeContinue(startAfter: string, revision: number): string {
+  return Buffer.from(JSON.stringify({ start: startAfter, rv: revision })).toString('base64');
+}
+
+function decodeContinue(token: string): { start: string; rv: number } {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64').toString('utf8'));
+    if (typeof parsed.start !== 'string' || typeof parsed.rv !== 'number') throw new Error('shape');
+    return parsed;
+  } catch {
+    throw badRequest('continue key is not valid: invalid continue token');
+  }
+}
+
+export class Registry {
+  private readonly store: Store;
+  private readonly scheme: Scheme;
+  private readonly now: () => number;
+  private readonly nextUid: () => string;
+
+  constructor(deps: RegistryDeps) {
+    this.store = deps.store;
+    this.scheme = deps.scheme;
+    this.now = deps.now;
+    this.nextUid = deps.uid;
+  }
+
+  /* ---------------- 读 ---------------- */
+
+  get(definition: ResourceDefinition, namespace: string | undefined, name: string): KubeObject {
+    this.assertScope(definition, namespace);
+    const kv = this.store.get(storageKey(definition, namespace, name));
+    if (!kv) throw notFound(definition.resource, name, definition.group);
+    return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  list(definition: ResourceDefinition, options: ListOptions = {}): KubeList {
+    const prefix = storagePrefix(definition, options.namespace);
+
+    let startAfter: string | undefined;
+    let atRevision: number | undefined;
+    if (options.continue) {
+      const cursor = decodeContinue(options.continue);
+      startAfter = cursor.start;
+      // 分页要读同一版快照，否则翻页期间的写会让结果错乱或重复
+      atRevision = cursor.rv;
+    } else if (options.resourceVersion && options.resourceVersion !== '0') {
+      atRevision = Number(options.resourceVersion);
+    }
+
+    let result;
+    try {
+      result = this.store.range(prefix, {
+        prefix: true,
+        startAfter,
+        revision: atRevision,
+      });
+    } catch (error) {
+      if (error instanceof CompactedError) {
+        throw tooOldResourceVersion(error.requiredRevision, error.compactRevision);
+      }
+      throw error;
+    }
+
+    let items = result.kvs.map((kv) => this.decorate(kv.value as KubeObject, kv.modRevision));
+
+    if (options.labelSelector) {
+      const matches = parseLabelSelector(options.labelSelector);
+      items = items.filter((item) => matches(item.metadata.labels ?? {}));
+    }
+    if (options.fieldSelector) {
+      const matches = parseFieldSelector(options.fieldSelector);
+      items = items.filter(matches);
+    }
+
+    const listRevision = atRevision ?? result.revision;
+    const meta: KubeList['metadata'] = { resourceVersion: String(listRevision) };
+
+    if (options.limit && options.limit > 0 && items.length > options.limit) {
+      const page = items.slice(0, options.limit);
+      const last = page[page.length - 1];
+      meta.continue = encodeContinue(
+        storageKey(definition, last.metadata.namespace, last.metadata.name),
+        listRevision
+      );
+      meta.remainingItemCount = items.length - page.length;
+      items = page;
+    }
+
+    return {
+      apiVersion: Scheme.toApiVersion(definition.group, definition.version),
+      kind: `${definition.kind}List`,
+      metadata: meta,
+      items,
+    };
+  }
+
+  /* ---------------- 写 ---------------- */
+
+  create(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    object: KubeObject,
+    options: CreateOptions = {}
+  ): KubeObject {
+    this.assertScope(definition, namespace);
+    const candidate = clone(object);
+    const meta = (candidate.metadata ?? (candidate.metadata = {} as ObjectMeta));
+
+    if (!meta.name) {
+      throw invalid(definition.kind, '', [
+        { reason: 'FieldValueRequired', message: 'Required value: name or generateName is required', field: 'metadata.name' },
+      ], definition.group);
+    }
+    if (meta.resourceVersion) {
+      throw badRequest(
+        `${definition.resource} "${meta.name}" is invalid: metadata.resourceVersion: Invalid value: ` +
+          `"${meta.resourceVersion}": must be empty on create`
+      );
+    }
+    if (definition.namespaced) {
+      if (meta.namespace && meta.namespace !== namespace) {
+        throw badRequest(
+          `the namespace of the provided object does not match the namespace sent on the request`
+        );
+      }
+      meta.namespace = namespace;
+    } else if (meta.namespace) {
+      throw badRequest(`the namespace of the provided object is not allowed on a cluster-scoped resource`);
+    }
+
+    const key = storageKey(definition, namespace, meta.name);
+    if (this.store.get(key)) throw alreadyExists(definition.resource, meta.name, definition.group);
+
+    meta.uid = meta.uid ?? this.nextUid();
+    meta.creationTimestamp = formatTimestamp(this.now());
+    meta.generation = 1;
+    candidate.apiVersion = Scheme.toApiVersion(definition.group, definition.version);
+    candidate.kind = definition.kind;
+    delete meta.resourceVersion;
+    delete meta.deletionTimestamp;
+
+    if (options.dryRun) return this.decorate(candidate, this.store.revision);
+
+    const kv = this.store.put(key, candidate);
+    return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  /**
+   * 整体替换。
+   *
+   * 三件事必须对：
+   *  - 带了 resourceVersion 就要和库里的一致，否则 409（乐观并发）；
+   *  - status 是子资源，主资源的 update 不许改它 —— 控制器和用户各写各的字段；
+   *  - spec 变了才 +generation，metadata 或 status 变不算。
+   */
+  update(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    name: string,
+    object: KubeObject,
+    options: UpdateOptions = {}
+  ): KubeObject {
+    this.assertScope(definition, namespace);
+    const key = storageKey(definition, namespace, name);
+    const existingKv = this.store.get(key);
+    if (!existingKv) throw notFound(definition.resource, name, definition.group);
+
+    const existing = existingKv.value as KubeObject;
+    const next = clone(object);
+    const meta = (next.metadata ?? (next.metadata = {} as ObjectMeta));
+
+    if (meta.name && meta.name !== name) {
+      throw badRequest(
+        `the name of the object (${meta.name}) does not match the name on the URL (${name})`
+      );
+    }
+    if (meta.resourceVersion && meta.resourceVersion !== String(existingKv.modRevision)) {
+      throw conflict(definition.resource, name, undefined, definition.group);
+    }
+
+    meta.name = name;
+    meta.namespace = definition.namespaced ? namespace : undefined;
+    if (!definition.namespaced) delete meta.namespace;
+    // 这些字段由服务端说了算，客户端改不动
+    meta.uid = existing.metadata.uid;
+    meta.creationTimestamp = existing.metadata.creationTimestamp;
+    meta.deletionTimestamp = existing.metadata.deletionTimestamp;
+    next.apiVersion = Scheme.toApiVersion(definition.group, definition.version);
+    next.kind = definition.kind;
+    // status 归 status 子资源管
+    next.status = existing.status;
+
+    const specChanged = JSON.stringify(next.spec ?? null) !== JSON.stringify(existing.spec ?? null);
+    meta.generation = (existing.metadata.generation ?? 1) + (specChanged ? 1 : 0);
+    delete meta.resourceVersion;
+
+    if (options.dryRun) return this.decorate(next, existingKv.modRevision);
+
+    const result = this.store.txn(
+      [{ key, target: 'MOD_REVISION', op: '=', value: existingKv.modRevision }],
+      [{ type: 'put', key, value: next }]
+    );
+    if (!result.succeeded) throw conflict(definition.resource, name, undefined, definition.group);
+    const kv = result.results[0] as { value: unknown; modRevision: number };
+    return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  /**
+   * 只写 status 子资源。
+   *
+   * 不动 spec、不 +generation —— 控制器每秒钟都在写 status，
+   * 如果它也 bump generation，`observedGeneration` 就永远追不上，
+   * 「这个 Deployment 收敛了没有」就没法判断了。
+   */
+  updateStatus(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    name: string,
+    object: KubeObject,
+    options: UpdateOptions = {}
+  ): KubeObject {
+    this.assertScope(definition, namespace);
+    const key = storageKey(definition, namespace, name);
+    const existingKv = this.store.get(key);
+    if (!existingKv) throw notFound(definition.resource, name, definition.group);
+
+    const existing = existingKv.value as KubeObject;
+    if (object.metadata?.resourceVersion && object.metadata.resourceVersion !== String(existingKv.modRevision)) {
+      throw conflict(definition.resource, name, undefined, definition.group);
+    }
+
+    const next = clone(existing);
+    next.status = clone(object.status);
+
+    if (options.dryRun) return this.decorate(next, existingKv.modRevision);
+
+    const result = this.store.txn(
+      [{ key, target: 'MOD_REVISION', op: '=', value: existingKv.modRevision }],
+      [{ type: 'put', key, value: next }]
+    );
+    if (!result.succeeded) throw conflict(definition.resource, name, undefined, definition.group);
+    const kv = result.results[0] as { value: unknown; modRevision: number };
+    return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  /**
+   * 删除。
+   *
+   * 有 finalizer 的对象删不掉 —— 只打上 deletionTimestamp，对象继续存在，
+   * 等把 finalizer 一个个摘干净才真的消失。级联删除也是通过加 finalizer 表达意图，
+   * 真正去删依赖对象的是 GC 控制器，apiserver 只负责记下这个意图。
+   */
+  delete(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    name: string,
+    options: DeleteOptions = {}
+  ): KubeObject {
+    this.assertScope(definition, namespace);
+    const key = storageKey(definition, namespace, name);
+    const existingKv = this.store.get(key);
+    if (!existingKv) throw notFound(definition.resource, name, definition.group);
+
+    const existing = existingKv.value as KubeObject;
+    const preconditions = options.preconditions;
+    if (preconditions?.uid && preconditions.uid !== existing.metadata.uid) {
+      throw conflict(
+        definition.resource, name,
+        `the UID in the precondition (${preconditions.uid}) does not match the UID in record (${existing.metadata.uid}). The object might have been deleted and then recreated`,
+        definition.group
+      );
+    }
+    if (preconditions?.resourceVersion && preconditions.resourceVersion !== String(existingKv.modRevision)) {
+      throw conflict(definition.resource, name, undefined, definition.group);
+    }
+
+    const policy = options.propagationPolicy ?? 'Background';
+    const finalizers = [...(existing.metadata.finalizers ?? [])];
+    if (policy === 'Foreground' && !finalizers.includes(FOREGROUND_DELETION)) {
+      finalizers.push(FOREGROUND_DELETION);
+    }
+    if (policy === 'Orphan' && !finalizers.includes(ORPHAN_DEPENDENTS)) {
+      finalizers.push(ORPHAN_DEPENDENTS);
+    }
+
+    if (finalizers.length === 0) {
+      const kv = this.store.delete(key)!;
+      return this.decorate(kv.value as KubeObject, kv.modRevision);
+    }
+
+    // 有 finalizer：只标记，不真删
+    const marked = clone(existing);
+    marked.metadata.deletionTimestamp = marked.metadata.deletionTimestamp ?? formatTimestamp(this.now());
+    marked.metadata.deletionGracePeriodSeconds = options.gracePeriodSeconds ?? 0;
+    marked.metadata.finalizers = finalizers;
+
+    const result = this.store.txn(
+      [{ key, target: 'MOD_REVISION', op: '=', value: existingKv.modRevision }],
+      [{ type: 'put', key, value: marked }]
+    );
+    if (!result.succeeded) throw conflict(definition.resource, name, undefined, definition.group);
+    const kv = result.results[0] as { value: unknown; modRevision: number };
+    return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  /**
+   * 摘掉一个 finalizer；摘完最后一个而且已经标了删除时间，对象就真的消失。
+   * 这是控制器清理完自己那摊事之后要做的动作。
+   */
+  removeFinalizer(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    name: string,
+    finalizer: string
+  ): KubeObject | null {
+    const key = storageKey(definition, namespace, name);
+    const existingKv = this.store.get(key);
+    if (!existingKv) throw notFound(definition.resource, name, definition.group);
+
+    const existing = existingKv.value as KubeObject;
+    const remaining = (existing.metadata.finalizers ?? []).filter((f) => f !== finalizer);
+
+    if (remaining.length === 0 && existing.metadata.deletionTimestamp) {
+      this.store.delete(key);
+      return null;                                  // 真的删掉了
+    }
+
+    const next = clone(existing);
+    next.metadata.finalizers = remaining;
+    const kv = this.store.put(key, next);
+    return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  deleteCollection(definition: ResourceDefinition, options: ListOptions = {}): KubeObject[] {
+    const listed = this.list(definition, options);
+    return listed.items.map((item) =>
+      this.delete(definition, item.metadata.namespace, item.metadata.name)
+    );
+  }
+
+  /* ---------------- watch ---------------- */
+
+  /**
+   * 订阅变更。
+   *
+   * 传了 resourceVersion 就先补齐这之后错过的事件 ——
+   * informer「先 list 拿到 rv，再从那一版 watch」不能漏事件。
+   * 版本太老（已被压缩）时抛 410 Gone，informer 收到后应当丢掉缓存重新 list。
+   */
+  watch(
+    definition: ResourceDefinition,
+    options: { namespace?: string; resourceVersion?: string; labelSelector?: string },
+    onEvent: (event: WatchEventOut) => void
+  ): { cancel: () => void } {
+    const prefix = storagePrefix(definition, options.namespace);
+    const matchesLabels = options.labelSelector ? parseLabelSelector(options.labelSelector) : null;
+
+    const startRevision =
+      options.resourceVersion !== undefined && options.resourceVersion !== '0'
+        ? Number(options.resourceVersion)
+        : undefined;
+
+    const emit = (event: WatchEvent) => {
+      const object = this.decorate(
+        (event.type === 'DELETE' ? event.prevKv?.value : event.kv.value) as KubeObject,
+        event.kv.modRevision
+      );
+      if (matchesLabels && !matchesLabels(object.metadata.labels ?? {})) return;
+      onEvent({
+        type: event.type === 'DELETE' ? 'DELETED' : event.kv.version === 1 ? 'ADDED' : 'MODIFIED',
+        object,
+      });
+    };
+
+    try {
+      return this.store.watch(prefix, { prefix: true, startRevision }, emit);
+    } catch (error) {
+      if (error instanceof CompactedError) {
+        throw tooOldResourceVersion(error.requiredRevision, error.compactRevision);
+      }
+      throw error;
+    }
+  }
+
+  /* ---------------- 内部 ---------------- */
+
+  /** 把存储层的 modRevision 贴成对象的 resourceVersion */
+  private decorate(object: KubeObject, revision: number): KubeObject {
+    const copy = clone(object);
+    copy.metadata = { ...copy.metadata, resourceVersion: String(revision) };
+    return copy;
+  }
+
+  private assertScope(definition: ResourceDefinition, namespace: string | undefined): void {
+    if (definition.namespaced && !namespace) {
+      throw badRequest(`an empty namespace may not be set when a resource name is provided`);
+    }
+    if (!definition.namespaced && namespace) {
+      throw badRequest(`namespace is not allowed on a cluster-scoped resource`);
+    }
+  }
+}

--- a/src/lib/opslab/apiserver/registry.ts
+++ b/src/lib/opslab/apiserver/registry.ts
@@ -125,14 +125,34 @@ export function parseFieldSelector(selector: string): (object: KubeObject) => bo
   return (object) => matchers.every((m) => m(object));
 }
 
+/**
+ * base64 编解码。
+ *
+ * 用 btoa/atob 而不是 Buffer —— 这段代码要在浏览器里跑，
+ * 而 webpack 5 不给 Node 内置模块打 polyfill，Buffer 在前端 bundle 里是 undefined。
+ * 测试跑在 Node 里发现不了这个问题（见 tests/opslab/browser-safety.test.ts 的守卫）。
+ */
+function toBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(encoded: string): string {
+  const binary = atob(encoded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
 /** continue token 与真 apiserver 同形：base64 的 JSON，带上起始键与读的那一版 */
 function encodeContinue(startAfter: string, revision: number): string {
-  return Buffer.from(JSON.stringify({ start: startAfter, rv: revision })).toString('base64');
+  return toBase64(JSON.stringify({ start: startAfter, rv: revision }));
 }
 
 function decodeContinue(token: string): { start: string; rv: number } {
   try {
-    const parsed = JSON.parse(Buffer.from(token, 'base64').toString('utf8'));
+    const parsed = JSON.parse(fromBase64(token));
     if (typeof parsed.start !== 'string' || typeof parsed.rv !== 'number') throw new Error('shape');
     return parsed;
   } catch {

--- a/src/lib/opslab/apiserver/scheme.ts
+++ b/src/lib/opslab/apiserver/scheme.ts
@@ -1,0 +1,169 @@
+/**
+ * GVK / GVR 注册表
+ *
+ * apiserver 靠它回答三类问题：
+ *  - discovery：`/api`、`/apis`、`/api/v1` 里该列出什么（kubectl 启动时先问这个，
+ *    `po` 能解析成 `pods` 也是靠它）；
+ *  - 路由：一个 URL 对应哪个资源、是不是带命名空间；
+ *  - 存储：对象在 etcd 里落到哪个键。
+ */
+import { badRequest } from './errors';
+
+export interface ResourceDefinition {
+  /** 组名。核心组是空串 */
+  group: string;
+  version: string;
+  /** 复数小写，URL 里那个，如 `pods` */
+  resource: string;
+  /** 单数小写，如 `pod` */
+  singular: string;
+  kind: string;
+  namespaced: boolean;
+  shortNames?: string[];
+  /** `kubectl api-resources --categories=all` 用 */
+  categories?: string[];
+  verbs?: string[];
+  /** 有哪些子资源，如 status / scale */
+  subresources?: string[];
+}
+
+const DEFAULT_VERBS = [
+  'create', 'delete', 'deletecollection', 'get', 'list', 'patch', 'update', 'watch',
+];
+
+export interface GVR {
+  group: string;
+  version: string;
+  resource: string;
+}
+
+export class Scheme {
+  private byKey = new Map<string, ResourceDefinition>();
+
+  register(definition: ResourceDefinition): void {
+    const complete: ResourceDefinition = {
+      verbs: DEFAULT_VERBS,
+      shortNames: [],
+      categories: [],
+      subresources: [],
+      ...definition,
+    };
+    this.byKey.set(this.key(complete), complete);
+  }
+
+  registerAll(definitions: ResourceDefinition[]): void {
+    for (const definition of definitions) this.register(definition);
+  }
+
+  private key(gvr: GVR): string {
+    return `${gvr.group}/${gvr.version}/${gvr.resource}`;
+  }
+
+  get(gvr: GVR): ResourceDefinition | undefined {
+    return this.byKey.get(this.key(gvr));
+  }
+
+  /** 找不到就抛 —— 调用方几乎总是想要这个行为 */
+  mustGet(gvr: GVR): ResourceDefinition {
+    const definition = this.get(gvr);
+    if (!definition) {
+      throw badRequest(`the server could not find the requested resource (${this.key(gvr)})`);
+    }
+    return definition;
+  }
+
+  /**
+   * 按用户敲的名字找资源：复数、单数、简称、带组的全名都认。
+   *
+   * `kubectl get po` / `get pod` / `get pods` / `get pods.apps` 都要能落到同一个资源上。
+   * 返回**排序稳定**的第一个匹配 —— 多个组里有同名资源时，核心组优先，
+   * 其余按组名字典序，免得同一条命令在不同次运行里解析到不同资源。
+   */
+  resolve(name: string): ResourceDefinition | undefined {
+    const lower = name.toLowerCase();
+    const [head, ...groupParts] = lower.split('.');
+    const wantedGroup = groupParts.length > 0 ? groupParts.join('.') : undefined;
+
+    const candidates = this.list()
+      .filter((definition) => {
+        if (wantedGroup !== undefined && definition.group !== wantedGroup) return false;
+        return (
+          definition.resource === head ||
+          definition.singular === head ||
+          (definition.shortNames ?? []).includes(head)
+        );
+      })
+      .sort((a, b) => {
+        // 核心组（空串）排最前，其余按组名再按资源名
+        if (a.group !== b.group) return a.group < b.group ? -1 : 1;
+        return a.resource < b.resource ? -1 : 1;
+      });
+
+    return candidates[0];
+  }
+
+  /** 全部资源定义，按 (组, 版本, 资源) 稳定排序 */
+  list(): ResourceDefinition[] {
+    return [...this.byKey.values()].sort((a, b) => {
+      if (a.group !== b.group) return a.group < b.group ? -1 : 1;
+      if (a.version !== b.version) return a.version < b.version ? -1 : 1;
+      return a.resource < b.resource ? -1 : 1;
+    });
+  }
+
+  /** 某个 group/version 下的资源 */
+  listGroupVersion(group: string, version: string): ResourceDefinition[] {
+    return this.list().filter((d) => d.group === group && d.version === version);
+  }
+
+  /** 有哪些 groupVersion，稳定排序。核心组的 `v1` 排最前。 */
+  groupVersions(): string[] {
+    const seen = new Set<string>();
+    for (const definition of this.list()) {
+      seen.add(definition.group ? `${definition.group}/${definition.version}` : definition.version);
+    }
+    return [...seen].sort((a, b) => {
+      const aCore = !a.includes('/');
+      const bCore = !b.includes('/');
+      if (aCore !== bCore) return aCore ? -1 : 1;
+      return a < b ? -1 : 1;
+    });
+  }
+
+  /** `apps/v1` -> { group: 'apps', version: 'v1' }；`v1` -> { group: '', version: 'v1' } */
+  static parseApiVersion(apiVersion: string): { group: string; version: string } {
+    const index = apiVersion.indexOf('/');
+    if (index < 0) return { group: '', version: apiVersion };
+    return { group: apiVersion.slice(0, index), version: apiVersion.slice(index + 1) };
+  }
+
+  static toApiVersion(group: string, version: string): string {
+    return group ? `${group}/${version}` : version;
+  }
+}
+
+/**
+ * 对象在存储里的键。
+ *
+ * 形状照抄 k8s：`/registry/<resource>/<namespace>/<name>`，
+ * 集群级资源没有命名空间那一段。前缀读因此天然支持「某个命名空间下的全部」。
+ */
+export function storageKey(definition: ResourceDefinition, namespace: string | undefined, name: string): string {
+  return definition.namespaced
+    ? `/registry/${definition.resource}/${namespace}/${name}`
+    : `/registry/${definition.resource}/${name}`;
+}
+
+/** 某个资源（可选某个命名空间）的键前缀 */
+export function storagePrefix(definition: ResourceDefinition, namespace?: string): string {
+  if (!definition.namespaced) return `/registry/${definition.resource}/`;
+  return namespace
+    ? `/registry/${definition.resource}/${namespace}/`
+    : `/registry/${definition.resource}/`;
+}
+
+export function createScheme(definitions: ResourceDefinition[] = []): Scheme {
+  const scheme = new Scheme();
+  scheme.registerAll(definitions);
+  return scheme;
+}

--- a/src/lib/opslab/apiserver/types.ts
+++ b/src/lib/opslab/apiserver/types.ts
@@ -1,0 +1,102 @@
+/**
+ * apiserver 的对象模型
+ *
+ * 字段与语义照抄 Kubernetes —— 学员从 `kubectl get -o yaml` 里看到什么，
+ * 这里就得有什么。字段名一律用 k8s 的原名，不做本地化的重命名。
+ */
+
+export interface OwnerReference {
+  apiVersion: string;
+  kind: string;
+  name: string;
+  uid: string;
+  /** 属主被删时是否连带删掉这个对象。默认按 true 处理。 */
+  blockOwnerDeletion?: boolean;
+  controller?: boolean;
+}
+
+export interface ObjectMeta {
+  name: string;
+  namespace?: string;
+  uid?: string;
+  /** 就是存储层的 modRevision，字符串形式 —— k8s 对外一律用字符串 */
+  resourceVersion?: string;
+  /** spec 每变一次 +1；status 变不算。控制器拿它和 observedGeneration 比 */
+  generation?: number;
+  creationTimestamp?: string;
+  /**
+   * 标记删除的时刻。
+   *
+   * 有 finalizer 的对象删不掉，只会被打上这个时间戳 —— 对象还在，
+   * 但已经处在「正在删除」状态。所有 finalizer 摘干净了才真的消失。
+   */
+  deletionTimestamp?: string;
+  deletionGracePeriodSeconds?: number;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  finalizers?: string[];
+  ownerReferences?: OwnerReference[];
+}
+
+export interface KubeObject {
+  apiVersion: string;
+  kind: string;
+  metadata: ObjectMeta;
+  spec?: unknown;
+  status?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ListMeta {
+  resourceVersion: string;
+  /** 分页游标；还有下一页时才有 */
+  continue?: string;
+  remainingItemCount?: number;
+}
+
+export interface KubeList {
+  apiVersion: string;
+  kind: string;
+  metadata: ListMeta;
+  items: KubeObject[];
+}
+
+/** 删除策略。对应 kubectl 的 --cascade */
+export type PropagationPolicy = 'Foreground' | 'Background' | 'Orphan';
+
+export interface DeleteOptions {
+  propagationPolicy?: PropagationPolicy;
+  gracePeriodSeconds?: number;
+  /** 前置条件：uid / resourceVersion 对不上就拒绝 */
+  preconditions?: { uid?: string; resourceVersion?: string };
+}
+
+export interface ListOptions {
+  namespace?: string;
+  labelSelector?: string;
+  fieldSelector?: string;
+  limit?: number;
+  /** 上一页返回的 continue */
+  continue?: string;
+  /** 从这一版开始读；不传读最新 */
+  resourceVersion?: string;
+}
+
+export interface CreateOptions {
+  /** 只校验不写 */
+  dryRun?: boolean;
+  fieldManager?: string;
+}
+
+export interface UpdateOptions extends CreateOptions {}
+
+export type PatchType =
+  | 'application/json-patch+json'
+  | 'application/merge-patch+json'
+  | 'application/strategic-merge-patch+json'
+  | 'application/apply-patch+yaml';
+
+export interface WatchEventOut {
+  type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'BOOKMARK';
+  object: KubeObject;
+}

--- a/tests/opslab/apiserver.test.ts
+++ b/tests/opslab/apiserver.test.ts
@@ -1,0 +1,487 @@
+/**
+ * apiserver REST 语义的回归测试
+ *
+ * 这一层的规矩学员会直接撞上：改冲突了报什么、删不掉是因为什么、
+ * 为什么 status 写了不算改 spec。所以报错文本也一并钉死 ——
+ * 那是学员排查问题的全部线索。
+ */
+import { createStore, Store } from '../../src/lib/opslab/store';
+import {
+  ApiError,
+  createScheme,
+  FOREGROUND_DELETION,
+  KubeObject,
+  parseLabelSelector,
+  Registry,
+  ResourceDefinition,
+  Scheme,
+} from '../../src/lib/opslab/apiserver';
+
+const PODS: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'pods', singular: 'pod', kind: 'Pod',
+  namespaced: true, shortNames: ['po'],
+};
+const DEPLOYMENTS: ResourceDefinition = {
+  group: 'apps', version: 'v1', resource: 'deployments', singular: 'deployment',
+  kind: 'Deployment', namespaced: true, shortNames: ['deploy'],
+};
+const NAMESPACES: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'namespaces', singular: 'namespace',
+  kind: 'Namespace', namespaced: false, shortNames: ['ns'],
+};
+
+function setup() {
+  const store: Store = createStore();
+  const scheme = createScheme([PODS, DEPLOYMENTS, NAMESPACES]);
+  let clock = Date.parse('2026-01-01T00:00:00Z');
+  let uidSeq = 0;
+  const registry = new Registry({
+    store,
+    scheme,
+    now: () => clock,
+    uid: () => `uid-${++uidSeq}`,
+  });
+  return {
+    store, scheme, registry,
+    tick: (ms: number) => { clock += ms; },
+  };
+}
+
+const pod = (name: string, extra: Partial<KubeObject> = {}): KubeObject => ({
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name },
+  spec: { containers: [{ name: 'app', image: 'nginx:1.0' }] },
+  ...extra,
+});
+
+describe('创建', () => {
+  it('补上 uid、创建时间、generation 与 resourceVersion', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    expect(created.metadata).toMatchObject({
+      name: 'web',
+      namespace: 'default',
+      uid: 'uid-1',
+      generation: 1,
+      creationTimestamp: '2026-01-01T00:00:00Z',
+    });
+    expect(created.metadata.resourceVersion).toBe('1');
+    expect(created.apiVersion).toBe('v1');
+    expect(created.kind).toBe('Pod');
+  });
+
+  it('重名报 AlreadyExists，文本和真集群一致', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web'));
+    try {
+      registry.create(PODS, 'default', pod('web'));
+      throw new Error('应该抛错');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).code).toBe(409);
+      expect((error as ApiError).reason).toBe('AlreadyExists');
+      expect((error as ApiError).message).toBe('pods "web" already exists');
+    }
+  });
+
+  it('没有名字报 Invalid', () => {
+    const { registry } = setup();
+    expect(() => registry.create(PODS, 'default', pod('') as KubeObject))
+      .toThrow(/Required value: name or generateName is required/);
+  });
+
+  it('创建时带 resourceVersion 会被拒绝', () => {
+    const { registry } = setup();
+    const candidate = pod('web');
+    candidate.metadata.resourceVersion = '5';
+    expect(() => registry.create(PODS, 'default', candidate))
+      .toThrow(/must be empty on create/);
+  });
+
+  it('对象里的 namespace 和 URL 上的对不上会被拒绝', () => {
+    const { registry } = setup();
+    const candidate = pod('web');
+    candidate.metadata.namespace = 'other';
+    expect(() => registry.create(PODS, 'default', candidate))
+      .toThrow(/does not match the namespace sent on the request/);
+  });
+
+  it('集群级资源不接受 namespace', () => {
+    const { registry } = setup();
+    expect(() => registry.create(NAMESPACES, 'default', { apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'x' } }))
+      .toThrow(/namespace is not allowed on a cluster-scoped resource/);
+    const created = registry.create(NAMESPACES, undefined, { apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'x' } });
+    expect(created.metadata.namespace).toBeUndefined();
+  });
+
+  it('dryRun 不落盘', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web'), { dryRun: true });
+    expect(() => registry.get(PODS, 'default', 'web')).toThrow(/pods "web" not found/);
+  });
+});
+
+describe('读取与找不到', () => {
+  it('找不到的报错文本和真集群一致', () => {
+    const { registry } = setup();
+    try {
+      registry.get(PODS, 'default', 'nope');
+      throw new Error('应该抛错');
+    } catch (error) {
+      const api = error as ApiError;
+      expect(api.code).toBe(404);
+      expect(api.message).toBe('pods "nope" not found');
+      expect(api.status.details).toMatchObject({ name: 'nope', kind: 'pods' });
+    }
+  });
+
+  it('列表按名字排序并带上 resourceVersion', () => {
+    const { registry } = setup();
+    for (const name of ['zeta', 'alpha', 'mid']) registry.create(PODS, 'default', pod(name));
+    const list = registry.list(PODS, { namespace: 'default' });
+    expect(list.items.map((i) => i.metadata.name)).toEqual(['alpha', 'mid', 'zeta']);
+    expect(list.kind).toBe('PodList');
+    expect(list.metadata.resourceVersion).toBe('3');
+  });
+
+  it('只列出指定命名空间', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('a'));
+    registry.create(PODS, 'kube-system', pod('b'));
+    expect(registry.list(PODS, { namespace: 'default' }).items.map((i) => i.metadata.name)).toEqual(['a']);
+    expect(registry.list(PODS, {}).items.map((i) => i.metadata.name)).toEqual(['a', 'b']);
+  });
+
+  it('标签选择器', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web', { metadata: { name: 'web', labels: { app: 'web', tier: 'front' } } }));
+    registry.create(PODS, 'default', pod('db', { metadata: { name: 'db', labels: { app: 'db' } } }));
+    const list = registry.list(PODS, { namespace: 'default', labelSelector: 'app=web' });
+    expect(list.items.map((i) => i.metadata.name)).toEqual(['web']);
+  });
+
+  it('字段选择器', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('a', { spec: { nodeName: 'node-1' } }));
+    registry.create(PODS, 'default', pod('b', { spec: { nodeName: 'node-2' } }));
+    const list = registry.list(PODS, { namespace: 'default', fieldSelector: 'spec.nodeName=node-1' });
+    expect(list.items.map((i) => i.metadata.name)).toEqual(['a']);
+  });
+
+  it('分页：continue 翻页且期间的写不会串进来', () => {
+    const { registry } = setup();
+    for (const name of ['a', 'b', 'c', 'd', 'e']) registry.create(PODS, 'default', pod(name));
+
+    const page1 = registry.list(PODS, { namespace: 'default', limit: 2 });
+    expect(page1.items.map((i) => i.metadata.name)).toEqual(['a', 'b']);
+    expect(page1.metadata.continue).toBeDefined();
+    expect(page1.metadata.remainingItemCount).toBe(3);
+
+    // 翻页期间插入新对象，不应该出现在后续页里 —— 翻的是同一版快照
+    registry.create(PODS, 'default', pod('aa'));
+
+    const page2 = registry.list(PODS, { namespace: 'default', limit: 2, continue: page1.metadata.continue });
+    expect(page2.items.map((i) => i.metadata.name)).toEqual(['c', 'd']);
+
+    const page3 = registry.list(PODS, { namespace: 'default', limit: 2, continue: page2.metadata.continue });
+    expect(page3.items.map((i) => i.metadata.name)).toEqual(['e']);
+    expect(page3.metadata.continue).toBeUndefined();
+  });
+
+  it('坏掉的 continue token 报 BadRequest', () => {
+    const { registry } = setup();
+    expect(() => registry.list(PODS, { namespace: 'default', continue: 'garbage' }))
+      .toThrow(/continue key is not valid/);
+  });
+});
+
+describe('更新与乐观并发', () => {
+  it('resourceVersion 对得上就更新成功', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    const next = { ...created, spec: { containers: [{ name: 'app', image: 'nginx:2.0' }] } };
+    const updated = registry.update(PODS, 'default', 'web', next);
+    expect((updated.spec as any).containers[0].image).toBe('nginx:2.0');
+    expect(updated.metadata.resourceVersion).toBe('2');
+  });
+
+  it('中间被别人改过就 409，文本和真集群一致', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    // 别人先改了一版
+    registry.update(PODS, 'default', 'web', { ...created, spec: { note: 'someone else' } });
+
+    try {
+      registry.update(PODS, 'default', 'web', { ...created, spec: { note: 'mine' } });
+      throw new Error('应该抛错');
+    } catch (error) {
+      const api = error as ApiError;
+      expect(api.code).toBe(409);
+      expect(api.reason).toBe('Conflict');
+      expect(api.message).toBe(
+        'Operation cannot be fulfilled on pods "web": the object has been modified; ' +
+          'please apply your changes to the latest version and try again'
+      );
+    }
+  });
+
+  it('不带 resourceVersion 就是无条件覆盖', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web'));
+    const blind = pod('web', { spec: { note: 'blind write' } });
+    expect(() => registry.update(PODS, 'default', 'web', blind)).not.toThrow();
+  });
+
+  it('spec 变了才 +generation', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    expect(created.metadata.generation).toBe(1);
+
+    // 只改标签
+    const labelOnly = registry.update(PODS, 'default', 'web', {
+      ...created,
+      metadata: { ...created.metadata, labels: { a: 'b' } },
+    });
+    expect(labelOnly.metadata.generation).toBe(1);
+
+    const specChange = registry.update(PODS, 'default', 'web', {
+      ...labelOnly,
+      spec: { containers: [{ name: 'app', image: 'nginx:2.0' }] },
+    });
+    expect(specChange.metadata.generation).toBe(2);
+  });
+
+  it('主资源的 update 改不动 status —— 那是子资源', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    registry.updateStatus(PODS, 'default', 'web', { ...created, status: { phase: 'Running' } });
+
+    const sneaky = registry.get(PODS, 'default', 'web');
+    const after = registry.update(PODS, 'default', 'web', {
+      ...sneaky,
+      status: { phase: 'Succeeded' },              // 想顺手改 status
+      spec: { containers: [] },
+    });
+    expect((after.status as any).phase).toBe('Running');
+  });
+
+  it('写 status 不 +generation —— 否则 observedGeneration 永远追不上', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    const after = registry.updateStatus(PODS, 'default', 'web', { ...created, status: { phase: 'Running' } });
+    expect(after.metadata.generation).toBe(1);
+    expect((after.status as any).phase).toBe('Running');
+  });
+
+  it('改名字会被拒绝', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    expect(() => registry.update(PODS, 'default', 'web', {
+      ...created,
+      metadata: { ...created.metadata, name: 'renamed' },
+    })).toThrow(/does not match the name on the URL/);
+  });
+
+  it('uid 与创建时间由服务端说了算，客户端改不动', () => {
+    const { registry } = setup();
+    const created = registry.create(PODS, 'default', pod('web'));
+    const after = registry.update(PODS, 'default', 'web', {
+      ...created,
+      metadata: { ...created.metadata, uid: 'forged', creationTimestamp: '1999-01-01T00:00:00Z' },
+    });
+    expect(after.metadata.uid).toBe('uid-1');
+    expect(after.metadata.creationTimestamp).toBe('2026-01-01T00:00:00Z');
+  });
+});
+
+describe('删除与 finalizer', () => {
+  it('没有 finalizer 就直接删掉', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web'));
+    registry.delete(PODS, 'default', 'web');
+    expect(() => registry.get(PODS, 'default', 'web')).toThrow(/not found/);
+  });
+
+  it('有 finalizer 的删不掉，只是被标上 deletionTimestamp', () => {
+    const { registry, tick } = setup();
+    registry.create(PODS, 'default', pod('web', {
+      metadata: { name: 'web', finalizers: ['example.com/cleanup'] },
+    }));
+    tick(5000);
+    const deleted = registry.delete(PODS, 'default', 'web');
+    expect(deleted.metadata.deletionTimestamp).toBe('2026-01-01T00:00:05Z');
+
+    // 对象还在
+    const still = registry.get(PODS, 'default', 'web');
+    expect(still.metadata.deletionTimestamp).toBeDefined();
+    expect(still.metadata.finalizers).toEqual(['example.com/cleanup']);
+  });
+
+  it('摘掉最后一个 finalizer，对象才真的消失', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web', {
+      metadata: { name: 'web', finalizers: ['a', 'b'] },
+    }));
+    registry.delete(PODS, 'default', 'web');
+
+    const afterFirst = registry.removeFinalizer(PODS, 'default', 'web', 'a');
+    expect(afterFirst).not.toBeNull();
+    expect(afterFirst!.metadata.finalizers).toEqual(['b']);
+
+    const afterSecond = registry.removeFinalizer(PODS, 'default', 'web', 'b');
+    expect(afterSecond).toBeNull();
+    expect(() => registry.get(PODS, 'default', 'web')).toThrow(/not found/);
+  });
+
+  it('没标删除时摘 finalizer，对象继续活着', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web', { metadata: { name: 'web', finalizers: ['a'] } }));
+    const after = registry.removeFinalizer(PODS, 'default', 'web', 'a');
+    expect(after).not.toBeNull();
+    expect(after!.metadata.deletionTimestamp).toBeUndefined();
+  });
+
+  it('前台级联删除会加上 foregroundDeletion finalizer', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web'));
+    const deleted = registry.delete(PODS, 'default', 'web', { propagationPolicy: 'Foreground' });
+    expect(deleted.metadata.finalizers).toContain(FOREGROUND_DELETION);
+    expect(deleted.metadata.deletionTimestamp).toBeDefined();
+  });
+
+  it('uid 前置条件对不上会拒绝 —— 防的是「删到了重建后的同名对象」', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('web'));
+    expect(() => registry.delete(PODS, 'default', 'web', { preconditions: { uid: 'stale-uid' } }))
+      .toThrow(/The object might have been deleted and then recreated/);
+  });
+});
+
+describe('watch', () => {
+  it('ADDED / MODIFIED / DELETED 三种事件', () => {
+    const { registry } = setup();
+    const seen: string[] = [];
+    registry.watch(PODS, { namespace: 'default' }, (e) => seen.push(`${e.type} ${e.object.metadata.name}`));
+
+    const created = registry.create(PODS, 'default', pod('web'));
+    registry.update(PODS, 'default', 'web', { ...created, spec: { note: 'changed' } });
+    registry.delete(PODS, 'default', 'web');
+
+    expect(seen).toEqual(['ADDED web', 'MODIFIED web', 'DELETED web']);
+  });
+
+  it('从 list 拿到的 resourceVersion 起 watch 不会漏事件', () => {
+    const { registry } = setup();
+    registry.create(PODS, 'default', pod('a'));
+    const listed = registry.list(PODS, { namespace: 'default' });
+    // watch 建立之前发生的变更
+    registry.create(PODS, 'default', pod('b'));
+
+    const seen: string[] = [];
+    registry.watch(
+      PODS,
+      { namespace: 'default', resourceVersion: listed.metadata.resourceVersion },
+      (e) => seen.push(`${e.type} ${e.object.metadata.name}`)
+    );
+    expect(seen).toEqual(['ADDED b']);
+  });
+
+  it('版本太老报 410 Gone，informer 收到后应当重新 list', () => {
+    const { registry, store } = setup();
+    registry.create(PODS, 'default', pod('a'));
+    registry.create(PODS, 'default', pod('b'));
+    store.compact(2);
+    try {
+      registry.watch(PODS, { namespace: 'default', resourceVersion: '1' }, () => {});
+      throw new Error('应该抛错');
+    } catch (error) {
+      const api = error as ApiError;
+      expect(api.code).toBe(410);
+      expect(api.message).toMatch(/^too old resource version: 1 \(2\)$/);
+    }
+  });
+
+  it('watch 支持标签选择器', () => {
+    const { registry } = setup();
+    const seen: string[] = [];
+    registry.watch(PODS, { namespace: 'default', labelSelector: 'app=web' }, (e) => seen.push(e.object.metadata.name));
+    registry.create(PODS, 'default', pod('web', { metadata: { name: 'web', labels: { app: 'web' } } }));
+    registry.create(PODS, 'default', pod('db', { metadata: { name: 'db', labels: { app: 'db' } } }));
+    expect(seen).toEqual(['web']);
+  });
+});
+
+describe('scheme', () => {
+  it('复数、单数、简称、带组名都能解析到同一个资源', () => {
+    const scheme = createScheme([PODS, DEPLOYMENTS]);
+    for (const name of ['pods', 'pod', 'po', 'Pods', 'PO']) {
+      expect(scheme.resolve(name)?.kind).toBe('Pod');
+    }
+    expect(scheme.resolve('deploy')?.kind).toBe('Deployment');
+    expect(scheme.resolve('deployments.apps')?.kind).toBe('Deployment');
+  });
+
+  it('解析结果稳定 —— 同名资源按组名定序，核心组优先', () => {
+    const scheme = createScheme([
+      { group: 'zzz', version: 'v1', resource: 'widgets', singular: 'widget', kind: 'ZWidget', namespaced: true },
+      { group: '', version: 'v1', resource: 'widgets', singular: 'widget', kind: 'CoreWidget', namespaced: true },
+      { group: 'aaa', version: 'v1', resource: 'widgets', singular: 'widget', kind: 'AWidget', namespaced: true },
+    ]);
+    for (let i = 0; i < 20; i += 1) expect(scheme.resolve('widgets')?.kind).toBe('CoreWidget');
+  });
+
+  it('groupVersions 稳定排序，核心组的 v1 在最前', () => {
+    const scheme = createScheme([DEPLOYMENTS, PODS, NAMESPACES]);
+    expect(scheme.groupVersions()).toEqual(['v1', 'apps/v1']);
+  });
+
+  it('apiVersion 的拆与合', () => {
+    expect(Scheme.parseApiVersion('apps/v1')).toEqual({ group: 'apps', version: 'v1' });
+    expect(Scheme.parseApiVersion('v1')).toEqual({ group: '', version: 'v1' });
+    expect(Scheme.toApiVersion('apps', 'v1')).toBe('apps/v1');
+    expect(Scheme.toApiVersion('', 'v1')).toBe('v1');
+  });
+});
+
+describe('标签选择器语法', () => {
+  it('等于、不等于、存在、不存在、in、notin', () => {
+    const labels = { app: 'web', tier: 'front' };
+    expect(parseLabelSelector('app=web')(labels)).toBe(true);
+    expect(parseLabelSelector('app=db')(labels)).toBe(false);
+    expect(parseLabelSelector('app!=db')(labels)).toBe(true);
+    expect(parseLabelSelector('app')(labels)).toBe(true);
+    expect(parseLabelSelector('!missing')(labels)).toBe(true);
+    expect(parseLabelSelector('app in (web,db)')(labels)).toBe(true);
+    expect(parseLabelSelector('app notin (web,db)')(labels)).toBe(false);
+    expect(parseLabelSelector('app==web')(labels)).toBe(true);
+    expect(parseLabelSelector('app=web,tier=front')(labels)).toBe(true);
+    expect(parseLabelSelector('app=web,tier=back')(labels)).toBe(false);
+    // 括号里的逗号不是子句分隔符 —— 直接 split(',') 会把这条切碎
+    expect(parseLabelSelector('app in (web,db),tier=front')(labels)).toBe(true);
+    expect(parseLabelSelector('app in (db,cache),tier=front')(labels)).toBe(false);
+  });
+});
+
+describe('确定性', () => {
+  it('同一串操作重放 100 次，输出逐字节一致', () => {
+    const run = () => {
+      const { registry } = setup();
+      const log: string[] = [];
+      registry.watch(PODS, {}, (e) => log.push(`${e.type} ${e.object.metadata.name}@${e.object.metadata.resourceVersion}`));
+
+      for (const name of ['delta', 'alpha', 'charlie']) {
+        registry.create(PODS, 'default', pod(name, { metadata: { name, labels: { batch: 'one' } } }));
+      }
+      const alpha = registry.get(PODS, 'default', 'alpha');
+      registry.update(PODS, 'default', 'alpha', { ...alpha, spec: { note: 'updated' } });
+      registry.updateStatus(PODS, 'default', 'alpha', { ...registry.get(PODS, 'default', 'alpha'), status: { phase: 'Running' } });
+      registry.delete(PODS, 'default', 'delta');
+
+      log.push(JSON.stringify(registry.list(PODS, { namespace: 'default' })));
+      return log.join('\n');
+    };
+    const first = run();
+    for (let i = 0; i < 99; i += 1) expect(run()).toBe(first);
+  });
+});

--- a/tests/opslab/browser-safety.test.ts
+++ b/tests/opslab/browser-safety.test.ts
@@ -1,0 +1,55 @@
+/**
+ * opslab 的代码必须能在浏览器里跑
+ *
+ * 测试跑在 Node 里，Node 有 Buffer、process、__dirname 这些全局，浏览器没有。
+ * 于是「用了 Node 专属 API」这类错误在测试里完全看不出来，要到真在浏览器打开
+ * 才炸 —— 而且往往是分页、快照这种不常走的路径，很晚才被发现。
+ *
+ * 这里直接扫源码。粗糙，但拦得住。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.join(__dirname, '../../src/lib/opslab');
+
+/** 只在明确标了「Node 专用」的文件里允许 */
+const NODE_ONLY_PATTERNS: Array<{ pattern: RegExp; why: string }> = [
+  { pattern: /\bBuffer\s*\./, why: 'Buffer 在浏览器 bundle 里是 undefined（webpack 5 不打 polyfill）；用 btoa/atob 或 TextEncoder' },
+  { pattern: /\brequire\s*\(\s*['"]node:/, why: '不能直接 require node: 内置模块' },
+  { pattern: /\bfrom\s+['"]node:/, why: '不能 import node: 内置模块' },
+  { pattern: /\b__dirname\b/, why: '__dirname 在浏览器里不存在' },
+  { pattern: /\bprocess\.cwd\s*\(/, why: 'process.cwd 在浏览器里不存在' },
+];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (/\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+describe('opslab 源码的浏览器安全性', () => {
+  const files = walk(ROOT);
+
+  it('扫到了文件（否则这个守卫等于没有）', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it.each(NODE_ONLY_PATTERNS)('不使用 Node 专属 API：$why', ({ pattern, why }) => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = fs.readFileSync(file, 'utf8');
+      // 允许在注释里提到它们（上面那些说明就提到了 Buffer）
+      const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/.*$/gm, '$1');
+      if (pattern.test(code)) offenders.push(path.relative(ROOT, file));
+    }
+    if (offenders.length > 0) {
+      throw new Error(`${offenders.join(', ')} 用了 Node 专属 API —— ${why}`);
+    }
+  });
+});


### PR DESCRIPTION
第三段第 2 片的第二块，架在 [#28](https://github.com/zxypro1/algolocal/pull/28) 的 etcd 存储上。

## 这一层管什么

对象**生命周期**——不管字段合不合法（schema 校验接官方 OpenAPI，是下一片的事）。

| 语义 | 学员什么时候会撞上 |
| --- | --- |
| `resourceVersion` 乐观并发 | 两个地方同时改一个对象，后写的拿到 409 |
| `generation` 只在 spec 变时 +1 | `observedGeneration` 能不能追上，决定「这个 Deployment 收敛了没有」 |
| status 是子资源 | 控制器和用户各写各的字段，互不覆盖 |
| finalizer | `kubectl delete` 卡住不动，对象带着 `deletionTimestamp` 一直在 |
| 分页 continue | 大集群 `kubectl get pods` 分批取 |
| watch 410 Gone | informer 断线太久，必须丢缓存重新 list |

## 几个刻意做对的点

**`generation` 只在 spec 变时 +1。** status 每秒都在写，它要是也 bump，
`observedGeneration` 永远追不上，「收敛了没有」就没法判断了。

**分页翻的是同一版快照。** 翻页期间新建的对象不会串进后续页 —— 测试里专门插了一个验这个。

**级联删除只记意图。** apiserver 加 `foregroundDeletion` / `orphan` finalizer 就完事，
真正去删依赖对象的是 GC 控制器（下一片）。和真 k8s 的分工一致。

**报错文本照抄 k8s `errors.go`**，不自创措辞——那是学员排查问题的全部线索：

```
pods "nope" not found
pods "web" already exists
Operation cannot be fulfilled on pods "web": the object has been modified; please apply your changes to the latest version and try again
too old resource version: 1 (2)
```

**scheme 解析稳定**：同名资源按「核心组优先、再按组名」定序，
保证 `kubectl get widgets` 每次都落到同一个资源上，不看注册顺序。

## 自审抓到一个 bug

标签选择器先按逗号切分，把 `app in (web,db)` 切成了 `app in (web` 和 `db)` 两半。
改成括号感知的切分，补了回归；顺带支持 k8s 里等价的 `==` 写法。

## 验证

- 38 条 apiserver 测试全绿，含重放 100 次逐字节一致
- opslab 套件累计 **87 条**（内核 20 + 存储 29 + apiserver 38）
- `npm test` 8/8、`npm run build` 通过、`projects:verify` 全通过、`tsc` 干净
- 不碰既有代码路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)