### PR TITLE
feat(opslab): 控制器框架与核心控制器

### DIFF
--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -1,0 +1,223 @@
+/**
+ * 把内核、存储、apiserver、控制器接成一个能跑的集群
+ *
+ * 这是工作台真正拿在手里的东西：`cluster.apiServer.handle` 喂给 kubectl，
+ * `cluster.settle()` 把世界推到静止，`cluster.advanceBy()` 快进时间。
+ */
+import { Kernel, createKernel, Priority } from '../kernel';
+import { createStore, Store } from '../store';
+import {
+  ApiServer,
+  createApiServer,
+  createScheme,
+  KubeObject,
+  Registry,
+  ResourceDefinition,
+  Scheme,
+} from '../apiserver';
+import { Controller, ControllerContext } from './framework';
+import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
+import {
+  DeploymentController,
+  EndpointsController,
+  ImageSpec,
+  KubeletController,
+  ReplicaSetController,
+  SchedulerController,
+} from './workloads';
+
+export interface NodeSpec {
+  name: string;
+  /** 可分配 CPU，如 `4` 或 `4000m` */
+  cpu?: string;
+  memory?: string;
+  labels?: Record<string, string>;
+  /** 打上之后调度器不再往这里放新 Pod */
+  unschedulable?: boolean;
+}
+
+export interface ClusterOptions {
+  seed?: number;
+  /** 世界的起始时刻 */
+  startTime?: number;
+  nodes?: NodeSpec[];
+  namespaces?: string[];
+  /** 镜像目录：不在里面的镜像拉不到 */
+  images?: Record<string, ImageSpec>;
+  extraResources?: ResourceDefinition[];
+}
+
+export class Cluster {
+  readonly kernel: Kernel;
+  readonly store: Store;
+  readonly scheme: Scheme;
+  readonly registry: Registry;
+  readonly apiServer: ApiServer;
+
+  private controllers: Controller[] = [];
+  private uidSeq = 0;
+  private started = false;
+
+  constructor(private readonly options: ClusterOptions = {}) {
+    this.kernel = createKernel({ seed: options.seed ?? 1 });
+    // 世界的起始时刻是一个偏移量，内核的时钟从 0 开始走
+    const startTime = options.startTime ?? Date.parse('2026-01-01T00:00:00Z');
+    const now = () => startTime + this.kernel.now();
+
+    this.store = createStore();
+    this.scheme = createScheme([...CORE_RESOURCES, ...(options.extraResources ?? [])]);
+    this.registry = new Registry({
+      store: this.store,
+      scheme: this.scheme,
+      now,
+      uid: () => `uid-${String(++this.uidSeq).padStart(6, '0')}`,
+    });
+    this.apiServer = createApiServer({ registry: this.registry, scheme: this.scheme, now });
+
+    this.seed();
+  }
+
+  /** 世界的墙钟：起始时刻 + 虚拟流逝 */
+  wallClock(): number {
+    return (this.options.startTime ?? Date.parse('2026-01-01T00:00:00Z')) + this.kernel.now();
+  }
+
+  private get context(): ControllerContext {
+    return {
+      kernel: this.kernel,
+      registry: this.registry,
+      now: () => this.wallClock(),
+      recordEvent: (input) => this.recordEvent(input),
+    };
+  }
+
+  /** 建好命名空间与节点。这些是世界的初态，不是控制器造出来的。 */
+  private seed(): void {
+    const namespaces = this.options.namespaces ?? ['default', 'kube-system'];
+    for (const name of namespaces) {
+      this.registry.create(NAMESPACES, undefined, {
+        apiVersion: 'v1', kind: 'Namespace',
+        metadata: { name },
+        status: { phase: 'Active' },
+      });
+    }
+
+    const nodes = this.options.nodes ?? [
+      { name: 'node-1' }, { name: 'node-2' }, { name: 'node-3' },
+    ];
+    for (const node of nodes) {
+      const cpu = node.cpu ?? '4';
+      const memory = node.memory ?? '8Gi';
+      this.registry.create(NODES, undefined, {
+        apiVersion: 'v1', kind: 'Node',
+        metadata: {
+          name: node.name,
+          labels: {
+            'kubernetes.io/hostname': node.name,
+            'kubernetes.io/os': 'linux',
+            ...(node.labels ?? {}),
+          },
+        },
+        spec: { unschedulable: node.unschedulable ?? false },
+        status: {
+          capacity: { cpu, memory, pods: '110' },
+          allocatable: { cpu, memory, pods: '110' },
+          conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
+          addresses: [{ type: 'InternalIP', address: `10.0.0.${nodes.indexOf(node) + 10}` }],
+          nodeInfo: {
+            kubeletVersion: 'v1.36.0',
+            osImage: 'Debian GNU/Linux 12 (bookworm)',
+            kernelVersion: '6.1.0-opslab',
+            containerRuntimeVersion: 'containerd://2.0.0',
+          },
+        },
+      });
+    }
+  }
+
+  /**
+   * 记一条 Event。
+   *
+   * 名字带上时间，同一个对象上的多条事件不会互相覆盖 ——
+   * `kubectl describe` 底下那段事件列表就是从这里来的。
+   */
+  recordEvent(input: {
+    object: KubeObject;
+    type: 'Normal' | 'Warning';
+    reason: string;
+    message: string;
+  }): void {
+    const namespace = input.object.metadata.namespace ?? 'default';
+    const name = `${input.object.metadata.name}.${this.kernel.now().toString(16)}${this.eventSeq++}`;
+    try {
+      this.registry.create(EVENTS, namespace, {
+        apiVersion: 'v1', kind: 'Event',
+        metadata: { name, namespace },
+        type: input.type,
+        reason: input.reason,
+        message: input.message,
+        involvedObject: {
+          kind: input.object.kind,
+          name: input.object.metadata.name,
+          namespace: input.object.metadata.namespace,
+          uid: input.object.metadata.uid,
+        },
+        count: 1,
+      } as KubeObject);
+    } catch {
+      // 事件写不进去不该影响主流程
+    }
+  }
+
+  private eventSeq = 0;
+
+  /** 起所有控制器。调用之后世界开始自己动。 */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    const context = this.context;
+    this.controllers = [
+      new SchedulerController(context),
+      new ReplicaSetController(context),
+      new DeploymentController(context),
+      new EndpointsController(context),
+      ...(this.options.nodes ?? [{ name: 'node-1' }, { name: 'node-2' }, { name: 'node-3' }]).map(
+        (node) => new KubeletController(context, node.name, { images: this.options.images })
+      ),
+    ];
+    for (const controller of this.controllers) controller.start();
+  }
+
+  /** 把世界推到静止 */
+  settle(options?: { maxVirtualMs?: number }): Promise<void> {
+    return this.kernel.settle(options);
+  }
+
+  /**
+   * 快进一段虚拟时间。
+   *
+   * 只跑这段窗口内到期的东西，**不会**顺带把之后的也跑完 ——
+   * 想看中间态就小步快进，想要终态就调 settle()。
+   */
+  advanceBy(ms: number): Promise<void> {
+    return this.kernel.advanceBy(ms);
+  }
+
+  /** 当前虚拟时刻（毫秒，从世界起点算） */
+  now(): number {
+    return this.kernel.now();
+  }
+
+  stop(): void {
+    for (const controller of this.controllers) controller.stop();
+    this.controllers = [];
+    this.started = false;
+  }
+}
+
+export function createCluster(options?: ClusterOptions): Cluster {
+  return new Cluster(options);
+}
+
+export { Priority };

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -91,6 +91,11 @@ export class Cluster {
     };
   }
 
+  /** 节点清单。seed 和 start 都要用，只能有一处定义，否则两边会漂。 */
+  private get nodeSpecs(): NodeSpec[] {
+    return this.options.nodes ?? [{ name: 'node-1' }, { name: 'node-2' }, { name: 'node-3' }];
+  }
+
   /** 建好命名空间与节点。这些是世界的初态，不是控制器造出来的。 */
   private seed(): void {
     const namespaces = this.options.namespaces ?? ['default', 'kube-system'];
@@ -102,9 +107,7 @@ export class Cluster {
       });
     }
 
-    const nodes = this.options.nodes ?? [
-      { name: 'node-1' }, { name: 'node-2' }, { name: 'node-3' },
-    ];
+    const nodes = this.nodeSpecs;
     for (const node of nodes) {
       const cpu = node.cpu ?? '4';
       const memory = node.memory ?? '8Gi';
@@ -182,7 +185,7 @@ export class Cluster {
       new ReplicaSetController(context),
       new DeploymentController(context),
       new EndpointsController(context),
-      ...(this.options.nodes ?? [{ name: 'node-1' }, { name: 'node-2' }, { name: 'node-3' }]).map(
+      ...this.nodeSpecs.map(
         (node) => new KubeletController(context, node.name, { images: this.options.images })
       ),
     ];

--- a/src/lib/opslab/controllers/framework.ts
+++ b/src/lib/opslab/controllers/framework.ts
@@ -301,6 +301,17 @@ export abstract class Controller {
    * mapKey 决定「这个对象变了，该 reconcile 谁」——
    * ReplicaSet 控制器 watch Pod，但要 reconcile 的是 Pod 的属主。
    */
+  /**
+   * 登记一个 informer，让 start()/stop() 管它的生命周期。
+   *
+   * 只调 informer.onChange 而不登记的话，start() 不会启动它，
+   * 它就永远收不到事件 —— 这个坑很安静，专门给个方法避开。
+   */
+  protected track(informer: Informer): Informer {
+    if (!this.informers.includes(informer)) this.informers.push(informer);
+    return informer;
+  }
+
   protected watch(informer: Informer, mapKey: (object: KubeObject, key: string) => string | null = (_, key) => key): void {
     informer.onChange((key, object) => {
       // 删除时缓存里已经没有它了，用事件带来的最后一次状态来定位属主
@@ -308,7 +319,7 @@ export abstract class Controller {
       const target = known ? mapKey(known, key) : key;
       if (target) this.queue.add(target);
     });
-    this.informers.push(informer);
+    this.track(informer);
   }
 
   protected abstract reconcile(key: string): Promise<void> | void;

--- a/src/lib/opslab/controllers/framework.ts
+++ b/src/lib/opslab/controllers/framework.ts
@@ -1,0 +1,341 @@
+/**
+ * 控制器框架：informer + workqueue
+ *
+ * 照抄真 k8s 的形状，因为控制器的行为特征就是从这个形状里长出来的：
+ *
+ *  - **informer 先 list 再 watch**：拿到 list 的 resourceVersion，从那一版起 watch，
+ *    中间不漏事件。收到 410 Gone（版本被压缩了）就丢掉缓存重新 list。
+ *  - **workqueue 按 key 去重**：同一个对象在一次 reconcile 期间被改了五次，
+ *    只会再排一次队，而不是五次。这是控制器不被写放大压垮的原因。
+ *  - **失败按指数退避重排**：一个 reconcile 失败不会卡住整条队列，
+ *    也不会立刻疯狂重试。
+ *  - **定期重扫（resync）**：level-triggered 的兜底。哪怕漏了事件，
+ *    下一轮重扫也会把世界拉回期望状态 —— 这也是快照恢复之后
+ *    只要重新起控制器就能收敛的原因。
+ */
+import { Kernel, Priority } from '../kernel';
+import { ApiError, KubeObject, Registry, ResourceDefinition } from '../apiserver';
+
+/** 对象在队列里的身份：`namespace/name`，集群级资源就是 `name` */
+export function objectKey(object: KubeObject): string {
+  return object.metadata.namespace
+    ? `${object.metadata.namespace}/${object.metadata.name}`
+    : object.metadata.name;
+}
+
+export function splitKey(key: string): { namespace?: string; name: string } {
+  const index = key.indexOf('/');
+  if (index < 0) return { name: key };
+  return { namespace: key.slice(0, index), name: key.slice(index + 1) };
+}
+
+/**
+ * 本地缓存 + 事件订阅。
+ *
+ * 控制器读缓存而不是每次都打 apiserver —— 真 k8s 也是这样，
+ * 于是「控制器看到的世界可能比实际落后一点」这个特性被保留下来了，
+ * 而这正是很多竞态的来源，值得让学员感受到。
+ */
+export class Informer {
+  private cache = new Map<string, KubeObject>();
+  private handlers: Array<(key: string, object: KubeObject | undefined) => void> = [];
+  private watcher: { cancel: () => void } | null = null;
+  private started = false;
+
+  constructor(
+    private readonly registry: Registry,
+    private readonly definition: ResourceDefinition,
+    private readonly options: { namespace?: string; labelSelector?: string } = {}
+  ) {}
+
+  /**
+   * 对象变化的回调。
+   *
+   * object 是**最后一次已知状态** —— 删除时缓存里已经没有它了，但处理器多半
+   * 正需要它（ReplicaSet 控制器要靠 ownerReferences 才知道该 reconcile 谁）。
+   * 不给的话删掉一个 Pod，属主根本不会被通知，副本补不回来。
+   */
+  onChange(handler: (key: string, object: KubeObject | undefined) => void): void {
+    this.handlers.push(handler);
+  }
+
+  /** 先 list 建立缓存，再从那一版起 watch */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.resync();
+  }
+
+  /**
+   * 重新 list 并接上 watch。
+   *
+   * 缓存被清空重建，所以所有对象都会被重新入队一次 ——
+   * level-triggered 的控制器对此免疫（reconcile 是幂等的）。
+   */
+  resync(): void {
+    this.watcher?.cancel();
+    const list = this.registry.list(this.definition, {
+      namespace: this.options.namespace,
+      labelSelector: this.options.labelSelector,
+    });
+
+    this.cache = new Map(list.items.map((item) => [objectKey(item), item]));
+    for (const [key, object] of this.cache) this.notify(key, object);
+
+    this.watcher = this.registry.watch(
+      this.definition,
+      {
+        namespace: this.options.namespace,
+        labelSelector: this.options.labelSelector,
+        resourceVersion: list.metadata.resourceVersion,
+      },
+      (event) => {
+        const key = objectKey(event.object);
+        if (event.type === 'DELETED') this.cache.delete(key);
+        else this.cache.set(key, event.object);
+        this.notify(key, event.object);
+      }
+    );
+  }
+
+  private notify(key: string, object: KubeObject | undefined): void {
+    for (const handler of this.handlers) handler(key, object);
+  }
+
+  get(key: string): KubeObject | undefined {
+    return this.cache.get(key);
+  }
+
+  /** 缓存里的全部对象，按 key 稳定排序 */
+  list(): KubeObject[] {
+    return [...this.cache.entries()]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([, object]) => object);
+  }
+
+  stop(): void {
+    this.watcher?.cancel();
+    this.watcher = null;
+    this.started = false;
+  }
+}
+
+export interface WorkQueueOptions {
+  /** 首次重试的退避，之后翻倍 */
+  baseBackoffMs?: number;
+  maxBackoffMs?: number;
+  /** 同一个 key 连续失败多少次之后放弃并上报 */
+  maxRetries?: number;
+}
+
+/**
+ * 去重的工作队列。
+ *
+ * 「同一个 key 排队期间又来了几次变更，只算一次」这条是控制器的核心特性：
+ * 一个 Deployment 被连改十次，控制器只需要 reconcile 到最终状态一次。
+ */
+export class WorkQueue {
+  private queue: string[] = [];
+  private queued = new Set<string>();
+  private processing = new Set<string>();
+  /** 处理期间又被标脏的 key，处理完要再排一次 */
+  private dirty = new Set<string>();
+  private failures = new Map<string, number>();
+
+  constructor(
+    private readonly kernel: Kernel,
+    private readonly name: string,
+    private readonly options: WorkQueueOptions = {}
+  ) {}
+
+  add(key: string): void {
+    if (this.processing.has(key)) {
+      // 正在处理的对象又变了 —— 处理完再排一次，别丢掉这次变更
+      this.dirty.add(key);
+      return;
+    }
+    if (this.queued.has(key)) return;
+    this.queued.add(key);
+    this.queue.push(key);
+    this.schedulePump();
+  }
+
+  /** 延后入队，用于退避重试 */
+  addAfter(key: string, delayMs: number): void {
+    this.kernel.setTimeout(() => this.add(key), delayMs, {
+      priority: Priority.CONTROLLER,
+      label: `${this.name}:retry:${key}`,
+    });
+  }
+
+  get length(): number {
+    return this.queue.length;
+  }
+
+  private take(): string | undefined {
+    const key = this.queue.shift();
+    if (key === undefined) return undefined;
+    this.queued.delete(key);
+    this.processing.add(key);
+    return key;
+  }
+
+  private done(key: string): void {
+    this.processing.delete(key);
+    if (this.dirty.delete(key)) this.add(key);
+  }
+
+  /** 一次成功的 reconcile：清掉失败计数 */
+  private forget(key: string): void {
+    this.failures.delete(key);
+  }
+
+  /** 一次失败：按指数退避重排 */
+  private requeue(key: string): number | null {
+    const attempts = (this.failures.get(key) ?? 0) + 1;
+    this.failures.set(key, attempts);
+    const maxRetries = this.options.maxRetries ?? 15;
+    if (attempts > maxRetries) {
+      this.failures.delete(key);
+      return null;                                  // 放弃
+    }
+    const base = this.options.baseBackoffMs ?? 5;
+    const max = this.options.maxBackoffMs ?? 1000 * 300;
+    return Math.min(base * 2 ** (attempts - 1), max);
+  }
+
+  /**
+   * 起消费循环。
+   *
+   * 不能用「spawn 一个 for(;;) 的常驻任务」来做 —— 那样 kernel.liveTasks 永远大于 0，
+   * settle() 就再也返回不了（第一版这么写，测试直接挂死）。
+   *
+   * 正确的形状是：**有活才排一个前台定时器**。队列空了就没有定时器，
+   * 世界自然静下来；一有新 key 入队就再排一个。于是「控制器还有活没干完」
+   * 恰好等价于「还有前台定时器」，和内核的静止判定天然对齐。
+   */
+  run(reconcile: (key: string) => Promise<void> | void, onGiveUp?: (key: string, error: unknown) => void): void {
+    this.reconciler = reconcile;
+    this.onGiveUp = onGiveUp;
+    this.schedulePump();
+  }
+
+  private reconciler: ((key: string) => Promise<void> | void) | null = null;
+  private onGiveUp?: (key: string, error: unknown) => void;
+  private pumpScheduled = false;
+
+  private schedulePump(): void {
+    if (this.pumpScheduled || !this.reconciler || this.queue.length === 0) return;
+    this.pumpScheduled = true;
+    this.kernel.setTimeout(
+      () => {
+        this.pumpScheduled = false;
+        // 每一批是一个会结束的任务，liveTasks 只在处理期间大于 0
+        this.kernel.spawn(`${this.name}:pump`, async () => {
+          await this.pump();
+          this.schedulePump();
+        });
+      },
+      0,
+      { priority: Priority.CONTROLLER, label: `${this.name}:pump` }
+    );
+  }
+
+  private async pump(): Promise<void> {
+    const reconcile = this.reconciler;
+    if (!reconcile) return;
+    for (;;) {
+      const key = this.take();
+      if (key === undefined) break;
+      try {
+        await reconcile(key);
+        this.forget(key);
+      } catch (error) {
+        const backoff = this.requeue(key);
+        if (backoff === null) this.onGiveUp?.(key, error);
+        else this.addAfter(key, backoff);
+      } finally {
+        this.done(key);
+      }
+    }
+  }
+}
+
+export interface ControllerContext {
+  kernel: Kernel;
+  registry: Registry;
+  /** 世界的墙钟（起始时刻 + 虚拟流逝），写进对象时间戳用 —— 内核的 now() 是从 0 开始的 */
+  now: () => number;
+  /** 记一条 Event，学员在 describe 里能看到 */
+  recordEvent: (input: {
+    object: KubeObject;
+    type: 'Normal' | 'Warning';
+    reason: string;
+    message: string;
+  }) => void;
+}
+
+/**
+ * 控制器的骨架：一个 informer 喂一个 workqueue，队列驱动 reconcile。
+ *
+ * 子类只要实现 reconcile(key)。「拿不到对象说明它被删了」这类判断留给子类，
+ * 因为不同控制器对删除的反应不一样。
+ */
+export abstract class Controller {
+  protected readonly kernel: Kernel;
+  protected readonly registry: Registry;
+  protected readonly queue: WorkQueue;
+  protected readonly context: ControllerContext;
+  private informers: Informer[] = [];
+
+  constructor(context: ControllerContext, readonly name: string, options: WorkQueueOptions = {}) {
+    this.context = context;
+    this.kernel = context.kernel;
+    this.registry = context.registry;
+    this.queue = new WorkQueue(context.kernel, name, options);
+  }
+
+  /**
+   * 把一个 informer 接进队列。
+   *
+   * mapKey 决定「这个对象变了，该 reconcile 谁」——
+   * ReplicaSet 控制器 watch Pod，但要 reconcile 的是 Pod 的属主。
+   */
+  protected watch(informer: Informer, mapKey: (object: KubeObject, key: string) => string | null = (_, key) => key): void {
+    informer.onChange((key, object) => {
+      // 删除时缓存里已经没有它了，用事件带来的最后一次状态来定位属主
+      const known = object ?? informer.get(key);
+      const target = known ? mapKey(known, key) : key;
+      if (target) this.queue.add(target);
+    });
+    this.informers.push(informer);
+  }
+
+  protected abstract reconcile(key: string): Promise<void> | void;
+
+  start(): void {
+    this.queue.run(
+      (key) => this.reconcile(key),
+      (key, error) => {
+        // 放弃之前留个痕迹，否则对象会「无声地不收敛」
+        // eslint-disable-next-line no-console
+        console.warn(`[${this.name}] giving up on ${key}: ${(error as Error)?.message ?? error}`);
+      }
+    );
+    for (const informer of this.informers) informer.start();
+  }
+
+  stop(): void {
+    for (const informer of this.informers) informer.stop();
+  }
+}
+
+/** apiserver 返回 404 时，多数控制器的正确反应是「当它已经没了」 */
+export function isNotFound(error: unknown): boolean {
+  return error instanceof ApiError && error.code === 404;
+}
+
+/** 409 冲突：拿最新的重来一次，不是错误 */
+export function isConflict(error: unknown): boolean {
+  return error instanceof ApiError && error.code === 409;
+}

--- a/src/lib/opslab/controllers/index.ts
+++ b/src/lib/opslab/controllers/index.ts
@@ -1,0 +1,19 @@
+/**
+ * 控制器层
+ *
+ * informer/workqueue 框架 + 核心控制器（调度器、ReplicaSet、Deployment、
+ * Endpoints、kubelet），以及把它们和内核、存储、apiserver 接起来的 Cluster。
+ */
+export { Controller, Informer, WorkQueue, objectKey, splitKey, isConflict, isNotFound } from './framework';
+export type { ControllerContext, WorkQueueOptions } from './framework';
+export {
+  CORE_RESOURCES, DEPLOYMENTS, ENDPOINTS, EVENTS, NAMESPACES, NODES, PODS,
+  REPLICASETS, SERVICES, POD_TEMPLATE_HASH, matchesSelector, templateHash,
+} from './resources';
+export {
+  DeploymentController, EndpointsController, KubeletController,
+  ReplicaSetController, SchedulerController, isPodReady, parseCpu, resolveCount,
+} from './workloads';
+export type { ImageSpec, KubeletOptions } from './workloads';
+export { Cluster, createCluster } from './cluster';
+export type { ClusterOptions, NodeSpec } from './cluster';

--- a/src/lib/opslab/controllers/resources.ts
+++ b/src/lib/opslab/controllers/resources.ts
@@ -1,0 +1,90 @@
+/**
+ * 核心资源定义
+ *
+ * 这一批是「跑起一个服务」这条最短路径上必需的：
+ * Namespace / Node / Pod / ReplicaSet / Deployment / Service / Endpoints / Event。
+ * 字段与简称照抄真集群，`kubectl api-resources` 打出来要能对上。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const NAMESPACES: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'namespaces', singular: 'namespace', kind: 'Namespace',
+  namespaced: false, shortNames: ['ns'], subresources: ['status'],
+};
+
+export const NODES: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'nodes', singular: 'node', kind: 'Node',
+  namespaced: false, shortNames: ['no'], subresources: ['status'],
+};
+
+export const PODS: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'pods', singular: 'pod', kind: 'Pod',
+  namespaced: true, shortNames: ['po'], categories: ['all'], subresources: ['status'],
+};
+
+export const SERVICES: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'services', singular: 'service', kind: 'Service',
+  namespaced: true, shortNames: ['svc'], categories: ['all'], subresources: ['status'],
+};
+
+export const ENDPOINTS: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'endpoints', singular: 'endpoints', kind: 'Endpoints',
+  namespaced: true, shortNames: ['ep'],
+};
+
+export const EVENTS: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'events', singular: 'event', kind: 'Event',
+  namespaced: true, shortNames: ['ev'],
+};
+
+export const REPLICASETS: ResourceDefinition = {
+  group: 'apps', version: 'v1', resource: 'replicasets', singular: 'replicaset', kind: 'ReplicaSet',
+  namespaced: true, shortNames: ['rs'], categories: ['all'], subresources: ['status', 'scale'],
+};
+
+export const DEPLOYMENTS: ResourceDefinition = {
+  group: 'apps', version: 'v1', resource: 'deployments', singular: 'deployment', kind: 'Deployment',
+  namespaced: true, shortNames: ['deploy'], categories: ['all'], subresources: ['status', 'scale'],
+};
+
+export const CORE_RESOURCES: ResourceDefinition[] = [
+  NAMESPACES, NODES, PODS, SERVICES, ENDPOINTS, EVENTS, REPLICASETS, DEPLOYMENTS,
+];
+
+/** Deployment 给自己的 ReplicaSet 打的标签，用来区分不同版本 */
+export const POD_TEMPLATE_HASH = 'pod-template-hash';
+
+/**
+ * pod 模板的哈希。
+ *
+ * 真 k8s 用 FNV-1a 再做一次特殊编码；我们只要求「同样的模板得到同样的值、
+ * 不同的模板不同」，并且**确定性** —— 值本身不必和真集群逐位一致，
+ * 但同一份 manifest 在这里每次都得算出同一个后缀，否则回放就飘了。
+ */
+export function templateHash(template: unknown): string {
+  const text = JSON.stringify(template ?? {});
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  // k8s 的后缀用的是一套不含元音的字母表，避免拼出脏字
+  const alphabet = 'bcdfghjklmnpqrstvwxz2456789';
+  let out = '';
+  let value = hash;
+  for (let i = 0; i < 6; i += 1) {
+    out += alphabet[value % alphabet.length];
+    value = Math.floor(value / alphabet.length);
+  }
+  return out;
+}
+
+/** matchLabels 是否命中一组标签 */
+export function matchesSelector(
+  selector: { matchLabels?: Record<string, string> } | undefined,
+  labels: Record<string, string> | undefined
+): boolean {
+  const wanted = selector?.matchLabels ?? {};
+  const actual = labels ?? {};
+  return Object.entries(wanted).every(([key, value]) => actual[key] === value);
+}

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -1,0 +1,846 @@
+/**
+ * 核心控制器：调度器、ReplicaSet、Deployment、Endpoints、kubelet
+ *
+ * 每一个都按真 k8s 的结构写：watch → 入队 → reconcile → 写 status。
+ * 于是那些微妙的中间状态（Pending 一小会儿、observedGeneration 落后一拍、
+ * Endpoints 里只有 Ready 的 Pod）自然就对，不用逐个去仿。
+ */
+import { Priority } from '../kernel';
+import { formatTimestamp, KubeObject, Registry, ResourceDefinition } from '../apiserver';
+import {
+  Controller,
+  ControllerContext,
+  Informer,
+  isConflict,
+  isNotFound,
+  objectKey,
+  splitKey,
+} from './framework';
+import {
+  DEPLOYMENTS,
+  ENDPOINTS,
+  matchesSelector,
+  NODES,
+  PODS,
+  POD_TEMPLATE_HASH,
+  REPLICASETS,
+  SERVICES,
+  templateHash,
+} from './resources';
+
+/** 一次 reconcile 里改 status 时，冲突就放弃这一轮 —— 下一轮会带着新版本重来 */
+async function ignoreConflict(action: () => void): Promise<void> {
+  try {
+    action();
+  } catch (error) {
+    if (!isConflict(error) && !isNotFound(error)) throw error;
+  }
+}
+
+/**
+ * status 没变就不要写。
+ *
+ * 这不是省一次写那么简单 —— 无条件写 status 会触发自己的 informer，
+ * informer 把自己重新入队，reconcile 再写一次，如此往复。因为整个过程
+ * 不经过定时器，虚拟时间一点不走，于是变成一个纯微任务的死循环：
+ * 进程转死，连 jest 的超时都报不出来（第一版就是这样，查了很久）。
+ *
+ * 真 k8s 的控制器同样是「比较后再写」，原因一样。
+ */
+function updateStatusIfChanged(
+  registry: Registry,
+  definition: ResourceDefinition,
+  namespace: string | undefined,
+  name: string,
+  nextStatus: unknown
+): void {
+  const latest = registry.get(definition, namespace, name);
+  if (JSON.stringify(latest.status ?? null) === JSON.stringify(nextStatus ?? null)) return;
+  registry.updateStatus(definition, namespace, name, { ...latest, status: nextStatus });
+}
+
+/* ------------------------------------------------------------------ */
+/* 调度器                                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 把没有 nodeName 的 Pod 绑到某个节点上。
+ *
+ * 过滤：节点 Ready、可调度、资源装得下、nodeSelector 命中。
+ * 打分：least-allocated（谁空谁得），同分按名字 —— 定序必须稳定，
+ * 否则同一份 manifest 两次跑出来 Pod 落在不同节点上，回放就废了。
+ */
+export class SchedulerController extends Controller {
+  private pods: Informer;
+  private nodes: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'scheduler');
+    this.pods = new Informer(this.registry, PODS);
+    this.nodes = new Informer(this.registry, NODES);
+    this.watch(this.pods);
+    // 节点变了，所有待调度的 Pod 都值得再看一眼
+    this.nodes.onChange(() => {
+      for (const pod of this.pods.list()) {
+        if (!(pod.spec as any)?.nodeName) this.queue.add(objectKey(pod));
+      }
+    });
+  }
+
+  start(): void {
+    super.start();
+    this.nodes.start();
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let pod: KubeObject;
+    try {
+      pod = this.registry.get(PODS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+
+    const spec = (pod.spec ?? {}) as any;
+    if (spec.nodeName) return;                       // 已经调度过了
+    if (pod.metadata.deletionTimestamp) return;
+
+    const candidates = this.nodes.list().filter((node) => this.fits(node, pod));
+    if (candidates.length === 0) {
+      let changed = false;
+      await ignoreConflict(() => {
+        const before = JSON.stringify(this.registry.get(PODS, namespace, name).status ?? null);
+        updateStatusIfChanged(this.registry, PODS, namespace, name, {
+          ...(pod.status as any),
+          phase: 'Pending',
+          conditions: [{
+            type: 'PodScheduled', status: 'False', reason: 'Unschedulable',
+            message: '0/' + this.nodes.list().length + ' nodes are available: insufficient resources or no matching node.',
+          }],
+        });
+        changed = before !== JSON.stringify(this.registry.get(PODS, namespace, name).status ?? null);
+      });
+      // 状态没变就别再刷一条一样的事件出来
+      if (!changed) return;
+      this.context.recordEvent({
+        object: pod, type: 'Warning', reason: 'FailedScheduling',
+        message: `0/${this.nodes.list().length} nodes are available.`,
+      });
+      return;
+    }
+
+    const chosen = this.pick(candidates);
+    await ignoreConflict(() => {
+      const latest = this.registry.get(PODS, namespace, name);
+      this.registry.update(PODS, namespace, name, {
+        ...latest,
+        spec: { ...(latest.spec as any), nodeName: chosen.metadata.name },
+      });
+    });
+    this.context.recordEvent({
+      object: pod, type: 'Normal', reason: 'Scheduled',
+      message: `Successfully assigned ${namespace}/${name} to ${chosen.metadata.name}`,
+    });
+  }
+
+  private fits(node: KubeObject, pod: KubeObject): boolean {
+    const nodeSpec = (node.spec ?? {}) as any;
+    const nodeStatus = (node.status ?? {}) as any;
+    if (nodeSpec.unschedulable) return false;
+    const ready = (nodeStatus.conditions ?? []).find((c: any) => c.type === 'Ready');
+    if (ready?.status !== 'True') return false;
+
+    const selector = (pod.spec as any)?.nodeSelector as Record<string, string> | undefined;
+    if (selector && !Object.entries(selector).every(([k, v]) => node.metadata.labels?.[k] === v)) {
+      return false;
+    }
+    return this.freeCpu(node) >= this.requestedCpu(pod);
+  }
+
+  /** 节点上还剩多少 CPU（毫核） */
+  private freeCpu(node: KubeObject): number {
+    const allocatable = parseCpu((node.status as any)?.allocatable?.cpu ?? '0');
+    const used = this.pods
+      .list()
+      .filter((pod) => (pod.spec as any)?.nodeName === node.metadata.name)
+      .reduce((sum, pod) => sum + this.requestedCpu(pod), 0);
+    return allocatable - used;
+  }
+
+  private requestedCpu(pod: KubeObject): number {
+    const containers: any[] = (pod.spec as any)?.containers ?? [];
+    return containers.reduce((sum, c) => sum + parseCpu(c.resources?.requests?.cpu ?? '0'), 0);
+  }
+
+  /** least-allocated，同分按名字 —— 稳定定序是确定性的一部分 */
+  private pick(candidates: KubeObject[]): KubeObject {
+    return [...candidates].sort((a, b) => {
+      const diff = this.freeCpu(b) - this.freeCpu(a);
+      if (diff !== 0) return diff;
+      return a.metadata.name < b.metadata.name ? -1 : 1;
+    })[0];
+  }
+}
+
+/** kubelet 重启崩溃容器的退避：10s 起步翻倍，封顶 5 分钟，和真 kubelet 一致 */
+export function backoffOf(restarts: number): number {
+  return Math.min(10_000 * 2 ** Math.max(0, restarts - 1), 300_000);
+}
+
+/** `500m` -> 500，`2` -> 2000 */
+export function parseCpu(value: string | number | undefined): number {
+  if (value === undefined) return 0;
+  const text = String(value);
+  if (text.endsWith('m')) return Number(text.slice(0, -1)) || 0;
+  return (Number(text) || 0) * 1000;
+}
+
+/* ------------------------------------------------------------------ */
+/* ReplicaSet                                                          */
+/* ------------------------------------------------------------------ */
+
+/** 让实际 Pod 数向 spec.replicas 收敛，并维护 status */
+export class ReplicaSetController extends Controller {
+  private replicaSets: Informer;
+  private pods: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'replicaset');
+    this.replicaSets = new Informer(this.registry, REPLICASETS);
+    this.pods = new Informer(this.registry, PODS);
+    this.watch(this.replicaSets);
+    // Pod 变了要 reconcile 它的属主，不是 Pod 自己
+    this.watch(this.pods, (pod) => {
+      const owner = (pod.metadata.ownerReferences ?? []).find((ref) => ref.kind === 'ReplicaSet');
+      return owner ? `${pod.metadata.namespace}/${owner.name}` : null;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let replicaSet: KubeObject;
+    try {
+      replicaSet = this.registry.get(REPLICASETS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (replicaSet.metadata.deletionTimestamp) return;
+
+    const spec = (replicaSet.spec ?? {}) as any;
+    const desired = spec.replicas ?? 1;
+    const owned = this.ownedPods(replicaSet);
+    const alive = owned.filter((pod) => !pod.metadata.deletionTimestamp);
+
+    if (alive.length < desired) {
+      for (let i = alive.length; i < desired; i += 1) this.createPod(replicaSet);
+    } else if (alive.length > desired) {
+      // 多出来的先删「最不成熟」的：没 Ready 的优先，其次按名字倒序
+      const victims = [...alive]
+        .sort((a, b) => {
+          const aReady = isPodReady(a) ? 1 : 0;
+          const bReady = isPodReady(b) ? 1 : 0;
+          if (aReady !== bReady) return aReady - bReady;
+          return a.metadata.name < b.metadata.name ? 1 : -1;
+        })
+        .slice(0, alive.length - desired);
+      for (const victim of victims) {
+        try {
+          this.registry.delete(PODS, victim.metadata.namespace, victim.metadata.name);
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+        }
+      }
+    }
+
+    const current = this.ownedPods(replicaSet).filter((pod) => !pod.metadata.deletionTimestamp);
+    const ready = current.filter(isPodReady);
+    await ignoreConflict(() => {
+      const latest = this.registry.get(REPLICASETS, namespace, name);
+      updateStatusIfChanged(this.registry, REPLICASETS, namespace, name, {
+        replicas: current.length,
+        readyReplicas: ready.length,
+        availableReplicas: ready.length,
+        fullyLabeledReplicas: current.length,
+        observedGeneration: latest.metadata.generation,
+      });
+    });
+  }
+
+  private ownedPods(replicaSet: KubeObject): KubeObject[] {
+    return this.registry
+      .list(PODS, { namespace: replicaSet.metadata.namespace })
+      .items.filter((pod) =>
+        (pod.metadata.ownerReferences ?? []).some((ref) => ref.uid === replicaSet.metadata.uid)
+      );
+  }
+
+  private createPod(replicaSet: KubeObject): void {
+    const spec = (replicaSet.spec ?? {}) as any;
+    const template = spec.template ?? {};
+    const suffix = this.kernel.random.suffix(5);
+    const pod: KubeObject = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: `${replicaSet.metadata.name}-${suffix}`,
+        namespace: replicaSet.metadata.namespace,
+        labels: { ...(template.metadata?.labels ?? {}) },
+        ownerReferences: [{
+          apiVersion: 'apps/v1', kind: 'ReplicaSet',
+          name: replicaSet.metadata.name, uid: replicaSet.metadata.uid!,
+          controller: true, blockOwnerDeletion: true,
+        }],
+      },
+      spec: { ...(template.spec ?? {}) },
+      status: { phase: 'Pending' },
+    };
+    try {
+      this.registry.create(PODS, replicaSet.metadata.namespace, pod);
+      this.context.recordEvent({
+        object: replicaSet, type: 'Normal', reason: 'SuccessfulCreate',
+        message: `Created pod: ${pod.metadata.name}`,
+      });
+    } catch (error) {
+      if (!isConflict(error)) throw error;
+    }
+  }
+}
+
+export function isPodReady(pod: KubeObject): boolean {
+  const conditions: any[] = (pod.status as any)?.conditions ?? [];
+  return conditions.some((c) => c.type === 'Ready' && c.status === 'True');
+}
+
+/* ------------------------------------------------------------------ */
+/* Deployment                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 维护 ReplicaSet。
+ *
+ * 模板变了就建一个新 RS（名字带模板哈希），按 maxSurge / maxUnavailable
+ * 一点点把副本从旧 RS 挪到新 RS —— 滚动更新期间可用副本数不掉到线下，
+ * 正是学员要观察的东西。
+ */
+export class DeploymentController extends Controller {
+  private deployments: Informer;
+  private replicaSets: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'deployment');
+    this.deployments = new Informer(this.registry, DEPLOYMENTS);
+    this.replicaSets = new Informer(this.registry, REPLICASETS);
+    this.watch(this.deployments);
+    this.watch(this.replicaSets, (rs) => {
+      const owner = (rs.metadata.ownerReferences ?? []).find((ref) => ref.kind === 'Deployment');
+      return owner ? `${rs.metadata.namespace}/${owner.name}` : null;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let deployment: KubeObject;
+    try {
+      deployment = this.registry.get(DEPLOYMENTS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (deployment.metadata.deletionTimestamp) return;
+
+    const spec = (deployment.spec ?? {}) as any;
+    const desired = spec.replicas ?? 1;
+    const hash = templateHash(spec.template);
+    const owned = this.ownedReplicaSets(deployment);
+    const current = owned.find((rs) => rs.metadata.labels?.[POD_TEMPLATE_HASH] === hash)
+      ?? this.createReplicaSet(deployment, hash);
+    const old = owned.filter((rs) => rs.metadata.uid !== current.metadata.uid);
+
+    const strategy = spec.strategy?.rollingUpdate ?? {};
+    const maxSurge = resolveCount(strategy.maxSurge ?? '25%', desired, 1);
+    const maxUnavailable = resolveCount(strategy.maxUnavailable ?? '25%', desired, 1);
+
+    const oldReplicas = old.reduce((sum, rs) => sum + ((rs.spec as any)?.replicas ?? 0), 0);
+    const currentReplicas = (current.spec as any)?.replicas ?? 0;
+
+    /**
+     * 可用副本数要**数活着的 Pod**，不能读 ReplicaSet 的 status.readyReplicas。
+     *
+     * RS 的 status 是异步写回的，一次 reconcile 里连着做几步决策时它是滞后的。
+     * 早先按 status 算，结果同一瞬间里「以为还有 4 个 ready」，
+     * 于是把旧 RS 一路缩到 0，新 Pod 却一个都还没就绪 —— 可用副本数掉到 0，
+     * 正是 maxUnavailable 本该拦住的那种停机。
+     */
+    const availableNow = this.availablePods(deployment);
+
+    /**
+     * 已经下达但还没执行完的缩容。
+     *
+     * Deployment 把某个旧 RS 的 replicas 调小之后，真正去删 Pod 的是 RS 控制器，
+     * 那是下一轮的事。同一瞬间里 Deployment 可能被自己的写触发反复 reconcile，
+     * 每次都看到「Pod 还在、还 ready」，于是一路把旧 RS 缩到 0 —— 新 Pod
+     * 一个没起来，服务就断了。把在途的缩容算进来，这一步才收得住。
+     */
+    const inFlightScaleDown = old.reduce((sum, rs) => {
+      const intended = (rs.spec as any)?.replicas ?? 0;
+      const alive = this.aliveOwnedPods(rs);
+      return sum + Math.max(0, alive - intended);
+    }, 0);
+
+    // 先扩新的（不超过 desired + maxSurge）
+    const surgeRoom = desired + maxSurge - (currentReplicas + oldReplicas);
+    if (currentReplicas < desired && surgeRoom > 0) {
+      this.scale(current, Math.min(desired, currentReplicas + surgeRoom));
+    } else if (oldReplicas > 0) {
+      // 再缩旧的，但一次最多缩到「可用数不低于 desired - maxUnavailable」为止
+      const room = availableNow - inFlightScaleDown - (desired - maxUnavailable);
+      if (room > 0) {
+        const victim = old.find((rs) => ((rs.spec as any)?.replicas ?? 0) > 0);
+        if (victim) {
+          const replicas = (victim.spec as any)?.replicas ?? 0;
+          this.scale(victim, Math.max(0, replicas - Math.min(room, replicas)));
+        }
+      }
+    } else if (currentReplicas > desired) {
+      this.scale(current, desired);
+    }
+
+    const refreshed = this.ownedReplicaSets(deployment);
+    const totalReady = refreshed.reduce((sum, rs) => sum + this.readyOf(rs), 0);
+    const totalReplicas = refreshed.reduce((sum, rs) => sum + ((rs.status as any)?.replicas ?? 0), 0);
+    const updated = this.readyOf(refreshed.find((rs) => rs.metadata.uid === current.metadata.uid) ?? current);
+
+    await ignoreConflict(() => {
+      const latest = this.registry.get(DEPLOYMENTS, namespace, name);
+      updateStatusIfChanged(this.registry, DEPLOYMENTS, namespace, name, {
+        replicas: totalReplicas,
+        readyReplicas: totalReady,
+        availableReplicas: totalReady,
+        updatedReplicas: updated,
+        observedGeneration: latest.metadata.generation,
+        conditions: [{
+          type: 'Available',
+          status: totalReady >= desired ? 'True' : 'False',
+          reason: totalReady >= desired ? 'MinimumReplicasAvailable' : 'MinimumReplicasUnavailable',
+        }],
+      });
+    });
+
+    // 这里**不能**因为「还没收敛」就自己再排一次队。
+    //
+    // 收敛不了是常态：镜像拉不到、资源不够、探针一直不过 —— 这些恰恰是要教的场景。
+    // 自我重排会让世界永远静不下来（前台定时器不断），settle() 撞预算超时。
+    // 推进滚动更新的下一步本来就是事件驱动的：Pod 变 Ready → RS 的 status 变 →
+    // 我们的 RS informer 收到 → 重新入队。不需要轮询。
+  }
+
+  /** 某个 ReplicaSet 名下还活着的 Pod 数 */
+  private aliveOwnedPods(replicaSet: KubeObject): number {
+    return this.registry
+      .list(PODS, { namespace: replicaSet.metadata.namespace })
+      .items.filter(
+        (pod) =>
+          !pod.metadata.deletionTimestamp &&
+          (pod.metadata.ownerReferences ?? []).some((ref) => ref.uid === replicaSet.metadata.uid)
+      ).length;
+  }
+
+  /** 这个 Deployment 名下真正就绪、且没在删除中的 Pod 数 */
+  private availablePods(deployment: KubeObject): number {
+    const owned = this.ownedReplicaSets(deployment);
+    const uids = new Set(owned.map((rs) => rs.metadata.uid));
+    return this.registry
+      .list(PODS, { namespace: deployment.metadata.namespace })
+      .items.filter(
+        (pod) =>
+          !pod.metadata.deletionTimestamp &&
+          isPodReady(pod) &&
+          (pod.metadata.ownerReferences ?? []).some((ref) => uids.has(ref.uid))
+      ).length;
+  }
+
+  private readyOf(rs: KubeObject): number {
+    return ((rs.status as any)?.readyReplicas ?? 0) as number;
+  }
+
+  private ownedReplicaSets(deployment: KubeObject): KubeObject[] {
+    return this.registry
+      .list(REPLICASETS, { namespace: deployment.metadata.namespace })
+      .items.filter((rs) =>
+        (rs.metadata.ownerReferences ?? []).some((ref) => ref.uid === deployment.metadata.uid)
+      );
+  }
+
+  private createReplicaSet(deployment: KubeObject, hash: string): KubeObject {
+    const spec = (deployment.spec ?? {}) as any;
+    const template = spec.template ?? {};
+    const replicaSet: KubeObject = {
+      apiVersion: 'apps/v1',
+      kind: 'ReplicaSet',
+      metadata: {
+        name: `${deployment.metadata.name}-${hash}`,
+        namespace: deployment.metadata.namespace,
+        labels: { ...(template.metadata?.labels ?? {}), [POD_TEMPLATE_HASH]: hash },
+        ownerReferences: [{
+          apiVersion: 'apps/v1', kind: 'Deployment',
+          name: deployment.metadata.name, uid: deployment.metadata.uid!,
+          controller: true, blockOwnerDeletion: true,
+        }],
+      },
+      spec: {
+        replicas: 0,
+        selector: {
+          matchLabels: { ...(spec.selector?.matchLabels ?? {}), [POD_TEMPLATE_HASH]: hash },
+        },
+        template: {
+          ...template,
+          metadata: {
+            ...(template.metadata ?? {}),
+            labels: { ...(template.metadata?.labels ?? {}), [POD_TEMPLATE_HASH]: hash },
+          },
+        },
+      },
+      status: {},
+    };
+    const created = this.registry.create(REPLICASETS, deployment.metadata.namespace, replicaSet);
+    this.context.recordEvent({
+      object: deployment, type: 'Normal', reason: 'ScalingReplicaSet',
+      message: `Scaled up replica set ${created.metadata.name} to ${spec.replicas ?? 1}`,
+    });
+    return created;
+  }
+
+  private scale(replicaSet: KubeObject, replicas: number): void {
+    if (((replicaSet.spec as any)?.replicas ?? 0) === replicas) return;
+    ignoreConflict(() => {
+      const latest = this.registry.get(REPLICASETS, replicaSet.metadata.namespace, replicaSet.metadata.name);
+      this.registry.update(REPLICASETS, latest.metadata.namespace, latest.metadata.name, {
+        ...latest,
+        spec: { ...(latest.spec as any), replicas },
+      });
+    });
+  }
+}
+
+/** `25%` / `1` -> 具体个数 */
+export function resolveCount(value: string | number, total: number, fallback: number): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.endsWith('%')) {
+    const percent = Number(value.slice(0, -1));
+    if (!Number.isFinite(percent)) return fallback;
+    return Math.max(1, Math.floor((total * percent) / 100));
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/* ------------------------------------------------------------------ */
+/* Endpoints                                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 维护 Service 的端点。
+ *
+ * **只收 Ready 的 Pod** —— 这条是「探针配错 → Service 没有端点 → 502」
+ * 这个经典故障链的根，必须准确。
+ */
+export class EndpointsController extends Controller {
+  private services: Informer;
+  private pods: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'endpoints');
+    this.services = new Informer(this.registry, SERVICES);
+    this.pods = new Informer(this.registry, PODS);
+    this.watch(this.services);
+    // Pod 变了，命名空间里所有 Service 都要重算（谁选中它不好反查）
+    this.pods.onChange((key) => {
+      const { namespace } = splitKey(key);
+      for (const service of this.services.list()) {
+        if (service.metadata.namespace === namespace) this.queue.add(objectKey(service));
+      }
+    });
+  }
+
+  start(): void {
+    super.start();
+    this.pods.start();
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let service: KubeObject;
+    try {
+      service = this.registry.get(SERVICES, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) {
+        try { this.registry.delete(ENDPOINTS, namespace, name); } catch { /* 已经没了 */ }
+        return;
+      }
+      throw error;
+    }
+
+    const selector = (service.spec as any)?.selector as Record<string, string> | undefined;
+    const ready = selector
+      ? this.registry
+          .list(PODS, { namespace })
+          .items.filter((pod) =>
+            matchesSelector({ matchLabels: selector }, pod.metadata.labels) &&
+            isPodReady(pod) &&
+            !pod.metadata.deletionTimestamp &&
+            (pod.status as any)?.podIP
+          )
+          .sort((a, b) => (a.metadata.name < b.metadata.name ? -1 : 1))
+      : [];
+
+    const ports: any[] = (service.spec as any)?.ports ?? [];
+    const subsets = ready.length > 0
+      ? [{
+          addresses: ready.map((pod) => ({
+            ip: (pod.status as any).podIP,
+            nodeName: (pod.spec as any)?.nodeName,
+            targetRef: { kind: 'Pod', name: pod.metadata.name, namespace, uid: pod.metadata.uid },
+          })),
+          ports: ports.map((port) => ({
+            name: port.name,
+            port: port.targetPort ?? port.port,
+            protocol: port.protocol ?? 'TCP',
+          })),
+        }]
+      : [];
+
+    const endpoints: KubeObject = {
+      apiVersion: 'v1', kind: 'Endpoints',
+      metadata: { name, namespace },
+      subsets,
+    };
+
+    try {
+      const existing = this.registry.get(ENDPOINTS, namespace, name);
+      if (JSON.stringify((existing as any).subsets ?? []) === JSON.stringify(subsets)) return;
+      await ignoreConflict(() => {
+        this.registry.update(ENDPOINTS, namespace, name, { ...existing, subsets });
+      });
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      await ignoreConflict(() => { this.registry.create(ENDPOINTS, namespace, endpoints); });
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* kubelet                                                             */
+/* ------------------------------------------------------------------ */
+
+export interface ImageSpec {
+  /** 拉取耗时（虚拟毫秒） */
+  pullMs?: number;
+  /** 启动到进程就绪的耗时 */
+  startupMs?: number;
+  /** 就绪探针通过还要多久 */
+  readyAfterMs?: number;
+  /** 缺了这些环境变量就崩 */
+  needsEnv?: string[];
+}
+
+export interface KubeletOptions {
+  /** 镜像目录。不在目录里的镜像 = 拉不到，进 ImagePullBackOff */
+  images?: Record<string, ImageSpec>;
+}
+
+/**
+ * 每个节点上的 kubelet：推进落在自己身上的 Pod 的生命周期。
+ *
+ * Pending → ContainerCreating → Running → Ready，
+ * 拉不到镜像进 ImagePullBackOff，缺环境变量进 CrashLoopBackOff。
+ * 所有耗时都走虚拟时钟，所以「等 5 秒看它起来没」是一次快进，不是真的等。
+ */
+export class KubeletController extends Controller {
+  private pods: Informer;
+  private readonly images: Record<string, ImageSpec>;
+  /** 已经在推进中的 Pod，避免重复排定时器 */
+  private advancing = new Set<string>();
+  /** 每个 Pod 崩了几次，决定退避时长与 restartCount */
+  private restartCount = new Map<string, number>();
+
+  constructor(context: ControllerContext, private readonly nodeName: string, options: KubeletOptions = {}) {
+    super(context, `kubelet:${nodeName}`);
+    this.images = options.images ?? {};
+    this.pods = new Informer(this.registry, PODS);
+    this.watch(this.pods, (pod, key) => ((pod.spec as any)?.nodeName === nodeName ? key : null));
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let pod: KubeObject;
+    try {
+      pod = this.registry.get(PODS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) { this.advancing.delete(key); return; }
+      throw error;
+    }
+    if ((pod.spec as any)?.nodeName !== this.nodeName) return;
+
+    if (pod.metadata.deletionTimestamp) {
+      this.advancing.delete(key);
+      return;
+    }
+    const status = (pod.status ?? {}) as any;
+    if (status.phase === 'Running' || status.phase === 'Failed') return;
+    if (this.advancing.has(key)) return;
+    this.advancing.add(key);
+
+    const containers: any[] = (pod.spec as any)?.containers ?? [];
+    const missingImage = containers.find((c) => !(c.image in this.images));
+    if (missingImage) {
+      await ignoreConflict(() => {
+        const latest = this.registry.get(PODS, namespace, name);
+        updateStatusIfChanged(this.registry, PODS, namespace, name, {
+          ...(latest.status as any), phase: 'Pending',
+          containerStatuses: containers.map((c) => ({
+            name: c.name, ready: false, restartCount: 0,
+            state: { waiting: { reason: 'ImagePullBackOff', message: `Back-off pulling image "${c.image}"` } },
+          })),
+        });
+      });
+      this.context.recordEvent({
+        object: pod, type: 'Warning', reason: 'Failed',
+        message: `Failed to pull image "${missingImage.image}": image not found in registry`,
+      });
+      this.advancing.delete(key);
+      return;
+    }
+
+    const spec = this.images[containers[0]?.image] ?? {};
+    const env: any[] = containers[0]?.env ?? [];
+    const provided = new Set(env.map((e) => e.name));
+    const missingEnv = (spec.needsEnv ?? []).filter((needed) => !provided.has(needed));
+
+    const pullMs = spec.pullMs ?? 200;
+    const startupMs = spec.startupMs ?? 300;
+    const readyAfterMs = spec.readyAfterMs ?? 200;
+
+    // ContainerCreating
+    this.kernel.setTimeout(() => {
+      ignoreConflict(() => {
+        const latest = this.registry.get(PODS, namespace, name);
+        if (latest.metadata.deletionTimestamp) return;
+        updateStatusIfChanged(this.registry, PODS, namespace, name, {
+          ...(latest.status as any), phase: 'Pending',
+          containerStatuses: containers.map((c) => ({
+            name: c.name, ready: false, restartCount: 0,
+            state: { waiting: { reason: 'ContainerCreating' } },
+          })),
+        });
+      });
+    }, pullMs, { priority: Priority.NODE, label: `${this.name}:creating:${key}` });
+
+    if (missingEnv.length > 0) {
+      const restarts = (this.restartCount.get(key) ?? 0) + 1;
+      this.restartCount.set(key, restarts);
+      this.kernel.setTimeout(() => {
+        ignoreConflict(() => {
+          const latest = this.registry.get(PODS, namespace, name);
+          if (latest.metadata.deletionTimestamp) return;
+          updateStatusIfChanged(this.registry, PODS, namespace, name, {
+            ...(latest.status as any), phase: 'Pending',
+            containerStatuses: containers.map((c) => ({
+              name: c.name, ready: false, restartCount: restarts,
+              state: {
+                waiting: {
+                  reason: 'CrashLoopBackOff',
+                  message: `back-off ${backoffOf(restarts) / 1000}s restarting failed container=${c.name} pod=${name}_${namespace}`,
+                },
+              },
+              lastState: { terminated: { exitCode: 1, reason: 'Error' } },
+            })),
+          });
+        });
+        if (restarts === 1) {
+          this.context.recordEvent({
+            object: pod, type: 'Warning', reason: 'BackOff',
+            message: `Back-off restarting failed container app in pod ${name}_${namespace}`,
+          });
+        }
+        // 注意这里**不**清 advancing —— 清了的话，status 变化会经 informer
+        // 立刻把这个 Pod 重新入队，前台链路马上又跑一遍，世界永远静不下来。
+        // 只有下面那个后台退避定时器才有资格把它放出来。
+
+        /**
+         * 排下一次重启，**后台定时器**。
+         *
+         * 真 kubelet 会一直按指数退避重启崩溃的容器，永不放弃 —— 语义上世界确实
+         * 「永远有事要做」。但如果把它算成前台工作，settle() 就再也返回不了，
+         * 而「Pod 卡在 CrashLoopBackOff」恰恰是一个稳定的、要给学员看的终态。
+         * 所以标成 background：静止判定不看它，快进时间时照常重启。
+         */
+        this.kernel.setTimeout(
+          () => {
+            this.advancing.delete(key);
+            this.queue.add(key);
+          },
+          backoffOf(restarts),
+          { priority: Priority.NODE, background: true, label: `${this.name}:restart:${key}` }
+        );
+      }, pullMs + startupMs, { priority: Priority.NODE, label: `${this.name}:crash:${key}` });
+      return;
+    }
+
+    // Running（还没 Ready）
+    this.kernel.setTimeout(() => {
+      ignoreConflict(() => {
+        const latest = this.registry.get(PODS, namespace, name);
+        if (latest.metadata.deletionTimestamp) return;
+        updateStatusIfChanged(this.registry, PODS, namespace, name, {
+            ...(latest.status as any),
+            phase: 'Running',
+            podIP: this.assignPodIp(latest),
+            startTime: formatTimestamp(this.context.now()),
+            containerStatuses: containers.map((c) => ({
+              name: c.name, ready: false, restartCount: 0,
+              state: { running: { startedAt: formatTimestamp(this.context.now()) } },
+            })),
+            conditions: [{ type: 'Ready', status: 'False', reason: 'ContainersNotReady' }],
+        });
+      });
+    }, pullMs + startupMs, { priority: Priority.NODE, label: `${this.name}:running:${key}` });
+
+    // Ready
+    this.kernel.setTimeout(() => {
+      ignoreConflict(() => {
+        const latest = this.registry.get(PODS, namespace, name);
+        if (latest.metadata.deletionTimestamp) return;
+        const current = (latest.status ?? {}) as any;
+        updateStatusIfChanged(this.registry, PODS, namespace, name, {
+          ...current,
+          containerStatuses: (current.containerStatuses ?? []).map((c: any) => ({ ...c, ready: true })),
+          conditions: [
+            { type: 'Initialized', status: 'True' },
+            { type: 'Ready', status: 'True' },
+            { type: 'ContainersReady', status: 'True' },
+            { type: 'PodScheduled', status: 'True' },
+          ],
+        });
+      });
+      this.advancing.delete(key);
+    }, pullMs + startupMs + readyAfterMs, { priority: Priority.NODE, label: `${this.name}:ready:${key}` });
+  }
+
+  /**
+   * 给 Pod 分一个 IP。
+   *
+   * 用 uid 派生而不是递增计数器 —— 计数器会让「同一个世界重放两次」
+   * 因为创建顺序的细微差别而分到不同 IP。
+   */
+  private assignPodIp(pod: KubeObject): string {
+    const uid = pod.metadata.uid ?? pod.metadata.name;
+    let hash = 2166136261;
+    for (let i = 0; i < uid.length; i += 1) {
+      hash ^= uid.charCodeAt(i);
+      hash = Math.imul(hash, 16777619) >>> 0;
+    }
+    return `10.42.${(hash >>> 8) % 256}.${(hash % 254) + 1}`;
+  }
+}

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -77,7 +77,7 @@ export class SchedulerController extends Controller {
   constructor(context: ControllerContext) {
     super(context, 'scheduler');
     this.pods = new Informer(this.registry, PODS);
-    this.nodes = new Informer(this.registry, NODES);
+    this.nodes = this.track(new Informer(this.registry, NODES));
     this.watch(this.pods);
     // 节点变了，所有待调度的 Pod 都值得再看一眼
     this.nodes.onChange(() => {
@@ -85,11 +85,6 @@ export class SchedulerController extends Controller {
         if (!(pod.spec as any)?.nodeName) this.queue.add(objectKey(pod));
       }
     });
-  }
-
-  start(): void {
-    super.start();
-    this.nodes.start();
   }
 
   protected async reconcile(key: string): Promise<void> {
@@ -553,7 +548,7 @@ export class EndpointsController extends Controller {
   constructor(context: ControllerContext) {
     super(context, 'endpoints');
     this.services = new Informer(this.registry, SERVICES);
-    this.pods = new Informer(this.registry, PODS);
+    this.pods = this.track(new Informer(this.registry, PODS));
     this.watch(this.services);
     // Pod 变了，命名空间里所有 Service 都要重算（谁选中它不好反查）
     this.pods.onChange((key) => {
@@ -562,11 +557,6 @@ export class EndpointsController extends Controller {
         if (service.metadata.namespace === namespace) this.queue.add(objectKey(service));
       }
     });
-  }
-
-  start(): void {
-    super.start();
-    this.pods.start();
   }
 
   protected async reconcile(key: string): Promise<void> {

--- a/src/lib/opslab/kernel/kernel.ts
+++ b/src/lib/opslab/kernel/kernel.ts
@@ -219,8 +219,11 @@ export class Kernel {
   /**
    * 快进一段虚拟时间，沿途所有定时器（含后台）都会触发。
    *
-   * 「等 30 秒看滚动更新走到哪」「让证书过期」用这个。推进完再 settle 一次，
-   * 让被唤醒的那些实体把手上的活干完。
+   * 「等 30 秒看滚动更新走到哪」「让证书过期」用这个。
+   *
+   * **只推进这段窗口内到期的东西**，不会顺带把之后的也跑完 ——
+   * 早先的版本在末尾调了一次 settle()，结果「只走 150ms 看看中间态」
+   * 会直接看到终态，中间过程完全观察不到。要静止请显式调 settle()。
    */
   async advanceBy(ms: number, options: SettleOptions = {}): Promise<void> {
     const target = this.clock.now() + Math.max(0, Math.floor(ms));
@@ -234,7 +237,11 @@ export class Kernel {
       this.throwTaskFailure();
     }
     this.clock.advanceTo(target);
-    await this.settle(options);
+    // 让这一刻被唤醒的微任务链跑完，但不驱动未来的定时器
+    await flushMicrotasks();
+    const trailing = this.clock.takeFailure();
+    if (trailing) throw trailing.error;
+    this.throwTaskFailure();
   }
 
   /**

--- a/tests/opslab/controllers.test.ts
+++ b/tests/opslab/controllers.test.ts
@@ -1,0 +1,376 @@
+/**
+ * 控制器的回归测试
+ *
+ * 重点是**因果链**：apply 一个 Deployment → 长出 ReplicaSet → 长出 Pod →
+ * 被调度 → 变 Running → 变 Ready → 进 Service 的端点。
+ * 这条链是四块面板里学员看到的第一个「东西自己动起来了」。
+ */
+import { createCluster, Cluster, DEPLOYMENTS, ENDPOINTS, EVENTS, PODS, REPLICASETS, SERVICES, NODES, isPodReady, parseCpu, resolveCount, templateHash } from '../../src/lib/opslab/controllers';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const IMAGES = {
+  'registry.corp.internal/web:1.0': { pullMs: 100, startupMs: 200, readyAfterMs: 100 },
+  'registry.corp.internal/web:2.0': { pullMs: 100, startupMs: 200, readyAfterMs: 100 },
+  'registry.corp.internal/needs-db:1.0': { needsEnv: ['DB_PASSWORD'] },
+};
+
+function newCluster(overrides: Parameters<typeof createCluster>[0] = {}): Cluster {
+  const cluster = createCluster({ images: IMAGES, ...overrides });
+  cluster.start();
+  return cluster;
+}
+
+function deployment(name: string, replicas = 3, image = 'registry.corp.internal/web:1.0'): KubeObject {
+  return {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name },
+    spec: {
+      replicas,
+      selector: { matchLabels: { app: name } },
+      template: {
+        metadata: { labels: { app: name } },
+        spec: { containers: [{ name: 'app', image, resources: { requests: { cpu: '100m' } } }] },
+      },
+    },
+  };
+}
+
+const podsOf = (cluster: Cluster, ns = 'default') =>
+  cluster.registry.list(PODS, { namespace: ns }).items;
+
+describe('世界的初态', () => {
+  it('命名空间与节点就位，节点是 Ready 的', async () => {
+    const cluster = newCluster();
+    await cluster.settle();
+    const nodes = cluster.registry.list(NODES, {}).items;
+    expect(nodes.map((n) => n.metadata.name)).toEqual(['node-1', 'node-2', 'node-3']);
+    expect((nodes[0].status as any).conditions[0]).toMatchObject({ type: 'Ready', status: 'True' });
+  });
+});
+
+describe('Deployment → ReplicaSet → Pod 这条因果链', () => {
+  it('apply 一个 Deployment 之后，Pod 会自己长出来并变成 Ready', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+    await cluster.settle();
+
+    const replicaSets = cluster.registry.list(REPLICASETS, { namespace: 'default' }).items;
+    expect(replicaSets).toHaveLength(1);
+    expect(replicaSets[0].metadata.ownerReferences?.[0].kind).toBe('Deployment');
+
+    const pods = podsOf(cluster);
+    expect(pods).toHaveLength(3);
+    expect(pods.every((pod) => (pod.status as any).phase === 'Running')).toBe(true);
+    expect(pods.every(isPodReady)).toBe(true);
+    expect(pods.every((pod) => (pod.spec as any).nodeName)).toBe(true);
+
+    const deploy = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+    expect(deploy.status).toMatchObject({ replicas: 3, readyReplicas: 3, availableReplicas: 3 });
+    expect((deploy.status as any).observedGeneration).toBe(deploy.metadata.generation);
+  });
+
+  it('ReplicaSet 的名字带模板哈希，Pod 名字带 RS 名', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 1));
+    await cluster.settle();
+
+    const rs = cluster.registry.list(REPLICASETS, { namespace: 'default' }).items[0];
+    expect(rs.metadata.name).toMatch(/^web-[a-z0-9]{6}$/);
+    expect(podsOf(cluster)[0].metadata.name.startsWith(`${rs.metadata.name}-`)).toBe(true);
+  });
+
+  it('扩容与缩容', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 2));
+    await cluster.settle();
+    expect(podsOf(cluster)).toHaveLength(2);
+
+    const current = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+    cluster.registry.update(DEPLOYMENTS, 'default', 'web', {
+      ...current, spec: { ...(current.spec as any), replicas: 5 },
+    });
+    await cluster.settle();
+    expect(podsOf(cluster)).toHaveLength(5);
+
+    const grown = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+    cluster.registry.update(DEPLOYMENTS, 'default', 'web', {
+      ...grown, spec: { ...(grown.spec as any), replicas: 1 },
+    });
+    await cluster.settle();
+    expect(podsOf(cluster).filter((p) => !p.metadata.deletionTimestamp)).toHaveLength(1);
+  });
+
+  it('删掉一个 Pod，ReplicaSet 会补回来 —— 自愈', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+    await cluster.settle();
+    const victim = podsOf(cluster)[0];
+
+    cluster.registry.delete(PODS, 'default', victim.metadata.name);
+    await cluster.settle();
+
+    const after = podsOf(cluster);
+    expect(after).toHaveLength(3);
+    expect(after.map((p) => p.metadata.name)).not.toContain(victim.metadata.name);
+    expect(after.every(isPodReady)).toBe(true);
+  });
+});
+
+describe('调度器', () => {
+  it('Pod 被分散到不同节点（least-allocated）', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+    await cluster.settle();
+    const nodes = podsOf(cluster).map((pod) => (pod.spec as any).nodeName);
+    expect(new Set(nodes).size).toBe(3);
+  });
+
+  it('资源不够时 Pod 卡在 Pending 并给出 Unschedulable 的原因', async () => {
+    const cluster = newCluster({ nodes: [{ name: 'tiny', cpu: '100m' }] });
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+    await cluster.settle();
+
+    const pods = podsOf(cluster);
+    const scheduled = pods.filter((pod) => (pod.spec as any).nodeName);
+    expect(scheduled).toHaveLength(1);                    // 只装得下一个
+
+    const pending = pods.filter((pod) => !(pod.spec as any).nodeName);
+    expect(pending.length).toBeGreaterThan(0);
+    expect((pending[0].status as any).conditions[0]).toMatchObject({
+      type: 'PodScheduled', status: 'False', reason: 'Unschedulable',
+    });
+  });
+
+  it('cordon 过的节点不接新 Pod', async () => {
+    const cluster = newCluster({ nodes: [{ name: 'a' }, { name: 'b', unschedulable: true }] });
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+    await cluster.settle();
+    const nodes = new Set(podsOf(cluster).map((pod) => (pod.spec as any).nodeName));
+    expect(nodes).toEqual(new Set(['a']));
+  });
+
+  it('nodeSelector 生效', async () => {
+    const cluster = newCluster({
+      nodes: [{ name: 'ssd', labels: { disk: 'ssd' } }, { name: 'hdd', labels: { disk: 'hdd' } }],
+    });
+    const deploy = deployment('web', 2);
+    (deploy.spec as any).template.spec.nodeSelector = { disk: 'ssd' };
+    cluster.registry.create(DEPLOYMENTS, 'default', deploy);
+    await cluster.settle();
+    expect(new Set(podsOf(cluster).map((p) => (p.spec as any).nodeName))).toEqual(new Set(['ssd']));
+  });
+});
+
+describe('kubelet', () => {
+  it('拉不到的镜像进 ImagePullBackOff，并记一条 Warning 事件', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 1, 'registry.corp.internal/nope:9.9'));
+    await cluster.settle();
+
+    const pod = podsOf(cluster)[0];
+    expect((pod.status as any).containerStatuses[0].state.waiting.reason).toBe('ImagePullBackOff');
+    expect(isPodReady(pod)).toBe(false);
+
+    const events = cluster.registry.list(EVENTS, { namespace: 'default' }).items;
+    const failed = events.find((e) => (e as any).reason === 'Failed');
+    expect((failed as any)?.message).toContain('Failed to pull image');
+  });
+
+  it('缺环境变量进 CrashLoopBackOff', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('api', 1, 'registry.corp.internal/needs-db:1.0'));
+    await cluster.settle();
+
+    const pod = podsOf(cluster)[0];
+    const state = (pod.status as any).containerStatuses[0];
+    expect(state.state.waiting.reason).toBe('CrashLoopBackOff');
+    expect(state.lastState.terminated.exitCode).toBe(1);
+  });
+
+  it('给了环境变量就能起来', async () => {
+    const cluster = newCluster();
+    const deploy = deployment('api', 1, 'registry.corp.internal/needs-db:1.0');
+    (deploy.spec as any).template.spec.containers[0].env = [{ name: 'DB_PASSWORD', value: 's3cret' }];
+    cluster.registry.create(DEPLOYMENTS, 'default', deploy);
+    await cluster.settle();
+    expect(isPodReady(podsOf(cluster)[0])).toBe(true);
+  });
+
+  it('Pod 拿到 IP，且同一个世界重放时 IP 一样', async () => {
+    const ips = async () => {
+      const cluster = newCluster();
+      cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+      await cluster.settle();
+      return podsOf(cluster).map((p) => (p.status as any).podIP).sort();
+    };
+    const first = await ips();
+    expect(first.every((ip) => /^10\.42\.\d+\.\d+$/.test(ip))).toBe(true);
+    expect(await ips()).toEqual(first);
+  });
+
+  it('生命周期是逐步推进的，不是一步到位', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 1));
+    // 只推进到刚够创建容器，还不够 Running
+    await cluster.advanceBy(150);
+    const mid = podsOf(cluster)[0];
+    expect((mid.status as any).phase).toBe('Pending');
+    expect((mid.status as any).containerStatuses?.[0].state.waiting.reason).toBe('ContainerCreating');
+
+    await cluster.settle();
+    expect(isPodReady(podsOf(cluster)[0])).toBe(true);
+  });
+});
+
+describe('Endpoints', () => {
+  const service = (name: string, selector: Record<string, string>): KubeObject => ({
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name },
+    spec: { selector, ports: [{ port: 80, targetPort: 8080, protocol: 'TCP' }], clusterIP: '10.96.0.10' },
+  });
+
+  it('只收 Ready 的 Pod', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 2));
+    cluster.registry.create(SERVICES, 'default', service('web', { app: 'web' }));
+    await cluster.settle();
+
+    const endpoints = cluster.registry.get(ENDPOINTS, 'default', 'web');
+    expect((endpoints as any).subsets[0].addresses).toHaveLength(2);
+    expect((endpoints as any).subsets[0].ports[0]).toMatchObject({ port: 8080, protocol: 'TCP' });
+  });
+
+  it('Pod 起不来时端点是空的 —— 探针配错导致 502 的根', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 2, 'registry.corp.internal/nope:9.9'));
+    cluster.registry.create(SERVICES, 'default', service('web', { app: 'web' }));
+    await cluster.settle();
+
+    const endpoints = cluster.registry.get(ENDPOINTS, 'default', 'web');
+    expect((endpoints as any).subsets).toEqual([]);
+  });
+
+  it('选不中任何 Pod 的 Service 端点为空', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(SERVICES, 'default', service('orphan', { app: 'nothing' }));
+    await cluster.settle();
+    expect((cluster.registry.get(ENDPOINTS, 'default', 'orphan') as any).subsets).toEqual([]);
+  });
+
+  it('Service 删掉之后 Endpoints 跟着走', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 1));
+    cluster.registry.create(SERVICES, 'default', service('web', { app: 'web' }));
+    await cluster.settle();
+    expect(() => cluster.registry.get(ENDPOINTS, 'default', 'web')).not.toThrow();
+
+    cluster.registry.delete(SERVICES, 'default', 'web');
+    await cluster.settle();
+    expect(() => cluster.registry.get(ENDPOINTS, 'default', 'web')).toThrow(/not found/);
+  });
+});
+
+describe('滚动更新', () => {
+  it('换镜像会建新 ReplicaSet，最终旧的缩到 0', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+    await cluster.settle();
+    const firstRs = cluster.registry.list(REPLICASETS, { namespace: 'default' }).items[0];
+
+    const current = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+    const spec = current.spec as any;
+    spec.template.spec.containers[0].image = 'registry.corp.internal/web:2.0';
+    cluster.registry.update(DEPLOYMENTS, 'default', 'web', { ...current, spec });
+    await cluster.settle();
+
+    const replicaSets = cluster.registry.list(REPLICASETS, { namespace: 'default' }).items;
+    expect(replicaSets).toHaveLength(2);
+    const oldRs = replicaSets.find((rs) => rs.metadata.uid === firstRs.metadata.uid)!;
+    const newRs = replicaSets.find((rs) => rs.metadata.uid !== firstRs.metadata.uid)!;
+    expect((oldRs.spec as any).replicas).toBe(0);
+    expect((newRs.spec as any).replicas).toBe(3);
+
+    const pods = podsOf(cluster).filter((p) => !p.metadata.deletionTimestamp);
+    expect(pods).toHaveLength(3);
+    expect(pods.every((p) => (p.spec as any).containers[0].image === 'registry.corp.internal/web:2.0')).toBe(true);
+  });
+
+  it('滚动更新期间可用副本数不掉到 maxUnavailable 线下', async () => {
+    const cluster = newCluster();
+    cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 4));
+    await cluster.settle();
+
+    const current = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+    const spec = current.spec as any;
+    spec.strategy = { rollingUpdate: { maxSurge: 1, maxUnavailable: 1 } };
+    spec.template.spec.containers[0].image = 'registry.corp.internal/web:2.0';
+    cluster.registry.update(DEPLOYMENTS, 'default', 'web', { ...current, spec });
+
+    // 一小步一小步推进，全程盯着可用副本数
+    let worst = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < 60; i += 1) {
+      await cluster.advanceBy(100);
+      const ready = podsOf(cluster).filter((p) => isPodReady(p) && !p.metadata.deletionTimestamp).length;
+      worst = Math.min(worst, ready);
+      const deploy = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+      if ((deploy.status as any).updatedReplicas === 4 && (deploy.status as any).readyReplicas === 4) break;
+    }
+    expect(worst).toBeGreaterThanOrEqual(3);            // 4 - maxUnavailable(1)
+  });
+});
+
+describe('工具函数', () => {
+  it('parseCpu', () => {
+    expect(parseCpu('500m')).toBe(500);
+    expect(parseCpu('2')).toBe(2000);
+    expect(parseCpu(undefined)).toBe(0);
+  });
+
+  it('resolveCount 支持百分比与绝对值', () => {
+    expect(resolveCount('25%', 4, 1)).toBe(1);
+    expect(resolveCount('50%', 4, 1)).toBe(2);
+    expect(resolveCount(2, 4, 1)).toBe(2);
+  });
+
+  it('templateHash 确定且区分不同模板', () => {
+    const a = { spec: { containers: [{ image: 'x' }] } };
+    const b = { spec: { containers: [{ image: 'y' }] } };
+    expect(templateHash(a)).toBe(templateHash(a));
+    expect(templateHash(a)).not.toBe(templateHash(b));
+    expect(templateHash(a)).toMatch(/^[a-z0-9]{6}$/);
+  });
+});
+
+describe('确定性', () => {
+  it('同一个世界重放 20 次，最终状态逐字节一致', async () => {
+    const run = async () => {
+      const cluster = newCluster();
+      cluster.registry.create(DEPLOYMENTS, 'default', deployment('web', 3));
+      cluster.registry.create(SERVICES, 'default', {
+        apiVersion: 'v1', kind: 'Service',
+        metadata: { name: 'web' },
+        spec: { selector: { app: 'web' }, ports: [{ port: 80, targetPort: 8080 }], clusterIP: '10.96.0.10' },
+      });
+      await cluster.settle();
+      // 再来一次扰动，让控制器多跑几轮
+      const deploy = cluster.registry.get(DEPLOYMENTS, 'default', 'web');
+      cluster.registry.update(DEPLOYMENTS, 'default', 'web', {
+        ...deploy, spec: { ...(deploy.spec as any), replicas: 5 },
+      });
+      await cluster.settle();
+
+      return JSON.stringify({
+        pods: podsOf(cluster).map((p) => ({
+          name: p.metadata.name, node: (p.spec as any).nodeName,
+          phase: (p.status as any).phase, ip: (p.status as any).podIP, ready: isPodReady(p),
+        })),
+        endpoints: (cluster.registry.get(ENDPOINTS, 'default', 'web') as any).subsets,
+        deployment: cluster.registry.get(DEPLOYMENTS, 'default', 'web').status,
+      }, null, 1);
+    };
+
+    const first = await run();
+    expect(first).toContain('"ready": true');
+    for (let i = 0; i < 19; i += 1) expect(await run()).toBe(first);
+  }, 60_000);
+});


### PR DESCRIPTION
第三段第 3 片。**第一条完整因果链通了**：

```
apply 一个 Deployment
  → 建 ReplicaSet（名字带模板哈希）
  → 建 Pod
  → 调度器绑到节点
  → kubelet 拉镜像 → ContainerCreating → Running → Ready
  → Endpoints 收进这个 Pod
```

删掉一个 Pod 会被补回来；换镜像会滚动更新；镜像拉不到进 ImagePullBackOff；
缺环境变量进 CrashLoopBackOff；资源不够卡 Pending 并给出 Unschedulable 原因。

## 内容

`framework.ts` —— informer（先 list 再 watch，从 list 的 rv 续上不漏事件）
+ workqueue（按 key 去重、指数退避重试）。
`workloads.ts` —— 调度器、ReplicaSet、Deployment、Endpoints、kubelet。
`cluster.ts` —— 把内核/存储/apiserver/控制器接成一个能跑的集群，
`cluster.apiServer.handle` 就是喂给 kubectl 的那个入口。

## 写的过程中撞上四个真问题

**1. 常驻消费任务让世界永远静不下来。** WorkQueue 第一版 spawn 了一个 `for(;;)`
的任务消费队列，于是 `kernel.liveTasks` 永远 > 0，`settle()` 再也返回不了，
测试直接挂死。改成「**有活才排一个前台定时器**」—— 队列空了就没有定时器，
「控制器还有活没干完」恰好等价于「还有前台定时器」，和内核的静止判定天然对齐。

**2. 无条件写 status = 纯微任务死循环。** 控制器写 status → 触发自己的 informer
→ 重新入队 → 再写。整个过程不经过定时器，虚拟时间一点不走，**进程转死，
连 jest 的超时都报不出来**（查了很久）。改成比较后再写 —— 真 k8s 控制器也这么做，
原因一模一样。

**3. informer 的删除事件丢了对象。** 缓存里已经没有它了，而 ReplicaSet 控制器
正需要从 `ownerReferences` 找属主。结果删掉一个 Pod，属主根本不会被通知，
副本补不回来。现在删除事件带上最后一次已知状态。

**4. 滚动更新会把服务打到 0。** Deployment 按 RS 的 `status.readyReplicas` 判断
可用副本数，而那是异步写回的、滞后的。同一瞬间里反复 reconcile，每次都以为
「还有 4 个 ready」，于是把旧 RS 一路缩到 0，新 Pod 一个都没起来。
实测可用副本数掉到 **0** —— 正是 `maxUnavailable` 该拦住的那种停机。
改成数**活着的 Pod**，并把「已下达但还没执行的缩容」算进来。修复后逐步观察：

```
t=500   old=3/3  new=2/0   ready=3
t=800   old=1/1  new=4/2   ready=3
t=1200  old=0/0  new=4/4   ready=4
```

最低可用数稳稳停在 `desired - maxUnavailable`。

## 两处语义修正

- `kernel.advanceBy` 末尾原先顺带 `settle()`，导致「只走 150ms 看中间态」
  直接看到终态。现在只跑窗口内到期的东西。
- **CrashLoopBackOff 的重启排成后台定时器。** 真 kubelet 会永远按退避重启，
  算成前台工作世界就永远静不下来 —— 而「卡在 CrashLoopBackOff」恰恰是
  要给学员看的稳定终态。

## 验证

24 条控制器测试，含滚动更新全程盯可用副本数、重放 20 次最终状态逐字节一致。
opslab 套件累计 **157 条**；`npm test` 8/8、`build` 通过、`projects:verify` 全通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)