### PR TITLE
给 jest 更大的堆：opslab 测试偶发整套失败

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -140,9 +140,20 @@ class TestRunner {
         jestArgs.push('--bail');
       }
 
+      /**
+       * 给 jest 更大的堆。
+       *
+       * opslab 那套要把 142MB 的 CLI 产物编成 WebAssembly，每个测试文件各编一次
+       * （jest 的模块注册表是按文件隔离的）。默认堆在机器同时干着别的活时会不够，
+       * 表现成偶发的整套失败 —— 偶发的失败比稳定的失败更费人。
+       */
       const jest = spawn('npx', ['jest', ...jestArgs], {
         stdio: 'inherit',
-        shell: true
+        shell: true,
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS || ''} --max-old-space-size=8192`.trim(),
+        },
       });
 
       jest.on('close', (code) => {


### PR DESCRIPTION
`npm test` 有一次报 opslab 那套失败，但单独 `npx jest tests/opslab` 连跑 6 次都过。

原因是内存：opslab 的测试要把 142MB 的 CLI 产物编成 WebAssembly，而且**每个测试文件各编一次**（jest 的模块注册表按文件隔离，`kubectl-integration` / `cli-runtime` / `stages` 三个文件各一份）。那次失败发生在同一条命令链里 `npm run build` 刚跑完之后，机器上还压着 Next 的构建。

测试运行器给 jest 的子进程加上 `--max-old-space-size=8192`。

偶发的失败比稳定的失败更费人：重跑一次就过，于是没人会去查。

验证：`npm test` 8/8。