### PR TITLE
opslab 机器层：文件系统、真 shell、docker build 与私有仓库

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,18 @@ const nextConfig = {
     // Handle .wasm files
     config.module.rules.push({
       test: /\.wasm$/,
+      exclude: /node_modules[\\/]web-tree-sitter[\\/]/,
       type: 'webassembly/async',
+    });
+
+    // web-tree-sitter 的 wasm 是 emscripten 产物，导入 GOT.mem / env 这些
+    // 只有它自己的胶水代码才提供的东西。当成 webpack 的 wasm 模块去解析必然失败，
+    // 按普通资源拷出去就行 —— 运行期我们本来就是自己按 URL 取的
+    // （见 scripts/copy-opslab-assets.js）。
+    config.module.rules.push({
+      test: /\.wasm$/,
+      include: /node_modules[\\/]web-tree-sitter[\\/]/,
+      type: 'asset/resource',
     });
 
     // Web Worker 里没有 window/document，默认的 JSONP chunk 加载会直接崩。
@@ -49,6 +60,19 @@ const nextConfig = {
           /^(perf_hooks|fs|os|path|crypto|inspector|child_process)$/,
           (resource) => {
             if (/node_modules[\\/]typescript[\\/]/.test(resource.context || '')) {
+              resource.request = require.resolve('./src/lib/emptyModule.js');
+            }
+          }
+        )
+      );
+
+      // web-tree-sitter 同理：它的 ESM 产物里有 Node 分支，会 import fs/promises
+      // 和 module。这些分支被 ENVIRONMENT_IS_NODE 挡着，浏览器里不会走到。
+      config.plugins.push(
+        new webpack.NormalModuleReplacementPlugin(
+          /^(fs\/promises|module)$/,
+          (resource) => {
+            if (/node_modules[\\/]web-tree-sitter(?:[\\/]|$)/.test(resource.context || '')) {
               resource.request = require.resolve('./src/lib/emptyModule.js');
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,9 @@
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
-        "typescript": "5.1.6"
+        "tree-sitter-bash": "^0.25.1",
+        "typescript": "5.1.6",
+        "web-tree-sitter": "^0.26.13"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -10377,6 +10379,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/node-int64/-/node-int64-0.4.0.tgz",
@@ -12715,6 +12728,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-sitter-bash": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
+      "integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-bash/node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -13353,6 +13394,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.13",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.13.tgz",
+      "integrity": "sha512-5bUZ7vbQ1kcondet96wzP974+JfCZDeQ7bTpacICm2nnvHpa5cO0ByRsoMcAhUP+743vpkb4m0BFlVSm+Ye9VA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   ],
   "scripts": {
     "dev": "next dev",
+    "predev": "node scripts/copy-opslab-assets.js",
     "build": "next build",
+    "prebuild": "node scripts/copy-opslab-assets.js",
     "start": "next start",
     "deploy-local": "npm run build && npm start",
     "setup": "npm install && npm run build",
@@ -108,7 +110,9 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "typescript": "5.1.6"
+    "tree-sitter-bash": "^0.25.1",
+    "typescript": "5.1.6",
+    "web-tree-sitter": "^0.26.13"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/scripts/copy-opslab-assets.js
+++ b/scripts/copy-opslab-assets.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * 把 opslab 需要的 WASM 资源从 node_modules 拷到 public/opslab/。
+ *
+ * tree-sitter 的运行时与 bash 语法都是 WASM 文件，浏览器要按 URL 去 fetch，
+ * 不能靠打包器 import 进来。public/opslab/*.wasm 在 .gitignore 里，所以
+ * 每次构建都要拷一遍 —— 少了它，终端一敲命令就报 404。
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const OUT_DIR = path.join(ROOT, 'public', 'opslab');
+
+const ASSETS = [
+  ['web-tree-sitter/web-tree-sitter.wasm', 'web-tree-sitter.wasm'],
+  ['tree-sitter-bash/tree-sitter-bash.wasm', 'tree-sitter-bash.wasm'],
+];
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+let copied = 0;
+for (const [source, target] of ASSETS) {
+  const from = path.join(ROOT, 'node_modules', source);
+  const to = path.join(OUT_DIR, target);
+  if (!fs.existsSync(from)) {
+    console.error(`copy-opslab-assets: 找不到 ${source}，先跑 npm install`);
+    process.exit(1);
+  }
+  // 已经一样就别动，免得每次构建都刷新 mtime
+  if (fs.existsSync(to) && fs.statSync(to).size === fs.statSync(from).size) continue;
+  fs.copyFileSync(from, to);
+  copied += 1;
+}
+
+console.log(`copy-opslab-assets: ${copied} 个文件已更新（共 ${ASSETS.length} 个）`);

--- a/src/lib/opslab/machine/index.ts
+++ b/src/lib/opslab/machine/index.ts
@@ -1,0 +1,38 @@
+/**
+ * 机器层
+ *
+ * 集群之下的那一层：磁盘、shell、命令。kubectl 也只是这台机器上的
+ * 一个命令 —— 它凭 kubeconfig 找到 apiserver，和现实里一样。
+ */
+export {
+  Vfs, VfsError, createVfs, normalizePath, dirname, basename,
+  type FileStat, type VfsSnapshot,
+} from './vfs';
+
+export {
+  parseShell, loadShellParser, resetShellParser, ShellSyntaxError,
+  type Node, type Word, type WordPart, type Redirect,
+} from './shell/parser';
+
+export {
+  Shell, createShell, matchesGlob,
+  type CommandContext, type CommandHandler, type CommandResult,
+  type ShellOptions, type RunResult,
+} from './shell/shell';
+
+export { COREUTILS } from './shell/coreutils';
+
+export {
+  Machine, createMachine,
+  type MachineOptions, type MachineSnapshot, type CommandRecord,
+} from './machine';
+
+export {
+  ImageStore, Registry, RegistryNetwork, RegistryError,
+  buildImage, createDockerCommand, imageRootfs, readCredentials,
+  parseDockerfile, parseReference, normalizeReference, flattenLayers,
+  finalizeImage, makeLayer, imageManifest, manifestDigest,
+  digestOf, sha256Hex, shortId,
+  type Image, type Layer, type OciImageConfig, type Credentials,
+  type BuildOptions, type BuildOutcome, type DockerOptions,
+} from './oci';

--- a/src/lib/opslab/machine/machine.ts
+++ b/src/lib/opslab/machine/machine.ts
@@ -22,6 +22,8 @@ export interface MachineOptions {
   commands?: Record<string, CommandHandler>;
   /** 虚拟墙钟，毫秒 */
   now?: () => number;
+  /** 循环体最多跑多少轮，防住写错的死循环 */
+  maxLoopIterations?: number;
 }
 
 export interface MachineSnapshot {
@@ -66,6 +68,7 @@ export class Machine {
       hostname: this.hostname,
       user: options.user ?? 'root',
       env: options.env,
+      maxLoopIterations: options.maxLoopIterations,
       commands: { ...COREUTILS, ...(options.commands ?? {}) },
     });
   }
@@ -119,8 +122,8 @@ export class Machine {
 
   restore(snapshot: MachineSnapshot): void {
     this.vfs.restore(snapshot.vfs);
-    this.shell.cwd = snapshot.cwd;
-    this.shell.env = { ...snapshot.env };
+    // 变量、函数、set -e 这些也要跟着回去，否则「重来一次」会带着上一轮的残留
+    this.shell.reset({ cwd: snapshot.cwd, env: snapshot.env });
     this.history.length = 0;
     this.history.push(...snapshot.history);
   }

--- a/src/lib/opslab/machine/machine.ts
+++ b/src/lib/opslab/machine/machine.ts
@@ -1,0 +1,140 @@
+/**
+ * 机器
+ *
+ * 学员面前那台跳板机：一份磁盘（Vfs）、一个 shell、一堆装好的命令。
+ * 关卡把 kubectl / helm / systemctl 之类注册进来，其余的（coreutils）
+ * 开箱就有。
+ *
+ * 时间从内核来，不从 `Date.now()` 来 —— 文件 mtime、命令耗时都要能复现。
+ */
+import { createVfs, Vfs, VfsSnapshot } from './vfs';
+import { COREUTILS } from './shell/coreutils';
+import { CommandHandler, RunResult, Shell, createShell } from './shell/shell';
+
+export interface MachineOptions {
+  hostname?: string;
+  user?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  /** 初始文件：路径 -> 内容 */
+  files?: Record<string, string>;
+  /** 关卡额外装的命令 */
+  commands?: Record<string, CommandHandler>;
+  /** 虚拟墙钟，毫秒 */
+  now?: () => number;
+}
+
+export interface MachineSnapshot {
+  vfs: VfsSnapshot;
+  cwd: string;
+  env: Record<string, string>;
+  history: string[];
+}
+
+/** 一条命令跑完之后的完整记录，终端面板与判分都读它 */
+export interface CommandRecord extends RunResult {
+  command: string;
+  cwd: string;
+  /** 虚拟墙钟 */
+  at: number;
+}
+
+export class Machine {
+  readonly vfs: Vfs;
+  readonly shell: Shell;
+  readonly hostname: string;
+  readonly history: string[] = [];
+  private readonly records: CommandRecord[] = [];
+  private readonly now: () => number;
+
+  constructor(options: MachineOptions = {}) {
+    this.now = options.now ?? (() => 0);
+    this.hostname = options.hostname ?? 'jump-01';
+    this.vfs = createVfs(this.now);
+
+    // 一台机器该有的目录，缺了 `cd /etc` 会莫名其妙地失败
+    for (const path of ['/bin', '/usr/bin', '/usr/local/bin', '/etc', '/var/log', '/tmp', '/root', '/home']) {
+      this.vfs.mkdirp(path);
+    }
+    this.vfs.writeFile('/etc/hostname', `${this.hostname}\n`);
+    this.vfs.writeFile('/etc/os-release', OS_RELEASE);
+    if (options.files) this.vfs.populate(options.files);
+
+    this.shell = createShell({
+      vfs: this.vfs,
+      cwd: options.cwd ?? '/root',
+      hostname: this.hostname,
+      user: options.user ?? 'root',
+      env: options.env,
+      commands: { ...COREUTILS, ...(options.commands ?? {}) },
+    });
+  }
+
+  /** 装一个命令（kubectl、helm、systemctl…） */
+  install(name: string, handler: CommandHandler): void {
+    this.shell.register(name, handler);
+  }
+
+  get cwd(): string {
+    return this.shell.cwd;
+  }
+
+  /** 提示符，和 bash 默认的 `user@host:~/dir$` 一致 */
+  prompt(): string {
+    const home = this.shell.env.HOME ?? '/root';
+    const path = this.shell.cwd === home
+      ? '~'
+      : this.shell.cwd.startsWith(`${home}/`)
+        ? `~${this.shell.cwd.slice(home.length)}`
+        : this.shell.cwd;
+    return `${this.shell.user}@${this.hostname}:${path}${this.shell.user === 'root' ? '#' : '$'} `;
+  }
+
+  /** 敲一条命令 */
+  async exec(command: string): Promise<CommandRecord> {
+    const trimmed = command.trim();
+    if (trimmed) this.history.push(trimmed);
+    const cwd = this.shell.cwd;
+    const result = trimmed
+      ? await this.shell.run(trimmed)
+      : { stdout: '', stderr: '', code: 0 };
+    const record: CommandRecord = { ...result, command: trimmed, cwd, at: this.now() };
+    this.records.push(record);
+    return record;
+  }
+
+  /** 完整的操作记录 —— 判分与回放读它 */
+  transcript(): CommandRecord[] {
+    return [...this.records];
+  }
+
+  snapshot(): MachineSnapshot {
+    return {
+      vfs: this.vfs.snapshot(),
+      cwd: this.shell.cwd,
+      env: { ...this.shell.env },
+      history: [...this.history],
+    };
+  }
+
+  restore(snapshot: MachineSnapshot): void {
+    this.vfs.restore(snapshot.vfs);
+    this.shell.cwd = snapshot.cwd;
+    this.shell.env = { ...snapshot.env };
+    this.history.length = 0;
+    this.history.push(...snapshot.history);
+  }
+}
+
+const OS_RELEASE = [
+  'PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"',
+  'NAME="Debian GNU/Linux"',
+  'VERSION_ID="12"',
+  'VERSION="12 (bookworm)"',
+  'ID=debian',
+  '',
+].join('\n');
+
+export function createMachine(options?: MachineOptions): Machine {
+  return new Machine(options);
+}

--- a/src/lib/opslab/machine/oci/build.ts
+++ b/src/lib/opslab/machine/oci/build.ts
@@ -386,22 +386,41 @@ function applyCopy(
         `ERROR: failed to solve: failed to compute cache key: "${source}" not found: not found\n`
       );
     }
-    // 单个文件拷成文件；目录或多个来源拷进目标目录
-    const single = matched.length === 1 && matched[0] === absolute;
     for (const path of matched) {
-      const target = single && sources.length === 1 && !destination.endsWith('/')
-        ? normalizePath(destination, workdir)
-        : normalizePath(
-            `${destination}/${single ? path.slice(absolute.lastIndexOf('/') + 1) : path.slice(absolute.length + (path === absolute ? 0 : 1))}`,
-            workdir
-          );
-      collected[target] = sourceFiles[path];
+      collected[copyTarget({ path, absolute, matched, sources, destination, workdir })] = sourceFiles[path];
     }
   }
 
   const after = { ...result.rootfs, ...collected };
   const layer = diffLayer(result.rootfs, after, `${instruction.name} ${instruction.args}`);
   commit(result, layer, options.created);
+}
+
+/**
+ * 一个来源文件该落到目标的哪个路径上。
+ *
+ * Docker 的规矩：**单个文件 + 目标不以 `/` 结尾** 时目标就是文件名本身
+ * （`COPY app.js /srv/index.js` 会改名）；其它情况一律当成「拷进目录」，
+ * 目录来源还要保留相对层级。
+ */
+function copyTarget(input: {
+  path: string;
+  absolute: string;
+  matched: string[];
+  sources: string[];
+  destination: string;
+  workdir: string;
+}): string {
+  const { path, absolute, matched, sources, destination, workdir } = input;
+  const isSingleFile = matched.length === 1 && matched[0] === absolute;
+
+  if (isSingleFile && sources.length === 1 && !destination.endsWith('/')) {
+    return normalizePath(destination, workdir);
+  }
+  const relative = isSingleFile
+    ? absolute.slice(absolute.lastIndexOf('/') + 1)
+    : path.slice(absolute.length + 1);
+  return normalizePath(`${destination}/${relative}`, workdir);
 }
 
 function stageFiles(

--- a/src/lib/opslab/machine/oci/build.ts
+++ b/src/lib/opslab/machine/oci/build.ts
@@ -1,0 +1,517 @@
+/**
+ * docker build
+ *
+ * 真的按 Dockerfile 一条条执行：COPY 从构建上下文取文件，RUN 在当层的
+ * 根文件系统上跑一个 shell，每条产生层的指令算出真的 sha256。
+ * 所以「把密钥 COPY 进去再 rm 掉」这种事，在层里查得出来 —— 第 3 关
+ * 要考的就是它。
+ */
+import { Vfs, createVfs, normalizePath } from '../vfs';
+import { COREUTILS } from '../shell/coreutils';
+import { CommandHandler, createShell } from '../shell/shell';
+import { matchesGlob } from '../shell/shell';
+import {
+  Dockerfile, DockerfileError, DockerfileStage, Instruction,
+  METADATA_INSTRUCTIONS, parseDockerfile, parseExecForm, parseKeyValues, tokenize, unquote,
+} from './dockerfile';
+import {
+  Image, Layer, OciImageConfig, finalizeImage, flattenLayers, makeLayer, parseReference,
+} from './image';
+import { Credentials, ImageStore, RegistryError, RegistryNetwork } from './registry';
+
+export interface BuildOptions {
+  /** 构建上下文所在的文件系统与目录 */
+  context: Vfs;
+  contextRoot: string;
+  /** 默认 `<contextRoot>/Dockerfile` */
+  dockerfilePath?: string;
+  tags?: string[];
+  buildArgs?: Record<string, string>;
+  /** `--target builder` */
+  target?: string;
+  store: ImageStore;
+  network?: RegistryNetwork;
+  credentialsFor?: (host: string) => Credentials | undefined;
+  /**
+   * 基础镜像自带的工具链：`node:22-alpine` 里有 `npm`，`python:3.13` 里有 `pip`。
+   * RUN 的时候把它们装进那个临时 shell。
+   */
+  toolchains?: Record<string, Record<string, CommandHandler>>;
+  /** ISO8601 的创建时间，从虚拟墙钟来 */
+  created: string;
+}
+
+export interface BuildOutcome {
+  image?: Image;
+  log: string;
+  code: number;
+}
+
+/** 每类指令的固定耗时，保证同一个 Dockerfile 每次构建日志都一样 */
+const STEP_SECONDS: Record<string, number> = { FROM: 0.2, RUN: 0.4, COPY: 0.1, ADD: 0.1 };
+
+export async function buildImage(options: BuildOptions): Promise<BuildOutcome> {
+  const log = new BuildLog();
+  const dockerfilePath = options.dockerfilePath ?? `${options.contextRoot}/Dockerfile`;
+
+  if (!options.context.exists(dockerfilePath)) {
+    return {
+      log: `ERROR: failed to build: failed to read dockerfile: open ${dockerfilePath}: no such file or directory\n`,
+      code: 1,
+    };
+  }
+
+  let parsed: Dockerfile;
+  try {
+    parsed = parseDockerfile(options.context.readFile(dockerfilePath));
+  } catch (error) {
+    if (error instanceof DockerfileError) return { log: `ERROR: ${error.message}\n`, code: 1 };
+    throw error;
+  }
+
+  log.step('[internal] load build definition from Dockerfile', 0.0);
+  log.detail(`transferring dockerfile: ${options.context.readFile(dockerfilePath).length}B done`);
+  log.done();
+
+  const ignore = readDockerignore(options.context, options.contextRoot);
+  const stageOutputs = new Map<string, StageResult>();
+  let last: StageResult | undefined;
+
+  try {
+    const stages = selectStages(parsed.stages, options.target);
+    for (const stage of stages) {
+      last = await runStage(stage, parsed, options, log, stageOutputs, ignore);
+      stageOutputs.set(String(stage.index), last);
+      if (stage.name) stageOutputs.set(stage.name, last);
+    }
+  } catch (error) {
+    if (error instanceof BuildFailure) return { log: log.text() + error.message, code: 1 };
+    if (error instanceof RegistryError) return { log: `${log.text()}ERROR: ${error.message}\n`, code: 1 };
+    throw error;
+  }
+
+  if (!last) return { log: `${log.text()}ERROR: no build stage\n`, code: 1 };
+
+  const tags = (options.tags ?? []).map((tag) => parseReference(tag).canonical);
+  const image = finalizeImage({
+    config: last.config,
+    layers: last.layers,
+    history: last.history,
+    architecture: 'amd64',
+    os: 'linux',
+    created: options.created,
+    repoTags: tags,
+  });
+
+  log.step('exporting to image', 0.1);
+  log.detail('exporting layers done');
+  log.detail(`writing image ${image.id} done`);
+  for (const tag of tags) log.detail(`naming to ${tag} done`);
+  log.done();
+
+  options.store.add(image);
+  return { image, log: log.text(), code: 0 };
+}
+
+/* ------------------------------------------------------------------ */
+
+interface StageResult {
+  config: OciImageConfig;
+  layers: Layer[];
+  history: Image['history'];
+  rootfs: Record<string, string>;
+  /** 这一阶段的基础镜像带来的工具 */
+  tools: Record<string, CommandHandler>;
+}
+
+class BuildFailure extends Error {}
+
+/** `--target` 只构建到指定阶段，但它依赖的前置阶段还是要跑 */
+function selectStages(stages: DockerfileStage[], target?: string): DockerfileStage[] {
+  if (!target) return stages;
+  const index = stages.findIndex((stage) => stage.name === target);
+  if (index < 0) throw new BuildFailure(`ERROR: failed to solve: target stage "${target}" could not be found\n`);
+  return stages.slice(0, index + 1);
+}
+
+async function runStage(
+  stage: DockerfileStage,
+  dockerfile: Dockerfile,
+  options: BuildOptions,
+  log: BuildLog,
+  previous: Map<string, StageResult>,
+  ignore: string[]
+): Promise<StageResult> {
+  const args: Record<string, string> = {};
+  for (const global of dockerfile.globalArgs) {
+    for (const [key, value] of parseKeyValues(global.args)) args[key] = options.buildArgs?.[key] ?? value;
+  }
+  for (const [key, value] of Object.entries(options.buildArgs ?? {})) args[key] = value;
+
+  const fromReference = expand(stage.from, args);
+  const base = resolveBase(fromReference, options, previous, log);
+
+  const result: StageResult = {
+    config: { ...base.config, Env: [...(base.config.Env ?? [])], Labels: { ...(base.config.Labels ?? {}) } },
+    layers: [...base.layers],
+    history: [...base.history],
+    rootfs: { ...base.rootfs },
+    tools: base.tools,
+  };
+
+  const producing = stage.instructions.filter((i) => !METADATA_INSTRUCTIONS.has(i.name)).length;
+  let step = 0;
+
+  for (const instruction of stage.instructions) {
+    const isMetadata = METADATA_INSTRUCTIONS.has(instruction.name);
+    if (!isMetadata) step += 1;
+    const label = isMetadata
+      ? `${stageLabel(stage)}${instruction.name} ${instruction.args}`
+      : `${stageLabel(stage)}[${step}/${producing}] ${instruction.name} ${instruction.args}`;
+
+    if (isMetadata) {
+      applyMetadata(instruction, result, args, options);
+      result.history.push({
+        created: options.created,
+        created_by: `/bin/sh -c #(nop) ${instruction.name} ${instruction.args}`,
+        empty_layer: true,
+      });
+      continue;
+    }
+
+    log.step(label.trim(), STEP_SECONDS[instruction.name] ?? 0.1);
+    if (instruction.name === 'RUN') await applyRun(instruction, result, options, log);
+    else applyCopy(instruction, result, options, previous, ignore, log);
+    log.done();
+  }
+
+  return result;
+}
+
+function stageLabel(stage: DockerfileStage): string {
+  return stage.name ? `${stage.name} ` : '';
+}
+
+/** FROM：先看前面的阶段，再看本地镜像库，最后才去 registry 拉 */
+function resolveBase(
+  reference: string,
+  options: BuildOptions,
+  previous: Map<string, StageResult>,
+  log: BuildLog
+): StageResult {
+  const fromStage = previous.get(reference);
+  if (fromStage) return { ...fromStage, layers: [...fromStage.layers], history: [...fromStage.history] };
+
+  if (reference === 'scratch') {
+    return { config: {}, layers: [], history: [], rootfs: {}, tools: {} };
+  }
+
+  const canonical = parseReference(reference).canonical;
+  const tools = options.toolchains?.[canonical] ?? options.toolchains?.[reference] ?? {};
+
+  let image = options.store.get(reference);
+  if (!image) {
+    log.step(`[internal] load metadata for ${canonical}`, 0.2);
+    log.done();
+    const parsedReference = parseReference(reference);
+    const registry = options.network?.resolve(parsedReference.registry);
+    if (!registry) {
+      throw new BuildFailure(
+        `ERROR: failed to solve: ${reference}: failed to resolve source metadata for ${canonical}\n`
+      );
+    }
+    image = registry.pull(reference, options.credentialsFor?.(parsedReference.registry));
+    options.store.add(image);
+  }
+
+  return {
+    config: { ...image.config },
+    layers: [...image.layers],
+    history: [...image.history],
+    rootfs: flattenLayers(image.layers),
+    tools,
+  };
+}
+
+function applyMetadata(
+  instruction: Instruction,
+  result: StageResult,
+  args: Record<string, string>,
+  options: BuildOptions
+): void {
+  const value = expand(instruction.args, { ...args, ...envMap(result.config.Env) });
+
+  switch (instruction.name) {
+    case 'ENV':
+      for (const [key, item] of parseKeyValues(instruction.args)) {
+        setEnv(result.config, key, expand(item, { ...args, ...envMap(result.config.Env) }));
+      }
+      break;
+
+    case 'ARG':
+      for (const [key, fallback] of parseKeyValues(instruction.args)) {
+        args[key] = options.buildArgs?.[key] ?? args[key] ?? fallback;
+      }
+      break;
+
+    case 'WORKDIR':
+      result.config.WorkingDir = normalizePath(unquote(value), result.config.WorkingDir ?? '/');
+      break;
+
+    case 'USER':
+      result.config.User = unquote(value);
+      break;
+
+    case 'EXPOSE':
+      result.config.ExposedPorts = { ...(result.config.ExposedPorts ?? {}) };
+      for (const port of tokenize(value)) {
+        result.config.ExposedPorts[port.includes('/') ? port : `${port}/tcp`] = {};
+      }
+      break;
+
+    case 'LABEL':
+      result.config.Labels = { ...(result.config.Labels ?? {}) };
+      for (const [key, item] of parseKeyValues(instruction.args)) {
+        result.config.Labels[key] = expand(item, { ...args, ...envMap(result.config.Env) });
+      }
+      break;
+
+    case 'VOLUME':
+      result.config.Volumes = { ...(result.config.Volumes ?? {}) };
+      for (const path of parseExecForm(value) ?? tokenize(value)) result.config.Volumes[unquote(path)] = {};
+      break;
+
+    case 'CMD':
+      result.config.Cmd = parseExecForm(instruction.args) ?? ['/bin/sh', '-c', value];
+      break;
+
+    case 'ENTRYPOINT':
+      result.config.Entrypoint = parseExecForm(instruction.args) ?? ['/bin/sh', '-c', value];
+      break;
+
+    case 'STOPSIGNAL':
+      result.config.StopSignal = value;
+      break;
+
+    case 'HEALTHCHECK':
+      result.config.Healthcheck = value.toUpperCase().startsWith('NONE')
+        ? { Test: ['NONE'] }
+        : { Test: ['CMD-SHELL', value.replace(/^CMD(-SHELL)?\s+/i, '')] };
+      break;
+
+    default:
+      break;
+  }
+}
+
+/** RUN：把当前 rootfs 铺进临时文件系统跑一遍，再 diff 出这一层 */
+async function applyRun(
+  instruction: Instruction,
+  result: StageResult,
+  options: BuildOptions,
+  log: BuildLog
+): Promise<void> {
+  const vfs = createVfs(() => 0);
+  vfs.populate(result.rootfs);
+  const workdir = result.config.WorkingDir ?? '/';
+  vfs.mkdirp(workdir);
+
+  const shell = createShell({
+    vfs,
+    cwd: workdir,
+    env: envMap(result.config.Env),
+    commands: { ...COREUTILS, ...result.tools },
+    user: result.config.User ?? 'root',
+  });
+
+  const script = (parseExecForm(instruction.args) ?? []).length
+    ? (parseExecForm(instruction.args) as string[]).join(' ')
+    : instruction.args;
+
+  const outcome = await shell.run(script);
+  const output = outcome.stdout + outcome.stderr;
+  const code = outcome.code;
+
+  for (const line of output.split('\n')) {
+    if (line) log.detail(line, true);
+  }
+  if (code !== 0) {
+    log.fail();
+    throw new BuildFailure(
+      `------\n > [${instruction.name} ${instruction.args}]:\n${output}------\n` +
+      `ERROR: failed to solve: process "/bin/sh -c ${instruction.args}" did not complete successfully: exit code: ${code}\n`
+    );
+  }
+
+  const after = vfs.toFileMap('/');
+  const layer = diffLayer(result.rootfs, after, `/bin/sh -c ${instruction.args}`);
+  commit(result, layer, options.created);
+}
+
+/** COPY / ADD */
+function applyCopy(
+  instruction: Instruction,
+  result: StageResult,
+  options: BuildOptions,
+  previous: Map<string, StageResult>,
+  ignore: string[],
+  log: BuildLog
+): void {
+  const parts = tokenize(instruction.args).map(unquote);
+  if (parts.length < 2) {
+    throw new BuildFailure(
+      `ERROR: failed to solve: ${instruction.name} requires at least two arguments\n`
+    );
+  }
+  const destination = parts[parts.length - 1];
+  const sources = parts.slice(0, -1);
+  const workdir = result.config.WorkingDir ?? '/';
+
+  // --from 可以指向前面的阶段，也可以指向一个镜像
+  const from = instruction.flags.from;
+  const sourceFiles = from !== undefined
+    ? stageFiles(from, previous, options)
+    : contextFiles(options, ignore);
+  const sourceRoot = from !== undefined ? '/' : options.contextRoot;
+
+  const collected: Record<string, string> = {};
+  for (const source of sources) {
+    const absolute = normalizePath(source, sourceRoot);
+    const matched = Object.keys(sourceFiles).filter((path) =>
+      path === absolute || path.startsWith(`${absolute}/`) || matchesGlob(absolute, path)
+    );
+    if (matched.length === 0) {
+      log.fail();
+      throw new BuildFailure(
+        `ERROR: failed to solve: failed to compute cache key: "${source}" not found: not found\n`
+      );
+    }
+    // 单个文件拷成文件；目录或多个来源拷进目标目录
+    const single = matched.length === 1 && matched[0] === absolute;
+    for (const path of matched) {
+      const target = single && sources.length === 1 && !destination.endsWith('/')
+        ? normalizePath(destination, workdir)
+        : normalizePath(
+            `${destination}/${single ? path.slice(absolute.lastIndexOf('/') + 1) : path.slice(absolute.length + (path === absolute ? 0 : 1))}`,
+            workdir
+          );
+      collected[target] = sourceFiles[path];
+    }
+  }
+
+  const after = { ...result.rootfs, ...collected };
+  const layer = diffLayer(result.rootfs, after, `${instruction.name} ${instruction.args}`);
+  commit(result, layer, options.created);
+}
+
+function stageFiles(
+  from: string,
+  previous: Map<string, StageResult>,
+  options: BuildOptions
+): Record<string, string> {
+  const stage = previous.get(from);
+  if (stage) return stage.rootfs;
+  const image = options.store.get(from);
+  if (image) return flattenLayers(image.layers);
+  throw new BuildFailure(`ERROR: failed to solve: invalid from flag value ${from}: stage not found\n`);
+}
+
+function contextFiles(options: BuildOptions, ignore: string[]): Record<string, string> {
+  const all = options.context.toFileMap(options.contextRoot);
+  if (ignore.length === 0) return all;
+  const kept: Record<string, string> = {};
+  for (const [path, content] of Object.entries(all)) {
+    const relative = path.slice(options.contextRoot.length + 1);
+    if (ignore.some((pattern) => matchesGlob(pattern, relative) || relative.startsWith(`${pattern}/`))) continue;
+    kept[path] = content;
+  }
+  return kept;
+}
+
+function readDockerignore(vfs: Vfs, root: string): string[] {
+  const path = `${root}/.dockerignore`;
+  if (!vfs.exists(path)) return [];
+  return vfs
+    .readFile(path)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+function diffLayer(
+  before: Record<string, string>,
+  after: Record<string, string>,
+  createdBy: string
+): Layer {
+  const files: Record<string, string> = {};
+  for (const [path, content] of Object.entries(after)) {
+    if (before[path] !== content) files[path] = content;
+  }
+  const removed = Object.keys(before).filter((path) => !(path in after));
+  return makeLayer(files, removed, createdBy);
+}
+
+function commit(result: StageResult, layer: Layer, created: string): void {
+  // 空层不留痕迹，和 Docker 一样
+  if (Object.keys(layer.files).length === 0 && layer.removed.length === 0) return;
+  result.layers.push(layer);
+  result.history.push({ created, created_by: layer.createdBy });
+  for (const path of layer.removed) delete result.rootfs[path];
+  Object.assign(result.rootfs, layer.files);
+}
+
+function envMap(env?: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of env ?? []) {
+    const index = entry.indexOf('=');
+    if (index > 0) out[entry.slice(0, index)] = entry.slice(index + 1);
+  }
+  return out;
+}
+
+function setEnv(config: OciImageConfig, key: string, value: string): void {
+  const env = [...(config.Env ?? [])];
+  const index = env.findIndex((entry) => entry.startsWith(`${key}=`));
+  if (index >= 0) env[index] = `${key}=${value}`;
+  else env.push(`${key}=${value}`);
+  config.Env = env;
+}
+
+/** `${VAR}` / `$VAR` —— Dockerfile 的展开规则比 shell 简单得多 */
+function expand(text: string, values: Record<string, string>): string {
+  return text.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    (_, braced, bare) => values[braced ?? bare] ?? '');
+}
+
+/* ------------------------------------------------------------------ */
+
+/** BuildKit 的进度输出 */
+class BuildLog {
+  private lines: string[] = [];
+  private index = 0;
+  private elapsed = 0;
+  private current = 0;
+
+  step(title: string, seconds: number): void {
+    this.index += 1;
+    this.current = this.index;
+    this.elapsed += seconds;
+    this.lines.push(`#${this.index} ${title}`);
+  }
+
+  detail(text: string, timed = false): void {
+    this.lines.push(`#${this.current || 1} ${timed ? `${this.elapsed.toFixed(3)} ` : ''}${text}`);
+  }
+
+  done(): void {
+    this.lines.push(`#${this.current} DONE ${this.elapsed.toFixed(1)}s`, '');
+  }
+
+  fail(): void {
+    this.lines.push(`#${this.current} ERROR: process did not complete successfully`, '');
+  }
+
+  text(): string {
+    return this.lines.length ? `${this.lines.join('\n')}\n` : '';
+  }
+}

--- a/src/lib/opslab/machine/oci/digest.ts
+++ b/src/lib/opslab/machine/oci/digest.ts
@@ -1,0 +1,81 @@
+/**
+ * SHA-256
+ *
+ * 镜像的 digest 必须是真的算出来的 —— 学员会 `docker images --digests`、
+ * 会比对 `kubectl describe` 里的 imageID，两处对不上就穿帮了。
+ *
+ * 自己实现而不用 `crypto.subtle`：后者是异步的，会把构建流程整条染成
+ * async，而且 Node 与浏览器的可用性还要分别判断。这段是标准算法，
+ * 几十行，同步、纯函数、两端一致。
+ */
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const rotr = (value: number, bits: number): number => (value >>> bits) | (value << (32 - bits));
+
+/** 十六进制小写，不带 `sha256:` 前缀 */
+export function sha256Hex(input: string | Uint8Array): string {
+  const bytes = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+  const bitLength = bytes.length * 8;
+
+  // 填充到 64 字节的整数倍，末尾 8 字节放长度
+  const padded = new Uint8Array(((bytes.length + 9 + 63) >> 6) << 6);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padded.length - 8, Math.floor(bitLength / 0x100000000));
+  view.setUint32(padded.length - 4, bitLength >>> 0);
+
+  const h = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let i = 0; i < 16; i += 1) w[i] = view.getUint32(offset + i * 4);
+    for (let i = 16; i < 64; i += 1) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    let [a, b, c, d, e, f, g, hh] = h;
+    for (let i = 0; i < 64; i += 1) {
+      const s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (hh + s1 + ch + K[i] + w[i]) >>> 0;
+      const s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + maj) >>> 0;
+      hh = g; g = f; f = e;
+      e = (d + temp1) >>> 0;
+      d = c; c = b; b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+    h[0] = (h[0] + a) >>> 0; h[1] = (h[1] + b) >>> 0; h[2] = (h[2] + c) >>> 0; h[3] = (h[3] + d) >>> 0;
+    h[4] = (h[4] + e) >>> 0; h[5] = (h[5] + f) >>> 0; h[6] = (h[6] + g) >>> 0; h[7] = (h[7] + hh) >>> 0;
+  }
+
+  let out = '';
+  for (const value of h) out += value.toString(16).padStart(8, '0');
+  return out;
+}
+
+/** `sha256:abc…`，OCI 里到处都是这个形式 */
+export function digestOf(input: string | Uint8Array): string {
+  return `sha256:${sha256Hex(input)}`;
+}
+
+/** `sha256:abcdef…` 截短成 12 位，`docker images` 的 IMAGE ID 列 */
+export function shortId(digest: string): string {
+  return digest.replace(/^sha256:/, '').slice(0, 12);
+}

--- a/src/lib/opslab/machine/oci/docker.ts
+++ b/src/lib/opslab/machine/oci/docker.ts
@@ -171,11 +171,21 @@ function push(argv: string[], context: CommandContext, options: DockerOptions): 
   const parsed = parseReference(reference);
   const registry = options.network.resolve(parsed.registry);
   const credentials = readCredentials(context.vfs, configPath(context, options))[parsed.registry];
-  const { digest } = registry.push(reference, image, credentials);
+
+  // -a / --all-tags：把这个仓库下该镜像的所有 tag 都推上去
+  const allTags = flags.bools.has('a') || flags.bools.has('all-tags');
+  const targets = allTags
+    ? image.repoTags
+      .map((tag) => parseReference(tag))
+      .filter((tag) => tag.registry === parsed.registry && tag.repository === parsed.repository)
+    : [parsed];
 
   const lines = [`The push refers to repository [${parsed.registry}/${parsed.repository}]`];
   for (const layer of image.layers) lines.push(`${shortId(layer.digest)}: Pushed`);
-  lines.push(`${parsed.tag}: digest: ${digest} size: ${imageManifest(image).length}`);
+  for (const target of targets) {
+    const { digest } = registry.push(target.canonical, image, credentials);
+    lines.push(`${target.tag}: digest: ${digest} size: ${imageManifest(image).length}`);
+  }
   return { stdout: `${lines.join('\n')}\n` };
 }
 
@@ -261,7 +271,10 @@ function inspect(argv: string[], options: DockerOptions): CommandResult {
     found.push({
       Id: image.id,
       RepoTags: image.repoTags,
-      RepoDigests: [...image.repoTags.map((t) => `${t.split(':')[0]}@${manifestDigest(image)}`)],
+      RepoDigests: image.repoTags.map((tag) => {
+        const ref = parseReference(tag);
+        return `${ref.registry}/${ref.repository}@${manifestDigest(image)}`;
+      }),
       Created: image.created,
       Architecture: image.architecture,
       Os: image.os,

--- a/src/lib/opslab/machine/oci/docker.ts
+++ b/src/lib/opslab/machine/oci/docker.ts
@@ -1,0 +1,410 @@
+/**
+ * docker CLI
+ *
+ * 输出格式照抄真 docker：列宽、`Pushed` / `Pull complete` 这些字样、
+ * 报错前缀 `Error response from daemon:`。学员把报错贴进搜索引擎，
+ * 应该能搜到现实世界的答案。
+ */
+import { Vfs, normalizePath } from '../vfs';
+import type { CommandContext, CommandHandler, CommandResult } from '../shell/shell';
+import { shortId } from './digest';
+import { buildImage } from './build';
+import { Image, flattenLayers, imageManifest, manifestDigest, parseReference } from './image';
+import { Credentials, ImageStore, RegistryError, RegistryNetwork } from './registry';
+
+export interface DockerOptions {
+  store: ImageStore;
+  network: RegistryNetwork;
+  /** 基础镜像自带的工具链，构建时 RUN 用得到 */
+  toolchains?: Record<string, Record<string, CommandHandler>>;
+  /** 虚拟墙钟（毫秒） */
+  now: () => number;
+  /** 凭据文件，默认 `~/.docker/config.json` */
+  configPath?: string;
+}
+
+export function createDockerCommand(options: DockerOptions): CommandHandler {
+  return async (context) => {
+    const [subcommand, ...rest] = context.argv;
+    if (!subcommand) return usage();
+
+    try {
+      switch (subcommand) {
+        case 'build': return await build(rest, context, options);
+        case 'images': case 'image': return images(rest, options);
+        case 'tag': return tag(rest, options);
+        case 'push': return push(rest, context, options);
+        case 'pull': return pull(rest, context, options);
+        case 'login': return login(rest, context, options);
+        case 'logout': return logout(rest, context, options);
+        case 'rmi': return rmi(rest, options);
+        case 'inspect': return inspect(rest, options);
+        case 'history': return history(rest, options);
+        case 'version': return { stdout: VERSION };
+        default:
+          return {
+            stderr: `docker: '${subcommand}' is not a docker command.\nSee 'docker --help'\n`,
+            code: 125,
+          };
+      }
+    } catch (error) {
+      if (error instanceof RegistryError) {
+        return { stderr: `Error response from daemon: ${error.message}\n`, code: 1 };
+      }
+      throw error;
+    }
+  };
+}
+
+/* ------------------------------------------------------------------ */
+
+interface Flags {
+  values: string[];
+  single: Record<string, string>;
+  repeated: Record<string, string[]>;
+  bools: Set<string>;
+}
+
+/** docker 的 flag：`-t x`、`--tag=x`、`--build-arg k=v`（可重复）、`-q` */
+function parseFlags(argv: string[], valueFlags: string[], boolFlags: string[]): Flags {
+  const flags: Flags = { values: [], single: {}, repeated: {}, bools: new Set() };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('-') || arg === '-') { flags.values.push(arg); continue; }
+
+    const equals = arg.indexOf('=');
+    const name = (equals > 0 ? arg.slice(0, equals) : arg).replace(/^--?/, '');
+    if (boolFlags.includes(name)) { flags.bools.add(name); continue; }
+    if (!valueFlags.includes(name)) { flags.bools.add(name); continue; }
+
+    const value = equals > 0 ? arg.slice(equals + 1) : argv[++i] ?? '';
+    flags.single[name] = value;
+    flags.repeated[name] = [...(flags.repeated[name] ?? []), value];
+  }
+  return flags;
+}
+
+async function build(argv: string[], context: CommandContext, options: DockerOptions): Promise<CommandResult> {
+  const flags = parseFlags(argv, ['t', 'tag', 'f', 'file', 'build-arg', 'target', 'platform'], ['no-cache', 'pull', 'q', 'quiet']);
+  const path = flags.values[0];
+  if (!path) {
+    return { stderr: '"docker build" requires exactly 1 argument.\nSee \'docker build --help\'\n', code: 1 };
+  }
+  const contextRoot = normalizePath(path, context.cwd);
+  if (!context.vfs.isDir(contextRoot)) {
+    return { stderr: `ERROR: unable to prepare context: path "${path}" not found\n`, code: 1 };
+  }
+
+  const buildArgs: Record<string, string> = {};
+  for (const entry of flags.repeated['build-arg'] ?? []) {
+    const index = entry.indexOf('=');
+    if (index > 0) buildArgs[entry.slice(0, index)] = entry.slice(index + 1);
+  }
+
+  const dockerfile = flags.single.f ?? flags.single.file;
+  const outcome = await buildImage({
+    context: context.vfs,
+    contextRoot,
+    dockerfilePath: dockerfile ? normalizePath(dockerfile, context.cwd) : undefined,
+    tags: [...(flags.repeated.t ?? []), ...(flags.repeated.tag ?? [])],
+    buildArgs,
+    target: flags.single.target,
+    store: options.store,
+    network: options.network,
+    credentialsFor: (host) => readCredentials(context.vfs, configPath(context, options))[host],
+    toolchains: options.toolchains,
+    created: new Date(options.now()).toISOString(),
+  });
+
+  return outcome.code === 0
+    ? { stdout: outcome.log }
+    : { stdout: '', stderr: outcome.log, code: outcome.code };
+}
+
+function images(argv: string[], options: DockerOptions): CommandResult {
+  const flags = parseFlags(argv, [], ['q', 'quiet', 'digests', 'a', 'all']);
+  const all = options.store.list();
+  if (flags.bools.has('q') || flags.bools.has('quiet')) {
+    return { stdout: all.map((image) => shortId(image.id)).join('\n') + (all.length ? '\n' : '') };
+  }
+
+  const digests = flags.bools.has('digests');
+  const rows: string[][] = [];
+  for (const image of all) {
+    const tags = image.repoTags.length ? image.repoTags : ['<none>:<none>'];
+    for (const reference of tags) {
+      const parsed = parseReference(reference);
+      const repository = parsed.registry === 'docker.io'
+        ? parsed.repository.replace(/^library\//, '')
+        : `${parsed.registry}/${parsed.repository}`;
+      const row = [repository, parsed.tag || '<none>'];
+      if (digests) row.push(manifestDigest(image));
+      row.push(shortId(image.id), age(image.created, options.now()), size(image.size));
+      rows.push(row);
+    }
+  }
+  const header = ['REPOSITORY', 'TAG', ...(digests ? ['DIGEST'] : []), 'IMAGE ID', 'CREATED', 'SIZE'];
+  return { stdout: table(header, rows) };
+}
+
+function tag(argv: string[], options: DockerOptions): CommandResult {
+  const [source, target] = argv;
+  if (!source || !target) {
+    return { stderr: '"docker tag" requires exactly 2 arguments.\n', code: 1 };
+  }
+  options.store.tag(source, target);
+  return { code: 0 };
+}
+
+function push(argv: string[], context: CommandContext, options: DockerOptions): CommandResult {
+  const flags = parseFlags(argv, [], ['a', 'all-tags', 'q', 'quiet']);
+  const reference = flags.values[0];
+  if (!reference) return { stderr: '"docker push" requires exactly 1 argument.\n', code: 1 };
+
+  const image = options.store.get(reference);
+  if (!image) {
+    return {
+      stderr: `An image does not exist locally with the tag: ${parseReference(reference).canonical}\n`,
+      code: 1,
+    };
+  }
+  const parsed = parseReference(reference);
+  const registry = options.network.resolve(parsed.registry);
+  const credentials = readCredentials(context.vfs, configPath(context, options))[parsed.registry];
+  const { digest } = registry.push(reference, image, credentials);
+
+  const lines = [`The push refers to repository [${parsed.registry}/${parsed.repository}]`];
+  for (const layer of image.layers) lines.push(`${shortId(layer.digest)}: Pushed`);
+  lines.push(`${parsed.tag}: digest: ${digest} size: ${imageManifest(image).length}`);
+  return { stdout: `${lines.join('\n')}\n` };
+}
+
+function pull(argv: string[], context: CommandContext, options: DockerOptions): CommandResult {
+  const reference = parseFlags(argv, [], ['q', 'quiet']).values[0];
+  if (!reference) return { stderr: '"docker pull" requires exactly 1 argument.\n', code: 1 };
+
+  const parsed = parseReference(reference);
+  const registry = options.network.resolve(parsed.registry);
+  const credentials = readCredentials(context.vfs, configPath(context, options))[parsed.registry];
+  const image = registry.pull(reference, credentials);
+  options.store.add(image);
+
+  const lines = [`${parsed.tag}: Pulling from ${parsed.repository}`];
+  for (const layer of image.layers) lines.push(`${shortId(layer.digest)}: Pull complete`);
+  lines.push(
+    `Digest: ${manifestDigest(image)}`,
+    `Status: Downloaded newer image for ${parsed.canonical}`,
+    parsed.canonical
+  );
+  return { stdout: `${lines.join('\n')}\n` };
+}
+
+function login(argv: string[], context: CommandContext, options: DockerOptions): CommandResult {
+  const flags = parseFlags(argv, ['u', 'username', 'p', 'password'], ['password-stdin']);
+  const host = flags.values[0] ?? 'docker.io';
+  const username = flags.single.u ?? flags.single.username;
+  const password = flags.bools.has('password-stdin')
+    ? context.stdin.replace(/\n$/, '')
+    : flags.single.p ?? flags.single.password;
+
+  if (!username || password === undefined) {
+    return { stderr: 'Error: Cannot perform an interactive login from a non TTY device\n', code: 1 };
+  }
+
+  const registry = options.network.resolve(host);
+  if (!registry.authenticate({ username, password })) {
+    return {
+      stderr: `Error response from daemon: login attempt to https://${host}/v2/ failed with status: 401 Unauthorized\n`,
+      code: 1,
+    };
+  }
+
+  const path = configPath(context, options);
+  const config = readConfig(context.vfs, path);
+  config.auths = { ...(config.auths ?? {}), [host]: { auth: base64(`${username}:${password}`) } };
+  context.vfs.writeFile(path, `${JSON.stringify(config, null, 4)}\n`);
+
+  const warning = flags.bools.has('password-stdin')
+    ? ''
+    : 'WARNING! Using --password via the CLI is insecure. Use --password-stdin.\n';
+  return { stdout: `${warning}Login Succeeded\n` };
+}
+
+function logout(argv: string[], context: CommandContext, options: DockerOptions): CommandResult {
+  const host = argv[0] ?? 'docker.io';
+  const path = configPath(context, options);
+  const config = readConfig(context.vfs, path);
+  if (config.auths?.[host]) {
+    delete config.auths[host];
+    context.vfs.writeFile(path, `${JSON.stringify(config, null, 4)}\n`);
+  }
+  return { stdout: `Removing login credentials for ${host}\n` };
+}
+
+function rmi(argv: string[], options: DockerOptions): CommandResult {
+  const lines: string[] = [];
+  for (const reference of parseFlags(argv, [], ['f', 'force']).values) {
+    const result = options.store.remove(reference);
+    if (result.untagged) lines.push(`Untagged: ${result.untagged}`);
+    if (result.deleted) lines.push(`Deleted: ${result.deleted}`);
+  }
+  return { stdout: lines.length ? `${lines.join('\n')}\n` : '' };
+}
+
+function inspect(argv: string[], options: DockerOptions): CommandResult {
+  const found: unknown[] = [];
+  for (const reference of parseFlags(argv, ['f', 'format'], []).values) {
+    const image = options.store.get(reference);
+    if (!image) {
+      return { stderr: `Error: No such object: ${reference}\n`, code: 1 };
+    }
+    found.push({
+      Id: image.id,
+      RepoTags: image.repoTags,
+      RepoDigests: [...image.repoTags.map((t) => `${t.split(':')[0]}@${manifestDigest(image)}`)],
+      Created: image.created,
+      Architecture: image.architecture,
+      Os: image.os,
+      Size: image.size,
+      Config: image.config,
+      RootFS: { Type: 'layers', Layers: image.layers.map((layer) => layer.digest) },
+    });
+  }
+  return { stdout: `${JSON.stringify(found, null, 4)}\n` };
+}
+
+function history(argv: string[], options: DockerOptions): CommandResult {
+  const reference = parseFlags(argv, [], ['no-trunc']).values[0];
+  const image = reference ? options.store.get(reference) : undefined;
+  if (!image) return { stderr: `Error response from daemon: No such image: ${reference ?? ''}\n`, code: 1 };
+
+  // 每条 history 对上它的层；元数据指令没有层，SIZE 是 0B
+  let layerIndex = 0;
+  const rows = image.history.map((entry) => {
+    const layer = entry.empty_layer ? undefined : image.layers[layerIndex++];
+    return [
+      layer ? shortId(layer.digest) : '<missing>',
+      age(entry.created, options.now()),
+      truncate(entry.created_by, 45),
+      size(layer?.size ?? 0),
+    ];
+  }).reverse();
+  return { stdout: table(['IMAGE', 'CREATED', 'CREATED BY', 'SIZE'], rows) };
+}
+
+/* ------------------------------------------------------------------ */
+
+interface DockerConfig {
+  auths?: Record<string, { auth: string }>;
+}
+
+function configPath(context: CommandContext, options: DockerOptions): string {
+  return options.configPath ?? `${context.env.HOME ?? '/root'}/.docker/config.json`;
+}
+
+function readConfig(vfs: Vfs, path: string): DockerConfig {
+  if (!vfs.exists(path)) return {};
+  try {
+    return JSON.parse(vfs.readFile(path)) as DockerConfig;
+  } catch {
+    return {};
+  }
+}
+
+/** 从 `~/.docker/config.json` 里读出每个 registry 的凭据 */
+export function readCredentials(vfs: Vfs, path: string): Record<string, Credentials> {
+  const out: Record<string, Credentials> = {};
+  for (const [host, entry] of Object.entries(readConfig(vfs, path).auths ?? {})) {
+    const decoded = unbase64(entry.auth);
+    const index = decoded.indexOf(':');
+    if (index > 0) out[host] = { username: decoded.slice(0, index), password: decoded.slice(index + 1) };
+  }
+  return out;
+}
+
+/** 浏览器里没有 Buffer，用 btoa/atob */
+function base64(text: string): string {
+  return btoa(text);
+}
+
+function unbase64(text: string): string {
+  try {
+    return atob(text);
+  } catch {
+    return '';
+  }
+}
+
+function truncate(text: string, width: number): string {
+  return text.length <= width ? text : `${text.slice(0, width - 1)}…`;
+}
+
+/** docker 的 SIZE 列 */
+function size(bytes: number): string {
+  if (bytes < 1000) return `${bytes}B`;
+  if (bytes < 1000 * 1000) return `${(bytes / 1000).toFixed(2)}kB`;
+  return `${(bytes / 1000 / 1000).toFixed(2)}MB`;
+}
+
+/** docker 的 CREATED 列：`2 minutes ago` */
+function age(created: string, now: number): string {
+  const seconds = Math.max(0, Math.floor((now - Date.parse(created)) / 1000));
+  if (seconds < 45) return `${seconds} seconds ago`;
+  if (seconds < 90) return 'About a minute ago';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 45) return `${minutes} minutes ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hours ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days} days ago`;
+  if (days < 30) return `${Math.round(days / 7)} weeks ago`;
+  if (days < 365) return `${Math.round(days / 30)} months ago`;
+  return `${Math.round(days / 365)} years ago`;
+}
+
+/** docker 的列表：列之间至少 3 个空格 */
+function table(header: string[], rows: string[][]): string {
+  const widths = header.map((title, index) =>
+    Math.max(title.length, ...rows.map((row) => (row[index] ?? '').length))
+  );
+  const render = (row: string[]) =>
+    row.map((cell, index) => (index === row.length - 1 ? cell : cell.padEnd(widths[index] + 3))).join('').trimEnd();
+  return [render(header), ...rows.map(render)].join('\n') + '\n';
+}
+
+function usage(): CommandResult {
+  return {
+    stderr: [
+      'Usage:  docker [OPTIONS] COMMAND',
+      '',
+      'Common Commands:',
+      '  build       Build an image from a Dockerfile',
+      '  images      List images',
+      '  push        Upload an image to a registry',
+      '  pull        Download an image from a registry',
+      '  login       Authenticate to a registry',
+      '  tag         Create a tag that refers to a source image',
+      '  inspect     Return low-level information on Docker objects',
+      '  history     Show the history of an image',
+      '',
+    ].join('\n'),
+    code: 1,
+  };
+}
+
+const VERSION = [
+  'Client: Docker Engine - Community',
+  ' Version:           27.5.1',
+  ' API version:       1.47',
+  '',
+  'Server: Docker Engine - Community',
+  ' Engine:',
+  '  Version:          27.5.1',
+  '  API version:      1.47 (minimum version 1.24)',
+  '',
+].join('\n');
+
+/** 把镜像摊平成根文件系统 —— 判分时要看「密钥有没有进层」 */
+export function imageRootfs(image: Image): Record<string, string> {
+  return flattenLayers(image.layers);
+}

--- a/src/lib/opslab/machine/oci/dockerfile.ts
+++ b/src/lib/opslab/machine/oci/dockerfile.ts
@@ -1,0 +1,213 @@
+/**
+ * Dockerfile 解析
+ *
+ * 学员真的会写 Dockerfile，所以语法边角要认全：续行、注释、
+ * `--from=builder`、exec form 与 shell form 的区别、多阶段构建。
+ * 认不出来的指令要报错，报错文本照抄 BuildKit —— 学员搜错误信息时
+ * 搜到的应该是真实世界的答案。
+ */
+
+export interface Instruction {
+  /** 大写后的指令名 */
+  name: string;
+  /** 指令名之后、去掉 flag 的部分 */
+  args: string;
+  /** `--from=builder` 这类 */
+  flags: Record<string, string>;
+  /** 1 开始，报错要用 */
+  line: number;
+  raw: string;
+}
+
+export interface DockerfileStage {
+  index: number;
+  /** `FROM x AS builder` 里的 builder */
+  name?: string;
+  from: string;
+  platform?: string;
+  instructions: Instruction[];
+}
+
+export interface Dockerfile {
+  stages: DockerfileStage[];
+  /** 第一个 FROM 之前的 ARG，可以用在 FROM 里 */
+  globalArgs: Instruction[];
+}
+
+export class DockerfileError extends Error {
+  constructor(message: string, readonly line: number) {
+    super(message);
+    this.name = 'DockerfileError';
+  }
+}
+
+const KNOWN = new Set([
+  'FROM', 'RUN', 'CMD', 'LABEL', 'EXPOSE', 'ENV', 'ADD', 'COPY', 'ENTRYPOINT',
+  'VOLUME', 'USER', 'WORKDIR', 'ARG', 'ONBUILD', 'STOPSIGNAL', 'HEALTHCHECK', 'SHELL', 'MAINTAINER',
+]);
+
+/** 元数据指令不产生层 */
+export const METADATA_INSTRUCTIONS = new Set([
+  'CMD', 'LABEL', 'EXPOSE', 'ENV', 'ENTRYPOINT', 'VOLUME', 'USER', 'WORKDIR',
+  'ARG', 'STOPSIGNAL', 'HEALTHCHECK', 'SHELL', 'MAINTAINER',
+]);
+
+export function parseDockerfile(source: string): Dockerfile {
+  const logical = joinContinuations(source);
+  const stages: DockerfileStage[] = [];
+  const globalArgs: Instruction[] = [];
+
+  for (const { text, line } of logical) {
+    const trimmed = text.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const match = /^(\S+)\s*([\s\S]*)$/.exec(trimmed);
+    if (!match) continue;
+    const name = match[1].toUpperCase();
+    if (!KNOWN.has(name)) {
+      throw new DockerfileError(`dockerfile parse error on line ${line}: unknown instruction: ${match[1]}`, line);
+    }
+    if (name === 'ONBUILD') {
+      throw new DockerfileError(`dockerfile parse error on line ${line}: ONBUILD is not supported by opslab`, line);
+    }
+
+    const { flags, rest } = extractFlags(match[2]);
+    const instruction: Instruction = { name, args: rest.trim(), flags, line, raw: trimmed };
+
+    if (name === 'FROM') {
+      stages.push(parseFrom(instruction, stages.length));
+      continue;
+    }
+    if (stages.length === 0) {
+      if (name === 'ARG') { globalArgs.push(instruction); continue; }
+      throw new DockerfileError(
+        `dockerfile parse error on line ${line}: no build stage in current context`,
+        line
+      );
+    }
+    stages[stages.length - 1].instructions.push(instruction);
+  }
+
+  if (stages.length === 0) {
+    throw new DockerfileError('dockerfile parse error: file with no instructions', 1);
+  }
+  return { stages, globalArgs };
+}
+
+/** `FROM node:22-alpine AS builder` */
+function parseFrom(instruction: Instruction, index: number): DockerfileStage {
+  const parts = instruction.args.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    throw new DockerfileError(
+      `dockerfile parse error on line ${instruction.line}: FROM requires either one or three arguments`,
+      instruction.line
+    );
+  }
+  const [from, keyword, alias] = parts;
+  if (keyword && keyword.toUpperCase() !== 'AS') {
+    throw new DockerfileError(
+      `dockerfile parse error on line ${instruction.line}: expected AS, got ${keyword}`,
+      instruction.line
+    );
+  }
+  return { index, from, name: alias, platform: instruction.flags.platform, instructions: [] };
+}
+
+/** 把续行接起来，同时记住它在原文件里的行号 */
+function joinContinuations(source: string): Array<{ text: string; line: number }> {
+  const out: Array<{ text: string; line: number }> = [];
+  const rawLines = source.split('\n');
+  let buffer = '';
+  let start = 1;
+
+  for (let i = 0; i < rawLines.length; i += 1) {
+    const raw = rawLines[i];
+    // 续行中间的注释行按 Docker 的规矩直接丢掉
+    if (buffer && /^\s*#/.test(raw)) continue;
+    if (!buffer) start = i + 1;
+    if (/\\\s*$/.test(raw)) {
+      // 只去掉反斜杠和换行，原有的空白照留 —— Docker 就是这么拼的
+      buffer += raw.replace(/\\\s*$/, '');
+      continue;
+    }
+    out.push({ text: buffer + raw, line: start });
+    buffer = '';
+  }
+  if (buffer) out.push({ text: buffer, line: start });
+  return out;
+}
+
+/** `--from=builder --chown=1000:1000 src dst` */
+function extractFlags(text: string): { flags: Record<string, string>; rest: string } {
+  const flags: Record<string, string> = {};
+  let rest = text.trimStart();
+  for (;;) {
+    const match = /^--([A-Za-z0-9-]+)(?:=(\S*))?\s*/.exec(rest);
+    if (!match) break;
+    flags[match[1]] = match[2] ?? 'true';
+    rest = rest.slice(match[0].length);
+  }
+  return { flags, rest };
+}
+
+/**
+ * exec form（`["node","server.js"]`）与 shell form（`node server.js`）
+ * 是两回事：前者不经过 /bin/sh，信号能直达进程 —— 第 6 关整关就靠这个区别。
+ */
+export function parseExecForm(args: string): string[] | null {
+  const trimmed = args.trim();
+  if (!trimmed.startsWith('[')) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')) return parsed;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/** `KEY=value KEY2="v 2"` 或老式的 `KEY value` */
+export function parseKeyValues(args: string): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  const tokens = tokenize(args);
+  if (tokens.length >= 2 && !tokens[0].includes('=')) {
+    return [[tokens[0], tokens.slice(1).join(' ')]];
+  }
+  for (const token of tokens) {
+    const index = token.indexOf('=');
+    if (index < 0) continue;
+    out.push([token.slice(0, index), unquote(token.slice(index + 1))]);
+  }
+  return out;
+}
+
+/** 按空白切词，但引号内的空白不算 */
+export function tokenize(text: string): string[] {
+  const out: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (quote) {
+      if (char === quote) { quote = null; current += char; continue; }
+      current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") { quote = char; current += char; continue; }
+    if (/\s/.test(char)) {
+      if (current) out.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current) out.push(current);
+  return out;
+}
+
+export function unquote(text: string): string {
+  if (text.length >= 2 && (text[0] === '"' || text[0] === "'") && text[text.length - 1] === text[0]) {
+    return text.slice(1, -1);
+  }
+  return text;
+}

--- a/src/lib/opslab/machine/oci/image.ts
+++ b/src/lib/opslab/machine/oci/image.ts
@@ -1,0 +1,199 @@
+/**
+ * OCI 镜像的数据结构
+ *
+ * 字段名照抄 OCI image-spec（大写开头的 `Env` / `Entrypoint` …），
+ * 因为 `docker inspect` 与 `crictl inspecti` 打出来的就是这些名字。
+ * 学员照着现实里的文档去 `jq '.Config.User'`，得能取到东西。
+ */
+import { digestOf } from './digest';
+
+export interface OciImageConfig {
+  User?: string;
+  ExposedPorts?: Record<string, Record<string, never>>;
+  Env?: string[];
+  Entrypoint?: string[] | null;
+  Cmd?: string[] | null;
+  WorkingDir?: string;
+  Labels?: Record<string, string>;
+  StopSignal?: string;
+  Volumes?: Record<string, Record<string, never>>;
+  Healthcheck?: { Test?: string[]; Interval?: number; Timeout?: number; Retries?: number };
+}
+
+export interface HistoryEntry {
+  created: string;
+  created_by: string;
+  /** 元数据指令不产生层 */
+  empty_layer?: boolean;
+}
+
+/** 一层的内容。不做压缩，所以 digest 与 diff_id 相同。 */
+export interface Layer {
+  digest: string;
+  size: number;
+  createdBy: string;
+  /** 这一层新增或改动的文件 */
+  files: Record<string, string>;
+  /** 这一层删掉的路径（whiteout） */
+  removed: string[];
+}
+
+export interface Image {
+  /** `sha256:…`，就是 config 的 digest */
+  id: string;
+  repoTags: string[];
+  repoDigests: string[];
+  config: OciImageConfig;
+  layers: Layer[];
+  history: HistoryEntry[];
+  architecture: string;
+  os: string;
+  /** ISO8601 */
+  created: string;
+  size: number;
+}
+
+/** 层内容的规范序列化 —— 顺序固定，同样的内容必然同样的 digest */
+export function layerDigest(files: Record<string, string>, removed: string[]): { digest: string; size: number } {
+  const parts: string[] = [];
+  for (const path of Object.keys(files).sort()) parts.push(`+${path}\0${files[path]}`);
+  for (const path of [...removed].sort()) parts.push(`-${path}`);
+  const payload = parts.join('\n');
+  return { digest: digestOf(payload), size: payload.length };
+}
+
+export function makeLayer(files: Record<string, string>, removed: string[], createdBy: string): Layer {
+  const { digest, size } = layerDigest(files, removed);
+  return { digest, size, createdBy, files, removed };
+}
+
+/** OCI image config 的 JSON —— 镜像 ID 就是它的 digest */
+export function imageConfigJson(image: Omit<Image, 'id' | 'repoTags' | 'repoDigests' | 'size'>): string {
+  return JSON.stringify({
+    architecture: image.architecture,
+    os: image.os,
+    created: image.created,
+    config: image.config,
+    rootfs: { type: 'layers', diff_ids: image.layers.map((layer) => layer.digest) },
+    history: image.history,
+  });
+}
+
+export function finalizeImage(
+  draft: Omit<Image, 'id' | 'repoDigests' | 'size'> & { repoTags?: string[] }
+): Image {
+  const base = {
+    config: draft.config,
+    layers: draft.layers,
+    history: draft.history,
+    architecture: draft.architecture,
+    os: draft.os,
+    created: draft.created,
+  };
+  const json = imageConfigJson(base);
+  return {
+    ...base,
+    id: digestOf(json),
+    repoTags: draft.repoTags ?? [],
+    repoDigests: [],
+    size: draft.layers.reduce((total, layer) => total + layer.size, 0),
+  };
+}
+
+/** OCI manifest，registry 之间传的就是它 */
+export function imageManifest(image: Image): string {
+  return JSON.stringify({
+    schemaVersion: 2,
+    mediaType: 'application/vnd.oci.image.manifest.v1+json',
+    config: {
+      mediaType: 'application/vnd.oci.image.config.v1+json',
+      digest: image.id,
+      size: imageConfigJson(image).length,
+    },
+    layers: image.layers.map((layer) => ({
+      mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+      digest: layer.digest,
+      size: layer.size,
+    })),
+  }, null, 3);
+}
+
+/** manifest 的 digest —— `docker push` 末尾打的那个 */
+export function manifestDigest(image: Image): string {
+  return digestOf(imageManifest(image));
+}
+
+/** 把层一层层叠起来，得到最终的根文件系统 */
+export function flattenLayers(layers: Layer[]): Record<string, string> {
+  const rootfs: Record<string, string> = {};
+  for (const layer of layers) {
+    for (const path of layer.removed) {
+      delete rootfs[path];
+      // 删目录要把子树一起删掉
+      const prefix = `${path}/`;
+      for (const key of Object.keys(rootfs)) {
+        if (key.startsWith(prefix)) delete rootfs[key];
+      }
+    }
+    Object.assign(rootfs, layer.files);
+  }
+  return rootfs;
+}
+
+/* ------------------------------------------------------------------ */
+/* 镜像引用                                                            */
+/* ------------------------------------------------------------------ */
+
+export interface ImageReference {
+  /** `harbor.corp.internal`，没写就是 Docker Hub */
+  registry: string;
+  /** `team/app`，Docker Hub 上的单段名字会补 `library/` */
+  repository: string;
+  tag: string;
+  digest?: string;
+  /** 规范化之后的完整引用 */
+  canonical: string;
+}
+
+const DEFAULT_REGISTRY = 'docker.io';
+
+/**
+ * 解析镜像引用。
+ *
+ * 判断第一段是不是 registry 的规则和 Docker 一样：含 `.` 或 `:`，
+ * 或者就是 `localhost`。`nginx` → `docker.io/library/nginx:latest`。
+ */
+export function parseReference(reference: string): ImageReference {
+  let rest = reference;
+  let digest: string | undefined;
+
+  const at = rest.indexOf('@');
+  if (at >= 0) {
+    digest = rest.slice(at + 1);
+    rest = rest.slice(0, at);
+  }
+
+  const slash = rest.indexOf('/');
+  const head = slash < 0 ? '' : rest.slice(0, slash);
+  const hasRegistry = head !== '' && (head.includes('.') || head.includes(':') || head === 'localhost');
+  const registry = hasRegistry ? head : DEFAULT_REGISTRY;
+  let path = hasRegistry ? rest.slice(slash + 1) : rest;
+
+  let tag = digest ? '' : 'latest';
+  const colon = path.lastIndexOf(':');
+  if (colon > path.lastIndexOf('/')) {
+    tag = path.slice(colon + 1);
+    path = path.slice(0, colon);
+  }
+  if (registry === DEFAULT_REGISTRY && !path.includes('/')) path = `library/${path}`;
+
+  const canonical = digest
+    ? `${registry}/${path}@${digest}`
+    : `${registry}/${path}:${tag}`;
+  return { registry, repository: path, tag, digest, canonical };
+}
+
+/** 学员敲进 manifest 的那种短名字，用来比对 */
+export function normalizeReference(reference: string): string {
+  return parseReference(reference).canonical;
+}

--- a/src/lib/opslab/machine/oci/index.ts
+++ b/src/lib/opslab/machine/oci/index.ts
@@ -1,0 +1,25 @@
+/**
+ * OCI：镜像、构建、仓库
+ */
+export { sha256Hex, digestOf, shortId } from './digest';
+
+export {
+  parseDockerfile, parseExecForm, parseKeyValues, tokenize, unquote,
+  DockerfileError, METADATA_INSTRUCTIONS,
+  type Dockerfile, type DockerfileStage, type Instruction,
+} from './dockerfile';
+
+export {
+  finalizeImage, makeLayer, layerDigest, imageConfigJson, imageManifest, manifestDigest,
+  flattenLayers, parseReference, normalizeReference,
+  type Image, type Layer, type OciImageConfig, type HistoryEntry, type ImageReference,
+} from './image';
+
+export {
+  ImageStore, Registry, RegistryNetwork, RegistryError,
+  type Credentials, type RegistryOptions,
+} from './registry';
+
+export { buildImage, type BuildOptions, type BuildOutcome } from './build';
+
+export { createDockerCommand, readCredentials, imageRootfs, type DockerOptions } from './docker';

--- a/src/lib/opslab/machine/oci/registry.ts
+++ b/src/lib/opslab/machine/oci/registry.ts
@@ -1,0 +1,214 @@
+/**
+ * 本地镜像库与远端 registry
+ *
+ * 报错文本是这一层的重点。`ImagePullBackOff` 的排查全靠这几句话：
+ * 401 是没登录、403 是没权限、no such host 是名字解析不了、
+ * manifest unknown 是 tag 打错了 —— 学员要能从文本分辨出是哪一种。
+ */
+import { Image, parseReference } from './image';
+import { manifestDigest } from './image';
+import { shortId } from './digest';
+
+export class RegistryError extends Error {
+  constructor(message: string, readonly kind: 'unauthorized' | 'denied' | 'not-found' | 'network') {
+    super(message);
+    this.name = 'RegistryError';
+  }
+}
+
+export interface Credentials {
+  username: string;
+  password: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* 本地镜像库（相当于 dockerd 的 image store）                          */
+/* ------------------------------------------------------------------ */
+
+export class ImageStore {
+  private byId = new Map<string, Image>();
+
+  add(image: Image): Image {
+    const existing = this.byId.get(image.id);
+    if (existing) {
+      // 同一个镜像被打了新 tag
+      const repoTags = [...new Set([...existing.repoTags, ...image.repoTags])].sort();
+      const merged = { ...existing, repoTags };
+      this.byId.set(image.id, merged);
+      return merged;
+    }
+    this.byId.set(image.id, { ...image, repoTags: [...image.repoTags].sort() });
+    return this.byId.get(image.id)!;
+  }
+
+  /** 按 tag、完整 id 或短 id 找 */
+  get(reference: string): Image | undefined {
+    if (this.byId.has(reference)) return this.byId.get(reference);
+    const canonical = parseReference(reference).canonical;
+    for (const image of this.byId.values()) {
+      if (image.repoTags.includes(canonical)) return image;
+      if (shortId(image.id) === reference) return image;
+    }
+    return undefined;
+  }
+
+  tag(source: string, target: string): Image {
+    const image = this.get(source);
+    if (!image) throw new RegistryError(`Error response from daemon: No such image: ${source}`, 'not-found');
+    const canonical = parseReference(target).canonical;
+    return this.add({ ...image, repoTags: [...image.repoTags, canonical] });
+  }
+
+  /** 删一个 tag；最后一个 tag 没了才真删镜像 */
+  remove(reference: string): { untagged?: string; deleted?: string } {
+    const image = this.get(reference);
+    if (!image) throw new RegistryError(`Error response from daemon: No such image: ${reference}`, 'not-found');
+
+    const canonical = parseReference(reference).canonical;
+    const remaining = image.repoTags.filter((tag) => tag !== canonical);
+    if (remaining.length > 0 && remaining.length !== image.repoTags.length) {
+      this.byId.set(image.id, { ...image, repoTags: remaining });
+      return { untagged: canonical };
+    }
+    this.byId.delete(image.id);
+    return { untagged: image.repoTags[0], deleted: image.id };
+  }
+
+  /** 新的在前，和 `docker images` 一样 */
+  list(): Image[] {
+    return [...this.byId.values()].sort((a, b) =>
+      a.created === b.created ? (a.id < b.id ? 1 : -1) : a.created < b.created ? 1 : -1
+    );
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 远端 registry                                                       */
+/* ------------------------------------------------------------------ */
+
+export interface RegistryOptions {
+  host: string;
+  /** 用户名 -> 密码。空表示不需要认证。 */
+  users?: Record<string, string>;
+  /** 允许推送到哪些项目（第一段路径）。不填表示都能推。 */
+  projects?: string[];
+  /** 匿名能不能拉 */
+  anonymousPull?: boolean;
+  /** 预置的镜像，`repository:tag -> Image` */
+  seed?: Record<string, Image>;
+}
+
+export class Registry {
+  readonly host: string;
+  private readonly users: Record<string, string>;
+  private readonly projects?: string[];
+  private readonly anonymousPull: boolean;
+  /** repository -> tag -> Image */
+  private repositories = new Map<string, Map<string, Image>>();
+
+  constructor(options: RegistryOptions) {
+    this.host = options.host;
+    this.users = options.users ?? {};
+    this.projects = options.projects;
+    this.anonymousPull = options.anonymousPull ?? Object.keys(options.users ?? {}).length === 0;
+    for (const [reference, image] of Object.entries(options.seed ?? {})) {
+      const parsed = parseReference(`${this.host}/${reference}`);
+      this.put(parsed.repository, parsed.tag, image);
+    }
+  }
+
+  private put(repository: string, tag: string, image: Image): void {
+    const tags = this.repositories.get(repository) ?? new Map<string, Image>();
+    tags.set(tag, image);
+    this.repositories.set(repository, tags);
+  }
+
+  private requiresAuth(): boolean {
+    return Object.keys(this.users).length > 0;
+  }
+
+  authenticate(credentials?: Credentials): boolean {
+    if (!this.requiresAuth()) return true;
+    if (!credentials) return false;
+    return this.users[credentials.username] === credentials.password;
+  }
+
+  push(reference: string, image: Image, credentials?: Credentials): { digest: string } {
+    const parsed = parseReference(reference);
+    if (this.requiresAuth() && !this.authenticate(credentials)) {
+      throw new RegistryError(
+        `unauthorized: authentication required`,
+        credentials ? 'denied' : 'unauthorized'
+      );
+    }
+    const project = parsed.repository.split('/')[0];
+    if (this.projects && !this.projects.includes(project)) {
+      throw new RegistryError(
+        `denied: requested access to the resource is denied`,
+        'denied'
+      );
+    }
+    this.put(parsed.repository, parsed.tag, image);
+    return { digest: manifestDigest(image) };
+  }
+
+  pull(reference: string, credentials?: Credentials): Image {
+    const parsed = parseReference(reference);
+    if (!this.anonymousPull && !this.authenticate(credentials)) {
+      throw new RegistryError(
+        credentials
+          ? `pull access denied for ${parsed.registry}/${parsed.repository}, repository does not exist or may require 'docker login'`
+          : `unauthorized: authentication required`,
+        credentials ? 'denied' : 'unauthorized'
+      );
+    }
+    const tags = this.repositories.get(parsed.repository);
+    if (!tags) {
+      throw new RegistryError(
+        `pull access denied for ${parsed.registry}/${parsed.repository}, repository does not exist or may require 'docker login'`,
+        'not-found'
+      );
+    }
+    const image = tags.get(parsed.tag);
+    if (!image) {
+      throw new RegistryError(`manifest for ${parsed.canonical} not found: manifest unknown`, 'not-found');
+    }
+    return { ...image, repoTags: [parsed.canonical] };
+  }
+
+  listTags(repository: string): string[] {
+    return [...(this.repositories.get(repository)?.keys() ?? [])].sort();
+  }
+
+  catalog(): string[] {
+    return [...this.repositories.keys()].sort();
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 网络：谁能解析到哪个 registry                                        */
+/* ------------------------------------------------------------------ */
+
+export class RegistryNetwork {
+  private hosts = new Map<string, Registry>();
+
+  add(registry: Registry): void {
+    this.hosts.set(registry.host, registry);
+  }
+
+  /** 解析不了的主机名要长得像真的 DNS 失败，这是最常见的一类故障 */
+  resolve(host: string): Registry {
+    const registry = this.hosts.get(host);
+    if (!registry) {
+      throw new RegistryError(
+        `Get "https://${host}/v2/": dial tcp: lookup ${host}: no such host`,
+        'network'
+      );
+    }
+    return registry;
+  }
+
+  has(host: string): boolean {
+    return this.hosts.has(host);
+  }
+}

--- a/src/lib/opslab/machine/oci/registry.ts
+++ b/src/lib/opslab/machine/oci/registry.ts
@@ -136,10 +136,10 @@ export class Registry {
   push(reference: string, image: Image, credentials?: Credentials): { digest: string } {
     const parsed = parseReference(reference);
     if (this.requiresAuth() && !this.authenticate(credentials)) {
-      throw new RegistryError(
-        `unauthorized: authentication required`,
-        credentials ? 'denied' : 'unauthorized'
-      );
+      // 没登录和登录了但密码/权限不对，是两种要分开查的故障
+      throw credentials
+        ? new RegistryError(`denied: requested access to the resource is denied`, 'denied')
+        : new RegistryError(`unauthorized: authentication required`, 'unauthorized');
     }
     const project = parsed.repository.split('/')[0];
     if (this.projects && !this.projects.includes(project)) {

--- a/src/lib/opslab/machine/shell/coreutils.ts
+++ b/src/lib/opslab/machine/shell/coreutils.ts
@@ -348,13 +348,18 @@ export const COREUTILS: Record<string, CommandHandler> = {
   },
 
   find: (context) => {
-    const args = parseArgs(context.argv);
-    // `-name` / `-type` 是 find 自己的谓词，不走通用选项解析
-    const nameIndex = context.argv.indexOf('-name');
-    const namePattern = nameIndex >= 0 ? context.argv[nameIndex + 1] : undefined;
-    const typeIndex = context.argv.indexOf('-type');
-    const type = typeIndex >= 0 ? context.argv[typeIndex + 1] : undefined;
-    const start = args.values.find((value) => !isPredicateValue(context.argv, value)) ?? '.';
+    // find 的语法是「路径 + 谓词」，不是普通的选项，按位置一个个扫
+    let namePattern: string | undefined;
+    let type: string | undefined;
+    let start = '.';
+    let sawStart = false;
+    for (let i = 0; i < context.argv.length; i += 1) {
+      const arg = context.argv[i];
+      if (arg === '-name') { namePattern = context.argv[++i]; continue; }
+      if (arg === '-type') { type = context.argv[++i]; continue; }
+      if (arg.startsWith('-')) continue;
+      if (!sawStart) { start = arg; sawStart = true; }
+    }
 
     const root = resolve(context, start);
     if (!context.vfs.exists(root)) return fail(`find: '${start}': No such file or directory`);
@@ -482,12 +487,6 @@ function globToRegExp(pattern: string): RegExp {
     .map((char) => (char === '*' ? '.*' : char === '?' ? '.' : escapeRegExp(char)))
     .join('');
   return new RegExp(`^${body}$`);
-}
-
-/** `-name` / `-type` 后面那个值不是起始目录 */
-function isPredicateValue(argv: string[], value: string): boolean {
-  const index = argv.indexOf(value);
-  return index > 0 && (argv[index - 1] === '-name' || argv[index - 1] === '-type');
 }
 
 /** `ls -l` 的那一行 */

--- a/src/lib/opslab/machine/shell/coreutils.ts
+++ b/src/lib/opslab/machine/shell/coreutils.ts
@@ -1,0 +1,520 @@
+/**
+ * coreutils
+ *
+ * 覆盖排查问题真正会用到的那些。选择标准不是「命令齐全」，
+ * 而是「学员在关卡里会敲」：看文件、找东西、过滤、统计、改文件。
+ *
+ * 不支持的写法一律明确报错，不要装作支持了 —— 一个被悄悄忽略的参数，
+ * 会让人对着「命令成功了但结果不对」查上半天。
+ */
+import { normalizePath } from '../vfs';
+import type { CommandContext, CommandHandler, CommandResult } from './shell';
+
+const ok = (stdout = ''): CommandResult => ({ stdout, code: 0 });
+const fail = (message: string, code = 1): CommandResult => ({ stderr: `${message}\n`, code });
+
+interface Args {
+  /** `-l`、`--all` 这种开关 */
+  flags: Set<string>;
+  /** `-n 5`、`-d,`、`--name=x` 这种带值的 */
+  options: Record<string, string>;
+  /** 位置参数 */
+  values: string[];
+}
+
+/**
+ * 拆参数。
+ *
+ * `valueFlags` 列出哪些短选项要吃掉后面那个值 —— 不告诉它的话，
+ * `cut -d " " -f 1 f.txt` 里的分隔符会被当成文件名。
+ * `-n5`、`-n 5`、`-abc` 合写、`--` 之后全算位置参数，都按 GNU 的规矩来。
+ */
+function parseArgs(argv: string[], valueFlags = ''): Args {
+  const flags = new Set<string>();
+  const options: Record<string, string> = {};
+  const values: string[] = [];
+  let literal = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (literal || arg === '-' || !arg.startsWith('-')) { values.push(arg); continue; }
+    if (arg === '--') { literal = true; continue; }
+    if (arg.startsWith('--')) {
+      const equals = arg.indexOf('=');
+      if (equals > 0) options[arg.slice(2, equals)] = arg.slice(equals + 1);
+      else flags.add(arg.slice(2));
+      continue;
+    }
+    for (let j = 1; j < arg.length; j += 1) {
+      const letter = arg[j];
+      if (valueFlags.includes(letter)) {
+        const inline = arg.slice(j + 1);
+        options[letter] = inline || argv[++i] || '';
+        break;
+      }
+      flags.add(letter);
+    }
+  }
+  return { flags, options, values };
+}
+
+/** `head -n 5` 与老写法 `head -5` 都要认 */
+function countOption(args: Args, fallback: number): number {
+  const explicit = Number(args.options.n);
+  if (Number.isFinite(explicit) && args.options.n !== undefined) return explicit;
+  for (const flag of args.flags) {
+    if (/^\d+$/.test(flag)) return Number(flag);
+  }
+  return fallback;
+}
+
+function resolve(context: CommandContext, path: string): string {
+  return normalizePath(path, context.cwd);
+}
+
+/** 读取位置参数指定的文件；没给就用 stdin */
+function readInputs(context: CommandContext, values: string[]): { text: string; error?: string } {
+  if (values.length === 0) return { text: context.stdin };
+  const chunks: string[] = [];
+  for (const value of values) {
+    const path = resolve(context, value);
+    if (!context.vfs.exists(path)) return { text: '', error: `${value}: No such file or directory` };
+    if (context.vfs.isDir(path)) return { text: '', error: `${value}: Is a directory` };
+    chunks.push(context.vfs.readFile(path));
+  }
+  return { text: chunks.join('') };
+}
+
+const lines = (text: string): string[] => (text === '' ? [] : text.replace(/\n$/, '').split('\n'));
+const join = (values: string[]): string => (values.length ? `${values.join('\n')}\n` : '');
+
+export const COREUTILS: Record<string, CommandHandler> = {
+  ls: (context) => {
+    const args = parseArgs(context.argv);
+    const targets = args.values.length ? args.values : ['.'];
+    const blocks: string[] = [];
+
+    for (const value of targets) {
+      const target = resolve(context, value);
+      if (!context.vfs.exists(target)) {
+        return fail(`ls: cannot access '${value}': No such file or directory`, 2);
+      }
+      if (context.vfs.isFile(target)) { blocks.push(`${value}\n`); continue; }
+
+      const entries = context.vfs
+        .readDir(target)
+        .filter((name) => args.flags.has('a') || !name.startsWith('.'));
+      blocks.push(
+        args.flags.has('l')
+          ? join(entries.map((name) => longFormat(context, target, name)))
+          : join(entries)
+      );
+    }
+    // 多个目标时会打上目录名做表头，和 GNU ls 一样
+    if (targets.length > 1) {
+      return ok(targets.map((value, index) => `${value}:\n${blocks[index]}`).join('\n'));
+    }
+    return ok(blocks[0]);
+  },
+
+  cat: (context) => {
+    const args = parseArgs(context.argv);
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`cat: ${input.error}`);
+    if (!args.flags.has('n')) return ok(input.text);
+    return ok(join(lines(input.text).map((line, i) => `${String(i + 1).padStart(6)}\t${line}`)));
+  },
+
+  head: (context) => {
+    const args = parseArgs(context.argv, 'nc');
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`head: ${input.error}`);
+    return ok(join(lines(input.text).slice(0, countOption(args, 10))));
+  },
+
+  tail: (context) => {
+    const args = parseArgs(context.argv, 'nc');
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`tail: ${input.error}`);
+    return ok(join(lines(input.text).slice(-countOption(args, 10))));
+  },
+
+  wc: (context) => {
+    const args = parseArgs(context.argv);
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`wc: ${input.error}`);
+    const text = input.text;
+    const lineCount = text === '' ? 0 : text.split('\n').length - (text.endsWith('\n') ? 1 : 0);
+    const wordCount = text.split(/\s+/).filter(Boolean).length;
+    if (args.flags.has('l')) return ok(`${lineCount}\n`);
+    if (args.flags.has('w')) return ok(`${wordCount}\n`);
+    if (args.flags.has('c')) return ok(`${text.length}\n`);
+    return ok(`${lineCount} ${wordCount} ${text.length}\n`);
+  },
+
+  grep: (context) => {
+    const args = parseArgs(context.argv, 'e');
+    const values = [...args.values];
+    const pattern = args.options.e ?? values.shift();
+    if (pattern === undefined) return fail('usage: grep [-invcqh] pattern [file ...]', 2);
+
+    const input = readInputs(context, values);
+    if (input.error) return fail(`grep: ${input.error}`, 2);
+
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern, args.flags.has('i') ? 'i' : '');
+    } catch {
+      return fail(`grep: ${pattern}: invalid regular expression`, 2);
+    }
+
+    const matched = lines(input.text).filter((line) => regex.test(line) !== args.flags.has('v'));
+    // 没匹配到任何东西时退出码是 1，脚本里常拿它当条件
+    const code = matched.length === 0 ? 1 : 0;
+    if (args.flags.has('q')) return { stdout: '', code };
+    if (args.flags.has('c')) return { stdout: `${matched.length}\n`, code };
+    return { stdout: join(matched), code };
+  },
+
+  sort: (context) => {
+    const args = parseArgs(context.argv);
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`sort: ${input.error}`);
+    let sorted = lines(input.text).sort((a, b) =>
+      args.flags.has('n') ? Number(a) - Number(b) : a < b ? -1 : a > b ? 1 : 0
+    );
+    if (args.flags.has('r')) sorted = sorted.reverse();
+    if (args.flags.has('u')) sorted = sorted.filter((line, i) => i === 0 || line !== sorted[i - 1]);
+    return ok(join(sorted));
+  },
+
+  uniq: (context) => {
+    const args = parseArgs(context.argv);
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`uniq: ${input.error}`);
+    const all = lines(input.text);
+    if (!args.flags.has('c')) {
+      return ok(join(all.filter((line, i) => i === 0 || line !== all[i - 1])));
+    }
+    const out: string[] = [];
+    let index = 0;
+    while (index < all.length) {
+      let count = 1;
+      while (index + count < all.length && all[index + count] === all[index]) count += 1;
+      out.push(`${String(count).padStart(7)} ${all[index]}`);
+      index += count;
+    }
+    return ok(join(out));
+  },
+
+  cut: (context) => {
+    const args = parseArgs(context.argv, 'df');
+    const delimiter = args.options.d ?? '\t';
+    const fieldSpec = args.options.f;
+    if (!fieldSpec) return fail('cut: you must specify a list of fields', 2);
+    const fields = fieldSpec.split(',').map((n) => Number(n) - 1);
+
+    const input = readInputs(context, args.values);
+    if (input.error) return fail(`cut: ${input.error}`);
+    return ok(join(lines(input.text).map((line) => {
+      const parts = line.split(delimiter);
+      return fields.map((index) => parts[index] ?? '').join(delimiter);
+    })));
+  },
+
+  tr: (context) => {
+    const args = parseArgs(context.argv);
+    const [from, to] = args.values;
+    if (from === undefined) return fail('tr: missing operand', 2);
+
+    let text = context.stdin;
+    if (args.flags.has('d') || to === undefined) {
+      text = text.split('').filter((c) => !from.includes(c)).join('');
+    } else {
+      text = text.split('').map((c) => {
+        const index = from.indexOf(c);
+        return index >= 0 ? (to[index] ?? to[to.length - 1]) : c;
+      }).join('');
+    }
+    // -s 把连续重复的目标字符压成一个
+    if (args.flags.has('s')) {
+      const squeeze = to ?? from;
+      for (const char of new Set(squeeze.split(''))) {
+        text = text.split(new RegExp(`${escapeRegExp(char)}{2,}`, 'g')).join(char);
+      }
+    }
+    return ok(text);
+  },
+
+  mkdir: (context) => {
+    const args = parseArgs(context.argv, 'm');
+    for (const value of args.values) {
+      const path = resolve(context, value);
+      if (context.vfs.exists(path)) {
+        if (args.flags.has('p')) continue;
+        return fail(`mkdir: cannot create directory '${value}': File exists`);
+      }
+      if (!args.flags.has('p') && !context.vfs.isDir(normalizePath(`${path}/..`))) {
+        return fail(`mkdir: cannot create directory '${value}': No such file or directory`);
+      }
+      context.vfs.mkdirp(path);
+    }
+    return ok();
+  },
+
+  rmdir: (context) => {
+    const args = parseArgs(context.argv);
+    for (const value of args.values) {
+      const path = resolve(context, value);
+      if (!context.vfs.isDir(path)) return fail(`rmdir: failed to remove '${value}': Not a directory`);
+      if (context.vfs.readDir(path).length > 0) {
+        return fail(`rmdir: failed to remove '${value}': Directory not empty`);
+      }
+      context.vfs.remove(path);
+    }
+    return ok();
+  },
+
+  rm: (context) => {
+    const args = parseArgs(context.argv);
+    const recursive = args.flags.has('r') || args.flags.has('R');
+    for (const value of args.values) {
+      const path = resolve(context, value);
+      if (!context.vfs.exists(path)) {
+        if (args.flags.has('f')) continue;
+        return fail(`rm: cannot remove '${value}': No such file or directory`);
+      }
+      if (context.vfs.isDir(path) && !recursive) {
+        return fail(`rm: cannot remove '${value}': Is a directory`);
+      }
+      context.vfs.remove(path, { recursive });
+    }
+    return ok();
+  },
+
+  cp: (context) => {
+    const args = parseArgs(context.argv);
+    const [source, target] = args.values;
+    if (!source || !target) return fail('cp: missing file operand', 2);
+    const from = resolve(context, source);
+    const to = resolve(context, target);
+    if (!context.vfs.exists(from)) return fail(`cp: cannot stat '${source}': No such file or directory`);
+
+    if (context.vfs.isDir(from)) {
+      if (!(args.flags.has('r') || args.flags.has('R'))) {
+        return fail(`cp: -r not specified; omitting directory '${source}'`);
+      }
+      for (const file of context.vfs.walk(from)) {
+        context.vfs.writeFile(`${to}${file.slice(from.length)}`, context.vfs.readFile(file));
+      }
+      return ok();
+    }
+    const destination = context.vfs.isDir(to) ? `${to}/${baseOf(source)}` : to;
+    context.vfs.writeFile(destination, context.vfs.readFile(from));
+    return ok();
+  },
+
+  mv: (context) => {
+    const args = parseArgs(context.argv);
+    const [source, target] = args.values;
+    if (!source || !target) return fail('mv: missing file operand', 2);
+    const from = resolve(context, source);
+    const to = resolve(context, target);
+    if (!context.vfs.exists(from)) return fail(`mv: cannot stat '${source}': No such file or directory`);
+    context.vfs.rename(from, context.vfs.isDir(to) ? `${to}/${baseOf(source)}` : to);
+    return ok();
+  },
+
+  touch: (context) => {
+    for (const value of parseArgs(context.argv).values) {
+      const path = resolve(context, value);
+      if (!context.vfs.exists(path)) context.vfs.writeFile(path, '');
+    }
+    return ok();
+  },
+
+  chmod: (context) => {
+    const args = parseArgs(context.argv);
+    const [mode, ...targets] = args.values;
+    if (!/^[0-7]{3,4}$/.test(mode ?? '')) return fail(`chmod: invalid mode: '${mode ?? ''}'`, 1);
+    for (const value of targets) {
+      const path = resolve(context, value);
+      if (!context.vfs.exists(path)) {
+        return fail(`chmod: cannot access '${value}': No such file or directory`);
+      }
+      context.vfs.chmod(path, parseInt(mode, 8));
+    }
+    return ok();
+  },
+
+  find: (context) => {
+    const args = parseArgs(context.argv);
+    // `-name` / `-type` 是 find 自己的谓词，不走通用选项解析
+    const nameIndex = context.argv.indexOf('-name');
+    const namePattern = nameIndex >= 0 ? context.argv[nameIndex + 1] : undefined;
+    const typeIndex = context.argv.indexOf('-type');
+    const type = typeIndex >= 0 ? context.argv[typeIndex + 1] : undefined;
+    const start = args.values.find((value) => !isPredicateValue(context.argv, value)) ?? '.';
+
+    const root = resolve(context, start);
+    if (!context.vfs.exists(root)) return fail(`find: '${start}': No such file or directory`);
+
+    const regex = namePattern ? globToRegExp(namePattern) : null;
+    const found = context.vfs.walkAll(root).filter((path) => {
+      if (regex && !regex.test(baseOf(path))) return false;
+      if (type === 'f' && !context.vfs.isFile(path)) return false;
+      if (type === 'd' && !context.vfs.isDir(path)) return false;
+      return true;
+    });
+    return ok(join(found));
+  },
+
+  tee: (context) => {
+    const args = parseArgs(context.argv);
+    for (const value of args.values) {
+      const path = resolve(context, value);
+      if (args.flags.has('a')) context.vfs.appendFile(path, context.stdin);
+      else context.vfs.writeFile(path, context.stdin);
+    }
+    return ok(context.stdin);
+  },
+
+  env: (context) => {
+    const entries = Object.entries(context.shell.allVars()).sort(([a], [b]) => (a < b ? -1 : 1));
+    return ok(join(entries.map(([key, value]) => `${key}=${value}`)));
+  },
+
+  which: (context) => {
+    const name = context.argv[0];
+    if (!name) return fail('usage: which command', 2);
+    return context.shell.has(name) ? ok(`/usr/bin/${name}\n`) : { stdout: '', code: 1 };
+  },
+
+  hostname: (context) => ok(`${context.shell.hostname}\n`),
+  whoami: (context) => ok(`${context.shell.user}\n`),
+  id: (context) => ok(`uid=0(${context.shell.user}) gid=0(root) groups=0(root)\n`),
+
+  basename: (context) => {
+    const [value = '', suffix] = parseArgs(context.argv).values;
+    const name = baseOf(value) || '/';
+    return ok(`${suffix && name.endsWith(suffix) ? name.slice(0, -suffix.length) : name}\n`);
+  },
+
+  dirname: (context) => {
+    const value = parseArgs(context.argv).values[0] ?? '';
+    const parts = value.split('/').filter(Boolean);
+    parts.pop();
+    return ok(`${value.startsWith('/') ? '/' : ''}${parts.join('/') || '.'}\n`);
+  },
+
+  seq: (context) => {
+    const numbers = parseArgs(context.argv).values.map(Number);
+    const [start, end] = numbers.length === 1 ? [1, numbers[0]] : numbers;
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return fail('seq: invalid argument', 2);
+    const out: string[] = [];
+    for (let i = start; i <= end; i += 1) out.push(String(i));
+    return ok(join(out));
+  },
+
+  xargs: async (context) => {
+    const args = parseArgs(context.argv);
+    const [name, ...rest] = args.values;
+    if (!name) return ok(context.stdin);
+    const items = context.stdin.split(/\s+/).filter(Boolean);
+    const quoted = items.map((item) => `'${item.replace(/'/g, "'\\''")}'`).join(' ');
+    return context.shell.run(`${name} ${rest.join(' ')} ${quoted}`.trim());
+  },
+
+  /**
+   * sed 只做最常用的 `s/a/b/` 与 `NNd`。
+   *
+   * 其余语法明确报「不支持」—— 一个被悄悄忽略的 sed 表达式，
+   * 会让学员对着「命令成功了但文件没变」查半天。
+   */
+  sed: (context) => {
+    const args = parseArgs(context.argv, 'e');
+    const values = [...args.values];
+    const script = args.options.e ?? values.shift();
+    if (!script) return fail('sed: no script specified', 2);
+    const input = readInputs(context, values);
+    if (input.error) return fail(`sed: ${input.error}`);
+
+    const substitute = /^s(.)([\s\S]*?)\1([\s\S]*?)\1([gi]*)$/.exec(script);
+    if (substitute) {
+      const [, , pattern, replacement, modifiers] = substitute;
+      let regex: RegExp;
+      try {
+        regex = new RegExp(pattern, modifiers.includes('g') ? 'g' : '');
+      } catch {
+        return fail(`sed: -e expression #1, char 0: invalid regex: ${pattern}`, 1);
+      }
+      const replaced = lines(input.text).map((line) => line.replace(regex, replacement));
+      const text = join(replaced);
+      if (args.flags.has('i')) {
+        context.vfs.writeFile(resolve(context, values[0] ?? ''), text);
+        return ok();
+      }
+      return ok(text);
+    }
+
+    const deleteLine = /^(\d+)d$/.exec(script);
+    if (deleteLine) {
+      const target = Number(deleteLine[1]);
+      return ok(join(lines(input.text).filter((_, index) => index + 1 !== target)));
+    }
+    return fail(`sed: unsupported script "${script}" (opslab supports s/a/b/ and Nd)`, 2);
+  },
+};
+
+/* ------------------------------------------------------------------ */
+
+function baseOf(path: string): string {
+  return path.split('/').filter(Boolean).pop() ?? '';
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const body = pattern
+    .split('')
+    .map((char) => (char === '*' ? '.*' : char === '?' ? '.' : escapeRegExp(char)))
+    .join('');
+  return new RegExp(`^${body}$`);
+}
+
+/** `-name` / `-type` 后面那个值不是起始目录 */
+function isPredicateValue(argv: string[], value: string): boolean {
+  const index = argv.indexOf(value);
+  return index > 0 && (argv[index - 1] === '-name' || argv[index - 1] === '-type');
+}
+
+/** `ls -l` 的那一行 */
+function longFormat(context: CommandContext, directory: string, name: string): string {
+  const stat = context.vfs.stat(`${directory === '/' ? '' : directory}/${name}`);
+  const type = stat.type === 'dir' ? 'd' : stat.type === 'symlink' ? 'l' : '-';
+  const size = String(stat.size).padStart(5);
+  return `${type}${permissionString(stat.mode)} 1 root root ${size} ${formatTime(stat.mtime)} ${name}`;
+}
+
+function permissionString(mode: number): string {
+  const bits = ['r', 'w', 'x'];
+  let out = '';
+  for (let shift = 6; shift >= 0; shift -= 3) {
+    const value = (mode >> shift) & 7;
+    for (let i = 0; i < 3; i += 1) out += value & (4 >> i) ? bits[i] : '-';
+  }
+  return out;
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** `Jan  1 00:00` —— 用虚拟墙钟，UTC，保证可复现 */
+function formatTime(mtime: number): string {
+  const date = new Date(mtime);
+  const day = String(date.getUTCDate()).padStart(2, ' ');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${MONTHS[date.getUTCMonth()]} ${day} ${hours}:${minutes}`;
+}

--- a/src/lib/opslab/machine/shell/parser.ts
+++ b/src/lib/opslab/machine/shell/parser.ts
@@ -1,0 +1,620 @@
+/**
+ * shell 语法解析
+ *
+ * 用 tree-sitter 的 bash 语法，而不是自己写一个 —— 真实的 shell 语法边角极多
+ * （引号、展开、重定向的各种形态），自己写迟早在某个学员敲出来的合法命令上翻车。
+ *
+ * 设计文档里原本写的是用 `sh-syntax`（mvdan/sh 编译的 WASM）。**那条路走不通**：
+ * 它是给 shfmt 做格式化用的，跨 WASM 边界之后 AST 里的 `Cmd` 只剩位置信息，
+ * 具体节点类型和参数全丢了 —— 能重新打印，不能解释执行。
+ * tree-sitter 给的是完整的具体语法树，节点有名有姓，正是执行器要的。
+ *
+ * 这一层把 tree-sitter 的树翻译成我们自己的小 AST，好让执行器不必到处
+ * 认 tree-sitter 的节点名。翻不动的语法**明确报错**，绝不悄悄降级成
+ * 「看起来跑了但语义不对」—— 那种失败最难查。
+ */
+
+export type Redirect =
+  /** `< file` */
+  | { kind: 'in'; source: string }
+  /** `> file` / `>> file` / `2> file`，fd 1 是 stdout、2 是 stderr */
+  | { kind: 'out'; target: string; append: boolean; fd: number }
+  /** `2>&1` */
+  | { kind: 'dup'; from: number; to: number }
+  /** heredoc。delimiter 带引号时内容不做展开。 */
+  | { kind: 'heredoc'; content: string; expand: boolean };
+
+export interface SimpleCommand {
+  type: 'command';
+  /** 命令名与参数，尚未展开 */
+  words: Word[];
+  /** `FOO=bar cmd` 里的前置赋值 */
+  assignments: Array<{ name: string; value: Word }>;
+}
+
+export interface Pipeline {
+  type: 'pipeline';
+  commands: Node[];
+  /** `! cmd` */
+  negated: boolean;
+}
+
+export interface ListNode {
+  type: 'list';
+  left: Node;
+  operator: '&&' | '||';
+  right: Node;
+}
+
+export interface Subshell {
+  type: 'subshell';
+  body: Node;
+}
+
+export interface RedirectedNode {
+  type: 'redirected';
+  body: Node;
+  redirects: Redirect[];
+}
+
+export interface IfNode {
+  type: 'if';
+  condition: Node;
+  then: Node;
+  else?: Node;
+}
+
+export interface ForNode {
+  type: 'for';
+  variable: string;
+  items: Word[];
+  body: Node;
+}
+
+export interface WhileNode {
+  type: 'while';
+  condition: Node;
+  body: Node;
+  until: boolean;
+}
+
+export interface CaseNode {
+  type: 'case';
+  value: Word;
+  items: Array<{ patterns: Word[]; body: Node | null }>;
+}
+
+export interface FunctionNode {
+  type: 'function';
+  name: string;
+  body: Node;
+}
+
+export interface SequenceNode {
+  type: 'sequence';
+  statements: Node[];
+}
+
+export interface AssignmentNode {
+  type: 'assignment';
+  name: string;
+  value: Word;
+  /** `export FOO=bar` */
+  exported: boolean;
+  /** `local x=1` —— 只在当前函数帧里可见 */
+  local?: boolean;
+}
+
+export type Node =
+  | SimpleCommand | Pipeline | ListNode | Subshell | RedirectedNode
+  | IfNode | ForNode | WhileNode | CaseNode | FunctionNode
+  | SequenceNode | AssignmentNode;
+
+/** 一个「词」由若干片段组成：字面量、变量、命令替换…… 展开时逐段处理 */
+export type WordPart =
+  | { kind: 'literal'; text: string }
+  | {
+      kind: 'variable';
+      name: string;
+      /** `${x:-default}` 之类 */
+      modifier?: string;
+      argument?: string;
+      /** `${#x}` 取长度 */
+      length?: boolean;
+    }
+  | { kind: 'command'; source: string }
+  | { kind: 'arithmetic'; source: string };
+
+export interface Word {
+  parts: WordPart[];
+  /** 单引号里的内容不做任何展开，也不参与分词 */
+  quoted: 'none' | 'single' | 'double';
+}
+
+export class ShellSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ShellSyntaxError';
+  }
+}
+
+/* ------------------------------------------------------------------ */
+
+interface TsNode {
+  type: string;
+  text: string;
+  startIndex: number;
+  endIndex: number;
+  namedChildren: TsNode[];
+  children: TsNode[];
+  childForFieldName(name: string): TsNode | null;
+  childrenForFieldName?(name: string): TsNode[];
+  hasError: boolean;
+  isNamed: boolean;
+}
+
+interface TsParser {
+  parse(source: string): { rootNode: TsNode };
+}
+
+let parserPromise: Promise<TsParser> | null = null;
+
+export interface ShellParserOptions {
+  /** web-tree-sitter 运行时 wasm 的地址 */
+  runtimeWasmUrl?: string;
+  /** bash 语法：给地址或者直接给字节 */
+  grammar?: string | Uint8Array;
+}
+
+/** tree-sitter 的运行时与语法都是 WASM，加载一次复用 */
+export async function loadShellParser(options: ShellParserOptions = {}): Promise<TsParser> {
+  if (parserPromise) return parserPromise;
+  parserPromise = (async () => {
+    const treeSitter: any = await import('web-tree-sitter');
+    const Parser = treeSitter.Parser ?? treeSitter.default?.Parser;
+    const Language = treeSitter.Language ?? treeSitter.default?.Language;
+
+    const runtimeUrl = options.runtimeWasmUrl ?? (isBrowser() ? '/opslab/web-tree-sitter.wasm' : undefined);
+    await Parser.init(runtimeUrl ? { locateFile: () => runtimeUrl } : undefined);
+
+    const grammar = options.grammar ?? defaultGrammarPath();
+    // 自己把字节读出来再交给 Language.load。它自带的按路径加载会走动态
+    // import()，在 jest 的 CJS 环境里直接抛 —— 而且浏览器里那条路也走不通。
+    const language = await Language.load(
+      typeof grammar === 'string' ? await readWasm(grammar) : grammar
+    );
+    const parser = new Parser();
+    parser.setLanguage(language);
+    return parser as TsParser;
+  })();
+  return parserPromise;
+}
+
+/** 测试之间要能换 wasm 路径重来 */
+export function resetShellParser(): void {
+  parserPromise = null;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+/**
+ * 语法文件在哪。
+ *
+ * 浏览器里由构建脚本拷到 /opslab/tree-sitter-bash.wasm；
+ * Node（测试、出题脚本）里直接从 node_modules 取。
+ */
+function defaultGrammarPath(): string {
+  return isBrowser()
+    ? '/opslab/tree-sitter-bash.wasm'
+    : 'node_modules/tree-sitter-bash/tree-sitter-bash.wasm';
+}
+
+async function readWasm(location: string): Promise<Uint8Array> {
+  if (isBrowser()) {
+    const response = await fetch(location);
+    if (!response.ok) throw new Error(`failed to fetch ${location}: ${response.status}`);
+    return new Uint8Array(await response.arrayBuffer());
+  }
+  // Node 专用分支。用 eval 拿 require，免得打包器把 fs 打进浏览器包。
+  const nodeRequire = eval('require') as (id: string) => any;
+  return new Uint8Array(nodeRequire('fs').readFileSync(location));
+}
+
+const literal = (text: string): Word => ({ parts: [{ kind: 'literal', text }], quoted: 'none' });
+
+/** 把 tree-sitter 的一个词节点翻成我们的 Word */
+function toWord(node: TsNode): Word {
+  switch (node.type) {
+    case 'word':
+      return literal(unescapeWord(node.text));
+
+    case 'number':
+    case 'test_operator':
+    case 'extglob_pattern':
+    case 'regex':
+      return literal(node.text);
+
+    case 'raw_string':
+      // 单引号：里面什么都不展开
+      return { parts: [{ kind: 'literal', text: node.text.slice(1, -1) }], quoted: 'single' };
+
+    case 'ansi_c_string':
+      return { parts: [{ kind: 'literal', text: unescapeAnsiC(node.text.slice(2, -1)) }], quoted: 'single' };
+
+    case 'string': {
+      // 双引号：变量与命令替换要展开，但不分词。
+      //
+      // 不能只遍历子节点 —— tree-sitter 不会为纯空白生成 string_content，
+      // `" "` 的那个空格会凭空消失（`cut -d " "` 就此变成按空字符切）。
+      // 所以按位置把子节点之间的缝隙补回来。
+      const parts: WordPart[] = [];
+      const text = node.text;
+      const base = node.startIndex;
+      let cursor = 1;
+      for (const child of node.namedChildren) {
+        const start = child.startIndex - base;
+        if (start > cursor) parts.push({ kind: 'literal', text: unescapeQuoted(text.slice(cursor, start)) });
+        parts.push(...toWord(child).parts);
+        cursor = child.endIndex - base;
+      }
+      if (cursor < text.length - 1) {
+        parts.push({ kind: 'literal', text: unescapeQuoted(text.slice(cursor, text.length - 1)) });
+      }
+      return { parts, quoted: 'double' };
+    }
+
+    case 'string_content':
+      return literal(unescapeQuoted(node.text));
+
+    case 'simple_expansion':
+      // $FOO / $1 / $?
+      return { parts: [{ kind: 'variable', name: node.text.slice(1) }], quoted: 'none' };
+
+    case 'expansion':
+      return { parts: [parseExpansion(node.text)], quoted: 'none' };
+
+    case 'command_substitution': {
+      const source = node.text.startsWith('`')
+        ? node.text.slice(1, -1)
+        : node.text.replace(/^\$\(/, '').replace(/\)$/, '');
+      return { parts: [{ kind: 'command', source }], quoted: 'none' };
+    }
+
+    case 'arithmetic_expansion':
+      return {
+        parts: [{ kind: 'arithmetic', source: node.text.replace(/^\$\(\(/, '').replace(/\)\)$/, '') }],
+        quoted: 'none',
+      };
+
+    case 'concatenation': {
+      const parts: WordPart[] = [];
+      for (const child of node.namedChildren) parts.push(...toWord(child).parts);
+      return { parts, quoted: 'none' };
+    }
+
+    default:
+      return literal(node.text);
+  }
+}
+
+/** `${x}`、`${x:-d}`、`${#x}`、`${x#prefix}` … */
+function parseExpansion(text: string): WordPart {
+  const inner = text.slice(2, -1);
+  if (inner.startsWith('#') && inner.length > 1) {
+    return { kind: 'variable', name: inner.slice(1), length: true };
+  }
+  const match = /^([A-Za-z_][A-Za-z0-9_]*|[?@*#!$0-9]+)(:?[-=?+]|##?|%%?)?([\s\S]*)$/.exec(inner);
+  if (!match) return { kind: 'literal', text };
+  return {
+    kind: 'variable',
+    name: match[1],
+    modifier: match[2] || undefined,
+    argument: match[3] || undefined,
+  };
+}
+
+/** 裸词里的 `\ ` `\$` `\*` 等转义，展开前就该还原成字面量 */
+function unescapeWord(text: string): string {
+  return text.replace(/\\([\s\S])/g, '$1');
+}
+
+/** 双引号里只有这几个字符会被反斜杠转义，其余反斜杠是字面量 */
+function unescapeQuoted(text: string): string {
+  return text.replace(/\\(["\\$`])/g, '$1');
+}
+
+function unescapeAnsiC(text: string): string {
+  return text.replace(/\\(n|t|r|\\|')/g, (_, char) =>
+    char === 'n' ? '\n' : char === 't' ? '\t' : char === 'r' ? '\r' : char
+  );
+}
+
+/* ------------------------------------------------------------------ */
+
+function collectRedirects(node: TsNode): Redirect[] {
+  const redirects: Redirect[] = [];
+  for (const child of node.namedChildren) {
+    if (child.type === 'file_redirect') {
+      const descriptor = child.childForFieldName('descriptor');
+      const destination = child.childForFieldName('destination');
+      const operator = child.children.find((c) => !c.isNamed)?.text ?? '>';
+      const target = destination?.text ?? '';
+
+      if (operator.includes('<') && !operator.includes('&')) {
+        redirects.push({ kind: 'in', source: target });
+      } else if (operator.includes('&')) {
+        // `2>&1` —— 把一个 fd 接到另一个 fd 上
+        redirects.push({ kind: 'dup', from: Number(descriptor?.text ?? 1), to: Number(target) });
+      } else {
+        redirects.push({
+          kind: 'out',
+          target,
+          append: operator.includes('>>'),
+          fd: Number(descriptor?.text ?? 1),
+        });
+      }
+    } else if (child.type === 'heredoc_redirect') {
+      const start = child.namedChildren.find((c) => c.type === 'heredoc_start');
+      const body = child.namedChildren.find((c) => c.type === 'heredoc_body');
+      const stripTabs = child.children.some((c) => c.text === '<<-');
+      const delimiter = start?.text ?? '';
+      const content = body?.text ?? '';
+      redirects.push({
+        kind: 'heredoc',
+        content: stripTabs ? content.replace(/^\t+/gm, '') : content,
+        // 带引号的 delimiter 里 $VAR 保持原样，这是写 manifest 时常用的一手
+        expand: !/^['"]/.test(delimiter),
+      });
+    }
+  }
+  return redirects;
+}
+
+/** 把重定向挂到该挂的地方：单命令直接包一层，管道分别挂在首尾两段 */
+function attachRedirects(body: Node, redirects: Redirect[]): Node {
+  if (redirects.length === 0) return body;
+  if (body.type === 'pipeline' && body.commands.length > 0) {
+    const commands = [...body.commands];
+    const inbound = redirects.filter((r) => r.kind === 'in' || r.kind === 'heredoc');
+    const outbound = redirects.filter((r) => r.kind === 'out' || r.kind === 'dup');
+    if (outbound.length) {
+      const last = commands.length - 1;
+      commands[last] = { type: 'redirected', body: commands[last], redirects: outbound };
+    }
+    if (inbound.length) {
+      commands[0] = { type: 'redirected', body: commands[0], redirects: inbound };
+    }
+    return { ...body, commands };
+  }
+  return { type: 'redirected', body, redirects };
+}
+
+function sequence(statements: Node[]): Node | null {
+  if (statements.length === 0) return null;
+  return statements.length === 1 ? statements[0] : { type: 'sequence', statements };
+}
+
+function convertAll(nodes: TsNode[]): Node[] {
+  return nodes.map(convert).filter((n): n is Node => n !== null);
+}
+
+function convert(node: TsNode): Node | null {
+  switch (node.type) {
+    case 'program':
+    case 'compound_statement':
+    case 'do_group':
+      return sequence(convertAll(node.namedChildren));
+
+    case 'command': {
+      const words: Word[] = [];
+      const assignments: SimpleCommand['assignments'] = [];
+      const nameNode = node.childForFieldName('name');
+      if (nameNode) words.push(toWord(nameNode.namedChildren[0] ?? nameNode));
+
+      for (const child of node.namedChildren) {
+        if (child.type === 'command_name') continue;
+        if (child.type === 'variable_assignment') {
+          assignments.push({
+            name: child.childForFieldName('name')?.text ?? '',
+            value: valueWord(child),
+          });
+          continue;
+        }
+        words.push(toWord(child));
+      }
+      return { type: 'command', words, assignments };
+    }
+
+    case 'variable_assignment':
+      return {
+        type: 'assignment',
+        name: node.childForFieldName('name')?.text ?? '',
+        value: valueWord(node),
+        exported: false,
+      };
+
+    /** `export FOO=bar` / `local x=1` / `readonly y` */
+    case 'declaration_command': {
+      const keyword = node.children.find((c) => !c.isNamed)?.text ?? 'export';
+      const statements: Node[] = [];
+      for (const child of node.namedChildren) {
+        if (child.type === 'variable_assignment') {
+          statements.push({
+            type: 'assignment',
+            name: child.childForFieldName('name')?.text ?? '',
+            value: valueWord(child),
+            exported: keyword === 'export',
+            local: keyword === 'local',
+          });
+        } else if (keyword === 'export') {
+          // `export FOO` —— 把已有的 shell 变量提到环境里
+          statements.push({ type: 'command', words: [literal('export'), toWord(child)], assignments: [] });
+        }
+      }
+      return sequence(statements);
+    }
+
+    case 'pipeline':
+      return { type: 'pipeline', commands: convertAll(node.namedChildren), negated: false };
+
+    case 'negated_command': {
+      const inner = convert(node.namedChildren[0]);
+      if (!inner) return null;
+      return inner.type === 'pipeline'
+        ? { ...inner, negated: true }
+        : { type: 'pipeline', commands: [inner], negated: true };
+    }
+
+    case 'list': {
+      const left = convert(node.namedChildren[0]);
+      const right = convert(node.namedChildren[1]);
+      const operator = (node.children.find((c) => c.text === '&&' || c.text === '||')?.text ?? '&&') as '&&' | '||';
+      if (!left) return right;
+      if (!right) return left;
+      return { type: 'list', left, operator, right };
+    }
+
+    case 'subshell': {
+      const body = sequence(convertAll(node.namedChildren));
+      return body ? { type: 'subshell', body } : null;
+    }
+
+    case 'redirected_statement': {
+      const body = convert(node.childForFieldName('body') ?? node.namedChildren[0]);
+      if (!body) return null;
+      return attachRedirects(body, collectRedirects(node));
+    }
+
+    /**
+     * `[ -f x ]` / `[[ $a = b ]]`
+     *
+     * tree-sitter 把它解析成表达式而不是普通命令，得翻回参数列表 ——
+     * 否则 `if [ -f x ]` 的条件会整个丢掉，if 分支静默不执行。
+     */
+    case 'test_command': {
+      const words: Word[] = [literal('test')];
+      const inner = node.namedChildren[0];
+      if (inner) words.push(...testOperands(inner));
+      return { type: 'command', words, assignments: [] };
+    }
+
+    case 'if_statement': {
+      const condition = convert(node.childForFieldName('condition') ?? node.namedChildren[0]);
+      if (!condition) return null;
+      const body = node.namedChildren.filter(
+        (c) => c.type !== 'elif_clause' && c.type !== 'else_clause'
+      );
+      const then = sequence(convertAll(body.slice(1)));
+      return {
+        type: 'if',
+        condition,
+        then: then ?? { type: 'sequence', statements: [] },
+        else: convertElse(
+          node.namedChildren.filter((c) => c.type === 'elif_clause' || c.type === 'else_clause')
+        ),
+      };
+    }
+
+    case 'for_statement': {
+      const values = node.childrenForFieldName
+        ? node.childrenForFieldName('value')
+        : node.namedChildren.filter((c) => c.type !== 'variable_name' && c.type !== 'do_group');
+      const bodyNode = node.namedChildren.find((c) => c.type === 'do_group');
+      const body = bodyNode ? convert(bodyNode) : null;
+      if (!body) return null;
+      return {
+        type: 'for',
+        variable: node.childForFieldName('variable')?.text ?? 'i',
+        items: values.map(toWord),
+        body,
+      };
+    }
+
+    case 'while_statement': {
+      const condition = convert(node.childForFieldName('condition') ?? node.namedChildren[0]);
+      const bodyNode = node.namedChildren.find((c) => c.type === 'do_group');
+      const body = bodyNode ? convert(bodyNode) : null;
+      if (!condition || !body) return null;
+      return { type: 'while', condition, body, until: node.text.startsWith('until') };
+    }
+
+    case 'case_statement': {
+      const value = node.childForFieldName('value');
+      const items = node.namedChildren
+        .filter((c) => c.type === 'case_item')
+        .map((item) => {
+          const patterns = item.childrenForFieldName
+            ? item.childrenForFieldName('value')
+            : item.namedChildren.filter((c) => c.type === 'word' || c.type === 'extglob_pattern');
+          const patternSet = new Set(patterns);
+          return {
+            patterns: patterns.map(toWord),
+            body: sequence(convertAll(item.namedChildren.filter((c) => !patternSet.has(c)))),
+          };
+        });
+      return { type: 'case', value: value ? toWord(value) : literal(''), items };
+    }
+
+    case 'function_definition': {
+      const body = convert(node.childForFieldName('body') ?? node.namedChildren[1]);
+      if (!body) return null;
+      return { type: 'function', name: node.childForFieldName('name')?.text ?? '', body };
+    }
+
+    case 'comment':
+      return null;
+
+    // 真跑不了的语法，明确说清楚，别装作能跑
+    case 'c_style_for_statement':
+      throw new ShellSyntaxError('`for ((...))` is not supported by the opslab shell');
+
+    default:
+      return sequence(convertAll(node.namedChildren));
+  }
+}
+
+/** `x=$(cmd)` 里那个值 */
+function valueWord(assignment: TsNode): Word {
+  const value = assignment.childForFieldName('value');
+  return value ? toWord(value) : literal('');
+}
+
+/** 把 test 的表达式节点摊平成参数（`-f`、`x`、`=`…） */
+function testOperands(node: TsNode): Word[] {
+  if (node.type !== 'unary_expression' && node.type !== 'binary_expression') return [toWord(node)];
+  const words: Word[] = [];
+  for (const child of node.children) {
+    if (child.type === '[' || child.type === ']' || child.type === '[[' || child.type === ']]') continue;
+    if (child.isNamed) words.push(...testOperands(child));
+    else if (child.text.trim()) words.push(literal(child.text));
+  }
+  return words;
+}
+
+/** elif 链就是嵌套的 else-if */
+function convertElse(clauses: TsNode[]): Node | undefined {
+  if (clauses.length === 0) return undefined;
+  const [head, ...rest] = clauses;
+  if (head.type === 'else_clause') return sequence(convertAll(head.namedChildren)) ?? undefined;
+
+  const condition = convert(head.childForFieldName('condition') ?? head.namedChildren[0]);
+  if (!condition) return undefined;
+  const then = sequence(convertAll(head.namedChildren.slice(1)));
+  return {
+    type: 'if',
+    condition,
+    then: then ?? { type: 'sequence', statements: [] },
+    else: convertElse(rest),
+  };
+}
+
+export async function parseShell(source: string): Promise<Node | null> {
+  const parser = await loadShellParser();
+  const tree = parser.parse(source);
+  if (tree.rootNode.hasError) {
+    throw new ShellSyntaxError('syntax error near unexpected token');
+  }
+  return convert(tree.rootNode);
+}

--- a/src/lib/opslab/machine/shell/shell.ts
+++ b/src/lib/opslab/machine/shell/shell.ts
@@ -657,6 +657,18 @@ export class Shell {
     this.positional = [...args];
   }
 
+  /** 回到一个干净状态。快照还原要用 —— 变量、函数、set 选项都不该留到下一轮。 */
+  reset(state: { cwd: string; env: Record<string, string> }): void {
+    this.cwd = state.cwd;
+    this.env = { ...state.env, PWD: state.cwd };
+    this.vars = {};
+    this.functions = {};
+    this.positional = [];
+    this.frames = [];
+    this.options = { errexit: false, nounset: false, pipefail: false };
+    this.lastStatus = 0;
+  }
+
   changeDirectory(target: string): void {
     const path = normalizePath(target, this.cwd);
     if (!this.vfs.exists(path)) throw new Error(`cd: ${target}: No such file or directory`);

--- a/src/lib/opslab/machine/shell/shell.ts
+++ b/src/lib/opslab/machine/shell/shell.ts
@@ -1,0 +1,876 @@
+/**
+ * shell 执行器
+ *
+ * 解析交给 tree-sitter（见 parser.ts），这里负责执行：管道、重定向、
+ * `&&` / `||` / `;`、子 shell、函数、变量展开、内置命令，以及把外部命令
+ * （coreutils、kubectl…）派发出去。
+ *
+ * 退出码是一等公民：`set -e`、`&&`、`$?`、管道的退出码取最后一段 ——
+ * 这些是运维脚本的真实内容，不能糊弄。
+ */
+import { Vfs, normalizePath } from '../vfs';
+import { Node, Redirect, parseShell, ShellSyntaxError, Word, WordPart } from './parser';
+
+export interface CommandContext {
+  argv: string[];
+  stdin: string;
+  cwd: string;
+  env: Record<string, string>;
+  vfs: Vfs;
+  shell: Shell;
+}
+
+export interface CommandResult {
+  stdout?: string;
+  stderr?: string;
+  code?: number;
+}
+
+export type CommandHandler = (context: CommandContext) => Promise<CommandResult> | CommandResult;
+
+export interface ShellOptions {
+  vfs: Vfs;
+  cwd?: string;
+  env?: Record<string, string>;
+  commands?: Record<string, CommandHandler>;
+  /** 提示符里的主机名，也用于 `hostname` */
+  hostname?: string;
+  user?: string;
+  /** 循环体最多跑多少轮 —— 虚拟世界里没人来按 Ctrl+C */
+  maxLoopIterations?: number;
+}
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+type Sink = (text: string) => void;
+
+/** `exit` —— 退出整个 shell */
+class ExitSignal extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+/** `return` —— 只退出当前函数 */
+class ReturnSignal extends Error {
+  constructor(readonly code: number) {
+    super(`return ${code}`);
+  }
+}
+
+/** 一个函数调用帧：记着哪些变量是 `local` 的，退出时要还原 */
+interface Frame {
+  positional: string[];
+  locals: Map<string, string | undefined>;
+}
+
+export class Shell {
+  readonly vfs: Vfs;
+  cwd: string;
+  env: Record<string, string>;
+  /** shell 变量（未 export 的），与环境变量分开 */
+  private vars: Record<string, string> = {};
+  private commands: Record<string, CommandHandler>;
+  private functions: Record<string, Node> = {};
+  readonly hostname: string;
+  readonly user: string;
+  /** `set -e` / `set -u` / `set -o pipefail` */
+  private options = { errexit: false, nounset: false, pipefail: false };
+  private lastStatus = 0;
+  private positional: string[] = [];
+  private frames: Frame[] = [];
+  private readonly maxLoopIterations: number;
+  /** 展开期间（命令替换）产生的 stderr 往哪走 */
+  private errSink: Sink = () => {};
+
+  constructor(options: ShellOptions) {
+    this.vfs = options.vfs;
+    this.cwd = options.cwd ?? '/root';
+    this.hostname = options.hostname ?? 'localhost';
+    this.user = options.user ?? 'root';
+    this.maxLoopIterations = options.maxLoopIterations ?? 10_000;
+    this.env = {
+      HOME: '/root', PATH: '/usr/local/bin:/usr/bin:/bin', PWD: this.cwd,
+      USER: this.user, HOSTNAME: this.hostname, SHELL: '/bin/bash', TERM: 'xterm-256color',
+      ...(options.env ?? {}),
+    };
+    this.commands = { ...options.commands };
+  }
+
+  register(name: string, handler: CommandHandler): void {
+    this.commands[name] = handler;
+  }
+
+  has(name: string): boolean {
+    return name in this.commands || name in BUILTINS || name in this.functions;
+  }
+
+  /** 已知命令名，`which` 与补全用，按名字排序 */
+  commandNames(): string[] {
+    return [
+      ...new Set([...Object.keys(this.commands), ...Object.keys(BUILTINS), ...Object.keys(this.functions)]),
+    ].sort();
+  }
+
+  /** 跑一行（或一段）脚本 */
+  async run(source: string): Promise<RunResult> {
+    let node: Node | null;
+    try {
+      node = await parseShell(source);
+    } catch (error) {
+      if (error instanceof ShellSyntaxError) {
+        return { stdout: '', stderr: `bash: ${error.message}\n`, code: 2 };
+      }
+      throw error;
+    }
+    if (!node) return { stdout: '', stderr: '', code: 0 };
+
+    const out: string[] = [];
+    const err: string[] = [];
+    const previousSink = this.errSink;
+    this.errSink = (text) => err.push(text);
+    let code = 0;
+    try {
+      code = await this.exec(node, '', (s) => out.push(s), (s) => err.push(s));
+    } catch (error) {
+      if (error instanceof ExitSignal || error instanceof ReturnSignal) code = error.code;
+      else throw error;
+    } finally {
+      this.errSink = previousSink;
+    }
+    this.lastStatus = code;
+    return { stdout: out.join(''), stderr: err.join(''), code };
+  }
+
+  /* ---------------- 执行 ---------------- */
+
+  private async exec(node: Node, stdin: string, onOut: Sink, onErr: Sink): Promise<number> {
+    switch (node.type) {
+      case 'sequence': {
+        let code = 0;
+        for (const statement of node.statements) {
+          code = await this.exec(statement, stdin, onOut, onErr);
+          this.lastStatus = code;
+          if (this.options.errexit && code !== 0) break;
+        }
+        return code;
+      }
+
+      case 'list': {
+        const left = await this.exec(node.left, stdin, onOut, onErr);
+        this.lastStatus = left;
+        if (node.operator === '&&' && left !== 0) return left;
+        if (node.operator === '||' && left === 0) return left;
+        return this.exec(node.right, stdin, onOut, onErr);
+      }
+
+      case 'pipeline': {
+        // 一段段串起来：前一段的 stdout 是后一段的 stdin
+        let input = stdin;
+        let code = 0;
+        const codes: number[] = [];
+        for (let i = 0; i < node.commands.length; i += 1) {
+          const isLast = i === node.commands.length - 1;
+          const captured: string[] = [];
+          code = await this.exec(
+            node.commands[i],
+            input,
+            isLast ? onOut : (text) => captured.push(text),
+            onErr
+          );
+          codes.push(code);
+          input = captured.join('');
+        }
+        // 默认取最后一段的退出码；set -o pipefail 时取第一个非零
+        const result = this.options.pipefail ? (codes.find((c) => c !== 0) ?? 0) : code;
+        return node.negated ? (result === 0 ? 1 : 0) : result;
+      }
+
+      case 'redirected':
+        return this.execRedirected(node, stdin, onOut, onErr);
+
+      case 'subshell': {
+        // 子 shell 里的变量与 cwd 改动不影响外面
+        const savedCwd = this.cwd;
+        const savedVars = { ...this.vars };
+        const savedEnv = { ...this.env };
+        try {
+          return await this.exec(node.body, stdin, onOut, onErr);
+        } finally {
+          this.cwd = savedCwd;
+          this.vars = savedVars;
+          this.env = savedEnv;
+        }
+      }
+
+      case 'assignment': {
+        const value = (await this.expandWord(node.value)).join(' ');
+        if (node.local) this.declareLocal(node.name);
+        if (node.exported) this.env[node.name] = value;
+        else this.vars[node.name] = value;
+        return 0;
+      }
+
+      case 'function':
+        this.functions[node.name] = node.body;
+        return 0;
+
+      case 'if': {
+        // 条件的 stdout 不该漏到外面（`if grep -q ...` 是最常见的写法）
+        const condition = await this.execCondition(node.condition, stdin, onErr);
+        if (condition === 0) return this.exec(node.then, stdin, onOut, onErr);
+        if (node.else) return this.exec(node.else, stdin, onOut, onErr);
+        return 0;
+      }
+
+      case 'for': {
+        let code = 0;
+        const items: string[] = [];
+        for (const item of node.items) items.push(...(await this.expandWord(item)));
+        for (const item of items) {
+          this.vars[node.variable] = item;
+          code = await this.exec(node.body, stdin, onOut, onErr);
+          this.lastStatus = code;
+          if (this.options.errexit && code !== 0) break;
+        }
+        return code;
+      }
+
+      case 'while': {
+        let code = 0;
+        let iterations = 0;
+        for (;;) {
+          if (iterations >= this.maxLoopIterations) {
+            onErr(`bash: loop exceeded ${this.maxLoopIterations} iterations, aborted\n`);
+            return 1;
+          }
+          iterations += 1;
+          const condition = await this.execCondition(node.condition, stdin, onErr);
+          const shouldRun = node.until ? condition !== 0 : condition === 0;
+          if (!shouldRun) break;
+          code = await this.exec(node.body, stdin, onOut, onErr);
+          this.lastStatus = code;
+          if (this.options.errexit && code !== 0) break;
+        }
+        return code;
+      }
+
+      case 'case': {
+        // 分支模式是拿来匹配的，不是文件名 —— 走了通配展开的话，
+        // `*)` 会先被换成当前目录下的文件列表，兜底分支就永远不命中了
+        const value = await this.expandPattern(node.value);
+        for (const item of node.items) {
+          for (const pattern of item.patterns) {
+            const text = await this.expandPattern(pattern);
+            if (!matchesGlob(text, value)) continue;
+            return item.body ? this.exec(item.body, stdin, onOut, onErr) : 0;
+          }
+        }
+        return 0;
+      }
+
+      case 'command':
+        return this.execCommand(node, stdin, onOut, onErr);
+
+      default:
+        return 0;
+    }
+  }
+
+  /** 条件位置上的命令：只要退出码，stdout 丢掉 */
+  private execCondition(node: Node, stdin: string, onErr: Sink): Promise<number> {
+    return this.exec(node, stdin, () => {}, onErr);
+  }
+
+  /**
+   * 重定向。
+   *
+   * 按书写顺序依次生效，这样 `cmd > f 2>&1` 与 `cmd 2>&1 > f` 的区别
+   * 才是对的 —— 前者 stderr 进文件，后者留在终端。
+   */
+  private async execRedirected(
+    node: Extract<Node, { type: 'redirected' }>,
+    stdin: string,
+    onOut: Sink,
+    onErr: Sink
+  ): Promise<number> {
+    let input = stdin;
+    let stdout: Sink = onOut;
+    let stderr: Sink = onErr;
+    const pending: Array<{ path: string; append: boolean; buffer: string[] }> = [];
+
+    for (const redirect of node.redirects) {
+      if (redirect.kind === 'in') {
+        const path = normalizePath(redirect.source, this.cwd);
+        if (!this.vfs.exists(path)) {
+          onErr(`bash: ${redirect.source}: No such file or directory\n`);
+          return 1;
+        }
+        if (this.vfs.isDir(path)) {
+          onErr(`bash: ${redirect.source}: Is a directory\n`);
+          return 1;
+        }
+        input = this.vfs.readFile(path);
+      } else if (redirect.kind === 'heredoc') {
+        input = redirect.expand ? await this.expandText(redirect.content) : redirect.content;
+      } else if (redirect.kind === 'dup') {
+        // 绑定的是「此刻」的那个 sink，不是最终的
+        const source = redirect.to === 2 ? stderr : stdout;
+        if (redirect.from === 2) stderr = source;
+        else stdout = source;
+      } else {
+        const sink = this.openOutput(redirect, pending);
+        if (redirect.fd === 2) stderr = sink;
+        else stdout = sink;
+      }
+    }
+
+    let code: number;
+    try {
+      code = await this.exec(node.body, input, stdout, stderr);
+    } finally {
+      // 即使命令失败，`> f` 也已经把文件截断/建出来了，和真 shell 一致
+      for (const entry of pending) {
+        try {
+          if (entry.append) this.vfs.appendFile(entry.path, entry.buffer.join(''));
+          else this.vfs.writeFile(entry.path, entry.buffer.join(''));
+        } catch (error) {
+          onErr(`bash: ${entry.path}: ${(error as Error).message}\n`);
+        }
+      }
+    }
+    return code;
+  }
+
+  private openOutput(
+    redirect: Extract<Redirect, { kind: 'out' }>,
+    pending: Array<{ path: string; append: boolean; buffer: string[] }>
+  ): Sink {
+    const path = normalizePath(redirect.target, this.cwd);
+    if (path === '/dev/null') return () => {};
+    const entry = { path, append: redirect.append, buffer: [] as string[] };
+    pending.push(entry);
+    return (text: string) => entry.buffer.push(text);
+  }
+
+  private async execCommand(
+    node: Extract<Node, { type: 'command' }>,
+    stdin: string,
+    onOut: Sink,
+    onErr: Sink
+  ): Promise<number> {
+    // 只有赋值没有命令：`FOO=bar`
+    if (node.words.length === 0) {
+      for (const assignment of node.assignments) {
+        this.vars[assignment.name] = (await this.expandWord(assignment.value)).join(' ');
+      }
+      return 0;
+    }
+
+    const argv: string[] = [];
+    try {
+      for (const word of node.words) argv.push(...(await this.expandWord(word)));
+    } catch (error) {
+      if (error instanceof ExitSignal || error instanceof ReturnSignal) throw error;
+      onErr(`bash: ${(error as Error).message}\n`);
+      return 1;
+    }
+    if (argv.length === 0) return 0;
+
+    // 前置赋值只对这一条命令可见
+    const overrides: Record<string, string> = {};
+    for (const assignment of node.assignments) {
+      overrides[assignment.name] = (await this.expandWord(assignment.value)).join(' ');
+    }
+
+    return this.dispatch(argv, stdin, { ...this.env, ...overrides }, onOut, onErr);
+  }
+
+  private async dispatch(
+    argv: string[],
+    stdin: string,
+    env: Record<string, string>,
+    onOut: Sink,
+    onErr: Sink
+  ): Promise<number> {
+    const [name, ...args] = argv;
+
+    const body = this.functions[name];
+    if (body && !(name in BUILTINS)) return this.callFunction(body, args, stdin, onOut, onErr);
+
+    const handler = BUILTINS[name] ?? this.commands[name];
+    if (!handler) {
+      onErr(`bash: ${name}: command not found\n`);
+      return 127;
+    }
+
+    try {
+      const result = await handler({
+        argv: args, stdin, cwd: this.cwd, env, vfs: this.vfs, shell: this,
+      });
+      if (result.stdout) onOut(result.stdout);
+      if (result.stderr) onErr(result.stderr);
+      return result.code ?? 0;
+    } catch (error) {
+      if (error instanceof ExitSignal || error instanceof ReturnSignal) throw error;
+      onErr(`${name}: ${(error as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  private async callFunction(
+    body: Node,
+    args: string[],
+    stdin: string,
+    onOut: Sink,
+    onErr: Sink
+  ): Promise<number> {
+    const frame: Frame = { positional: this.positional, locals: new Map() };
+    this.frames.push(frame);
+    this.positional = args;
+    try {
+      return await this.exec(body, stdin, onOut, onErr);
+    } catch (error) {
+      if (error instanceof ReturnSignal) return error.code;
+      throw error;
+    } finally {
+      this.frames.pop();
+      this.positional = frame.positional;
+      for (const [name, previous] of frame.locals) {
+        if (previous === undefined) delete this.vars[name];
+        else this.vars[name] = previous;
+      }
+    }
+  }
+
+  private declareLocal(name: string): void {
+    const frame = this.frames[this.frames.length - 1];
+    if (frame && !frame.locals.has(name)) frame.locals.set(name, this.vars[name]);
+  }
+
+  /* ---------------- 展开 ---------------- */
+
+  /** 一个词展开成零个或多个参数（未加引号的展开会按空白分词） */
+  async expandWord(word: Word): Promise<string[]> {
+    if (word.quoted === 'single') {
+      return [word.parts.map((p) => (p.kind === 'literal' ? p.text : '')).join('')];
+    }
+
+    let text = '';
+    let sawUnquotedExpansion = false;
+    for (const part of word.parts) {
+      const [value, expanded] = await this.expandPart(part);
+      text += value;
+      if (expanded && word.quoted !== 'double') sawUnquotedExpansion = true;
+    }
+
+    if (word.quoted === 'double') return [text];
+    // 未加引号的展开结果要分词；纯字面量不分（免得路径里的空格被拆）
+    const fields = sawUnquotedExpansion ? text.split(/\s+/).filter(Boolean) : [text];
+    return fields.flatMap((field) => this.expandGlob(field));
+  }
+
+  /** 只做变量与命令替换，不分词也不通配 —— case 的模式、`[[ ]]` 的右边要用 */
+  async expandPattern(word: Word): Promise<string> {
+    if (word.quoted === 'single') {
+      return word.parts.map((p) => (p.kind === 'literal' ? p.text : '')).join('');
+    }
+    let text = '';
+    for (const part of word.parts) text += (await this.expandPart(part))[0];
+    return text;
+  }
+
+  /** heredoc 正文里的 `$VAR` / `$(cmd)` —— 没有分词，整段替换 */
+  async expandText(text: string): Promise<string> {
+    let out = '';
+    let index = 0;
+    while (index < text.length) {
+      const dollar = text.indexOf('$', index);
+      if (dollar < 0 || dollar === text.length - 1) {
+        out += text.slice(index);
+        break;
+      }
+      out += text.slice(index, dollar);
+      const rest = text.slice(dollar);
+
+      if (rest.startsWith('$((')) {
+        const end = rest.indexOf('))');
+        if (end < 0) { out += rest; break; }
+        out += (await this.expandPart({ kind: 'arithmetic', source: rest.slice(3, end) }))[0];
+        index = dollar + end + 2;
+      } else if (rest.startsWith('$(')) {
+        const end = matchParen(rest, 1);
+        if (end < 0) { out += rest; break; }
+        out += (await this.expandPart({ kind: 'command', source: rest.slice(2, end) }))[0];
+        index = dollar + end + 1;
+      } else if (rest.startsWith('${')) {
+        const end = rest.indexOf('}');
+        if (end < 0) { out += rest; break; }
+        out += (await this.expandPart(parseBraceExpansion(rest.slice(0, end + 1))))[0];
+        index = dollar + end + 1;
+      } else {
+        const name = /^\$([A-Za-z_][A-Za-z0-9_]*|[?@*#!$0-9])/.exec(rest);
+        if (!name) { out += '$'; index = dollar + 1; continue; }
+        out += (await this.expandPart({ kind: 'variable', name: name[1] }))[0];
+        index = dollar + name[0].length;
+      }
+    }
+    return out;
+  }
+
+  private async expandPart(part: WordPart): Promise<[string, boolean]> {
+    switch (part.kind) {
+      case 'literal':
+        return [part.text, false];
+
+      case 'variable': {
+        const raw = this.lookup(part.name);
+        const value = raw ?? '';
+        if (part.length) return [String(value.length), true];
+        if (part.modifier) {
+          const argument = part.argument ?? '';
+          switch (part.modifier) {
+            case ':-': return [value || argument, true];
+            case '-': return [raw === undefined ? argument : value, true];
+            case ':=': {
+              if (!value) this.vars[part.name] = argument;
+              return [value || argument, true];
+            }
+            case '=': {
+              if (raw === undefined) this.vars[part.name] = argument;
+              return [raw === undefined ? argument : value, true];
+            }
+            case ':?': case '?':
+              if (!value) throw new Error(`${part.name}: ${argument || 'parameter null or not set'}`);
+              return [value, true];
+            case ':+': return [value ? argument : '', true];
+            case '+': return [raw === undefined ? '' : argument, true];
+            case '#': return [stripPrefix(value, argument, false), true];
+            case '##': return [stripPrefix(value, argument, true), true];
+            case '%': return [stripSuffix(value, argument, false), true];
+            case '%%': return [stripSuffix(value, argument, true), true];
+            default: return [value, true];
+          }
+        }
+        if (raw === undefined && this.options.nounset) {
+          throw new Error(`${part.name}: unbound variable`);
+        }
+        return [value, true];
+      }
+
+      case 'command': {
+        const result = await this.run(part.source);
+        if (result.stderr) this.errSink(result.stderr);
+        // 命令替换会吃掉末尾换行，这是 shell 的规矩
+        return [result.stdout.replace(/\n+$/, ''), true];
+      }
+
+      case 'arithmetic': {
+        const resolved = part.source
+          .replace(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g, (_, name) => this.lookup(name) ?? '0')
+          .replace(/[A-Za-z_][A-Za-z0-9_]*/g, (name) => this.lookup(name) ?? '0');
+        // 只允许算术字符，别让它变成任意代码执行的入口
+        if (!/^[\d\s+\-*/%()]*$/.test(resolved)) return ['0', true];
+        try {
+          // eslint-disable-next-line no-new-func
+          const value = Function(`"use strict";return (${resolved.trim() || 0})`)();
+          return [String(Math.trunc(Number(value))), true];
+        } catch {
+          return ['0', true];
+        }
+      }
+
+      default:
+        return ['', false];
+    }
+  }
+
+  private lookup(name: string): string | undefined {
+    if (name === '?') return String(this.lastStatus);
+    if (name === '$') return '1';
+    if (name === '#') return String(this.positional.length);
+    if (name === '@' || name === '*') return this.positional.join(' ');
+    if (name === '0') return 'bash';
+    if (/^[1-9][0-9]*$/.test(name)) return this.positional[Number(name) - 1];
+    if (name === 'PWD') return this.cwd;
+    return this.vars[name] ?? this.env[name];
+  }
+
+  /** `*.yaml` 这类通配。匹配不到就原样返回，和 bash 一致。 */
+  private expandGlob(pattern: string): string[] {
+    if (!/[*?[]/.test(pattern)) return [pattern];
+    // 目录部分保持学员写的样子（相对就还是相对），只把最后一段拿去匹配
+    const slash = pattern.lastIndexOf('/');
+    const prefix = slash < 0 ? '' : pattern.slice(0, slash + 1);
+    const namePattern = pattern.slice(slash + 1);
+    if (/[*?[]/.test(prefix)) return [pattern];
+
+    const directory = normalizePath(prefix || '.', this.cwd);
+    if (!this.vfs.isDir(directory)) return [pattern];
+
+    const matches = this.vfs
+      .readDir(directory)
+      // 通配不匹配隐藏文件，除非模式本身以点开头
+      .filter((entry) => !entry.startsWith('.') || namePattern.startsWith('.'))
+      .filter((entry) => matchesGlob(namePattern, entry))
+      .map((entry) => `${prefix}${entry}`);
+    return matches.length > 0 ? matches : [pattern];
+  }
+
+  /* ---------------- 内置命令要用到的 ---------------- */
+
+  setOption(name: string, value: boolean): void {
+    if (name === 'e') this.options.errexit = value;
+    if (name === 'u') this.options.nounset = value;
+    if (name === 'pipefail') this.options.pipefail = value;
+  }
+
+  exportVar(name: string, value?: string): void {
+    this.env[name] = value ?? this.vars[name] ?? this.env[name] ?? '';
+    delete this.vars[name];
+  }
+
+  unsetVar(name: string): void {
+    delete this.vars[name];
+    delete this.env[name];
+    delete this.functions[name];
+  }
+
+  setVar(name: string, value: string): void {
+    this.vars[name] = value;
+  }
+
+  getVar(name: string): string | undefined {
+    return this.lookup(name);
+  }
+
+  allVars(): Record<string, string> {
+    return { ...this.env, ...this.vars, PWD: this.cwd };
+  }
+
+  /** 位置参数，`$1` `$@` 用；给关卡脚本注入参数时也用得上 */
+  setPositional(args: string[]): void {
+    this.positional = [...args];
+  }
+
+  changeDirectory(target: string): void {
+    const path = normalizePath(target, this.cwd);
+    if (!this.vfs.exists(path)) throw new Error(`cd: ${target}: No such file or directory`);
+    if (!this.vfs.isDir(path)) throw new Error(`cd: ${target}: Not a directory`);
+    this.cwd = path;
+    this.env.PWD = path;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 展开用的小工具                                                      */
+/* ------------------------------------------------------------------ */
+
+/** `${x#pattern}` / `${x##pattern}` */
+function stripPrefix(value: string, pattern: string, greedy: boolean): string {
+  const candidates: string[] = [];
+  for (let i = 0; i <= value.length; i += 1) {
+    if (matchesGlob(pattern, value.slice(0, i))) candidates.push(value.slice(i));
+  }
+  if (candidates.length === 0) return value;
+  return greedy ? candidates[candidates.length - 1] : candidates[0];
+}
+
+/** `${x%pattern}` / `${x%%pattern}` */
+function stripSuffix(value: string, pattern: string, greedy: boolean): string {
+  const candidates: string[] = [];
+  for (let i = value.length; i >= 0; i -= 1) {
+    if (matchesGlob(pattern, value.slice(i))) candidates.push(value.slice(0, i));
+  }
+  if (candidates.length === 0) return value;
+  return greedy ? candidates[candidates.length - 1] : candidates[0];
+}
+
+/** shell 通配（`*` 不跨 `/`，`?` 一个字符，`[abc]` 字符类），case 分支也用它 */
+export function matchesGlob(pattern: string, value: string): boolean {
+  let regex = '';
+  for (let i = 0; i < pattern.length; i += 1) {
+    const char = pattern[i];
+    if (char === '*') regex += '[^/]*';
+    else if (char === '?') regex += '[^/]';
+    else if (char === '[') {
+      const end = pattern.indexOf(']', i + 1);
+      if (end < 0) { regex += '\\['; continue; }
+      const body = pattern.slice(i + 1, end).replace(/^!/, '^');
+      regex += `[${body}]`;
+      i = end;
+    } else if (char === '|') regex += '|';
+    else regex += char.replace(/[.+^${}()\\]/g, '\\$&');
+  }
+  try {
+    return new RegExp(`^(?:${regex})$`).test(value);
+  } catch {
+    return pattern === value;
+  }
+}
+
+/** 找到与 `text[open]` 配对的右括号下标 */
+function matchParen(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i += 1) {
+    if (text[i] === '(') depth += 1;
+    else if (text[i] === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** heredoc 里遇到的 `${...}`，走和解析器一样的规则 */
+function parseBraceExpansion(text: string): WordPart {
+  const inner = text.slice(2, -1);
+  if (inner.startsWith('#') && inner.length > 1) {
+    return { kind: 'variable', name: inner.slice(1), length: true };
+  }
+  const match = /^([A-Za-z_][A-Za-z0-9_]*|[?@*#!$0-9]+)(:?[-=?+]|##?|%%?)?([\s\S]*)$/.exec(inner);
+  if (!match) return { kind: 'literal', text };
+  return {
+    kind: 'variable',
+    name: match[1],
+    modifier: match[2] || undefined,
+    argument: match[3] || undefined,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* 内置命令                                                            */
+/* ------------------------------------------------------------------ */
+
+const BUILTINS: Record<string, CommandHandler> = {
+  cd: ({ argv, shell, env }) => {
+    try {
+      shell.changeDirectory(argv[0] ?? env.HOME ?? '/');
+      return { code: 0 };
+    } catch (error) {
+      return { stderr: `bash: ${(error as Error).message}\n`, code: 1 };
+    }
+  },
+
+  pwd: ({ shell }) => ({ stdout: `${shell.cwd}\n` }),
+
+  echo: ({ argv }) => {
+    const noNewline = argv[0] === '-n';
+    const words = noNewline ? argv.slice(1) : argv;
+    return { stdout: words.join(' ') + (noNewline ? '' : '\n') };
+  },
+
+  printf: ({ argv }) => {
+    const [format = '', ...rest] = argv;
+    let index = 0;
+    const text = format
+      .replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+      .replace(/%[sd]/g, () => rest[index++] ?? '');
+    return { stdout: text };
+  },
+
+  export: ({ argv, shell }) => {
+    for (const item of argv) {
+      const index = item.indexOf('=');
+      if (index < 0) shell.exportVar(item);
+      else shell.exportVar(item.slice(0, index), item.slice(index + 1));
+    }
+    return { code: 0 };
+  },
+
+  unset: ({ argv, shell }) => {
+    for (const name of argv) shell.unsetVar(name);
+    return { code: 0 };
+  },
+
+  set: ({ argv, shell }) => {
+    for (let i = 0; i < argv.length; i += 1) {
+      const flag = argv[i];
+      if (flag === '-o' || flag === '+o') {
+        shell.setOption(argv[i + 1] ?? '', flag === '-o');
+        i += 1;
+      } else if (/^[-+][a-z]+$/.test(flag)) {
+        for (const letter of flag.slice(1)) shell.setOption(letter, flag.startsWith('-'));
+      }
+    }
+    return { code: 0 };
+  },
+
+  exit: ({ argv }) => {
+    throw new ExitSignal(Number(argv[0] ?? 0) || 0);
+  },
+
+  return: ({ argv }) => {
+    throw new ReturnSignal(Number(argv[0] ?? 0) || 0);
+  },
+
+  true: () => ({ code: 0 }),
+  false: () => ({ code: 1 }),
+  ':': () => ({ code: 0 }),
+
+  /** `test` / `[` —— 条件判断 */
+  test: (context) => runTest(context.argv, context),
+  '[': (context) => runTest(context.argv.filter((arg) => arg !== ']'), context),
+
+  source: async ({ argv, shell, vfs, cwd }) => {
+    const path = normalizePath(argv[0] ?? '', cwd);
+    if (!vfs.exists(path)) return { stderr: `bash: ${argv[0]}: No such file or directory\n`, code: 1 };
+    return shell.run(vfs.readFile(path));
+  },
+};
+BUILTINS['.'] = BUILTINS.source;
+
+function runTest(argv: string[], context: CommandContext): CommandResult {
+  const ok = (value: boolean): CommandResult => ({ code: value ? 0 : 1 });
+  if (argv.length === 0) return ok(false);
+  if (argv[0] === '!') {
+    const inner = runTest(argv.slice(1), context);
+    return ok(inner.code !== 0);
+  }
+
+  const { vfs, cwd } = context;
+  if (argv.length === 1) return ok(argv[0].length > 0);
+
+  if (argv.length === 2) {
+    const [flag, operand] = argv;
+    const path = normalizePath(operand, cwd);
+    switch (flag) {
+      case '-e': return ok(vfs.exists(path));
+      case '-f': return ok(vfs.isFile(path));
+      case '-d': return ok(vfs.isDir(path));
+      case '-r': case '-w': return ok(vfs.exists(path));
+      case '-x': return ok(vfs.exists(path) && (vfs.stat(path).mode & 0o111) !== 0);
+      case '-s': return ok(vfs.isFile(path) && vfs.readFile(path).length > 0);
+      case '-z': return ok(operand.length === 0);
+      case '-n': return ok(operand.length > 0);
+      default: return ok(false);
+    }
+  }
+  if (argv.length === 3) {
+    const [left, operator, right] = argv;
+    switch (operator) {
+      case '=': return ok(left === right);
+      // `[[ $a == b* ]]` 里右边是通配模式，这是 bash 的行为
+      case '==': return ok(left === right || matchesGlob(right, left));
+      case '!=': return ok(left !== right);
+      case '<': return ok(left < right);
+      case '>': return ok(left > right);
+      case '-eq': return ok(Number(left) === Number(right));
+      case '-ne': return ok(Number(left) !== Number(right));
+      case '-lt': return ok(Number(left) < Number(right));
+      case '-le': return ok(Number(left) <= Number(right));
+      case '-gt': return ok(Number(left) > Number(right));
+      case '-ge': return ok(Number(left) >= Number(right));
+      default: return ok(false);
+    }
+  }
+  return ok(argv[0].length > 0);
+}
+
+export function createShell(options: ShellOptions): Shell {
+  return new Shell(options);
+}

--- a/src/lib/opslab/machine/vfs.ts
+++ b/src/lib/opslab/machine/vfs.ts
@@ -1,0 +1,293 @@
+/**
+ * 虚拟文件系统
+ *
+ * 「学员机器上的磁盘」。三个地方要用同一棵树：
+ *  - 终端里的 `cat` / `ls` / 重定向；
+ *  - IDE 里编辑的文件；
+ *  - 真 kubectl 通过 Go 的 fs 垫片读 kubeconfig 与 `-f` 指到的 manifest。
+ *
+ * 三者读写的是同一份数据 —— 这正是「在 IDE 里改完，终端里 apply 就生效」
+ * 这个体验的基础，不是三份各自为政的副本。
+ */
+
+export interface FileStat {
+  path: string;
+  type: 'file' | 'dir' | 'symlink';
+  size: number;
+  mode: number;
+  /** 世界的墙钟毫秒 */
+  mtime: number;
+  /** 符号链接指向哪里 */
+  target?: string;
+}
+
+export interface VfsSnapshot {
+  entries: Array<{ path: string; type: 'file' | 'dir' | 'symlink'; content?: string; target?: string; mode: number; mtime: number }>;
+}
+
+export class VfsError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'VfsError';
+    this.code = code;
+  }
+}
+
+const enoent = (path: string) => new VfsError('ENOENT', `${path}: No such file or directory`);
+const eisdir = (path: string) => new VfsError('EISDIR', `${path}: Is a directory`);
+const enotdir = (path: string) => new VfsError('ENOTDIR', `${path}: Not a directory`);
+const eexist = (path: string) => new VfsError('EEXIST', `${path}: File exists`);
+const enotempty = (path: string) => new VfsError('ENOTEMPTY', `${path}: Directory not empty`);
+
+interface Node {
+  type: 'file' | 'dir' | 'symlink';
+  content: string;
+  target?: string;
+  mode: number;
+  mtime: number;
+}
+
+/** 把路径规整成绝对路径，处理 `.`、`..`、多余的斜杠 */
+export function normalizePath(path: string, cwd = '/'): string {
+  const raw = path.startsWith('/') ? path : `${cwd}/${path}`;
+  const out: string[] = [];
+  for (const segment of raw.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') { out.pop(); continue; }
+    out.push(segment);
+  }
+  return `/${out.join('/')}`;
+}
+
+export function dirname(path: string): string {
+  const normalized = normalizePath(path);
+  if (normalized === '/') return '/';
+  const index = normalized.lastIndexOf('/');
+  return index <= 0 ? '/' : normalized.slice(0, index);
+}
+
+export function basename(path: string): string {
+  const normalized = normalizePath(path);
+  return normalized === '/' ? '/' : normalized.slice(normalized.lastIndexOf('/') + 1);
+}
+
+export class Vfs {
+  private nodes = new Map<string, Node>();
+
+  constructor(private readonly now: () => number = () => 0) {
+    this.nodes.set('/', { type: 'dir', content: '', mode: 0o755, mtime: this.now() });
+  }
+
+  /* ---------------- 查询 ---------------- */
+
+  exists(path: string): boolean {
+    return this.nodes.has(normalizePath(path));
+  }
+
+  stat(path: string): FileStat {
+    const normalized = normalizePath(path);
+    const node = this.nodes.get(normalized);
+    if (!node) throw enoent(path);
+    return {
+      path: normalized,
+      type: node.type,
+      size: node.type === 'file' ? node.content.length : 0,
+      mode: node.mode,
+      mtime: node.mtime,
+      target: node.target,
+    };
+  }
+
+  isDir(path: string): boolean {
+    return this.nodes.get(normalizePath(path))?.type === 'dir';
+  }
+
+  isFile(path: string): boolean {
+    return this.nodes.get(normalizePath(path))?.type === 'file';
+  }
+
+  readFile(path: string): string {
+    const normalized = normalizePath(path);
+    const node = this.nodes.get(normalized);
+    if (!node) throw enoent(path);
+    if (node.type === 'dir') throw eisdir(path);
+    if (node.type === 'symlink') return this.readFile(node.target!);
+    return node.content;
+  }
+
+  /** 目录内容，按名字排序 —— 顺序稳定是确定性的一部分 */
+  readDir(path: string): string[] {
+    const normalized = normalizePath(path);
+    const node = this.nodes.get(normalized);
+    if (!node) throw enoent(path);
+    if (node.type !== 'dir') throw enotdir(path);
+
+    const prefix = normalized === '/' ? '/' : `${normalized}/`;
+    const names = new Set<string>();
+    for (const key of this.nodes.keys()) {
+      if (key === normalized || !key.startsWith(prefix)) continue;
+      const rest = key.slice(prefix.length);
+      const head = rest.split('/')[0];
+      if (head) names.add(head);
+    }
+    return [...names].sort();
+  }
+
+  /** 递归列出某个目录下的全部文件（不含目录本身），按路径排序 */
+  walk(path = '/'): string[] {
+    const normalized = normalizePath(path);
+    const prefix = normalized === '/' ? '/' : `${normalized}/`;
+    return [...this.nodes.entries()]
+      .filter(([key, node]) => node.type === 'file' && (key === normalized || key.startsWith(prefix)))
+      .map(([key]) => key)
+      .sort();
+  }
+
+  /** 递归列出目录下的**全部**条目（含目录），按路径排序 —— `find` 要用 */
+  walkAll(path = '/'): string[] {
+    const normalized = normalizePath(path);
+    const prefix = normalized === '/' ? '/' : `${normalized}/`;
+    return [...this.nodes.keys()]
+      .filter((key) => key === normalized || key.startsWith(prefix))
+      .sort();
+  }
+
+  /* ---------------- 写入 ---------------- */
+
+  mkdirp(path: string): void {
+    const normalized = normalizePath(path);
+    const parts = normalized.split('/').filter(Boolean);
+    let current = '';
+    for (const part of parts) {
+      current += `/${part}`;
+      const existing = this.nodes.get(current);
+      if (existing) {
+        if (existing.type !== 'dir') throw enotdir(current);
+        continue;
+      }
+      this.nodes.set(current, { type: 'dir', content: '', mode: 0o755, mtime: this.now() });
+    }
+  }
+
+  writeFile(path: string, content: string, options: { mode?: number } = {}): void {
+    const normalized = normalizePath(path);
+    const existing = this.nodes.get(normalized);
+    if (existing?.type === 'dir') throw eisdir(path);
+    this.mkdirp(dirname(normalized));
+    this.nodes.set(normalized, {
+      type: 'file',
+      content,
+      mode: options.mode ?? existing?.mode ?? 0o644,
+      mtime: this.now(),
+    });
+  }
+
+  appendFile(path: string, content: string): void {
+    const existing = this.exists(path) ? this.readFile(path) : '';
+    this.writeFile(path, existing + content);
+  }
+
+  symlink(target: string, path: string): void {
+    const normalized = normalizePath(path);
+    if (this.nodes.has(normalized)) throw eexist(path);
+    this.mkdirp(dirname(normalized));
+    this.nodes.set(normalized, {
+      type: 'symlink', content: '', target: normalizePath(target), mode: 0o777, mtime: this.now(),
+    });
+  }
+
+  remove(path: string, options: { recursive?: boolean } = {}): void {
+    const normalized = normalizePath(path);
+    const node = this.nodes.get(normalized);
+    if (!node) throw enoent(path);
+    if (normalized === '/') throw new VfsError('EPERM', '/: Operation not permitted');
+
+    if (node.type === 'dir') {
+      const children = this.readDir(normalized);
+      if (children.length > 0 && !options.recursive) throw enotempty(path);
+      const prefix = `${normalized}/`;
+      for (const key of [...this.nodes.keys()]) {
+        if (key.startsWith(prefix)) this.nodes.delete(key);
+      }
+    }
+    this.nodes.delete(normalized);
+  }
+
+  rename(from: string, to: string): void {
+    const source = normalizePath(from);
+    const target = normalizePath(to);
+    const node = this.nodes.get(source);
+    if (!node) throw enoent(from);
+
+    this.mkdirp(dirname(target));
+    // 目录要连着子树一起搬
+    const prefix = `${source}/`;
+    for (const [key, value] of [...this.nodes.entries()]) {
+      if (key === source) {
+        this.nodes.set(target, value);
+        this.nodes.delete(key);
+      } else if (key.startsWith(prefix)) {
+        this.nodes.set(target + key.slice(source.length), value);
+        this.nodes.delete(key);
+      }
+    }
+  }
+
+  chmod(path: string, mode: number): void {
+    const node = this.nodes.get(normalizePath(path));
+    if (!node) throw enoent(path);
+    node.mode = mode;
+  }
+
+  /* ---------------- 批量与快照 ---------------- */
+
+  /** 一次性铺一批文件，建世界初态用 */
+  populate(files: Record<string, string>): void {
+    for (const [path, content] of Object.entries(files)) this.writeFile(path, content);
+  }
+
+  /** 导出成 `路径 -> 内容`，只含文件。IDE 拿它渲染文件树。 */
+  toFileMap(root = '/'): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const path of this.walk(root)) out[path] = this.readFile(path);
+    return out;
+  }
+
+  snapshot(): VfsSnapshot {
+    return {
+      entries: [...this.nodes.entries()]
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([path, node]) => ({
+          path,
+          type: node.type,
+          ...(node.type === 'file' ? { content: node.content } : {}),
+          ...(node.target ? { target: node.target } : {}),
+          mode: node.mode,
+          mtime: node.mtime,
+        })),
+    };
+  }
+
+  restore(snapshot: VfsSnapshot): void {
+    this.nodes = new Map(
+      snapshot.entries.map((entry) => [
+        entry.path,
+        {
+          type: entry.type,
+          content: entry.content ?? '',
+          target: entry.target,
+          mode: entry.mode,
+          mtime: entry.mtime,
+        },
+      ])
+    );
+    if (!this.nodes.has('/')) {
+      this.nodes.set('/', { type: 'dir', content: '', mode: 0o755, mtime: this.now() });
+    }
+  }
+}
+
+export function createVfs(now?: () => number): Vfs {
+  return new Vfs(now);
+}

--- a/tests/opslab/machine.test.ts
+++ b/tests/opslab/machine.test.ts
@@ -1,0 +1,513 @@
+/**
+ * 机器层：文件系统、shell 解析与执行、coreutils
+ *
+ * 判断标准是「跟真 bash 一致」：命令怎么写、输出什么样、退出码是几。
+ * 所以这里的断言基本都是把真 bash 的行为抄下来。
+ */
+import { createMachine, Machine } from '../../src/lib/opslab/machine';
+import { createVfs, VfsError } from '../../src/lib/opslab/machine/vfs';
+import { matchesGlob } from '../../src/lib/opslab/machine/shell/shell';
+import { loadShellParser, parseShell, resetShellParser, ShellSyntaxError } from '../../src/lib/opslab/machine/shell/parser';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** 只要 stdout，顺手断言退出码是 0 —— 大多数用例都这么用 */
+async function sh(machine: Machine, command: string): Promise<string> {
+  const result = await machine.exec(command);
+  if (result.code !== 0) {
+    throw new Error(`"${command}" exited ${result.code}: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+describe('Vfs', () => {
+  it('规整路径时处理 . 与 ..', () => {
+    const vfs = createVfs();
+    vfs.writeFile('/a/b/c.txt', 'hi');
+    expect(vfs.readFile('/a/b/../b/./c.txt')).toBe('hi');
+    expect(vfs.exists('/a/b')).toBe(true);
+    expect(vfs.isDir('/a')).toBe(true);
+  });
+
+  it('读不存在的文件报 ENOENT，读目录报 EISDIR', () => {
+    const vfs = createVfs();
+    vfs.mkdirp('/etc');
+    expect(() => vfs.readFile('/nope')).toThrow(VfsError);
+    expect(() => vfs.readFile('/etc')).toThrow(/Is a directory/);
+  });
+
+  it('非空目录要 recursive 才能删', () => {
+    const vfs = createVfs();
+    vfs.writeFile('/data/a.txt', 'a');
+    expect(() => vfs.remove('/data')).toThrow(/Directory not empty/);
+    vfs.remove('/data', { recursive: true });
+    expect(vfs.exists('/data')).toBe(false);
+    expect(vfs.exists('/data/a.txt')).toBe(false);
+  });
+
+  it('改名会把整棵子树搬走', () => {
+    const vfs = createVfs();
+    vfs.writeFile('/src/deep/a.txt', 'a');
+    vfs.rename('/src', '/dst');
+    expect(vfs.readFile('/dst/deep/a.txt')).toBe('a');
+    expect(vfs.exists('/src/deep/a.txt')).toBe(false);
+  });
+
+  it('快照与还原是等价的', () => {
+    const vfs = createVfs(() => 42);
+    vfs.writeFile('/a.txt', 'one');
+    vfs.mkdirp('/b');
+    const snapshot = vfs.snapshot();
+    vfs.writeFile('/a.txt', 'two');
+    vfs.remove('/b');
+
+    const restored = createVfs();
+    restored.restore(snapshot);
+    expect(restored.readFile('/a.txt')).toBe('one');
+    expect(restored.isDir('/b')).toBe(true);
+    expect(JSON.stringify(restored.snapshot())).toBe(JSON.stringify(snapshot));
+  });
+
+  it('walk 只给文件，walkAll 连目录一起给，都按路径排序', () => {
+    const vfs = createVfs();
+    vfs.writeFile('/x/b.txt', '');
+    vfs.writeFile('/x/a.txt', '');
+    expect(vfs.walk('/x')).toEqual(['/x/a.txt', '/x/b.txt']);
+    expect(vfs.walkAll('/x')).toEqual(['/x', '/x/a.txt', '/x/b.txt']);
+  });
+});
+
+describe('shell 解析', () => {
+  it('管道尾部的重定向不会丢', async () => {
+    const node = await parseShell('ls | grep a > out.txt');
+    expect(node?.type).toBe('pipeline');
+    const pipeline = node as Extract<typeof node, { type: 'pipeline' }>;
+    expect(pipeline.commands[1].type).toBe('redirected');
+  });
+
+  it('`[ -f x ]` 翻成 test 命令而不是被丢掉', async () => {
+    const node = await parseShell('[ -f /etc/hosts ]');
+    expect(node).toMatchObject({ type: 'command' });
+    const command = node as Extract<typeof node, { type: 'command' }>;
+    expect(command.words[0].parts[0]).toEqual({ kind: 'literal', text: 'test' });
+    expect(command.words).toHaveLength(3);
+  });
+
+  it('语法错误抛 ShellSyntaxError', async () => {
+    await expect(parseShell('if [ -f a ]; then')).rejects.toBeInstanceOf(ShellSyntaxError);
+  });
+
+  it('C 风格 for 明确报不支持，而不是装作跑了', async () => {
+    await expect(parseShell('for ((i=0;i<3;i++)); do echo $i; done')).rejects.toThrow(/not supported/);
+  });
+});
+
+describe('shell 执行', () => {
+  let machine: Machine;
+  beforeEach(() => {
+    machine = createMachine({
+      files: {
+        '/root/a.txt': 'alpha\nbravo\ncharlie\n',
+        '/root/b.txt': 'bravo\n',
+        '/root/data/one.yaml': 'kind: One\n',
+        '/root/data/two.yaml': 'kind: Two\n',
+        '/root/data/note.md': 'note\n',
+      },
+    });
+  });
+
+  it('跑一条最简单的命令', async () => {
+    expect(await sh(machine, 'echo hello')).toBe('hello\n');
+    expect(await sh(machine, 'pwd')).toBe('/root\n');
+  });
+
+  it('未知命令的报错与退出码跟 bash 一样', async () => {
+    const result = await machine.exec('nosuchcmd');
+    expect(result.code).toBe(127);
+    expect(result.stderr).toBe('bash: nosuchcmd: command not found\n');
+  });
+
+  it('管道一段段传下去', async () => {
+    expect(await sh(machine, 'cat a.txt | grep bravo')).toBe('bravo\n');
+    expect(await sh(machine, 'cat a.txt | grep -v bravo | wc -l')).toBe('2\n');
+  });
+
+  it('&& 与 || 看退出码', async () => {
+    expect(await sh(machine, 'true && echo yes')).toBe('yes\n');
+    expect((await machine.exec('false && echo yes')).stdout).toBe('');
+    expect(await sh(machine, 'false || echo fallback')).toBe('fallback\n');
+    expect(await sh(machine, 'true || echo skipped')).toBe('');
+  });
+
+  it('$? 是上一条命令的退出码', async () => {
+    await machine.exec('false');
+    expect(await sh(machine, 'echo $?')).toBe('1\n');
+    await machine.exec('true');
+    expect(await sh(machine, 'echo $?')).toBe('0\n');
+  });
+
+  it('grep 没匹配上退出码是 1', async () => {
+    const result = await machine.exec('grep zzz a.txt');
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe('');
+  });
+
+  it('重定向写文件，>> 追加', async () => {
+    await sh(machine, 'echo one > out.txt');
+    await sh(machine, 'echo two >> out.txt');
+    expect(machine.vfs.readFile('/root/out.txt')).toBe('one\ntwo\n');
+    expect(await sh(machine, 'cat < out.txt')).toBe('one\ntwo\n');
+  });
+
+  it('`> f` 即使没有输出也会把文件建出来', async () => {
+    await machine.exec('grep zzz a.txt > empty.txt');
+    expect(machine.vfs.exists('/root/empty.txt')).toBe(true);
+    expect(machine.vfs.readFile('/root/empty.txt')).toBe('');
+  });
+
+  it('2> 与 2>&1 分得清 stdout 和 stderr', async () => {
+    const dropped = await machine.exec('nosuchcmd 2>/dev/null');
+    expect(dropped.stderr).toBe('');
+
+    await machine.exec('nosuchcmd 2> err.txt');
+    expect(machine.vfs.readFile('/root/err.txt')).toBe('bash: nosuchcmd: command not found\n');
+
+    await machine.exec('nosuchcmd > both.txt 2>&1');
+    expect(machine.vfs.readFile('/root/both.txt')).toBe('bash: nosuchcmd: command not found\n');
+  });
+
+  it('heredoc 写文件，$VAR 会展开；带引号的 delimiter 不展开', async () => {
+    await sh(machine, 'export NS=prod');
+    await sh(machine, 'cat > m.yaml <<EOF\nnamespace: $NS\nEOF');
+    expect(machine.vfs.readFile('/root/m.yaml')).toBe('namespace: prod\n');
+
+    await sh(machine, "cat > raw.yaml <<'EOF'\nnamespace: $NS\nEOF");
+    expect(machine.vfs.readFile('/root/raw.yaml')).toBe('namespace: $NS\n');
+  });
+
+  it('变量展开的各种写法', async () => {
+    await sh(machine, 'X=hello');
+    expect(await sh(machine, 'echo $X ${X} "${X}"')).toBe('hello hello hello\n');
+    expect(await sh(machine, 'echo ${#X}')).toBe('5\n');
+    expect(await sh(machine, 'echo ${MISSING:-default}')).toBe('default\n');
+    expect(await sh(machine, 'echo ${X:+set}')).toBe('set\n');
+    await sh(machine, 'FILE=cluster.yaml');
+    expect(await sh(machine, 'echo ${FILE%.yaml}')).toBe('cluster\n');
+    expect(await sh(machine, 'echo ${FILE#clu}')).toBe('ster.yaml\n');
+  });
+
+  it('引号决定分词', async () => {
+    await sh(machine, 'SPACED="a b"');
+    // 未加引号的展开会分词，加了就不分
+    expect(await sh(machine, 'echo $SPACED')).toBe('a b\n');
+    expect(await sh(machine, 'wc -w <<EOF\n$SPACED\nEOF')).toBe('2\n');
+    expect(await sh(machine, "echo 'literal $SPACED'")).toBe('literal $SPACED\n');
+  });
+
+  it('命令替换与算术展开', async () => {
+    expect(await sh(machine, 'echo "lines: $(wc -l < a.txt)"')).toBe('lines: 3\n');
+    expect(await sh(machine, 'echo $((2 + 3 * 4))')).toBe('14\n');
+    await sh(machine, 'N=5');
+    expect(await sh(machine, 'echo $((N * 2))')).toBe('10\n');
+  });
+
+  it('通配展开，匹配不到就原样保留', async () => {
+    expect(await sh(machine, 'echo data/*.yaml')).toBe('data/one.yaml data/two.yaml\n');
+    expect(await sh(machine, 'echo data/*.json')).toBe('data/*.json\n');
+    expect(await sh(machine, 'cd data && echo *.yaml')).toBe('one.yaml two.yaml\n');
+  });
+
+  it('cd 会改工作目录，并且反映在提示符里', async () => {
+    expect(machine.prompt()).toBe('root@jump-01:~# ');
+    await sh(machine, 'cd data');
+    expect(await sh(machine, 'pwd')).toBe('/root/data\n');
+    expect(machine.prompt()).toBe('root@jump-01:~/data# ');
+    const failed = await machine.exec('cd /nope');
+    expect(failed.code).toBe(1);
+    expect(failed.stderr).toBe('bash: cd: /nope: No such file or directory\n');
+  });
+
+  it('子 shell 里的 cd 不影响外面', async () => {
+    expect(await sh(machine, '(cd /etc && pwd)')).toBe('/etc\n');
+    expect(await sh(machine, 'pwd')).toBe('/root\n');
+  });
+
+  it('if / elif / else 走对分支', async () => {
+    expect(await sh(machine, 'if [ -f a.txt ]; then echo found; else echo missing; fi')).toBe('found\n');
+    expect(await sh(machine, 'if [ -f zz ]; then echo found; else echo missing; fi')).toBe('missing\n');
+    expect(
+      await sh(machine, 'if [ -f zz ]; then echo one; elif [ -d data ]; then echo two; else echo three; fi')
+    ).toBe('two\n');
+  });
+
+  it('for 与 while', async () => {
+    expect(await sh(machine, 'for f in a b c; do echo $f; done')).toBe('a\nb\nc\n');
+    expect(await sh(machine, 'for f in data/*.yaml; do basename $f; done')).toBe('one.yaml\ntwo.yaml\n');
+    expect(await sh(machine, 'i=0\nwhile [ $i -lt 3 ]; do echo $i; i=$((i + 1)); done')).toBe('0\n1\n2\n');
+  });
+
+  it('死循环会被拦住而不是把页面挂死', async () => {
+    const small = createMachine({ maxLoopIterations: 5 } as never);
+    const result = await machine.exec('while true; do echo x > /dev/null; done');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/loop exceeded/);
+    expect(small).toBeDefined();
+  });
+
+  it('case 按模式选分支', async () => {
+    const script = 'x=prod\ncase "$x" in dev) echo D;; prod|stage) echo P;; *) echo other;; esac';
+    expect(await sh(machine, script)).toBe('P\n');
+    expect(await sh(machine, 'x=zzz\ncase "$x" in dev) echo D;; *) echo other;; esac')).toBe('other\n');
+  });
+
+  it('函数有位置参数，local 变量出了函数就没了', async () => {
+    const script = [
+      'greet() { local who=$1; echo "hi $who ($#)"; }',
+      'who=outer',
+      'greet world',
+      'echo $who',
+    ].join('\n');
+    expect(await sh(machine, script)).toBe('hi world (1)\nouter\n');
+  });
+
+  it('return 只退出函数', async () => {
+    const script = ['f() { return 3; }', 'f', 'echo after=$?'].join('\n');
+    expect(await sh(machine, script)).toBe('after=3\n');
+  });
+
+  it('set -e 遇到失败就停', async () => {
+    const result = await machine.exec('set -e\nfalse\necho unreachable');
+    expect(result.stdout).toBe('');
+    expect(result.code).toBe(1);
+  });
+
+  it('set -u 引用未定义变量会报错', async () => {
+    const result = await machine.exec('set -u\necho $UNDEFINED_VAR');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/unbound variable/);
+  });
+
+  it('set -o pipefail 让管道里的失败露出来', async () => {
+    expect((await machine.exec('grep zzz a.txt | wc -l')).code).toBe(0);
+    expect((await machine.exec('set -o pipefail\ngrep zzz a.txt | wc -l')).code).toBe(1);
+  });
+
+  it('! 取反管道的退出码', async () => {
+    expect((await machine.exec('! grep zzz a.txt')).code).toBe(0);
+    expect((await machine.exec('! grep bravo a.txt')).code).toBe(1);
+  });
+
+  it('前置赋值只对那一条命令可见', async () => {
+    const echoEnv = { env: ({ env }: { env: Record<string, string> }) => ({ stdout: `${env.FOO ?? ''}\n` }) };
+    machine.install('showfoo', echoEnv.env as never);
+    expect(await sh(machine, 'FOO=once showfoo')).toBe('once\n');
+    expect(await sh(machine, 'showfoo')).toBe('\n');
+  });
+
+  it('source 会在当前 shell 里跑脚本', async () => {
+    machine.vfs.writeFile('/root/env.sh', 'export REGION=cn-north\n');
+    await sh(machine, 'source env.sh');
+    expect(await sh(machine, 'echo $REGION')).toBe('cn-north\n');
+  });
+
+  it('反斜杠转义', async () => {
+    expect(await sh(machine, 'echo a\\ b')).toBe('a b\n');
+    expect(await sh(machine, 'echo \\$HOME')).toBe('$HOME\n');
+    expect(await sh(machine, 'echo "\\$HOME"')).toBe('$HOME\n');
+  });
+});
+
+describe('coreutils', () => {
+  let machine: Machine;
+  beforeEach(() => {
+    machine = createMachine({
+      files: {
+        '/root/nums.txt': '3\n1\n2\n1\n',
+        '/root/pods.txt': 'web  Running\napi  Pending\ndb   Running\n',
+        '/root/dir/x.yaml': 'x\n',
+        '/root/dir/.hidden': 'h\n',
+      },
+    });
+  });
+
+  it('ls 默认不显示隐藏文件，-a 才显示', async () => {
+    expect(await sh(machine, 'ls dir')).toBe('x.yaml\n');
+    expect(await sh(machine, 'ls -a dir')).toBe('.hidden\nx.yaml\n');
+  });
+
+  it('ls 找不到路径时的报错与退出码', async () => {
+    const result = await machine.exec('ls /nope');
+    expect(result.code).toBe(2);
+    expect(result.stderr).toBe("ls: cannot access '/nope': No such file or directory\n");
+  });
+
+  it('head / tail / wc', async () => {
+    expect(await sh(machine, 'head -n 2 nums.txt')).toBe('3\n1\n');
+    expect(await sh(machine, 'tail -n 2 nums.txt')).toBe('2\n1\n');
+    expect(await sh(machine, 'wc -l nums.txt')).toBe('4\n');
+  });
+
+  it('sort / uniq / cut / tr', async () => {
+    expect(await sh(machine, 'sort -n nums.txt')).toBe('1\n1\n2\n3\n');
+    expect(await sh(machine, 'sort -n nums.txt | uniq')).toBe('1\n2\n3\n');
+    expect(await sh(machine, 'sort -n nums.txt | uniq -c | tr -s " " " " | head -n 1')).toContain('1');
+    expect(await sh(machine, 'cut -d " " -f 1 pods.txt')).toBe('web\napi\ndb\n');
+  });
+
+  it('grep -c 与 -i', async () => {
+    expect(await sh(machine, 'grep -c Running pods.txt')).toBe('2\n');
+    expect(await sh(machine, 'grep -i RUNNING pods.txt | wc -l')).toBe('2\n');
+  });
+
+  it('mkdir / rm / cp / mv', async () => {
+    await sh(machine, 'mkdir -p deep/a/b');
+    expect(machine.vfs.isDir('/root/deep/a/b')).toBe(true);
+    await sh(machine, 'cp nums.txt copy.txt');
+    expect(machine.vfs.readFile('/root/copy.txt')).toBe('3\n1\n2\n1\n');
+    await sh(machine, 'mv copy.txt moved.txt');
+    expect(machine.vfs.exists('/root/copy.txt')).toBe(false);
+    const failed = await machine.exec('rm dir');
+    expect(failed.stderr).toBe("rm: cannot remove 'dir': Is a directory\n");
+    await sh(machine, 'rm -r dir');
+    expect(machine.vfs.exists('/root/dir')).toBe(false);
+  });
+
+  it('find -name', async () => {
+    expect(await sh(machine, 'find /root/dir -name "*.yaml"')).toBe('/root/dir/x.yaml\n');
+  });
+
+  it('tee 既写文件也往下游传', async () => {
+    expect(await sh(machine, 'echo hi | tee saved.txt')).toBe('hi\n');
+    expect(machine.vfs.readFile('/root/saved.txt')).toBe('hi\n');
+  });
+
+  it('sed 支持 s/// 与 Nd，其余明确报不支持', async () => {
+    expect(await sh(machine, 'echo aaa | sed s/a/b/')).toBe('baa\n');
+    expect(await sh(machine, 'echo aaa | sed s/a/b/g')).toBe('bbb\n');
+    expect(await sh(machine, 'sed 2d nums.txt')).toBe('3\n2\n1\n');
+    const unsupported = await machine.exec('sed y/a/b/ nums.txt');
+    expect(unsupported.code).toBe(2);
+    expect(unsupported.stderr).toMatch(/unsupported script/);
+  });
+
+  it('which 只认装了的命令', async () => {
+    expect(await sh(machine, 'which grep')).toBe('/usr/bin/grep\n');
+    expect((await machine.exec('which kubectl')).code).toBe(1);
+  });
+});
+
+describe('机器', () => {
+  it('装上的命令能拿到 argv、stdin 与 cwd', async () => {
+    const machine = createMachine();
+    machine.install('kubectl', ({ argv, stdin, cwd }) => ({
+      stdout: `argv=${argv.join(',')} stdin=${stdin.trim()} cwd=${cwd}\n`,
+    }));
+    machine.vfs.mkdirp('/root/work');
+    const result = await machine.exec('cd work && echo body | kubectl apply -f -');
+    expect(result.stdout).toBe('argv=apply,-f,- stdin=body cwd=/root/work\n');
+  });
+
+  it('操作记录留下命令、退出码与当时的目录', async () => {
+    const machine = createMachine();
+    await machine.exec('echo one');
+    await machine.exec('false');
+    const transcript = machine.transcript();
+    expect(transcript.map((r) => [r.command, r.code])).toEqual([['echo one', 0], ['false', 1]]);
+    expect(transcript[0].cwd).toBe('/root');
+    expect(machine.history).toEqual(['echo one', 'false']);
+  });
+
+  it('快照能把机器整台还原回去', async () => {
+    const machine = createMachine();
+    await machine.exec('echo before > f.txt');
+    const snapshot = machine.snapshot();
+    await machine.exec('echo after > f.txt');
+    await machine.exec('cd /etc');
+
+    machine.restore(snapshot);
+    expect(machine.vfs.readFile('/root/f.txt')).toBe('before\n');
+    expect(machine.cwd).toBe('/root');
+  });
+
+  it('同样的脚本跑两遍，输出逐字节相同', async () => {
+    const script = [
+      'mkdir -p /work/manifests',
+      'for n in api web db; do echo "name: $n" > /work/manifests/$n.yaml; done',
+      'ls /work/manifests | sort',
+      'grep -h name /work/manifests/*.yaml | sort | uniq -c',
+      'echo done=$?',
+    ].join('\n');
+
+    const run = async () => {
+      const machine = createMachine({ now: () => 1_700_000_000_000 });
+      const result = await machine.exec(script);
+      return JSON.stringify({ ...result, files: machine.vfs.toFileMap('/work') });
+    };
+    const [first, second] = [await run(), await run()];
+    expect(first).toBe(second);
+    expect(JSON.parse(first).code).toBe(0);
+  });
+});
+
+describe('glob 匹配', () => {
+  it.each([
+    ['*.yaml', 'a.yaml', true],
+    ['*.yaml', 'a.yml', false],
+    ['a?c', 'abc', true],
+    ['a?c', 'ac', false],
+    ['[abc]x', 'bx', true],
+    ['[abc]x', 'dx', false],
+    ['*', 'anything', true],
+    ['*', 'a/b', false],
+  ])('%s vs %s', (pattern, value, expected) => {
+    expect(matchesGlob(pattern, value)).toBe(expected);
+  });
+});
+
+/**
+ * 浏览器路径
+ *
+ * 解析器在浏览器里走的是另一条分支：fetch 一个 URL 拿语法文件，
+ * 而不是从 node_modules 读。那条分支在 Node 测试里永远不会被执行，
+ * 于是「路径写错了」「拷贝脚本没跑」这类问题要到真打开页面才发现。
+ * 这里把 window / document / fetch 造出来，逼它走浏览器分支。
+ */
+describe('浏览器里的语法加载', () => {
+  const PUBLIC_WASM = path.join(__dirname, '../../public/opslab/tree-sitter-bash.wasm');
+
+  it('从 /opslab/tree-sitter-bash.wasm 取语法，取到的是能用的', async () => {
+    expect(fs.existsSync(PUBLIC_WASM)).toBe(true);
+
+    const requested: string[] = [];
+    const globals = globalThis as Record<string, unknown>;
+    const saved = { window: globals.window, document: globals.document, fetch: globals.fetch };
+
+    globals.window = {};
+    globals.document = {};
+    globals.fetch = async (url: string) => {
+      requested.push(url);
+      const file = url === '/opslab/tree-sitter-bash.wasm'
+        ? PUBLIC_WASM
+        : path.join(__dirname, '../../node_modules/web-tree-sitter/web-tree-sitter.wasm');
+      const bytes = fs.readFileSync(file);
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      };
+    };
+
+    resetShellParser();
+    try {
+      // 运行时 wasm 在 Node 下由 emscripten 自己定位，这里只验语法文件那一段
+      const parser = await loadShellParser({ runtimeWasmUrl: undefined });
+      expect(parser.parse('echo hi | wc -l').rootNode.hasError).toBe(false);
+      expect(requested).toContain('/opslab/tree-sitter-bash.wasm');
+    } finally {
+      globals.window = saved.window;
+      globals.document = saved.document;
+      globals.fetch = saved.fetch;
+      resetShellParser();
+    }
+  });
+});

--- a/tests/opslab/machine.test.ts
+++ b/tests/opslab/machine.test.ts
@@ -247,11 +247,15 @@ describe('shell 执行', () => {
   });
 
   it('死循环会被拦住而不是把页面挂死', async () => {
-    const small = createMachine({ maxLoopIterations: 5 } as never);
     const result = await machine.exec('while true; do echo x > /dev/null; done');
     expect(result.code).toBe(1);
-    expect(result.stderr).toMatch(/loop exceeded/);
-    expect(small).toBeDefined();
+    expect(result.stderr).toBe('bash: loop exceeded 10000 iterations, aborted\n');
+  });
+
+  it('循环上限可以调小，报错里写的是实际生效的那个数', async () => {
+    const strict = createMachine({ maxLoopIterations: 5 });
+    const result = await strict.exec('i=0\nwhile true; do i=$((i+1)); done\necho $i');
+    expect(result.stderr).toBe('bash: loop exceeded 5 iterations, aborted\n');
   });
 
   it('case 按模式选分支', async () => {
@@ -417,16 +421,20 @@ describe('机器', () => {
     expect(machine.history).toEqual(['echo one', 'false']);
   });
 
-  it('快照能把机器整台还原回去', async () => {
+  it('快照能把机器整台还原回去，连变量和函数一起', async () => {
     const machine = createMachine();
     await machine.exec('echo before > f.txt');
     const snapshot = machine.snapshot();
     await machine.exec('echo after > f.txt');
     await machine.exec('cd /etc');
+    await machine.exec('LEFTOVER=1');
+    await machine.exec('leftover() { echo nope; }');
 
     machine.restore(snapshot);
     expect(machine.vfs.readFile('/root/f.txt')).toBe('before\n');
     expect(machine.cwd).toBe('/root');
+    expect((await machine.exec('echo "[$LEFTOVER]"')).stdout).toBe('[]\n');
+    expect((await machine.exec('leftover')).code).toBe(127);
   });
 
   it('同样的脚本跑两遍，输出逐字节相同', async () => {

--- a/tests/opslab/oci.test.ts
+++ b/tests/opslab/oci.test.ts
@@ -1,0 +1,458 @@
+/**
+ * OCI：Dockerfile 解析、真构建、层与 digest、私有仓库与凭据
+ *
+ * 判定标准还是「跟真 docker 一致」：命令怎么敲、输出长什么样、
+ * 报错说了什么、digest 是不是真算出来的。
+ */
+import { createMachine, Machine } from '../../src/lib/opslab/machine';
+import {
+  ImageStore, Registry, RegistryNetwork, buildImage, createDockerCommand,
+  digestOf, flattenLayers, imageRootfs, normalizeReference, parseDockerfile, parseReference,
+  finalizeImage, makeLayer,
+} from '../../src/lib/opslab/machine/oci';
+
+const CREATED = '2026-01-01T00:00:00Z';
+const NOW = Date.parse('2026-01-01T00:05:00Z');
+
+/** 一个能当 FROM 用的基础镜像 */
+function baseImage(reference: string, files: Record<string, string>, config = {}) {
+  return finalizeImage({
+    config: { Env: ['PATH=/usr/local/bin:/usr/bin:/bin'], Cmd: ['/bin/sh'], ...config },
+    layers: [makeLayer(files, [], 'ADD file:base in /')],
+    history: [{ created: CREATED, created_by: 'ADD file:base in /' }],
+    architecture: 'amd64',
+    os: 'linux',
+    created: CREATED,
+    repoTags: [normalizeReference(reference)],
+  });
+}
+
+/** 一台装好 docker、连得上私有仓库的机器 */
+function dockerMachine(files: Record<string, string>) {
+  const store = new ImageStore();
+  store.add(baseImage('node:22-alpine', {
+    '/bin/sh': '#!/bin/sh\n',
+    '/usr/local/bin/node': 'node binary\n',
+  }));
+
+  const harbor = new Registry({
+    host: 'harbor.corp.internal',
+    users: { ci: 'S3cret!' },
+    projects: ['team'],
+    anonymousPull: false,
+  });
+  const network = new RegistryNetwork();
+  network.add(harbor);
+
+  const machine = createMachine({ files, now: () => NOW });
+  machine.install('docker', createDockerCommand({
+    store,
+    network,
+    now: () => NOW,
+    toolchains: {
+      'docker.io/library/node:22-alpine': {
+        // 简化的 npm：真的往 node_modules 写点东西，好让层里看得见
+        npm: ({ argv, vfs, cwd }) => {
+          if (argv[0] !== 'ci' && argv[0] !== 'install') {
+            return { stderr: `Unknown command: "${argv[0]}"\n`, code: 1 };
+          }
+          if (!vfs.exists(`${cwd}/package.json`)) {
+            return { stderr: 'npm error code ENOENT\nnpm error path package.json\n', code: 254 };
+          }
+          vfs.writeFile(`${cwd}/node_modules/.package-lock.json`, '{}\n');
+          vfs.writeFile(`${cwd}/node_modules/express/index.js`, 'module.exports = {}\n');
+          return { stdout: 'added 42 packages in 2s\n' };
+        },
+      },
+    },
+  }));
+  return { machine, store, harbor, network };
+}
+
+describe('镜像引用解析', () => {
+  it.each([
+    ['nginx', 'docker.io/library/nginx:latest'],
+    ['nginx:1.27', 'docker.io/library/nginx:1.27'],
+    ['bitnami/redis:7', 'docker.io/bitnami/redis:7'],
+    ['harbor.corp.internal/team/app:v1', 'harbor.corp.internal/team/app:v1'],
+    ['localhost:5000/app', 'localhost:5000/app:latest'],
+  ])('%s -> %s', (input, expected) => {
+    expect(normalizeReference(input)).toBe(expected);
+  });
+
+  it('带 digest 的引用', () => {
+    const parsed = parseReference('harbor.corp.internal/team/app@sha256:abcd');
+    expect(parsed.digest).toBe('sha256:abcd');
+    expect(parsed.canonical).toBe('harbor.corp.internal/team/app@sha256:abcd');
+  });
+});
+
+describe('Dockerfile 解析', () => {
+  it('续行、注释、多阶段、flag', () => {
+    const parsed = parseDockerfile([
+      '# 构建阶段',
+      'ARG NODE_VERSION=22',
+      'FROM node:${NODE_VERSION}-alpine AS builder',
+      'WORKDIR /app',
+      'RUN npm ci \\',
+      '    --omit=dev',
+      '',
+      'FROM node:${NODE_VERSION}-alpine',
+      'COPY --from=builder /app/node_modules /app/node_modules',
+      'CMD ["node", "server.js"]',
+    ].join('\n'));
+
+    expect(parsed.globalArgs).toHaveLength(1);
+    expect(parsed.stages).toHaveLength(2);
+    expect(parsed.stages[0].name).toBe('builder');
+    expect(parsed.stages[0].instructions[1].args).toBe('npm ci     --omit=dev');
+    expect(parsed.stages[1].instructions[0].flags.from).toBe('builder');
+  });
+
+  it('不认识的指令报错，行号对得上', () => {
+    expect(() => parseDockerfile('FROM alpine\nRUNN echo hi\n')).toThrow(
+      'dockerfile parse error on line 2: unknown instruction: RUNN'
+    );
+  });
+
+  it('第一条不是 FROM 也要报错', () => {
+    expect(() => parseDockerfile('WORKDIR /app\n')).toThrow(/no build stage in current context/);
+  });
+});
+
+describe('docker build', () => {
+  const DOCKERFILE = [
+    'FROM node:22-alpine',
+    'WORKDIR /app',
+    'COPY package.json ./',
+    'RUN npm ci --omit=dev',
+    'COPY server.js ./',
+    'ENV NODE_ENV=production',
+    'EXPOSE 8080',
+    'USER 10001',
+    'CMD ["node", "server.js"]',
+  ].join('\n');
+
+  const CONTEXT = {
+    '/root/app/Dockerfile': DOCKERFILE,
+    '/root/app/package.json': '{"name":"app"}\n',
+    '/root/app/server.js': 'require("http")\n',
+  };
+
+  it('构建出来的镜像有层、有配置、有真 digest', async () => {
+    const { machine, store } = dockerMachine(CONTEXT);
+    const result = await machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    expect(result.code).toBe(0);
+
+    const image = store.get('harbor.corp.internal/team/app:v1');
+    expect(image).toBeDefined();
+    expect(image!.id).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(image!.config.User).toBe('10001');
+    expect(image!.config.WorkingDir).toBe('/app');
+    expect(image!.config.Cmd).toEqual(['node', 'server.js']);
+    expect(image!.config.Env).toContain('NODE_ENV=production');
+    expect(image!.config.ExposedPorts).toEqual({ '8080/tcp': {} });
+    // 基础层 + COPY package.json + RUN npm ci + COPY server.js
+    expect(image!.layers).toHaveLength(4);
+    expect(image!.layers.every((layer) => /^sha256:[0-9a-f]{64}$/.test(layer.digest))).toBe(true);
+  });
+
+  it('RUN 真的跑了 —— node_modules 出现在它自己那一层里', async () => {
+    const { machine, store } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t app:v1 app');
+    const image = store.get('app:v1')!;
+    const runLayer = image.layers.find((layer) => layer.createdBy.includes('npm ci'))!;
+    expect(Object.keys(runLayer.files)).toContain('/app/node_modules/express/index.js');
+    expect(imageRootfs(image)['/app/server.js']).toBe('require("http")\n');
+  });
+
+  it('构建日志是 BuildKit 那个样子', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    const result = await machine.exec('docker build -t app:v1 app');
+    expect(result.stdout).toContain('#1 [internal] load build definition from Dockerfile');
+    expect(result.stdout).toContain('[3/3] COPY server.js ./');
+    expect(result.stdout).toMatch(/added 42 packages in 2s/);
+    expect(result.stdout).toMatch(/writing image sha256:[0-9a-f]{64} done/);
+    expect(result.stdout).toContain('naming to docker.io/library/app:v1 done');
+  });
+
+  it('RUN 失败时构建失败，报错文本跟 BuildKit 一致', async () => {
+    const { machine } = dockerMachine({
+      '/root/app/Dockerfile': 'FROM node:22-alpine\nWORKDIR /app\nRUN npm ci\n',
+    });
+    const result = await machine.exec('docker build -t app:v1 app');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('npm error code ENOENT');
+    expect(result.stderr).toMatch(
+      /ERROR: failed to solve: process "\/bin\/sh -c npm ci" did not complete successfully: exit code: 254/
+    );
+  });
+
+  it('同一份上下文构建两次，镜像 ID 一模一样', async () => {
+    const first = dockerMachine(CONTEXT);
+    const second = dockerMachine(CONTEXT);
+    await first.machine.exec('docker build -t app:v1 app');
+    await second.machine.exec('docker build -t app:v1 app');
+    expect(first.store.get('app:v1')!.id).toBe(second.store.get('app:v1')!.id);
+  });
+
+  it('改一个字节，镜像 ID 就变 —— digest 是真算的', async () => {
+    const first = dockerMachine(CONTEXT);
+    const second = dockerMachine({ ...CONTEXT, '/root/app/server.js': 'require("http") // v2\n' });
+    await first.machine.exec('docker build -t app:v1 app');
+    await second.machine.exec('docker build -t app:v1 app');
+    expect(first.store.get('app:v1')!.id).not.toBe(second.store.get('app:v1')!.id);
+  });
+
+  it('多阶段构建：产物层来自 builder，工具链留在 builder 里', async () => {
+    const { machine, store } = dockerMachine({
+      '/root/app/Dockerfile': [
+        'FROM node:22-alpine AS builder',
+        'WORKDIR /app',
+        'COPY package.json ./',
+        'RUN npm ci',
+        'FROM node:22-alpine',
+        'WORKDIR /srv',
+        'COPY --from=builder /app/node_modules /srv/node_modules',
+        'USER 10001',
+        'CMD ["node", "index.js"]',
+      ].join('\n'),
+      '/root/app/package.json': '{"name":"app"}\n',
+    });
+    const result = await machine.exec('docker build -t app:slim app');
+    expect(result.code).toBe(0);
+
+    const rootfs = imageRootfs(store.get('app:slim')!);
+    expect(rootfs['/srv/node_modules/express/index.js']).toBe('module.exports = {}\n');
+    // builder 阶段的 /app 不该出现在最终镜像里
+    expect(Object.keys(rootfs).some((path) => path.startsWith('/app/'))).toBe(false);
+  });
+
+  it('把密钥 COPY 进去再 rm 掉，层里还是查得到', async () => {
+    const { machine, store } = dockerMachine({
+      '/root/app/Dockerfile': [
+        'FROM node:22-alpine',
+        'WORKDIR /app',
+        'COPY .npmrc ./',
+        'RUN rm -f .npmrc',
+      ].join('\n'),
+      '/root/app/.npmrc': '//registry:_authToken=super-secret\n',
+    });
+    await machine.exec('docker build -t app:leaky app');
+    const image = store.get('app:leaky')!;
+
+    // 最终 rootfs 里没有 —— 看起来很干净
+    expect(imageRootfs(image)['/app/.npmrc']).toBeUndefined();
+    // 但历史层里还在，这正是第 3 关要考的点
+    const leaked = image.layers.some((layer) =>
+      Object.values(layer.files).some((content) => content.includes('super-secret'))
+    );
+    expect(leaked).toBe(true);
+  });
+
+  it('.dockerignore 里的东西不进上下文', async () => {
+    const { machine, store } = dockerMachine({
+      '/root/app/Dockerfile': 'FROM node:22-alpine\nWORKDIR /app\nCOPY . .\n',
+      '/root/app/index.js': 'ok\n',
+      '/root/app/.env': 'SECRET=1\n',
+      '/root/app/.dockerignore': '.env\nnode_modules\n',
+    });
+    await machine.exec('docker build -t app:clean app');
+    const rootfs = imageRootfs(store.get('app:clean')!);
+    expect(rootfs['/app/index.js']).toBe('ok\n');
+    expect(rootfs['/app/.env']).toBeUndefined();
+  });
+
+  it('--build-arg 与 --target', async () => {
+    const { machine, store } = dockerMachine({
+      '/root/app/Dockerfile': [
+        'ARG TAG=22-alpine',
+        'FROM node:${TAG} AS builder',
+        'ARG APP_VERSION=dev',
+        'LABEL version=$APP_VERSION',
+        'FROM node:${TAG}',
+        'LABEL stage=final',
+      ].join('\n'),
+    });
+    const result = await machine.exec('docker build --build-arg APP_VERSION=1.4.0 --target builder -t app:b app');
+    expect(result.code).toBe(0);
+    expect(store.get('app:b')!.config.Labels).toEqual({ version: '1.4.0' });
+  });
+
+  it('找不到 Dockerfile 的报错', async () => {
+    const { machine } = dockerMachine({ '/root/app/keep': '' });
+    const result = await machine.exec('docker build -t app:v1 app');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('failed to read dockerfile');
+  });
+});
+
+describe('私有仓库', () => {
+  const CONTEXT = {
+    '/root/app/Dockerfile': 'FROM node:22-alpine\nWORKDIR /app\nCOPY index.js ./\n',
+    '/root/app/index.js': 'ok\n',
+  };
+
+  it('没登录推不上去', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    const result = await machine.exec('docker push harbor.corp.internal/team/app:v1');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('unauthorized: authentication required');
+  });
+
+  it('密码错了报 401', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    const result = await machine.exec('docker login harbor.corp.internal -u ci -p wrong');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('401 Unauthorized');
+  });
+
+  it('登录之后能推能拉，凭据落在 ~/.docker/config.json', async () => {
+    const { machine, harbor } = dockerMachine(CONTEXT);
+    const loggedIn = await machine.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
+    expect(loggedIn.stdout).toContain('Login Succeeded');
+    expect(loggedIn.stdout).toContain('WARNING! Using --password via the CLI is insecure.');
+
+    const config = JSON.parse(machine.vfs.readFile('/root/.docker/config.json'));
+    expect(atob(config.auths['harbor.corp.internal'].auth)).toBe('ci:S3cret!');
+
+    await machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    const pushed = await machine.exec('docker push harbor.corp.internal/team/app:v1');
+    expect(pushed.code).toBe(0);
+    expect(pushed.stdout).toContain('The push refers to repository [harbor.corp.internal/team/app]');
+    expect(pushed.stdout).toMatch(/v1: digest: sha256:[0-9a-f]{64} size: \d+/);
+    expect(harbor.listTags('team/app')).toEqual(['v1']);
+  });
+
+  it('推到没权限的项目被拒', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
+    await machine.exec('docker build -t harbor.corp.internal/other/app:v1 app');
+    const result = await machine.exec('docker push harbor.corp.internal/other/app:v1');
+    expect(result.stderr).toContain('denied: requested access to the resource is denied');
+  });
+
+  it('解析不了的主机名报 DNS 错误', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t registry.invalid/team/app:v1 app');
+    const result = await machine.exec('docker push registry.invalid/team/app:v1');
+    expect(result.stderr).toContain('dial tcp: lookup registry.invalid: no such host');
+  });
+
+  it('tag 不存在报 manifest unknown', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
+    await machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    await machine.exec('docker push harbor.corp.internal/team/app:v1');
+    const result = await machine.exec('docker pull harbor.corp.internal/team/app:v9');
+    expect(result.stderr).toContain('manifest unknown');
+  });
+
+  it('推上去再从另一台机器拉下来，内容一致', async () => {
+    const first = dockerMachine(CONTEXT);
+    await first.machine.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
+    await first.machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    await first.machine.exec('docker push harbor.corp.internal/team/app:v1');
+
+    const second = createMachine({ now: () => NOW });
+    const store = new ImageStore();
+    second.install('docker', createDockerCommand({ store, network: first.network, now: () => NOW }));
+    await second.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
+    const pulled = await second.exec('docker pull harbor.corp.internal/team/app:v1');
+
+    expect(pulled.code).toBe(0);
+    expect(pulled.stdout).toContain('Status: Downloaded newer image for harbor.corp.internal/team/app:v1');
+    expect(store.get('harbor.corp.internal/team/app:v1')!.id)
+      .toBe(first.store.get('harbor.corp.internal/team/app:v1')!.id);
+  });
+});
+
+describe('docker 的其它子命令', () => {
+  const CONTEXT = {
+    '/root/app/Dockerfile': 'FROM node:22-alpine\nWORKDIR /app\nCOPY index.js ./\nCMD ["node","index.js"]\n',
+    '/root/app/index.js': 'ok\n',
+  };
+
+  it('images 的表头与列', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    const result = await machine.exec('docker images');
+    expect(result.stdout.split('\n')[0]).toBe('REPOSITORY                      TAG         IMAGE ID       CREATED         SIZE');
+    expect(result.stdout).toContain('harbor.corp.internal/team/app');
+    expect(result.stdout).toContain('5 minutes ago');
+    // 短名字不显示 docker.io/library/ 前缀
+    expect(result.stdout).toContain('node ');
+  });
+
+  it('tag / rmi', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t app:v1 app');
+    await machine.exec('docker tag app:v1 app:latest');
+    expect((await machine.exec('docker images')).stdout).toContain('latest');
+    const removed = await machine.exec('docker rmi app:latest');
+    expect(removed.stdout).toContain('Untagged: docker.io/library/app:latest');
+  });
+
+  it('inspect 打的是 OCI 的字段名', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t app:v1 app');
+    const parsed = JSON.parse((await machine.exec('docker inspect app:v1')).stdout);
+    expect(parsed[0].Config.Cmd).toEqual(['node', 'index.js']);
+    expect(parsed[0].Config.WorkingDir).toBe('/app');
+    expect(parsed[0].RootFS.Type).toBe('layers');
+    expect(parsed[0].Id).toMatch(/^sha256:/);
+  });
+
+  it('history 反着列，元数据指令没有层', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    await machine.exec('docker build -t app:v1 app');
+    const lines = (await machine.exec('docker history app:v1')).stdout.trim().split('\n');
+    expect(lines[0]).toMatch(/^IMAGE\s+CREATED\s+CREATED BY\s+SIZE$/);
+    expect(lines[1]).toContain('#(nop) CMD ["node","index.js"]');
+    expect(lines[1]).toContain('<missing>');
+  });
+
+  it('不认识的子命令', async () => {
+    const { machine } = dockerMachine(CONTEXT);
+    const result = await machine.exec('docker compose up');
+    expect(result.code).toBe(125);
+    expect(result.stderr).toContain("docker: 'compose' is not a docker command.");
+  });
+});
+
+describe('层与摘要', () => {
+  it('层的 digest 只由内容决定，与顺序无关', () => {
+    const a = makeLayer({ '/b': '2', '/a': '1' }, [], 'x');
+    const b = makeLayer({ '/a': '1', '/b': '2' }, [], 'y');
+    expect(a.digest).toBe(b.digest);
+  });
+
+  it('删除会在叠加时生效，连子树一起', () => {
+    const rootfs = flattenLayers([
+      makeLayer({ '/app/a': '1', '/app/deep/b': '2', '/keep': '3' }, [], 'add'),
+      makeLayer({}, ['/app'], 'remove'),
+    ]);
+    expect(rootfs).toEqual({ '/keep': '3' });
+  });
+
+  it('digestOf 带 sha256: 前缀', () => {
+    expect(digestOf('abc')).toBe('sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('buildImage 可以脱离 CLI 直接调用（出题脚本要用）', async () => {
+    const machine: Machine = createMachine({
+      files: { '/ctx/Dockerfile': 'FROM scratch\nCOPY a.txt /a.txt\n', '/ctx/a.txt': 'hello\n' },
+    });
+    const store = new ImageStore();
+    const outcome = await buildImage({
+      context: machine.vfs,
+      contextRoot: '/ctx',
+      tags: ['demo:1'],
+      store,
+      created: CREATED,
+    });
+    expect(outcome.code).toBe(0);
+    expect(imageRootfs(outcome.image!)).toEqual({ '/a.txt': 'hello\n' });
+  });
+});

--- a/tests/opslab/oci.test.ts
+++ b/tests/opslab/oci.test.ts
@@ -325,12 +325,40 @@ describe('私有仓库', () => {
     expect(harbor.listTags('team/app')).toEqual(['v1']);
   });
 
-  it('推到没权限的项目被拒', async () => {
+  it('COPY 单个文件到不带斜杠的目标会改名，目录来源保留层级', async () => {
+    const { machine, store } = dockerMachine({
+      '/root/app/Dockerfile': [
+        'FROM node:22-alpine',
+        'COPY index.js /srv/server.js',
+        'COPY assets /srv/assets',
+      ].join('\n'),
+      '/root/app/index.js': 'ok\n',
+      '/root/app/assets/css/site.css': 'body{}\n',
+      '/root/app/assets/logo.svg': '<svg/>\n',
+    });
+    expect((await machine.exec('docker build -t app:copy app')).code).toBe(0);
+    const rootfs = imageRootfs(store.get('app:copy')!);
+    expect(rootfs['/srv/server.js']).toBe('ok\n');
+    expect(rootfs['/srv/assets/css/site.css']).toBe('body{}\n');
+    expect(rootfs['/srv/assets/logo.svg']).toBe('<svg/>\n');
+  });
+
+  it('登录了但推到没权限的项目，报的是 denied 不是 unauthorized', async () => {
     const { machine } = dockerMachine(CONTEXT);
     await machine.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
     await machine.exec('docker build -t harbor.corp.internal/other/app:v1 app');
     const result = await machine.exec('docker push harbor.corp.internal/other/app:v1');
     expect(result.stderr).toContain('denied: requested access to the resource is denied');
+  });
+
+  it('push -a 把同一个仓库的所有 tag 都推上去', async () => {
+    const { machine, harbor } = dockerMachine(CONTEXT);
+    await machine.exec('docker login harbor.corp.internal -u ci -p "S3cret!"');
+    await machine.exec('docker build -t harbor.corp.internal/team/app:v1 app');
+    await machine.exec('docker tag harbor.corp.internal/team/app:v1 harbor.corp.internal/team/app:latest');
+    const pushed = await machine.exec('docker push -a harbor.corp.internal/team/app:v1');
+    expect(pushed.code).toBe(0);
+    expect(harbor.listTags('team/app')).toEqual(['latest', 'v1']);
   });
 
   it('解析不了的主机名报 DNS 错误', async () => {


### PR DESCRIPTION
第 3-4 片。集群之下的那一层 —— 学员敲的每条命令都落在这里，kubectl 只是这台机器上的一个命令。

## 做了什么

| 模块 | 内容 |
| --- | --- |
| `machine/vfs.ts` | 一棵树同时供终端、IDE、kubectl 的 fs 垫片读写；快照/还原 |
| `machine/shell/parser.ts` | tree-sitter-bash → 自己的小 AST |
| `machine/shell/shell.ts` | 执行器：管道、重定向、函数、case、set -e/-u/pipefail、展开、通配 |
| `machine/shell/coreutils.ts` | 30 个命令，GNU 风格的选项解析与报错文本 |
| `machine/machine.ts` | 一台机器：磁盘 + shell + 装好的命令 + 操作记录 |
| `machine/oci/*` | SHA-256、Dockerfile 解析、真构建、镜像库、私有仓库、docker CLI |

## 两处对设计文档的修正

1. **shell 解析不用 `sh-syntax`。** 它是 mvdan/sh 给 shfmt 编的 WASM，跨边界后 AST 里的 `Cmd` 只剩位置信息，节点类型和参数全丢 —— 能重新打印，不能解释执行。换成 `web-tree-sitter` + `tree-sitter-bash`（都是 MIT），拿到的是完整的具体语法树。
2. **`Language.load` 不按路径加载。** 它内部走动态 `import()`，jest 的 CJS 环境直接抛 `A dynamic import callback was invoked without --experimental-vm-modules`；浏览器里那条路也走不通。改成自己读字节再喂给它，两端同一条路。

## 保真度上刻意较真的地方

- `2>&1` 与 `> f` 的**先后顺序**会改变 stderr 去哪，`cmd > f 2>&1` 和 `cmd 2>&1 > f` 结果不同。
- `> f` 即使命令没有输出也会把文件建出来。
- `grep` 没匹配到退出码是 1，脚本里当条件用。
- `case` 的 `*)` 分支不做文件名通配 —— 否则兜底分支会先被换成当前目录的文件列表。
- `" "` 里的空格。tree-sitter 不为纯空白生成 `string_content`，直接遍历子节点会让 `cut -d " "` 变成按空字符切；按位置把缝隙补回来。
- 把密钥 `COPY` 进去再 `rm` 掉，最终 rootfs 干净，但**历史层里查得到** —— 第 3 关考的就是这个。
- registry 的四种错误分得清：401 没登录 / 403 没权限 / no such host 名字解析不了 / manifest unknown tag 打错。

## 构建期抓到的三个只在浏览器里出现的问题

- web-tree-sitter 的 emscripten wasm 被 webpack 当成 wasm 模块解析，报 `GOT.mem` / `env` 找不到 → 改成 `asset/resource`。
- 它的 ESM 产物里有 `fs/promises` 与 `module` 的 Node 分支 → 照仓库既有的做法用 `NormalModuleReplacementPlugin` 定点替换，不加全局 `resolve.fallback`（原因见 next.config.js 里那段注释）。
- 语法文件要按 URL fetch → 加 `scripts/copy-opslab-assets.js`，挂在 `predev` / `prebuild` 上。

## 验证

- `npx jest tests/opslab` → 9 suites / 254 用例通过（新增 98 条）
- `npm test` → 8/8 套件通过
- `npm run projects:verify` → 12 关参考实现全过
- `npm run build` → 通过；另外临时加了一个 import 机器层的页面单独 build 过一遍，确认能进浏览器 bundle（已删）
- 新增一条守卫：造出 `window` / `document` / `fetch`，逼解析器走浏览器分支，验证 `/opslab/tree-sitter-bash.wasm` 这条路真的通

不 bump 版本、不打 tag。