### PR TITLE
opslab 网络层：连不上时症状要能反推出层

### DIFF
--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -238,6 +238,8 @@ export interface OpsWorldSpec {
   baseImages?: Record<string, 'node' | 'python' | 'static'>;
   registries?: OpsRegistrySpec[];
   machine?: OpsMachineSpec;
+  /** 集群外的名字：`git.corp.internal` -> ['10.10.0.30'] */
+  externalHosts?: Record<string, string[]>;
   /**
    * 哪些主机名解析得到 apiserver。
    *

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -26,7 +26,8 @@ import {
   ReplicaSetController,
   SchedulerController,
 } from './workloads';
-import type { RegistryAuth } from './runtime';
+import type { ImageBehavior, RegistryAuth } from './runtime';
+import { Network, createNetwork } from '../net';
 
 export interface NodeSpec {
   name: string;
@@ -50,6 +51,10 @@ export interface ClusterOptions {
   registries?: Record<string, RegistryAuth>;
   /** 目录里没有时再问一次（学员自己 push 上去的镜像） */
   resolveImage?: (image: string) => ImageSpec | undefined;
+  /** 集群外的名字，`harbor.corp.internal` 之类 */
+  externalHosts?: Record<string, string[]>;
+  /** 哪些地址暴露到了哪些分区（Gateway / LoadBalancer 往这里加） */
+  exposure?: (address: string) => import('../net').Zone[];
   /**
    * 集群「已经跑了多久」。
    *
@@ -67,6 +72,8 @@ export class Cluster {
   readonly scheme: Scheme;
   readonly registry: Registry;
   readonly apiServer: ApiServer;
+  /** 网络：DNS、Service 转发、NetworkPolicy 判定，全都读 apiserver 里的对象 */
+  readonly network: Network;
 
   private controllers: Controller[] = [];
   private uidSeq = 0;
@@ -89,8 +96,22 @@ export class Cluster {
       uid: () => `uid-${String(++this.uidSeq).padStart(6, '0')}`,
     });
     this.apiServer = createApiServer({ registry: this.registry, scheme: this.scheme, now });
+    this.network = createNetwork({
+      registry: this.registry,
+      scheme: this.scheme,
+      externalHosts: options.externalHosts,
+      exposure: options.exposure,
+      imageOf: (image) => this.imageBehaviorOf(image),
+      now,
+    });
 
     this.seed();
+  }
+
+  /** 这个镜像的运行时行为：端口、路由、内存。网络与 kubelet 共用同一份。 */
+  imageBehaviorOf(image: string | undefined): ImageBehavior | undefined {
+    if (!image) return undefined;
+    return this.options.images?.[image] ?? this.options.resolveImage?.(image);
   }
 
   /** 世界的墙钟：起始时刻 + 虚拟流逝 */

--- a/src/lib/opslab/controllers/index.ts
+++ b/src/lib/opslab/controllers/index.ts
@@ -7,7 +7,8 @@
 export { Controller, Informer, WorkQueue, objectKey, splitKey, isConflict, isNotFound } from './framework';
 export type { ControllerContext, WorkQueueOptions } from './framework';
 export {
-  CORE_RESOURCES, CONFIGMAPS, DEPLOYMENTS, ENDPOINTS, EVENTS, NAMESPACES, NODES, PODS,
+  CORE_RESOURCES, CONFIGMAPS, DEPLOYMENTS, ENDPOINTS, EVENTS, INGRESSCLASSES, INGRESSES,
+  NAMESPACES, NETWORKPOLICIES, NODES, PODS,
   REPLICASETS, SECRETS, SERVICEACCOUNTS, SERVICES, POD_TEMPLATE_HASH,
   matchesSelector, templateHash,
 } from './resources';

--- a/src/lib/opslab/controllers/resources.ts
+++ b/src/lib/opslab/controllers/resources.ts
@@ -62,10 +62,27 @@ export const SERVICEACCOUNTS: ResourceDefinition = {
   kind: 'ServiceAccount', namespaced: true, shortNames: ['sa'],
 };
 
+export const NETWORKPOLICIES: ResourceDefinition = {
+  group: 'networking.k8s.io', version: 'v1', resource: 'networkpolicies',
+  singular: 'networkpolicy', kind: 'NetworkPolicy', namespaced: true, shortNames: ['netpol'],
+};
+
+export const INGRESSES: ResourceDefinition = {
+  group: 'networking.k8s.io', version: 'v1', resource: 'ingresses',
+  singular: 'ingress', kind: 'Ingress', namespaced: true, shortNames: ['ing'],
+  subresources: ['status'],
+};
+
+export const INGRESSCLASSES: ResourceDefinition = {
+  group: 'networking.k8s.io', version: 'v1', resource: 'ingressclasses',
+  singular: 'ingressclass', kind: 'IngressClass', namespaced: false, shortNames: [],
+};
+
 export const CORE_RESOURCES: ResourceDefinition[] = [
   NAMESPACES, NODES, PODS, SERVICES, ENDPOINTS, EVENTS,
   CONFIGMAPS, SECRETS, SERVICEACCOUNTS,
   REPLICASETS, DEPLOYMENTS,
+  NETWORKPOLICIES, INGRESSES, INGRESSCLASSES,
 ];
 
 /** Deployment 给自己的 ReplicaSet 打的标签，用来区分不同版本 */

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -16,6 +16,7 @@ import {
 } from '../machine/oci';
 import type { ImageBehavior } from '../controllers';
 import { baseImageOf, toolchainFor } from './toolchains';
+import { createNetTools } from '../net';
 import { CliRuntime, installClusterCli } from '../wasm';
 import type { KubeObject } from '../apiserver';
 
@@ -72,6 +73,13 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     ])),
     clusterAgeMs,
     resolveImage: (image) => lookupPushedImage(image),
+    externalHosts: {
+      // 私有仓库这些内网服务，办公网与集群都该解析得到
+      ...Object.fromEntries((spec.registries ?? []).map((registry, index) => [
+        registry.host, [`10.10.0.${20 + index}`],
+      ])),
+      ...(spec.externalHosts ?? {}),
+    },
   });
 
   const machineSpec = spec.machine ?? {};
@@ -98,6 +106,15 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   for (const [reference, toolchain] of Object.entries(spec.baseImages ?? {})) {
     images.add(baseImageOf(reference, toolchain, new Date(cluster.wallClock()).toISOString()));
     toolchains[normalizeReference(reference)] = toolchainFor(toolchain);
+  }
+
+  // 网络工具。跳板机在办公网，够不到 Pod 网段与 ClusterIP —— 这是分区的意义。
+  for (const [name, handler] of Object.entries(createNetTools({
+    network: cluster.network,
+    source: () => ({ zone: 'office', label: machineSpec.hostname ?? 'jump-01', ip: '10.10.1.5' }),
+    advance: (ms) => { void cluster.advanceBy(ms); },
+  }))) {
+    machine.install(name, handler);
   }
 
   machine.install('docker', createDockerCommand({

--- a/src/lib/opslab/net/dns.ts
+++ b/src/lib/opslab/net/dns.ts
@@ -1,0 +1,151 @@
+/**
+ * 集群 DNS
+ *
+ * CoreDNS 的那套名字规则。看着琐碎，但「为什么 `curl portal` 在这个命名空间
+ * 能通、换个命名空间就不通」这类问题全靠它，而且第 10 关有一个专门的坑：
+ * egress 策略把 DNS 一起切断之后，症状是**名字解析失败**而不是连接超时，
+ * 两者查法完全不同。
+ *
+ * `ndots:5` 是最容易踩的一条：Pod 的 resolv.conf 默认写着它，意思是
+ * 「点数少于 5 的名字先当成相对名，挨个拼 search 域去试」。所以
+ * `curl portal.payments.svc.cluster.local`（4 个点）会先试
+ * `portal.payments.svc.cluster.local.payments.svc.cluster.local` —— 这就是
+ * 集群里 DNS 查询量异常高的经典原因。
+ */
+import type { Resolution, Source } from './types';
+
+export interface DnsView {
+  /** 命名空间里的 Service：名字 -> ClusterIP（headless 时为 undefined） */
+  service(namespace: string, name: string): { clusterIP?: string; externalName?: string; headless: boolean } | undefined;
+  /** headless Service 背后的 Pod 地址 */
+  endpoints(namespace: string, name: string): string[];
+  /** 集群外的名字，由世界定义（`harbor.corp.internal` 之类） */
+  external(name: string): string[] | undefined;
+}
+
+export const CLUSTER_DOMAIN = 'cluster.local';
+
+/** Pod 的 resolv.conf 长这样，`kubectl exec ... cat /etc/resolv.conf` 打出来的就是它 */
+export function resolvConf(namespace: string): string {
+  return [
+    'search '
+      + `${namespace}.svc.${CLUSTER_DOMAIN} svc.${CLUSTER_DOMAIN} ${CLUSTER_DOMAIN}`,
+    'nameserver 10.96.0.10',
+    'options ndots:5',
+    '',
+  ].join('\n');
+}
+
+export interface ResolveOptions {
+  view: DnsView;
+  source: Source;
+  /** DNS 本身通不通。egress 策略切断 53 端口时传 false。 */
+  dnsReachable?: boolean;
+}
+
+/**
+ * 解析一个名字。
+ *
+ * 集群里按 ndots + search 域来；集群外（办公网的跳板机）只查世界里声明过的
+ * 外部名字，查不到就是 NXDOMAIN，和真的一样。
+ */
+export function resolve(name: string, options: ResolveOptions): Resolution {
+  const { view, source } = options;
+  const attempts: string[] = [];
+
+  // IP 直接用，不查 DNS
+  if (isIpv4(name)) {
+    return { question: name, canonical: name, addresses: [name], attempts: [], kind: 'host' };
+  }
+
+  const inCluster = source.zone === 'cluster';
+  if (!inCluster) {
+    const external = view.external(name);
+    return external
+      ? { question: name, canonical: name, addresses: external, attempts: [name], kind: 'external' }
+      : { question: name, addresses: [], attempts: [name], kind: 'nxdomain' };
+  }
+
+  if (options.dnsReachable === false) {
+    // 查不到 DNS 服务器：症状是解析超时，不是「名字不存在」
+    return { question: name, addresses: [], attempts: [name], kind: 'nxdomain' };
+  }
+
+  const namespace = source.namespace ?? 'default';
+  for (const candidate of candidatesFor(name, namespace)) {
+    attempts.push(candidate);
+    const answer = lookupOne(candidate, view, namespace);
+    if (answer) return { ...answer, question: name, attempts };
+  }
+  return { question: name, addresses: [], attempts, kind: 'nxdomain' };
+}
+
+/**
+ * `ndots:5` 的展开顺序。
+ *
+ * 点数 < 5 的名字先拼 search 域再试自己；>= 5 的先试自己。绝对名（末尾带点）
+ * 不拼。这个顺序决定了查询次数，也决定了「短名字在本命名空间能通、跨命名空间
+ * 不通」的行为。
+ */
+export function candidatesFor(name: string, namespace: string): string[] {
+  if (name.endsWith('.')) return [name.slice(0, -1)];
+
+  const search = [
+    `${namespace}.svc.${CLUSTER_DOMAIN}`,
+    `svc.${CLUSTER_DOMAIN}`,
+    CLUSTER_DOMAIN,
+  ];
+  const dots = (name.match(/\./g) ?? []).length;
+  const suffixed = search.map((suffix) => `${name}.${suffix}`);
+  return dots >= 5 ? [name, ...suffixed] : [...suffixed, name];
+}
+
+function lookupOne(
+  candidate: string,
+  view: DnsView,
+  defaultNamespace: string
+): Omit<Resolution, 'question' | 'attempts'> | undefined {
+  const parts = candidate.split('.');
+
+  // <svc>.<ns>.svc.cluster.local
+  if (parts.length >= 5 && parts.slice(2).join('.') === `svc.${CLUSTER_DOMAIN}`) {
+    return serviceAnswer(view, parts[1], parts[0], candidate);
+  }
+  // <svc>.<ns>
+  if (parts.length === 2) {
+    const found = serviceAnswer(view, parts[1], parts[0], candidate);
+    if (found) return found;
+  }
+  // 裸名字：本命名空间
+  if (parts.length === 1) {
+    const found = serviceAnswer(view, defaultNamespace, parts[0], candidate);
+    if (found) return found;
+  }
+  const external = view.external(candidate);
+  return external ? { canonical: candidate, addresses: external, kind: 'external' } : undefined;
+}
+
+function serviceAnswer(
+  view: DnsView,
+  namespace: string,
+  name: string,
+  canonical: string
+): Omit<Resolution, 'question' | 'attempts'> | undefined {
+  const service = view.service(namespace, name);
+  if (!service) return undefined;
+
+  if (service.externalName) {
+    const target = view.external(service.externalName);
+    return { canonical, addresses: target ?? [], kind: 'external' };
+  }
+  if (service.headless) {
+    // headless 直接回后端 Pod 的地址，没有 VIP —— StatefulSet 靠它做稳定寻址
+    return { canonical, addresses: view.endpoints(namespace, name), kind: 'headless' };
+  }
+  return { canonical, addresses: service.clusterIP ? [service.clusterIP] : [], kind: 'service' };
+}
+
+export function isIpv4(value: string): boolean {
+  const parts = value.split('.');
+  return parts.length === 4 && parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}

--- a/src/lib/opslab/net/index.ts
+++ b/src/lib/opslab/net/index.ts
@@ -1,0 +1,13 @@
+/**
+ * 网络层
+ */
+export { Network, createNetwork, CONNECT_TIMEOUT_MS, type NetworkDeps } from './network';
+export {
+  resolve, candidatesFor, resolvConf, isIpv4, CLUSTER_DOMAIN, type DnsView, type ResolveOptions,
+} from './dns';
+export {
+  evaluate, evaluateEgress, evaluateIngress, directionsOf, matchesSelector, inCidr,
+  type PolicyDecision, type PolicyPeer, type Traffic,
+} from './policy';
+export type { ConnectResult, ConnectKind, Hop, Resolution, Source, Target, Zone } from './types';
+export { createNetTools, parseUrl, type NetToolsOptions } from './tools';

--- a/src/lib/opslab/net/network.ts
+++ b/src/lib/opslab/net/network.ts
@@ -1,0 +1,370 @@
+/**
+ * 网络
+ *
+ * 读的全是 apiserver 里的对象（Service、Endpoints、Pod、NetworkPolicy），
+ * 自己不存状态 —— 于是「改了策略之后立刻生效」是自然的，不需要谁去通知谁。
+ *
+ * 一次连接要过五关，每一关失败的症状都不同，这正是要教的东西：
+ *
+ *   1. 名字解析      → NXDOMAIN / 解析超时
+ *   2. 地址可达性    → no route（办公网够不到 Pod IP）
+ *   3. 网络策略      → 超时（丢包，不是拒绝）
+ *   4. 有没有后端    → 连接被拒绝（Service 存在但 Endpoints 是空的）
+ *   5. 应用怎么答    → HTTP 状态码
+ */
+import type { KubeObject, Registry, Scheme } from '../apiserver';
+import type { ImageBehavior } from '../controllers/runtime';
+import { CLUSTER_DOMAIN, isIpv4, resolve, type DnsView } from './dns';
+import { evaluate, type PolicyPeer } from './policy';
+import type { ConnectResult, Hop, Resolution, Source, Target, Zone } from './types';
+
+export interface NetworkDeps {
+  registry: Registry;
+  scheme: Scheme;
+  /** 集群外的名字：`harbor.corp.internal` -> ['10.10.0.20'] */
+  externalHosts?: Record<string, string[]>;
+  /** 镜像的行为：端口上有没有人听、HTTP 路径返回什么 */
+  imageOf(image: string): ImageBehavior | undefined;
+  now(): number;
+  /**
+   * 哪些地址能从哪些分区到达。
+   *
+   * Gateway 与 LoadBalancer 把集群里的服务暴露到某个分区，就是往这里加条目。
+   * 不在表里的地址，办公网与外网都够不到 —— Pod IP 天然如此。
+   */
+  exposure?(address: string): Zone[];
+}
+
+/** 连一次要多久（虚拟毫秒）。超时按 kube-proxy 的默认行为算。 */
+const LATENCY = { dns: 2, hop: 1, app: 8 };
+export const CONNECT_TIMEOUT_MS = 30_000;
+
+export class Network {
+  constructor(private readonly deps: NetworkDeps) {}
+
+  /** Pod 的 resolv.conf，`kubectl exec ... cat /etc/resolv.conf` 就该打这个 */
+  resolvConfOf(namespace: string): string {
+    return [
+      `search ${namespace}.svc.${CLUSTER_DOMAIN} svc.${CLUSTER_DOMAIN} ${CLUSTER_DOMAIN}`,
+      'nameserver 10.96.0.10',
+      'options ndots:5',
+      '',
+    ].join('\n');
+  }
+
+  /** 只查名字，不连。`dig` / `nslookup` 用它。 */
+  resolve(name: string, source: Source): Resolution {
+    return resolve(name, { view: this.dnsView(), source, dnsReachable: this.dnsReachable(source) });
+  }
+
+  /**
+   * 连一次。
+   *
+   * 返回的 hops 是完整的包路径，拓扑的数据面层与 Hubble 的流日志都读它。
+   */
+  connect(source: Source, target: Target): ConnectResult {
+    const hops: Hop[] = [];
+    let elapsed = 0;
+
+    // 1. 名字解析
+    let addresses: string[];
+    if (isIpv4(target.host)) {
+      addresses = [target.host];
+    } else {
+      const answer = this.resolve(target.host, source);
+      elapsed += LATENCY.dns;
+      hops.push({
+        at: 'dns',
+        detail: answer.addresses.length
+          ? `${target.host} -> ${answer.addresses.join(',')}`
+          : `${target.host}: NXDOMAIN（试过 ${answer.attempts.length} 个名字）`,
+        verdict: answer.addresses.length ? 'forward' : 'drop',
+        elapsedMs: LATENCY.dns,
+      });
+      if (answer.addresses.length === 0) {
+        return {
+          kind: 'dns-failure', hops, elapsedMs: elapsed,
+          blockedBy: this.dnsReachable(source) ? 'NXDOMAIN' : 'DNS unreachable',
+        };
+      }
+      addresses = answer.addresses;
+    }
+
+    const address = addresses[0];
+
+    // 2. 这个分区够不够得到这个地址
+    if (!this.reachable(source.zone, address)) {
+      elapsed += LATENCY.hop;
+      hops.push({
+        at: `net/${source.zone}`,
+        detail: `${address} 不在 ${source.zone} 能到达的范围里`,
+        verdict: 'drop',
+        elapsedMs: LATENCY.hop,
+      });
+      return { kind: 'no-route', hops, elapsedMs: elapsed, blockedBy: 'no route to host' };
+    }
+
+    // 3. 目标是 Service 还是 Pod
+    const service = this.serviceByClusterIp(address);
+    const backends = service
+      ? this.backendsOf(service, target.port)
+      : this.podByIp(address)
+        ? [{ pod: this.podByIp(address)!, port: target.port }]
+        : [];
+
+    if (service) {
+      elapsed += LATENCY.hop;
+      hops.push({
+        at: `svc/${service.metadata.namespace}/${service.metadata.name}`,
+        detail: backends.length
+          ? `ClusterIP ${address}:${target.port} -> ${backends.length} 个后端`
+          : `ClusterIP ${address}:${target.port} 没有后端（Endpoints 为空）`,
+        verdict: backends.length ? 'forward' : 'reject',
+        elapsedMs: LATENCY.hop,
+      });
+      if (backends.length === 0) {
+        // Service 有 VIP 但没有 Endpoints：kube-proxy 直接回 RST
+        return { kind: 'refused', hops, elapsedMs: elapsed, blockedBy: 'no endpoints' };
+      }
+    }
+
+    if (backends.length === 0) {
+      elapsed += LATENCY.hop;
+      hops.push({ at: `host/${address}`, detail: '没有这台主机', verdict: 'drop', elapsedMs: LATENCY.hop });
+      return { kind: 'no-route', hops, elapsedMs: elapsed, blockedBy: 'no route to host' };
+    }
+
+    // 4. 网络策略。两端都要放行，被拒绝表现为丢包 -> 超时。
+    const chosen = backends[0];
+    const decision = evaluate(this.policies(), {
+      source: this.peerOf(source),
+      destination: this.peerOfPod(chosen.pod),
+      port: chosen.port,
+      protocol: 'TCP',
+    });
+    if (!decision.allowed) {
+      hops.push({
+        at: `policy/${decision.blockedBy}`,
+        detail: '包被丢弃（NetworkPolicy 默认拒绝），表现为超时而不是拒绝',
+        verdict: 'drop',
+        elapsedMs: CONNECT_TIMEOUT_MS,
+      });
+      return {
+        kind: 'timeout',
+        hops,
+        elapsedMs: elapsed + CONNECT_TIMEOUT_MS,
+        blockedBy: decision.blockedBy,
+      };
+    }
+    if (decision.egress.allowedBy || decision.ingress.allowedBy) {
+      hops.push({
+        at: 'policy',
+        detail: [
+          decision.egress.allowedBy && `egress 放行：${decision.egress.allowedBy}`,
+          decision.ingress.allowedBy && `ingress 放行：${decision.ingress.allowedBy}`,
+        ].filter(Boolean).join('；'),
+        verdict: 'forward',
+        elapsedMs: 0,
+      });
+    }
+
+    // 5. 端口上有没有人听、应用怎么答
+    return this.deliver(chosen.pod, chosen.port, target, hops, elapsed);
+  }
+
+  private deliver(
+    pod: KubeObject,
+    port: number,
+    target: Target,
+    hops: Hop[],
+    elapsed: number
+  ): ConnectResult {
+    const containers = ((pod.spec ?? {}) as any).containers ?? [];
+    const behavior = this.deps.imageOf(containers[0]?.image) ?? {};
+    const listens = behavior.listens ?? declaredPorts(containers);
+    const podRef = `pod/${pod.metadata.namespace}/${pod.metadata.name}`;
+
+    if (!isRunning(pod)) {
+      hops.push({ at: podRef, detail: 'Pod 不在 Running', verdict: 'reject', elapsedMs: LATENCY.hop });
+      return { kind: 'refused', hops, elapsedMs: elapsed + LATENCY.hop, blockedBy: 'pod not running' };
+    }
+    if (listens.length > 0 && !listens.includes(port)) {
+      hops.push({
+        at: podRef,
+        detail: `${port} 端口上没有人听（它在听 ${listens.join(',')}）`,
+        verdict: 'reject',
+        elapsedMs: LATENCY.hop,
+      });
+      return { kind: 'refused', hops, elapsedMs: elapsed + LATENCY.hop, blockedBy: 'connection refused' };
+    }
+
+    const path = target.path ?? '/';
+    const status = behavior.routes?.[path] ?? (behavior.routes ? 404 : 200);
+    hops.push({
+      at: podRef,
+      detail: `${target.method ?? 'GET'} ${path} -> ${status}`,
+      verdict: 'deliver',
+      elapsedMs: LATENCY.app,
+    });
+    return {
+      kind: 'ok',
+      status,
+      body: bodyFor(status, pod),
+      hops,
+      elapsedMs: elapsed + LATENCY.app,
+    };
+  }
+
+  /* ---------------- 从 apiserver 里读出来的视图 ---------------- */
+
+  private list(resource: string, namespace?: string): KubeObject[] {
+    const definition = this.deps.scheme.get({ group: '', version: 'v1', resource });
+    if (!definition) return [];
+    return this.deps.registry.list(definition, { namespace }).items;
+  }
+
+  policies(): KubeObject[] {
+    const definition = this.deps.scheme.get({
+      group: 'networking.k8s.io', version: 'v1', resource: 'networkpolicies',
+    });
+    if (!definition) return [];
+    return this.deps.registry.list(definition).items;
+  }
+
+  private dnsView(): DnsView {
+    return {
+      service: (namespace, name) => {
+        const found = this.list('services', namespace).find((item) => item.metadata.name === name);
+        if (!found) return undefined;
+        const spec = (found.spec ?? {}) as any;
+        return {
+          clusterIP: spec.clusterIP,
+          externalName: spec.externalName,
+          headless: spec.clusterIP === 'None' || (!spec.clusterIP && !spec.externalName),
+        };
+      },
+      endpoints: (namespace, name) => {
+        const found = this.list('endpoints', namespace).find((item) => item.metadata.name === name);
+        return ((found?.subsets ?? []) as any[]).flatMap((subset) =>
+          (subset.addresses ?? []).map((entry: any) => entry.ip)
+        );
+      },
+      external: (name) => this.deps.externalHosts?.[name],
+    };
+  }
+
+  private serviceByClusterIp(ip: string): KubeObject | undefined {
+    return this.list('services').find((item) => ((item.spec ?? {}) as any).clusterIP === ip);
+  }
+
+  private podByIp(ip: string): KubeObject | undefined {
+    return this.list('pods').find((item) => ((item.status ?? {}) as any).podIP === ip);
+  }
+
+  /** Service 后面挂着哪些 Ready 的 Pod，以及要打到它们的哪个端口 */
+  private backendsOf(service: KubeObject, port: number): Array<{ pod: KubeObject; port: number }> {
+    const spec = (service.spec ?? {}) as any;
+    const mapping = (spec.ports ?? []).find((entry: any) => entry.port === port);
+    if (!mapping) return [];
+    const targetPort = Number(mapping.targetPort ?? mapping.port);
+
+    const namespace = service.metadata.namespace;
+    const endpoints = this.list('endpoints', namespace)
+      .find((item) => item.metadata.name === service.metadata.name);
+    const ips = ((endpoints?.subsets ?? []) as any[]).flatMap((subset) =>
+      (subset.addresses ?? []).map((entry: any) => entry.ip)
+    );
+    return ips
+      .map((ip) => this.podByIp(ip))
+      .filter((pod): pod is KubeObject => Boolean(pod))
+      .map((pod) => ({ pod, port: targetPort }));
+  }
+
+  private peerOf(source: Source): PolicyPeer {
+    if (source.zone !== 'cluster' || !source.podName) {
+      return { ip: source.ip ?? '10.10.0.1' };
+    }
+    const pod = this.list('pods', source.namespace)
+      .find((item) => item.metadata.name === source.podName);
+    return pod ? this.peerOfPod(pod) : { ip: source.ip };
+  }
+
+  private peerOfPod(pod: KubeObject): PolicyPeer {
+    return {
+      namespace: pod.metadata.namespace,
+      labels: pod.metadata.labels,
+      namespaceLabels: this.namespaceLabels(pod.metadata.namespace),
+      ip: ((pod.status ?? {}) as any).podIP,
+    };
+  }
+
+  private namespaceLabels(namespace?: string): Record<string, string> {
+    if (!namespace) return {};
+    const found = this.list('namespaces').find((item) => item.metadata.name === namespace);
+    // 真集群会自动打上 kubernetes.io/metadata.name，很多策略靠它选命名空间
+    return { 'kubernetes.io/metadata.name': namespace, ...(found?.metadata.labels ?? {}) };
+  }
+
+  /**
+   * DNS 通不通。
+   *
+   * 写了 egress 策略却没放行 kube-system 的 53 端口，是这一层最常见的自伤。
+   */
+  private dnsReachable(source: Source): boolean {
+    if (source.zone !== 'cluster' || !source.podName) return true;
+    const decision = evaluate(this.policies(), {
+      source: this.peerOf(source),
+      destination: {
+        namespace: 'kube-system',
+        labels: { 'k8s-app': 'kube-dns' },
+        namespaceLabels: this.namespaceLabels('kube-system'),
+        ip: '10.96.0.10',
+      },
+      port: 53,
+      protocol: 'UDP',
+    });
+    return decision.egress.allowed;
+  }
+
+  /** 这个分区够不够得到这个地址 */
+  private reachable(zone: Zone, address: string): boolean {
+    if (zone === 'cluster' || zone === 'node') return true;
+    const exposed = this.deps.exposure?.(address) ?? [];
+    if (exposed.includes(zone)) return true;
+    // 办公网能到节点，到不了 Pod 网段与 ClusterIP —— 这是分区的意义所在
+    if (zone === 'office') return this.nodeAddresses().includes(address) || this.isExternal(address);
+    return this.isExternal(address);
+  }
+
+  private nodeAddresses(): string[] {
+    return this.list('nodes').flatMap((node) =>
+      (((node.status ?? {}) as any).addresses ?? [])
+        .filter((entry: any) => entry.type === 'InternalIP')
+        .map((entry: any) => entry.address)
+    );
+  }
+
+  private isExternal(address: string): boolean {
+    return Object.values(this.deps.externalHosts ?? {}).some((list) => list.includes(address));
+  }
+}
+
+function isRunning(pod: KubeObject): boolean {
+  return ((pod.status ?? {}) as any).phase === 'Running';
+}
+
+function declaredPorts(containers: any[]): number[] {
+  return containers.flatMap((container) =>
+    (container.ports ?? []).map((entry: any) => Number(entry.containerPort))
+  ).filter((port: number) => Number.isFinite(port));
+}
+
+function bodyFor(status: number, pod: KubeObject): string {
+  if (status >= 200 && status < 300) return `${pod.metadata.name}\n`;
+  if (status === 404) return '404 page not found\n';
+  return `HTTP ${status}\n`;
+}
+
+export function createNetwork(deps: NetworkDeps): Network {
+  return new Network(deps);
+}

--- a/src/lib/opslab/net/policy.ts
+++ b/src/lib/opslab/net/policy.ts
@@ -1,0 +1,217 @@
+/**
+ * NetworkPolicy 判定
+ *
+ * 三条容易被误解的规则，这里都按真语义实现：
+ *
+ * 1. **策略是「白名单开关」，不是「防火墙规则链」。** 没有任何策略选中一个 Pod
+ *    时，它是全通的；一旦有策略选中它并声明了某个方向，那个方向就变成
+ *    「默认拒绝 + 按规则放行」。
+ * 2. **两端都要放行。** A 访问 B，要 A 的 egress 允许出去，且 B 的 ingress
+ *    允许进来。只改一边是最常见的错。
+ * 3. **拒绝表现为丢包，不是拒绝。** 所以症状是超时。
+ *
+ * 还有一个几乎人人踩一次的坑：写了 egress 策略却忘了放行 DNS（kube-system 的
+ * 53 端口），结果所有名字都解析不了 —— 症状是「域名不存在」，看着完全不像
+ * 网络策略的问题。第 10 关就考这个。
+ */
+import type { KubeObject } from '../apiserver';
+
+export interface PolicyPeer {
+  /** 发起方/接收方是 Pod 时 */
+  namespace?: string;
+  labels?: Record<string, string>;
+  /** 命名空间自己的标签，namespaceSelector 要用 */
+  namespaceLabels?: Record<string, string>;
+  ip?: string;
+}
+
+export interface PolicyDecision {
+  allowed: boolean;
+  /** 这个方向有没有被策略「接管」。没接管就是默认全通。 */
+  isolated: boolean;
+  /** 放行它的那条策略 */
+  allowedBy?: string;
+  /** 接管了这个方向、但没有一条规则匹配的策略们 */
+  isolatedBy: string[];
+}
+
+export interface Traffic {
+  source: PolicyPeer;
+  destination: PolicyPeer;
+  port: number;
+  protocol?: string;
+}
+
+/**
+ * 出方向：source 这个 Pod 允不允许连出去。
+ *
+ * 集群外发起的流量没有 egress 一说，直接放行。
+ */
+export function evaluateEgress(policies: KubeObject[], traffic: Traffic): PolicyDecision {
+  if (!traffic.source.namespace) return { allowed: true, isolated: false, isolatedBy: [] };
+
+  const selecting = policies.filter(
+    (policy) => policy.metadata.namespace === traffic.source.namespace
+      && matchesSelector(podSelectorOf(policy), traffic.source.labels)
+      && directionsOf(policy).includes('Egress')
+  );
+  if (selecting.length === 0) return { allowed: true, isolated: false, isolatedBy: [] };
+
+  for (const policy of selecting) {
+    for (const rule of rulesOf(policy, 'egress')) {
+      if (!portMatches(rule.ports, traffic)) continue;
+      if (peerMatches(rule.to, traffic.destination)) {
+        return { allowed: true, isolated: true, allowedBy: nameOf(policy), isolatedBy: [] };
+      }
+    }
+  }
+  return { allowed: false, isolated: true, isolatedBy: selecting.map(nameOf) };
+}
+
+/** 入方向：destination 这个 Pod 允不允许被连 */
+export function evaluateIngress(policies: KubeObject[], traffic: Traffic): PolicyDecision {
+  if (!traffic.destination.namespace) return { allowed: true, isolated: false, isolatedBy: [] };
+
+  const selecting = policies.filter(
+    (policy) => policy.metadata.namespace === traffic.destination.namespace
+      && matchesSelector(podSelectorOf(policy), traffic.destination.labels)
+      && directionsOf(policy).includes('Ingress')
+  );
+  if (selecting.length === 0) return { allowed: true, isolated: false, isolatedBy: [] };
+
+  for (const policy of selecting) {
+    for (const rule of rulesOf(policy, 'ingress')) {
+      if (!portMatches(rule.ports, traffic)) continue;
+      if (peerMatches(rule.from, traffic.source)) {
+        return { allowed: true, isolated: true, allowedBy: nameOf(policy), isolatedBy: [] };
+      }
+    }
+  }
+  return { allowed: false, isolated: true, isolatedBy: selecting.map(nameOf) };
+}
+
+/** 两端都放行才通 */
+export function evaluate(policies: KubeObject[], traffic: Traffic): {
+  allowed: boolean;
+  egress: PolicyDecision;
+  ingress: PolicyDecision;
+  blockedBy?: string;
+} {
+  const egress = evaluateEgress(policies, traffic);
+  const ingress = evaluateIngress(policies, traffic);
+  const blockedBy = !egress.allowed
+    ? `egress:${egress.isolatedBy.join(',')}`
+    : !ingress.allowed
+      ? `ingress:${ingress.isolatedBy.join(',')}`
+      : undefined;
+  return { allowed: egress.allowed && ingress.allowed, egress, ingress, blockedBy };
+}
+
+/* ------------------------------------------------------------------ */
+
+interface Rule {
+  from?: unknown[];
+  to?: unknown[];
+  ports?: Array<{ port?: number | string; protocol?: string; endPort?: number }>;
+}
+
+function nameOf(policy: KubeObject): string {
+  return `${policy.metadata.namespace}/${policy.metadata.name}`;
+}
+
+function podSelectorOf(policy: KubeObject): Record<string, string> | undefined {
+  const spec = (policy.spec ?? {}) as { podSelector?: { matchLabels?: Record<string, string> } };
+  return spec.podSelector?.matchLabels;
+}
+
+/**
+ * 这条策略管哪些方向。
+ *
+ * `policyTypes` 没写时按内容推：有 `egress` 段就管出方向，否则只管入方向 ——
+ * 注意「只写了 podSelector、什么规则都没有」的策略是**默认拒绝入方向**，
+ * 这正是 deny-all 的标准写法。
+ */
+export function directionsOf(policy: KubeObject): string[] {
+  const spec = (policy.spec ?? {}) as { policyTypes?: string[]; ingress?: unknown[]; egress?: unknown[] };
+  if (spec.policyTypes?.length) return spec.policyTypes;
+  return spec.egress ? ['Ingress', 'Egress'] : ['Ingress'];
+}
+
+function rulesOf(policy: KubeObject, direction: 'ingress' | 'egress'): Rule[] {
+  const spec = (policy.spec ?? {}) as Record<string, Rule[] | undefined>;
+  return spec[direction] ?? [];
+}
+
+/** `ports` 不写表示所有端口 */
+function portMatches(ports: Rule['ports'], traffic: Traffic): boolean {
+  if (!ports || ports.length === 0) return true;
+  return ports.some((entry) => {
+    if (entry.protocol && entry.protocol !== (traffic.protocol ?? 'TCP')) return false;
+    if (entry.port === undefined) return true;
+    const port = typeof entry.port === 'number' ? entry.port : Number(entry.port);
+    if (!Number.isFinite(port)) return true;   // 命名端口，这里放行
+    if (entry.endPort) return traffic.port >= port && traffic.port <= entry.endPort;
+    return traffic.port === port;
+  });
+}
+
+/** `from` / `to` 不写（或者是空数组）表示所有来源 */
+function peerMatches(peers: unknown[] | undefined, peer: PolicyPeer): boolean {
+  if (!peers || peers.length === 0) return true;
+  return peers.some((entry) => singlePeerMatches(entry as Record<string, any>, peer));
+}
+
+/**
+ * 一条 peer。
+ *
+ * 同一个数组元素里的 `podSelector` 与 `namespaceSelector` 是**与**的关系
+ * （「那个命名空间里的这些 Pod」），分成两个元素才是或 —— 这一处写反了，
+ * 策略会宽松得多，而且不会报错。
+ */
+function singlePeerMatches(entry: Record<string, any>, peer: PolicyPeer): boolean {
+  if (entry.ipBlock) {
+    if (!peer.ip) return false;
+    if (!inCidr(peer.ip, entry.ipBlock.cidr)) return false;
+    return !(entry.ipBlock.except ?? []).some((cidr: string) => inCidr(peer.ip!, cidr));
+  }
+
+  if (entry.namespaceSelector) {
+    const labels = entry.namespaceSelector.matchLabels as Record<string, string> | undefined;
+    // 空的 namespaceSelector 表示「所有命名空间」
+    if (labels && Object.keys(labels).length > 0) {
+      if (!matchesSelector(labels, peer.namespaceLabels)) return false;
+    }
+  } else if (entry.podSelector) {
+    // 没写 namespaceSelector 时，podSelector 只在策略自己的命名空间里找
+    // （调用方已经把 peer 的命名空间带进来了，这里交给下面的 podSelector 判断）
+  }
+
+  if (entry.podSelector) {
+    const labels = entry.podSelector.matchLabels as Record<string, string> | undefined;
+    if (labels && Object.keys(labels).length > 0 && !matchesSelector(labels, peer.labels)) {
+      return false;
+    }
+  }
+  return Boolean(entry.namespaceSelector || entry.podSelector);
+}
+
+export function matchesSelector(
+  selector: Record<string, string> | undefined,
+  labels: Record<string, string> | undefined
+): boolean {
+  if (!selector || Object.keys(selector).length === 0) return true;
+  return Object.entries(selector).every(([key, value]) => labels?.[key] === value);
+}
+
+/** `10.42.0.0/16` 这种。只做 IPv4，够用。 */
+export function inCidr(ip: string, cidr: string): boolean {
+  const [network, bitsText] = cidr.split('/');
+  const bits = Number(bitsText);
+  if (!Number.isFinite(bits)) return ip === network;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (toInt(ip) & mask) === (toInt(network) & mask);
+}
+
+function toInt(ip: string): number {
+  return ip.split('.').reduce((total, part) => ((total << 8) + Number(part)) >>> 0, 0);
+}

--- a/src/lib/opslab/net/policy.ts
+++ b/src/lib/opslab/net/policy.ts
@@ -60,7 +60,7 @@ export function evaluateEgress(policies: KubeObject[], traffic: Traffic): Policy
   for (const policy of selecting) {
     for (const rule of rulesOf(policy, 'egress')) {
       if (!portMatches(rule.ports, traffic)) continue;
-      if (peerMatches(rule.to, traffic.destination)) {
+      if (peerMatches(rule.to, traffic.destination, policy.metadata.namespace)) {
         return { allowed: true, isolated: true, allowedBy: nameOf(policy), isolatedBy: [] };
       }
     }
@@ -82,7 +82,7 @@ export function evaluateIngress(policies: KubeObject[], traffic: Traffic): Polic
   for (const policy of selecting) {
     for (const rule of rulesOf(policy, 'ingress')) {
       if (!portMatches(rule.ports, traffic)) continue;
-      if (peerMatches(rule.from, traffic.source)) {
+      if (peerMatches(rule.from, traffic.source, policy.metadata.namespace)) {
         return { allowed: true, isolated: true, allowedBy: nameOf(policy), isolatedBy: [] };
       }
     }
@@ -156,9 +156,13 @@ function portMatches(ports: Rule['ports'], traffic: Traffic): boolean {
 }
 
 /** `from` / `to` 不写（或者是空数组）表示所有来源 */
-function peerMatches(peers: unknown[] | undefined, peer: PolicyPeer): boolean {
+function peerMatches(
+  peers: unknown[] | undefined,
+  peer: PolicyPeer,
+  policyNamespace: string | undefined
+): boolean {
   if (!peers || peers.length === 0) return true;
-  return peers.some((entry) => singlePeerMatches(entry as Record<string, any>, peer));
+  return peers.some((entry) => singlePeerMatches(entry as Record<string, any>, peer, policyNamespace));
 }
 
 /**
@@ -168,7 +172,11 @@ function peerMatches(peers: unknown[] | undefined, peer: PolicyPeer): boolean {
  * （「那个命名空间里的这些 Pod」），分成两个元素才是或 —— 这一处写反了，
  * 策略会宽松得多，而且不会报错。
  */
-function singlePeerMatches(entry: Record<string, any>, peer: PolicyPeer): boolean {
+function singlePeerMatches(
+  entry: Record<string, any>,
+  peer: PolicyPeer,
+  policyNamespace: string | undefined
+): boolean {
   if (entry.ipBlock) {
     if (!peer.ip) return false;
     if (!inCidr(peer.ip, entry.ipBlock.cidr)) return false;
@@ -182,8 +190,13 @@ function singlePeerMatches(entry: Record<string, any>, peer: PolicyPeer): boolea
       if (!matchesSelector(labels, peer.namespaceLabels)) return false;
     }
   } else if (entry.podSelector) {
-    // 没写 namespaceSelector 时，podSelector 只在策略自己的命名空间里找
-    // （调用方已经把 peer 的命名空间带进来了，这里交给下面的 podSelector 判断）
+    /**
+     * 没写 namespaceSelector 时，podSelector **只在策略自己的命名空间里**找。
+     *
+     * 漏了这一条，`from: [{podSelector: {app: client}}]` 会把所有命名空间里
+     * 叫这个名字的 Pod 都放进来 —— 策略比写的人以为的宽得多，而且不报错。
+     */
+    if (peer.namespace !== policyNamespace) return false;
   }
 
   if (entry.podSelector) {

--- a/src/lib/opslab/net/tools.ts
+++ b/src/lib/opslab/net/tools.ts
@@ -1,0 +1,299 @@
+/**
+ * 网络工具：curl / dig / nslookup / nc / getent
+ *
+ * 输出与退出码照抄真命令 —— 学员判断「连不上」是哪一种，靠的就是这几句话：
+ *
+ *   curl: (6) Could not resolve host: X          名字解析不了
+ *   curl: (7) Failed to connect ... Connection refused   端口上没人听
+ *   curl: (7) ... No route to host               网段够不到
+ *   curl: (28) ... Timeout was reached           包被丢了（策略）
+ *
+ * 退出码也是真的（6 / 7 / 28 / 22），因为脚本里会拿它当条件。
+ */
+import type { CommandHandler, CommandResult } from '../machine';
+import type { Network } from './network';
+import type { Source, Target } from './types';
+
+export interface NetToolsOptions {
+  network: Network;
+  /** 这台机器在哪个分区、以什么身份发起连接 */
+  source: () => Source;
+  /** 推进虚拟时钟。超时要真的花掉 30 秒虚拟时间。 */
+  advance: (ms: number) => void;
+}
+
+export function createNetTools(options: NetToolsOptions): Record<string, CommandHandler> {
+  return {
+    curl: (context) => curl(context.argv, options),
+    dig: (context) => dig(context.argv, options),
+    nslookup: (context) => nslookup(context.argv, options),
+    nc: (context) => netcat(context.argv, options),
+    getent: (context) => getent(context.argv, options),
+    ping: (context) => ping(context.argv, options),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+
+interface CurlFlags {
+  silent: boolean;
+  headOnly: boolean;
+  failOnError: boolean;
+  include: boolean;
+  writeOut?: string;
+  output?: string;
+  maxTimeMs?: number;
+  url?: string;
+  method?: string;
+  verbose: boolean;
+}
+
+function parseCurl(argv: string[]): CurlFlags {
+  const flags: CurlFlags = { silent: false, headOnly: false, failOnError: false, include: false, verbose: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '-s': case '--silent': flags.silent = true; break;
+      case '-S': case '--show-error': break;
+      case '-I': case '--head': flags.headOnly = true; break;
+      case '-i': case '--include': flags.include = true; break;
+      case '-f': case '--fail': flags.failOnError = true; break;
+      case '-v': case '--verbose': flags.verbose = true; break;
+      case '-w': case '--write-out': flags.writeOut = argv[++i]; break;
+      case '-o': case '--output': flags.output = argv[++i]; break;
+      case '-X': case '--request': flags.method = argv[++i]; break;
+      case '-m': case '--max-time': flags.maxTimeMs = Number(argv[++i]) * 1000; break;
+      case '--connect-timeout': flags.maxTimeMs = Number(argv[++i]) * 1000; break;
+      case '-k': case '--insecure': break;
+      case '-L': case '--location': break;
+      default:
+        if (arg.startsWith('-s') && /^-[a-zA-Z]+$/.test(arg)) {
+          // 合写的短选项，如 -sS
+          for (const letter of arg.slice(1)) {
+            if (letter === 's') flags.silent = true;
+            if (letter === 'S') { /* show-error */ }
+            if (letter === 'f') flags.failOnError = true;
+            if (letter === 'I') flags.headOnly = true;
+            if (letter === 'i') flags.include = true;
+            if (letter === 'v') flags.verbose = true;
+          }
+          break;
+        }
+        if (!arg.startsWith('-')) flags.url = arg;
+    }
+  }
+  return flags;
+}
+
+/** `http://portal.payments.svc.cluster.local:8080/healthz` */
+export function parseUrl(raw: string): Target | undefined {
+  const text = /^[a-z]+:\/\//.test(raw) ? raw : `http://${raw}`;
+  const match = /^([a-z]+):\/\/([^/:]+)(?::(\d+))?(\/.*)?$/.exec(text);
+  if (!match) return undefined;
+  const [, scheme, host, port, path] = match;
+  const tls = scheme === 'https';
+  return { host, port: port ? Number(port) : tls ? 443 : 80, path: path ?? '/', tls };
+}
+
+function curl(argv: string[], options: NetToolsOptions): CommandResult {
+  const flags = parseCurl(argv);
+  if (!flags.url) {
+    return { stderr: 'curl: try \'curl --help\' for more information\n', code: 2 };
+  }
+  const target = parseUrl(flags.url);
+  if (!target) return { stderr: `curl: (3) URL rejected: Bad hostname\n`, code: 3 };
+  if (flags.method) target.method = flags.method;
+  if (flags.headOnly) target.method = 'HEAD';
+
+  const result = options.network.connect(options.source(), target);
+  const spent = flags.maxTimeMs !== undefined
+    ? Math.min(result.elapsedMs, flags.maxTimeMs)
+    : result.elapsedMs;
+  options.advance(spent);
+
+  const place = `${target.host} port ${target.port}`;
+  const timedOut = result.kind === 'timeout'
+    || (flags.maxTimeMs !== undefined && result.elapsedMs > flags.maxTimeMs);
+
+  if (timedOut) {
+    return {
+      stderr: `curl: (28) Failed to connect to ${place} after ${Math.round(spent)} ms: Timeout was reached\n`,
+      code: 28,
+    };
+  }
+  switch (result.kind) {
+    case 'dns-failure':
+      return { stderr: `curl: (6) Could not resolve host: ${target.host}\n`, code: 6 };
+    case 'no-route':
+      return {
+        stderr: `curl: (7) Failed to connect to ${place} after ${Math.round(spent)} ms: No route to host\n`,
+        code: 7,
+      };
+    case 'refused':
+      return {
+        stderr: `curl: (7) Failed to connect to ${place} after ${Math.round(spent)} ms: Connection refused\n`,
+        code: 7,
+      };
+    case 'reset':
+      return { stderr: `curl: (56) Recv failure: Connection reset by peer\n`, code: 56 };
+    default:
+      break;
+  }
+
+  const status = result.status ?? 200;
+  if (flags.failOnError && status >= 400) {
+    return {
+      stderr: `curl: (22) The requested URL returned error: ${status}\n`,
+      code: 22,
+    };
+  }
+
+  const headers = [
+    `HTTP/1.1 ${status} ${reasonOf(status)}`,
+    'content-type: text/plain',
+    '',
+    '',
+  ].join('\r\n');
+  const body = flags.headOnly ? '' : result.body ?? '';
+  let stdout = flags.include || flags.headOnly ? headers + body : body;
+  if (flags.output === '/dev/null') stdout = '';
+  if (flags.writeOut) stdout += renderWriteOut(flags.writeOut, status, spent);
+
+  return { stdout, code: 0 };
+}
+
+/** `-w '%{http_code}'` 这类 */
+function renderWriteOut(format: string, status: number, elapsedMs: number): string {
+  return format
+    .replace(/%\{http_code\}/g, String(status))
+    .replace(/%\{time_total\}/g, (elapsedMs / 1000).toFixed(6))
+    .replace(/\\n/g, '\n');
+}
+
+function reasonOf(status: number): string {
+  const reasons: Record<number, string> = {
+    200: 'OK', 201: 'Created', 204: 'No Content', 301: 'Moved Permanently',
+    400: 'Bad Request', 401: 'Unauthorized', 403: 'Forbidden', 404: 'Not Found',
+    500: 'Internal Server Error', 502: 'Bad Gateway', 503: 'Service Unavailable',
+  };
+  return reasons[status] ?? '';
+}
+
+/* ------------------------------------------------------------------ */
+
+function dig(argv: string[], options: NetToolsOptions): CommandResult {
+  const short = argv.includes('+short');
+  const name = argv.find((arg) => !arg.startsWith('+') && !arg.startsWith('-') && !arg.startsWith('@'));
+  if (!name) return { stderr: 'dig: no name given\n', code: 1 };
+
+  const answer = options.network.resolve(name, options.source());
+  options.advance(2);
+
+  if (short) {
+    return { stdout: answer.addresses.map((ip) => `${ip}\n`).join(''), code: 0 };
+  }
+
+  const found = answer.addresses.length > 0;
+  const lines = [
+    '',
+    `; <<>> DiG 9.20.4 <<>> ${name}`,
+    ';; global options: +cmd',
+    ';; Got answer:',
+    `;; ->>HEADER<<- opcode: QUERY, status: ${found ? 'NOERROR' : 'NXDOMAIN'}, id: 1`,
+    `;; flags: qr aa rd ra; QUERY: 1, ANSWER: ${answer.addresses.length}, AUTHORITY: 0, ADDITIONAL: 0`,
+    '',
+    ';; QUESTION SECTION:',
+    `;${answer.canonical ?? name}.\t\t\tIN\tA`,
+    '',
+  ];
+  if (found) {
+    lines.push(';; ANSWER SECTION:');
+    for (const ip of answer.addresses) lines.push(`${answer.canonical}.\t30\tIN\tA\t${ip}`);
+    lines.push('');
+  }
+  lines.push(';; SERVER: 10.96.0.10#53(10.96.0.10)', '');
+  return { stdout: lines.join('\n'), code: found ? 0 : 9 };
+}
+
+function nslookup(argv: string[], options: NetToolsOptions): CommandResult {
+  const name = argv.find((arg) => !arg.startsWith('-'));
+  if (!name) return { stderr: 'nslookup: no name given\n', code: 1 };
+  const answer = options.network.resolve(name, options.source());
+  options.advance(2);
+
+  if (answer.addresses.length === 0) {
+    return {
+      stdout: 'Server:\t\t10.96.0.10\nAddress:\t10.96.0.10#53\n\n',
+      stderr: `** server can't find ${name}: NXDOMAIN\n`,
+      code: 1,
+    };
+  }
+  const lines = ['Server:\t\t10.96.0.10', 'Address:\t10.96.0.10#53', '', 'Name:\t' + answer.canonical];
+  for (const ip of answer.addresses) lines.push(`Address: ${ip}`);
+  lines.push('');
+  return { stdout: lines.join('\n'), code: 0 };
+}
+
+function getent(argv: string[], options: NetToolsOptions): CommandResult {
+  if (argv[0] !== 'hosts' && argv[0] !== 'ahostsv4') {
+    return { stderr: `getent: Unknown database: ${argv[0] ?? ''}\n`, code: 2 };
+  }
+  const name = argv[1];
+  if (!name) return { code: 2 };
+  const answer = options.network.resolve(name, options.source());
+  options.advance(2);
+  if (answer.addresses.length === 0) return { code: 2 };
+  return {
+    stdout: answer.addresses.map((ip) => `${ip}       ${answer.canonical ?? name}\n`).join(''),
+    code: 0,
+  };
+}
+
+function netcat(argv: string[], options: NetToolsOptions): CommandResult {
+  const values = argv.filter((arg) => !arg.startsWith('-'));
+  // `-w 2` 的 2 会混进位置参数里，取最后两个才对
+  const port = Number(values[values.length - 1]);
+  const host = values[values.length - 2];
+  if (!host || !Number.isFinite(port)) {
+    return { stderr: 'nc: missing hostname and port\n', code: 1 };
+  }
+  const waitIndex = argv.indexOf('-w');
+  const waitMs = waitIndex >= 0 ? Number(argv[waitIndex + 1]) * 1000 : undefined;
+
+  const result = options.network.connect(options.source(), { host, port });
+  const spent = waitMs !== undefined ? Math.min(result.elapsedMs, waitMs) : result.elapsedMs;
+  options.advance(spent);
+
+  const timedOut = result.kind === 'timeout' || (waitMs !== undefined && result.elapsedMs > waitMs);
+  if (timedOut) return { stderr: `nc: connect to ${host} port ${port} (tcp) timed out\n`, code: 1 };
+  if (result.kind === 'dns-failure') {
+    return { stderr: `nc: getaddrinfo for host "${host}" port ${port}: Name or service not known\n`, code: 1 };
+  }
+  if (result.kind !== 'ok') {
+    const reason = result.kind === 'refused' ? 'Connection refused' : 'No route to host';
+    return { stderr: `nc: connect to ${host} port ${port} (tcp) failed: ${reason}\n`, code: 1 };
+  }
+  return { stderr: `Connection to ${host} ${port} port [tcp/*] succeeded!\n`, code: 0 };
+}
+
+function ping(argv: string[], options: NetToolsOptions): CommandResult {
+  const host = argv.find((arg) => !arg.startsWith('-'));
+  if (!host) return { stderr: 'ping: usage error: Destination address required\n', code: 2 };
+  const answer = options.network.resolve(host, options.source());
+  options.advance(2);
+  if (answer.addresses.length === 0) {
+    return { stderr: `ping: ${host}: Name or service not known\n`, code: 2 };
+  }
+  /**
+   * ICMP 不做。
+   *
+   * 说清楚比假装能 ping 更有用：集群里绝大多数「ping 不通」都不说明问题
+   * （ClusterIP 本来就不回 ICMP），学员该用的是 curl 或 nc。
+   */
+  return {
+    stdout: `PING ${host} (${answer.addresses[0]}): 56 data bytes\n`,
+    stderr: 'ping: ICMP 不在 opslab 的模拟范围内（ClusterIP 本来也不回 ICMP）。'
+      + '测连通性请用 `curl` 或 `nc -z`。\n',
+    code: 2,
+  };
+}

--- a/src/lib/opslab/net/tools.ts
+++ b/src/lib/opslab/net/tools.ts
@@ -250,10 +250,15 @@ function getent(argv: string[], options: NetToolsOptions): CommandResult {
 }
 
 function netcat(argv: string[], options: NetToolsOptions): CommandResult {
-  const values = argv.filter((arg) => !arg.startsWith('-'));
-  // `-w 2` 的 2 会混进位置参数里，取最后两个才对
-  const port = Number(values[values.length - 1]);
-  const host = values[values.length - 2];
+  // `-w` 后面那个数字是超时秒数，不是位置参数 —— 不跳过它，
+  // `nc -z host 80 -w 2` 会被解析成连 80 的 2 端口
+  const values: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '-w' || argv[i] === '-p' || argv[i] === '-s') { i += 1; continue; }
+    if (!argv[i].startsWith('-')) values.push(argv[i]);
+  }
+  const port = Number(values[1] ?? values[values.length - 1]);
+  const host = values[0];
   if (!host || !Number.isFinite(port)) {
     return { stderr: 'nc: missing hostname and port\n', code: 1 };
   }

--- a/src/lib/opslab/net/types.ts
+++ b/src/lib/opslab/net/types.ts
@@ -1,0 +1,81 @@
+/**
+ * 网络的语义模型
+ *
+ * 不做协议字节，做**连接结果的语义**。这条线是刻意划的：学员从网络问题里
+ * 真正要学会的是「连不上时，从症状反推是哪一层的问题」，而症状恰恰是
+ * 少数几种可区分的结果，不是字节流。
+ *
+ *   refused  端口上没人听        → 应用没起来 / 端口写错
+ *   timeout  包被丢了            → 策略拦了 / 路由不通（**不会**回 RST）
+ *   reset    连上了又被掐断      → 后端崩了 / 中间件主动断
+ *   no route 目标地址不可达      → 网段隔离
+ *   dns      名字解析不出来      → Service 名写错 / DNS 被策略切断
+ *
+ * 「被 NetworkPolicy 拒绝表现为超时而不是拒绝」是这套语义里最要紧的一条，
+ * 也是第 10 关的核心：学员必须能从「卡住」而不是「立刻失败」认出这是策略问题。
+ */
+
+/** 网络分区。跳板机在办公网，Pod 在集群网，外网是另一个世界。 */
+export type Zone = 'office' | 'internet' | 'cluster' | 'node';
+
+export type ConnectKind = 'ok' | 'refused' | 'timeout' | 'reset' | 'no-route' | 'dns-failure';
+
+/** 一跳。包路径回放与拓扑的数据面层都读它。 */
+export interface Hop {
+  /** 这一跳发生在哪：`pod/payments/portal-x`、`svc/payments/portal`、`policy/deny-all` */
+  at: string;
+  /** 干了什么 */
+  detail: string;
+  verdict: 'forward' | 'deliver' | 'drop' | 'reject';
+  /** 虚拟耗时（毫秒） */
+  elapsedMs: number;
+}
+
+export interface ConnectResult {
+  kind: ConnectKind;
+  /** HTTP 请求时才有 */
+  status?: number;
+  body?: string;
+  /** 走过的每一跳，按顺序 */
+  hops: Hop[];
+  /** 被谁挡了：策略名、或者「no listener」这类原因 */
+  blockedBy?: string;
+  /** 总耗时（虚拟毫秒）。超时的话就是超时时长。 */
+  elapsedMs: number;
+}
+
+/** 谁在发起连接 */
+export interface Source {
+  zone: Zone;
+  /** 在集群里发起时，是哪个 Pod */
+  namespace?: string;
+  podName?: string;
+  ip?: string;
+  /** 显示用，如 `jump-01` */
+  label: string;
+}
+
+/** 要连到哪 */
+export interface Target {
+  /** 主机名或 IP，学员敲进去的那个 */
+  host: string;
+  port: number;
+  /** HTTP 请求时才有 */
+  path?: string;
+  method?: string;
+  tls?: boolean;
+  /** TLS 时的 SNI，缺省用 host */
+  serverName?: string;
+}
+
+/** DNS 查出来的东西 */
+export interface Resolution {
+  /** 问的是什么 */
+  question: string;
+  /** 实际查到的完整名字（走完 search 之后） */
+  canonical?: string;
+  addresses: string[];
+  /** 解析路上试过哪些名字 —— ndots 的效果全在这里 */
+  attempts: string[];
+  kind: 'service' | 'headless' | 'external' | 'pod' | 'host' | 'nxdomain';
+}

--- a/tests/opslab/net.test.ts
+++ b/tests/opslab/net.test.ts
@@ -1,0 +1,487 @@
+/**
+ * 网络：连不上的时候，症状要能反推出是哪一层的问题
+ *
+ * 这一套用例的组织方式就是那张排查表：每一条对应一种症状，
+ * 断言的是「这种情况下学员看到的是什么」。
+ */
+import { createCluster } from '../../src/lib/opslab/controllers';
+import { candidatesFor, evaluate, inCidr, isIpv4 } from '../../src/lib/opslab/net';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+import type { Source } from '../../src/lib/opslab/net';
+
+const IMAGE = 'registry.corp.internal/portal:1.4';
+
+const OFFICE: Source = { zone: 'office', label: 'jump-01', ip: '10.10.1.5' };
+const inPod = (namespace: string, podName: string): Source =>
+  ({ zone: 'cluster', namespace, podName, label: podName });
+
+async function world(options: {
+  namespaces?: string[];
+  objects?: KubeObject[];
+  images?: Record<string, any>;
+  externalHosts?: Record<string, string[]>;
+} = {}) {
+  const cluster = createCluster({
+    namespaces: options.namespaces ?? ['default', 'kube-system', 'payments'],
+    images: options.images ?? { [IMAGE]: { listens: [8080], routes: { '/': 200, '/healthz': 200 } } },
+    externalHosts: options.externalHosts ?? { 'harbor.corp.internal': ['10.10.0.20'] },
+  });
+  cluster.start();
+  for (const object of options.objects ?? []) {
+    const [group, version] = object.apiVersion.includes('/')
+      ? object.apiVersion.split('/')
+      : ['', object.apiVersion];
+    const definition = cluster.scheme.resolveKind(group, version, object.kind)!;
+    cluster.registry.create(
+      definition,
+      definition.namespaced ? object.metadata.namespace ?? 'default' : undefined,
+      object
+    );
+  }
+  await cluster.settle();
+  return cluster;
+}
+
+const deployment = (name: string, namespace: string, labels: Record<string, string>) => ({
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name, namespace },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: labels },
+    template: {
+      metadata: { labels },
+      spec: { containers: [{ name: 'app', image: IMAGE, ports: [{ containerPort: 8080 }] }] },
+    },
+  },
+} as unknown as KubeObject);
+
+const service = (name: string, namespace: string, selector: Record<string, string>, clusterIP: string) => ({
+  apiVersion: 'v1', kind: 'Service',
+  metadata: { name, namespace },
+  spec: { clusterIP, selector, ports: [{ port: 80, targetPort: 8080 }] },
+} as unknown as KubeObject);
+
+const policy = (name: string, namespace: string, spec: Record<string, unknown>) => ({
+  apiVersion: 'networking.k8s.io/v1', kind: 'NetworkPolicy',
+  metadata: { name, namespace }, spec,
+} as unknown as KubeObject);
+
+/** 第一个 Pod 的名字，用来当发起方 */
+function firstPod(cluster: Awaited<ReturnType<typeof world>>, namespace: string): string {
+  return cluster.registry.list(
+    cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }),
+    { namespace }
+  ).items[0].metadata.name;
+}
+
+describe('DNS', () => {
+  it('ndots:5 决定 search 域的展开顺序', () => {
+    // 点数少于 5：先拼 search 域，最后才试自己
+    expect(candidatesFor('portal', 'payments')).toEqual([
+      'portal.payments.svc.cluster.local',
+      'portal.svc.cluster.local',
+      'portal.cluster.local',
+      'portal',
+    ]);
+    /**
+     * `portal.payments.svc.cluster.local` 有 4 个点，**少于 5**，所以它仍然
+     * 被当成相对名：先去试 `portal.payments.svc.cluster.local.payments.svc.cluster.local`。
+     * 这就是集群里 DNS 查询量异常高的那个经典原因，也是为什么讲究的写法
+     * 要在末尾加一个点。
+     */
+    expect(candidatesFor('portal.payments.svc.cluster.local', 'payments')[0])
+      .toBe('portal.payments.svc.cluster.local.payments.svc.cluster.local');
+    expect(candidatesFor('portal.payments.svc.cluster.local.', 'payments'))
+      .toEqual(['portal.payments.svc.cluster.local']);
+    // 点数够 5 个才先试自己
+    expect(candidatesFor('a.b.c.d.e.f', 'payments')[0]).toBe('a.b.c.d.e.f');
+    // 绝对名不拼
+    expect(candidatesFor('example.com.', 'payments')).toEqual(['example.com']);
+  });
+
+  it('Pod 里解析得到本命名空间的短名字', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+      ],
+    });
+    const from = inPod('payments', firstPod(cluster, 'payments'));
+    expect(cluster.network.resolve('portal', from).addresses).toEqual(['10.96.1.10']);
+    expect(cluster.network.resolve('portal.payments.svc.cluster.local', from).addresses)
+      .toEqual(['10.96.1.10']);
+  });
+
+  it('跨命名空间的短名字解析不出来 —— 要带命名空间', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+        deployment('client', 'default', { app: 'client' }),
+      ],
+    });
+    const from = inPod('default', firstPod(cluster, 'default'));
+    expect(cluster.network.resolve('portal', from).kind).toBe('nxdomain');
+    expect(cluster.network.resolve('portal.payments', from).addresses).toEqual(['10.96.1.10']);
+  });
+
+  it('办公网只解析得到世界里声明过的外部名字', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+      ],
+    });
+    expect(cluster.network.resolve('harbor.corp.internal', OFFICE).addresses).toEqual(['10.10.0.20']);
+    // 集群内的名字，办公网的 DNS 里没有
+    expect(cluster.network.resolve('portal.payments.svc.cluster.local', OFFICE).kind).toBe('nxdomain');
+  });
+
+  it('IP 直接用，不查 DNS', () => {
+    expect(isIpv4('10.96.1.10')).toBe(true);
+    expect(isIpv4('portal')).toBe(false);
+  });
+});
+
+describe('连不上的四种症状', () => {
+  it('名字不存在 -> dns-failure', async () => {
+    const cluster = await world();
+    const result = cluster.network.connect(OFFICE, { host: 'nope.corp.internal', port: 80 });
+    expect(result.kind).toBe('dns-failure');
+  });
+
+  it('办公网够不到 ClusterIP -> no-route', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+      ],
+    });
+    const result = cluster.network.connect(OFFICE, { host: '10.96.1.10', port: 80 });
+    expect(result.kind).toBe('no-route');
+    expect(result.blockedBy).toBe('no route to host');
+  });
+
+  it('Service 有 VIP 但没有 Endpoints -> refused，不是超时', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        // selector 打错，一个后端都匹配不上
+        service('portal', 'payments', { app: 'protal' }, '10.96.1.10'),
+        deployment('client', 'payments', { app: 'client' }),
+      ],
+    });
+    const from = inPod('payments', cluster.registry.list(
+      cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }), { namespace: 'payments' }
+    ).items.find((pod) => pod.metadata.labels?.app === 'client')!.metadata.name);
+
+    const result = cluster.network.connect(from, { host: 'portal', port: 80 });
+    expect(result.kind).toBe('refused');
+    expect(result.blockedBy).toBe('no endpoints');
+  });
+
+  it('端口上没人听 -> refused', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+        deployment('client', 'payments', { app: 'client' }),
+      ],
+    });
+    const pods = cluster.registry.list(
+      cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }), { namespace: 'payments' }
+    ).items;
+    const client = pods.find((pod) => pod.metadata.labels?.app === 'client')!;
+    const portal = pods.find((pod) => pod.metadata.labels?.app === 'portal')!;
+
+    const result = cluster.network.connect(
+      inPod('payments', client.metadata.name),
+      { host: (portal.status as any).podIP, port: 9999 }
+    );
+    expect(result.kind).toBe('refused');
+    expect(result.hops[result.hops.length - 1].detail).toContain('没有人听');
+  });
+
+  it('一切正常 -> ok，带 HTTP 状态码', async () => {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+        deployment('client', 'payments', { app: 'client' }),
+      ],
+    });
+    const pods = cluster.registry.list(
+      cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }), { namespace: 'payments' }
+    ).items;
+    const client = pods.find((pod) => pod.metadata.labels?.app === 'client')!;
+
+    const result = cluster.network.connect(
+      inPod('payments', client.metadata.name),
+      { host: 'portal', port: 80, path: '/healthz' }
+    );
+    expect(result.kind).toBe('ok');
+    expect(result.status).toBe(200);
+    // 包路径：DNS -> Service -> Pod
+    expect(result.hops.map((hop) => hop.at.split('/')[0])).toEqual(['dns', 'svc', 'pod']);
+  });
+});
+
+describe('NetworkPolicy', () => {
+  const clientPolicy = (spec: Record<string, unknown>) => policy('deny', 'payments', spec);
+
+  it('没有策略选中它时全通', () => {
+    const decision = evaluate([], {
+      source: { namespace: 'payments', labels: { app: 'client' } },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 8080,
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.ingress.isolated).toBe(false);
+  });
+
+  it('只写 podSelector 的空策略 = 该方向默认拒绝', () => {
+    const decision = evaluate([clientPolicy({ podSelector: { matchLabels: { app: 'portal' } } })], {
+      source: { namespace: 'payments', labels: { app: 'client' } },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 8080,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.ingress.isolated).toBe(true);
+  });
+
+  it('按标签放行', () => {
+    const allow = clientPolicy({
+      podSelector: { matchLabels: { app: 'portal' } },
+      ingress: [{ from: [{ podSelector: { matchLabels: { app: 'client' } } }], ports: [{ port: 8080 }] }],
+    });
+    const traffic = (app: string) => ({
+      source: { namespace: 'payments', labels: { app } },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 8080,
+    });
+    expect(evaluate([allow], traffic('client')).allowed).toBe(true);
+    expect(evaluate([allow], traffic('stranger')).allowed).toBe(false);
+  });
+
+  it('端口不匹配也不放行', () => {
+    const allow = clientPolicy({
+      podSelector: { matchLabels: { app: 'portal' } },
+      ingress: [{ from: [{ podSelector: { matchLabels: { app: 'client' } } }], ports: [{ port: 8080 }] }],
+    });
+    expect(evaluate([allow], {
+      source: { namespace: 'payments', labels: { app: 'client' } },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 9090,
+    }).allowed).toBe(false);
+  });
+
+  it('两端都要放行 —— 只改一边是最常见的错', () => {
+    const egressOnly = policy('egress-only', 'payments', {
+      podSelector: { matchLabels: { app: 'client' } },
+      policyTypes: ['Egress'],
+      egress: [{ to: [{ podSelector: { matchLabels: { app: 'portal' } } }] }],
+    });
+    const ingressDeny = policy('ingress-deny', 'payments', {
+      podSelector: { matchLabels: { app: 'portal' } },
+      policyTypes: ['Ingress'],
+    });
+    const decision = evaluate([egressOnly, ingressDeny], {
+      source: { namespace: 'payments', labels: { app: 'client' } },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 8080,
+    });
+    expect(decision.egress.allowed).toBe(true);
+    expect(decision.ingress.allowed).toBe(false);
+    expect(decision.blockedBy).toContain('ingress:');
+  });
+
+  it('namespaceSelector 认命名空间的标签', () => {
+    const allow = policy('from-monitoring', 'payments', {
+      podSelector: {},
+      ingress: [{ from: [{ namespaceSelector: { matchLabels: { team: 'sre' } } }] }],
+    });
+    const from = (namespaceLabels: Record<string, string>) => ({
+      source: { namespace: 'other', labels: {}, namespaceLabels },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 8080,
+    });
+    expect(evaluate([allow], from({ team: 'sre' })).allowed).toBe(true);
+    expect(evaluate([allow], from({ team: 'app' })).allowed).toBe(false);
+  });
+
+  it('ipBlock 与 except', () => {
+    const allow = policy('from-office', 'payments', {
+      podSelector: {},
+      ingress: [{ from: [{ ipBlock: { cidr: '10.10.0.0/16', except: ['10.10.9.0/24'] } }] }],
+    });
+    const from = (ip: string) => ({
+      source: { ip },
+      destination: { namespace: 'payments', labels: {} },
+      port: 8080,
+    });
+    expect(evaluate([allow], from('10.10.1.5')).allowed).toBe(true);
+    expect(evaluate([allow], from('10.10.9.7')).allowed).toBe(false);
+    expect(evaluate([allow], from('10.20.0.1')).allowed).toBe(false);
+  });
+
+  it.each([
+    ['10.42.1.7', '10.42.0.0/16', true],
+    ['10.43.1.7', '10.42.0.0/16', false],
+    ['10.10.9.7', '10.10.9.0/24', true],
+    ['1.2.3.4', '0.0.0.0/0', true],
+  ])('%s 在不在 %s 里', (ip, cidr, expected) => {
+    expect(inCidr(ip, cidr)).toBe(expected);
+  });
+});
+
+describe('策略在集群里真的会拦住流量', () => {
+  async function twoPods(policies: KubeObject[] = []) {
+    const cluster = await world({
+      objects: [
+        deployment('portal', 'payments', { app: 'portal' }),
+        service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+        deployment('client', 'payments', { app: 'client' }),
+        ...policies,
+      ],
+    });
+    const pods = cluster.registry.list(
+      cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }), { namespace: 'payments' }
+    ).items;
+    return {
+      cluster,
+      from: inPod('payments', pods.find((pod) => pod.metadata.labels?.app === 'client')!.metadata.name),
+    };
+  }
+
+  it('被策略拦住表现为超时，不是拒绝 —— 这是最要紧的一条', async () => {
+    const { cluster, from } = await twoPods([
+      policy('deny-all', 'payments', { podSelector: {}, policyTypes: ['Ingress'] }),
+    ]);
+    const result = cluster.network.connect(from, { host: 'portal', port: 80 });
+    expect(result.kind).toBe('timeout');
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(30_000);
+    expect(result.hops[result.hops.length - 1].verdict).toBe('drop');
+  });
+
+  it('egress 策略忘了放行 DNS，症状是名字解析不了', async () => {
+    const { cluster, from } = await twoPods([
+      policy('egress-portal-only', 'payments', {
+        podSelector: { matchLabels: { app: 'client' } },
+        policyTypes: ['Egress'],
+        egress: [{ to: [{ podSelector: { matchLabels: { app: 'portal' } } }] }],
+      }),
+    ]);
+    // 用名字连：DNS 先挂
+    expect(cluster.network.connect(from, { host: 'portal', port: 80 }).kind).toBe('dns-failure');
+    // 直接用 ClusterIP 就通了 —— 这个对比正是定位 DNS 问题的钥匙
+    expect(cluster.network.connect(from, { host: '10.96.1.10', port: 80 }).kind).toBe('ok');
+  });
+
+  it('放行了 DNS 之后一切正常', async () => {
+    const { cluster, from } = await twoPods([
+      policy('egress-ok', 'payments', {
+        podSelector: { matchLabels: { app: 'client' } },
+        policyTypes: ['Egress'],
+        egress: [
+          { to: [{ podSelector: { matchLabels: { app: 'portal' } } }] },
+          {
+            to: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'kube-system' } } }],
+            ports: [{ port: 53, protocol: 'UDP' }],
+          },
+        ],
+      }),
+    ]);
+    const result = cluster.network.connect(from, { host: 'portal', port: 80 });
+    expect(result.kind).toBe('ok');
+  });
+});
+
+describe('网络工具的输出与退出码', () => {
+  const { createOpsWorld } = require('../../src/lib/opslab/lab');
+
+  async function jumpHost(objects: KubeObject[] = []) {
+    return createOpsWorld({
+      world: {
+        namespaces: ['default', 'kube-system', 'payments'],
+        images: { [IMAGE]: { listens: [8080], routes: { '/': 200, '/healthz': 200, '/boom': 503 } } },
+        registries: [{ host: 'harbor.corp.internal', users: { ci: 'pw' } }],
+      },
+      stage: { objects: objects as never },
+    });
+  }
+
+  it('curl 解析不了名字：(6) Could not resolve host', async () => {
+    const world = await jumpHost();
+    const result = await world.run('curl -s http://nope.corp.internal/');
+    expect(result.code).toBe(6);
+    expect(result.stderr).toBe('curl: (6) Could not resolve host: nope.corp.internal\n');
+  });
+
+  it('curl 够不到 ClusterIP：(7) No route to host', async () => {
+    const world = await jumpHost([
+      deployment('portal', 'payments', { app: 'portal' }),
+      service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+    ]);
+    const result = await world.run('curl -s http://10.96.1.10/');
+    expect(result.code).toBe(7);
+    expect(result.stderr).toContain('No route to host');
+  });
+
+  it('dig +short 与完整输出', async () => {
+    const world = await jumpHost();
+    expect((await world.run('dig +short harbor.corp.internal')).stdout).toBe('10.10.0.20\n');
+
+    const full = await world.run('dig harbor.corp.internal');
+    expect(full.stdout).toContain(';; ANSWER SECTION:');
+    expect(full.stdout).toContain('harbor.corp.internal.\t30\tIN\tA\t10.10.0.20');
+
+    const missing = await world.run('dig nope.corp.internal');
+    expect(missing.code).toBe(9);
+    expect(missing.stdout).toContain('status: NXDOMAIN');
+  });
+
+  it('nc -z 报连接成功还是失败', async () => {
+    const world = await jumpHost();
+    const refused = await world.run('nc -z -w 2 10.96.1.10 80');
+    expect(refused.code).toBe(1);
+    expect(refused.stderr).toContain('No route to host');
+  });
+
+  it('ping 明确说不支持，并指出该用什么', async () => {
+    const world = await jumpHost();
+    const result = await world.run('ping harbor.corp.internal');
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('curl');
+    expect(result.stderr).toContain('nc -z');
+  });
+
+  it('curl -w %{http_code} 与 -o /dev/null', async () => {
+    const world = await jumpHost();
+    // 办公网到不了集群，但格式本身要对：先验一个能到的外部地址上的失败路径
+    const result = await world.run("curl -s -o /dev/null -w '%{http_code}' http://nope/");
+    expect(result.code).toBe(6);
+  });
+
+  it('超时会真的花掉虚拟时间', async () => {
+    const world = await jumpHost([
+      deployment('portal', 'payments', { app: 'portal' }),
+      service('portal', 'payments', { app: 'portal' }, '10.96.1.10'),
+      deployment('client', 'payments', { app: 'client' }),
+      policy('deny-all', 'payments', { podSelector: {}, policyTypes: ['Ingress'] }),
+    ]);
+    const before = world.now();
+    const pods = world.cluster.registry.list(
+      world.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }),
+      { namespace: 'payments' }
+    ).items;
+    const client = pods.find((pod: KubeObject) => pod.metadata.labels?.app === 'client')!;
+
+    const result = world.cluster.network.connect(
+      { zone: 'cluster', namespace: 'payments', podName: client.metadata.name, label: 'client' },
+      { host: 'portal', port: 80 }
+    );
+    expect(result.kind).toBe('timeout');
+    expect(world.now()).toBe(before);   // connect 自己不推时间，是工具推的
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(30_000);
+  });
+});

--- a/tests/opslab/net.test.ts
+++ b/tests/opslab/net.test.ts
@@ -295,6 +295,21 @@ describe('NetworkPolicy', () => {
     expect(decision.blockedBy).toContain('ingress:');
   });
 
+  it('没写 namespaceSelector 时，podSelector 只在策略自己的命名空间里找', () => {
+    const allow = policy('from-client', 'payments', {
+      podSelector: { matchLabels: { app: 'portal' } },
+      ingress: [{ from: [{ podSelector: { matchLabels: { app: 'client' } } }] }],
+    });
+    const from = (namespace: string) => ({
+      source: { namespace, labels: { app: 'client' } },
+      destination: { namespace: 'payments', labels: { app: 'portal' } },
+      port: 8080,
+    });
+    expect(evaluate([allow], from('payments')).allowed).toBe(true);
+    // 别的命名空间里同名同标签的 Pod 不该被放进来
+    expect(evaluate([allow], from('other')).allowed).toBe(false);
+  });
+
   it('namespaceSelector 认命名空间的标签', () => {
     const allow = policy('from-monitoring', 'payments', {
       podSelector: {},
@@ -440,11 +455,16 @@ describe('网络工具的输出与退出码', () => {
     expect(missing.stdout).toContain('status: NXDOMAIN');
   });
 
-  it('nc -z 报连接成功还是失败', async () => {
+  it('nc -z 报连接成功还是失败，-w 的参数不会被当成端口', async () => {
     const world = await jumpHost();
     const refused = await world.run('nc -z -w 2 10.96.1.10 80');
     expect(refused.code).toBe(1);
+    expect(refused.stderr).toContain('10.96.1.10 port 80');
     expect(refused.stderr).toContain('No route to host');
+
+    // 选项写在后面也要解析对
+    const trailing = await world.run('nc -z 10.96.1.10 80 -w 2');
+    expect(trailing.stderr).toContain('10.96.1.10 port 80');
   });
 
   it('ping 明确说不支持，并指出该用什么', async () => {


### PR DESCRIPTION
第 2 期第一片。第 8、10、11 关全压在这一层上。

不做协议字节，做**连接结果的语义**。学员从网络问题里真正要学会的是从症状反推到层，而症状恰恰是少数几种可区分的结果：

| 症状 | 是哪一层 |
| --- | --- |
| `curl: (6) Could not resolve host` | 名字 |
| `curl: (7) ... Connection refused` | 端口上没人听 |
| `curl: (7) ... No route to host` | 网段够不到 |
| `curl: (28) ... Timeout was reached` | 包被丢了（策略） |

**最要紧的一条**：被 NetworkPolicy 拒绝表现为超时而不是拒绝。学员必须能从「卡住」而不是「立刻失败」认出这是策略问题。

## 几个刻意较真的地方

- **ndots:5**。`portal.payments.svc.cluster.local` 只有 4 个点，仍然被当成相对名，先去试 `portal.payments.svc.cluster.local.payments.svc.cluster.local`。这就是集群里 DNS 查询量异常高的经典原因，用例把这个反直觉的行为钉住了（我第一版的断言写的是「先试自己」，是错的）。
- **同一个 peer 元素里的 `podSelector` 与 `namespaceSelector` 是「与」**，拆成两个元素才是「或」。写反了策略会宽松得多，而且不报错。
- **Service 有 VIP 但 Endpoints 为空 → 拒绝，不是超时**。kube-proxy 直接回 RST。和策略拦截是两种完全不同的症状。
- **`ping` 明确说不支持**并指出该用 `curl` 或 `nc -z`。集群里绝大多数「ping 不通」都不说明问题（ClusterIP 本来也不回 ICMP），做一个假的 ping 是在教错东西。
- **分区是真的**：跳板机在办公网，够不到 Pod 网段与 ClusterIP。第 8 关的「office 可达、internet 不可达」靠它。

## 架构

网络读的全是 apiserver 里的对象（Service / Endpoints / Pod / NetworkPolicy），自己不存状态 —— 所以「改了策略立刻生效」是自然的，不需要谁通知谁。一次连接走过的每一跳都记进 `hops`，后面给拓扑的数据面层和 Hubble 流日志用。

## 验证

`npx jest tests/opslab` → 15 suites / 419 用例（新增 31）；`npm test` 8/8；`npm run build` 通过。