### PR TITLE
opslab：Gateway API + Envoy Gateway，第 8 关

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -17,6 +17,9 @@ const { t, code, spec } = require('./_helpers');
 const PORTAL_IMAGE = 'harbor.corp.internal/team/portal:1.4.0';
 const PORTAL_IMAGE_NEXT = 'harbor.corp.internal/team/portal:1.5.0';
 const REPORTS_IMAGE = 'harbor.corp.internal/team/reports:2.1.0';
+const ENVOY_IMAGE = 'registry.k8s.io/gateway-api/envoy-gateway:v1.6.2';
+/** 已经从仓库里下架的镜像，拉不到 —— ingress-nginx 2026-03-24 退役 */
+const RETIRED_NGINX_IMAGE = 'registry.k8s.io/ingress-nginx/controller:v1.13.0';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -81,7 +84,7 @@ const WORLD = {
     { name: 'node-a2', cpu: '4', memory: '8Gi', labels: { 'topology.kubernetes.io/zone': 'a' } },
     { name: 'node-b1', cpu: '4', memory: '8Gi', labels: { 'topology.kubernetes.io/zone': 'b' } },
   ],
-  namespaces: ['default', 'kube-system', 'payments'],
+  namespaces: ['default', 'kube-system', 'payments', 'envoy-gateway-system', 'ingress-nginx'],
   images: {
     [PORTAL_IMAGE]: {
       pullMs: 400, startupMs: 600, readyAfterMs: 300,
@@ -92,6 +95,8 @@ const WORLD = {
       handlesSigterm: true,
       runAsUser: 10001,
     },
+    // 平台组装的入口控制器
+    [ENVOY_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200, listens: [18000] },
     // 财务的报表任务：吃 900Mi，limits 写小了就会被 OOMKill
     [REPORTS_IMAGE]: {
       pullMs: 500, startupMs: 800, readyAfterMs: 200,
@@ -102,6 +107,11 @@ const WORLD = {
   },
   // 本地已经有的基础镜像，写 Dockerfile 时 FROM 得着
   baseImages: { 'node:22-alpine': 'node' },
+  // 内网入口与公网入口用不同的地址池，这是「不能上公网」这条要求的落点
+  addressPools: [
+    { loadBalancerClass: 'corp.internal/office-lb', cidrPrefix: '10.10.8', zones: ['office'] },
+    { loadBalancerClass: 'corp.internal/public-lb', cidrPrefix: '203.0.113', zones: ['office', 'internet'] },
+  ],
   registries: [
     {
       host: 'harbor.corp.internal',
@@ -1651,6 +1661,362 @@ const stage7 = {
   ),
 };
 
+/* ------------------------------------------------------------------ */
+/* 第 8 关                                                             */
+/* ------------------------------------------------------------------ */
+
+/** 前任留下的老入口。ingress-nginx 已经退役，这个镜像在仓库里根本拉不到了。 */
+const LEGACY_INGRESS = code`
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: portal
+    namespace: payments
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+  spec:
+    ingressClassName: nginx
+    rules:
+    - host: portal.corp.internal
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: portal
+              port:
+                number: 80
+`;
+
+const GATEWAY_REFERENCE = code`
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: corp-gw
+    namespace: payments
+  spec:
+    gatewayClassName: envoy-internal
+    listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: portal.corp.internal
+      allowedRoutes:
+        namespaces:
+          from: Same
+  ---
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    parentRefs:
+    - name: corp-gw
+    hostnames:
+    - portal.corp.internal
+    rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+      - name: portal
+        port: 80
+`;
+
+const stage8 = {
+  id: 'gateway-migration',
+  title: t('从 Ingress 迁到 Gateway API', 'Migrate from Ingress to Gateway API'),
+  goal: t(
+    code`
+      门户的对外入口还挂在 ingress-nginx 上，而这个项目已经在 2026 年 3 月退役了 ——
+      镜像从仓库里下架，控制器起不来，Ingress 一直没有地址，门户从办公网访问不了。
+
+      平台组已经把 Envoy Gateway 装好了，也提供了两个 GatewayClass：
+      \`envoy-internal\`（只暴露到办公网）和 \`envoy-public\`（暴露到公网）。
+      **门户是内部系统，不能上公网。**
+
+      ## 通关标准
+
+      1. 建一个 Gateway（用对 class）和一条 HTTPRoute，把
+         \`portal.corp.internal\` 指到 \`portal\` 这个 Service；
+      2. Gateway 的 \`Programmed\` 是 True，拿到了地址；
+      3. 从跳板机（办公网）访问得到，返回 200；
+      4. **从公网访问不到**；
+      5. 老的 Ingress 与 ingress-nginx 的 Deployment 都删掉 —— 留着不只是脏，
+         还会让下一个人以为它还在起作用。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl get ingress,pods -n payments
+      kubectl get gatewayclass
+      kubectl apply -f infra/gateway.yaml
+      kubectl get gateway corp-gw -n payments -o yaml
+      kubectl describe httproute portal -n payments
+      curl -s -o /dev/null -w '%{http_code}\n' \\
+        --resolve portal.corp.internal:80:<Gateway 的地址> http://portal.corp.internal/
+      \`\`\`
+
+      跳板机上没有配 \`portal.corp.internal\` 的解析，直接用 Gateway 拿到的
+      地址访问就行。
+    `,
+    code`
+      The portal's external entrypoint still runs on ingress-nginx, a project that
+      was retired in March 2026. The image was pulled from the registry, the
+      controller cannot start, the Ingress never got an address, and the portal is
+      unreachable from the office network.
+
+      The platform team has already installed Envoy Gateway and offers two
+      GatewayClasses: \`envoy-internal\` (office network only) and \`envoy-public\`
+      (public internet). **The portal is an internal system and must not be public.**
+
+      ## Done when
+
+      1. a Gateway (with the right class) and an HTTPRoute send
+         \`portal.corp.internal\` to the \`portal\` Service;
+      2. the Gateway reports \`Programmed\` True and has an address;
+      3. it answers 200 from the jump host (office network);
+      4. **it is not reachable from the internet**;
+      5. the old Ingress and the ingress-nginx Deployment are both deleted. Leaving
+         them is not just untidy: the next person will assume they still do something.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl get ingress,pods -n payments
+      kubectl get gatewayclass
+      kubectl apply -f infra/gateway.yaml
+      kubectl get gateway corp-gw -n payments -o yaml
+      kubectl describe httproute portal -n payments
+      curl -s -o /dev/null -w '%{http_code}\n' \\
+        --resolve portal.corp.internal:80:<gateway address> http://portal.corp.internal/
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('Gateway 与 HTTPRoute 建好并生效', 'Gateway and HTTPRoute created and effective'),
+    t('办公网访问得到、公网访问不到', 'Reachable from the office network, not from the internet'),
+    t('老的 Ingress 与 ingress-nginx 都下线', 'The old Ingress and ingress-nginx are gone'),
+  ],
+  hints: [
+    t(
+      '\`kubectl get gatewayclass\` 会列出平台提供了哪几个 class，名字里就写着内外网。',
+      '\`kubectl get gatewayclass\` lists what the platform offers; the names say internal or public.'
+    ),
+    t(
+      'Gateway 的 \`status.addresses\` 里就是访问地址。\`kubectl get gateway -o wide\` 也看得到。',
+      'The address is in the Gateway’s \`status.addresses\`; \`kubectl get gateway -o wide\` shows it too.'
+    ),
+    t(
+      '路由不生效时先看 \`kubectl describe httproute\` 里的 \`ResolvedRefs\`，它会直接说是后端不存在还是别的。',
+      'When a route does not work, check \`ResolvedRefs\` in \`kubectl describe httproute\`; it names the actual problem.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '用了 \`envoy-public\` 那个 class。门户能访问了，但同时也暴露到了公网上 —— 判定会挂在这一条，现实里则是一次事故。',
+      'Using the \`envoy-public\` class. The portal works, and is also on the public internet. The grader catches it; production would not.'
+    ),
+    t(
+      '只删 Ingress 不删 ingress-nginx 的 Deployment。那个 Pod 还在那儿 CrashLoop，占着资源，还会让下一个人以为入口是它在管。',
+      'Deleting the Ingress but not the ingress-nginx Deployment. The pod keeps crash-looping, burning resources and misleading the next person.'
+    ),
+    t(
+      'HTTPRoute 的 \`hostnames\` 和 Gateway listener 的 \`hostname\` 对不上，两边都写了但不一样，结果是永远 404。',
+      'Mismatched \`hostnames\` between the HTTPRoute and the Gateway listener: both set, both different, permanent 404.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      // 平台组装好的 Envoy Gateway：控制器本身是集群里的一个工作负载
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: {
+          name: 'envoy-gateway', namespace: 'envoy-gateway-system',
+          labels: { 'app.kubernetes.io/name': 'envoy-gateway' },
+        },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { 'app.kubernetes.io/name': 'envoy-gateway' } },
+          template: {
+            metadata: { labels: { 'app.kubernetes.io/name': 'envoy-gateway' } },
+            spec: { containers: [{ name: 'controller', image: ENVOY_IMAGE }] },
+          },
+        },
+      },
+      {
+        apiVersion: 'gateway.envoyproxy.io/v1alpha1', kind: 'EnvoyProxy',
+        metadata: { name: 'internal', namespace: 'envoy-gateway-system' },
+        spec: { provider: { kubernetes: { envoyService: { loadBalancerClass: 'corp.internal/office-lb' } } } },
+      },
+      {
+        apiVersion: 'gateway.envoyproxy.io/v1alpha1', kind: 'EnvoyProxy',
+        metadata: { name: 'public', namespace: 'envoy-gateway-system' },
+        spec: { provider: { kubernetes: { envoyService: { loadBalancerClass: 'corp.internal/public-lb' } } } },
+      },
+      {
+        apiVersion: 'gateway.networking.k8s.io/v1', kind: 'GatewayClass',
+        metadata: { name: 'envoy-internal' },
+        spec: {
+          controllerName: 'gateway.envoyproxy.io/gatewayclass-controller',
+          parametersRef: {
+            group: 'gateway.envoyproxy.io', kind: 'EnvoyProxy',
+            name: 'internal', namespace: 'envoy-gateway-system',
+          },
+        },
+      },
+      {
+        apiVersion: 'gateway.networking.k8s.io/v1', kind: 'GatewayClass',
+        metadata: { name: 'envoy-public' },
+        spec: {
+          controllerName: 'gateway.envoyproxy.io/gatewayclass-controller',
+          parametersRef: {
+            group: 'gateway.envoyproxy.io', kind: 'EnvoyProxy',
+            name: 'public', namespace: 'envoy-gateway-system',
+          },
+        },
+      },
+      // 已经退役的 ingress-nginx：镜像下架了，控制器起不来
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: {
+          name: 'ingress-nginx-controller', namespace: 'ingress-nginx',
+          labels: { 'app.kubernetes.io/name': 'ingress-nginx' },
+        },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { 'app.kubernetes.io/name': 'ingress-nginx' } },
+          template: {
+            metadata: { labels: { 'app.kubernetes.io/name': 'ingress-nginx' } },
+            spec: { containers: [{ name: 'controller', image: RETIRED_NGINX_IMAGE }] },
+          },
+        },
+      },
+      // 门户本身
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'portal', namespace: 'payments' },
+        spec: {
+          replicas: 2,
+          selector: { matchLabels: { app: 'portal' } },
+          template: {
+            metadata: { labels: { app: 'portal' } },
+            spec: { containers: [{ name: 'web', image: PORTAL_IMAGE, ports: [{ containerPort: 8080 }] }] },
+          },
+        },
+      },
+      {
+        apiVersion: 'v1', kind: 'Service',
+        metadata: { name: 'portal', namespace: 'payments' },
+        spec: { clusterIP: '10.96.1.10', selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+      },
+    ],
+    files: {
+      '/root/infra/ingress.yaml': LEGACY_INGRESS,
+      '/root/infra/gateway.yaml': '# 在这里写 Gateway 与 HTTPRoute\n',
+    },
+    referenceFiles: { '/root/infra/gateway.yaml': GATEWAY_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/ingress.yaml',
+      'kubectl apply -f /root/infra/gateway.yaml',
+      'kubectl delete ingress portal -n payments',
+      'kubectl delete deployment ingress-nginx-controller -n ingress-nginx',
+      'rm -f /root/infra/ingress.yaml',
+    ],
+  },
+  specs: [
+    spec('gateway-migration.spec.ts', code`
+      import { get, list, sh, world } from '@ops/lab';
+
+      function conditionOf(object, type) {
+        return ((object.status || {}).conditions || []).find((entry) => entry.type === type);
+      }
+
+      describe('从 Ingress 迁到 Gateway API', () => {
+        it('Gateway 建出来了，而且被 program 了', () => {
+          const gateways = list('Gateway', { namespace: 'payments' });
+          expect(gateways.length).toBe(1);
+          expect(conditionOf(gateways[0], 'Programmed').status).toBe('True');
+          expect(gateways[0].status.addresses.length).toBe(1);
+        });
+
+        it('用的是内网 class，不是公网那个', () => {
+          const gateway = list('Gateway', { namespace: 'payments' })[0];
+          expect(gateway.spec.gatewayClassName).toBe('envoy-internal');
+        });
+
+        it('HTTPRoute 的后端解析得到', () => {
+          const routes = list('HTTPRoute', { namespace: 'payments' });
+          expect(routes.length).toBe(1);
+          const parent = routes[0].status.parents[0];
+          const resolved = parent.conditions.find((entry) => entry.type === 'ResolvedRefs');
+          expect(resolved.status).toBe('True');
+        });
+
+        it('办公网访问得到，返回 200', async () => {
+          const gateway = list('Gateway', { namespace: 'payments' })[0];
+          const address = gateway.status.addresses[0].value;
+          // DNS 还没改过来，用 --resolve 直连 Gateway 的地址
+          const result = await sh(
+            'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:80:' + address
+            + ' http://portal.corp.internal/'
+          );
+          expect(result.code).toBe(0);
+          expect(result.stdout).toBe('200');
+        });
+
+        it('公网访问不到', () => {
+          const gateway = list('Gateway', { namespace: 'payments' })[0];
+          const address = gateway.status.addresses[0].value;
+          const outcome = world.cluster.network.connect(
+            { zone: 'internet', label: 'outside', ip: '203.0.113.9' },
+            { host: 'portal.corp.internal', address, headerHost: 'portal.corp.internal', port: 80, path: '/' }
+          );
+          expect(outcome.kind).toBe('no-route');
+        });
+
+        it('老的 Ingress 下线了', () => {
+          expect(list('Ingress', { namespace: 'payments' }).length).toBe(0);
+        });
+
+        it('ingress-nginx 的控制器也下线了', () => {
+          const left = list('Deployment', { namespace: 'ingress-nginx' });
+          expect(left.length).toBe(0);
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'resilience'],
+  extension: t(
+    code`
+      Gateway API 相对 Ingress 最大的改进是**角色分离**：GatewayClass 归平台，
+      Gateway 归集群管理员（决定端口、证书、暴露到哪个网段），HTTPRoute 归应用
+      团队。Ingress 时代所有这些都挤在一个对象和一堆 annotation 里，
+      于是「谁能改什么」根本没法划清。
+
+      这一关里「内网还是公网」由 GatewayClass 背后的 EnvoyProxy 参数决定，
+      应用团队写 HTTPRoute 时碰不到它 —— 这正是分离的价值：
+      应用团队不可能不小心把自己暴露到公网上。
+    `,
+    code`
+      The biggest improvement Gateway API makes over Ingress is **role separation**:
+      GatewayClass belongs to the platform, Gateway to the cluster administrator
+      (ports, certificates, which network it is exposed on), and HTTPRoute to the
+      application team. Under Ingress all of that was crammed into one object and a
+      pile of annotations, so "who may change what" could not be drawn at all.
+
+      Here, internal-versus-public is decided by the EnvoyProxy parameters behind the
+      GatewayClass, and the application team never touches it while writing an
+      HTTPRoute. That is the point of the separation: an application team cannot
+      accidentally publish itself to the internet.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -1693,5 +2059,5 @@ module.exports = {
   ),
   workspace: { kind: 'ops', world: WORLD },
   files: [],
-  stages: [stage1, stage2, stage3, stage4, stage5, stage6, stage7],
+  stages: [stage1, stage2, stage3, stage4, stage5, stage6, stage7, stage8],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5612,7 +5612,9 @@
         "namespaces": [
           "default",
           "kube-system",
-          "payments"
+          "payments",
+          "envoy-gateway-system",
+          "ingress-nginx"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5631,6 +5633,14 @@
             "handlesSigterm": true,
             "runAsUser": 10001
           },
+          "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "listens": [
+              18000
+            ]
+          },
           "harbor.corp.internal/team/reports:2.1.0": {
             "pullMs": 500,
             "startupMs": 800,
@@ -5647,6 +5657,23 @@
         "baseImages": {
           "node:22-alpine": "node"
         },
+        "addressPools": [
+          {
+            "loadBalancerClass": "corp.internal/office-lb",
+            "cidrPrefix": "10.10.8",
+            "zones": [
+              "office"
+            ]
+          },
+          {
+            "loadBalancerClass": "corp.internal/public-lb",
+            "cidrPrefix": "203.0.113",
+            "zones": [
+              "office",
+              "internet"
+            ]
+          }
+        ],
         "registries": [
           {
             "host": "harbor.corp.internal",
@@ -6249,6 +6276,288 @@
         "primer": {
           "zh": "容器声明资源有两个字段，管的是两件事。`requests` 是给调度器看的：调度器按它做装箱，把 Pod 放到「已承诺容量」还够的节点上。`limits` 是运行时的硬约束，落到 cgroup 上。两者可以不相等，也可以只写一个，不同的写法会得到不同的后果。\n\n内存和 CPU 的超限行为完全不同。内存是不可压缩资源：用量超过 limit，内核直接 OOMKill 这个容器，退出码 137（128+9，SIGKILL），日志经常来不及写完。CPU 是可压缩资源：超过 limit 只是被限流，进程继续跑，只是变慢，表现为 P99 变差而不是进程消失。所以「应用没崩但突然变慢了」和「应用被杀了」要往两个方向查。\n\n`QoS 等级`不是自己填的，是 kubelet 根据 requests 与 limits 推出来的：每个容器的 cpu 和 memory 都写了且 requests 等于 limits，是 `Guaranteed`；一个都没写，是 `BestEffort`；其余是 `Burstable`。这个等级决定节点内存不够时谁先被赶走：BestEffort 最先，然后是用量超过自己 requests 的 Burstable，Guaranteed 最后。\n\n于是有一个很容易走进去的死胡同：容器被 OOMKill 了，把 limits 删掉「就不会被杀了」。确实不会，但它同时变成了 BestEffort，节点一紧张第一个被驱逐，只是把一种死法换成了另一种。正确的做法是先量出实际用量再设定数字。生产里有 VPA 的 recommender 帮忙算，以及 LimitRange 给命名空间兜一个默认值。",
           "en": "A container declares resources with two fields that govern two different things. `requests` is for the scheduler: it bin-packs by requests, placing pods on nodes that still have promised capacity. `limits` is a runtime constraint enforced by cgroups. The two need not be equal, and either may be omitted, with different consequences.\n\nMemory and CPU behave completely differently when exceeded. Memory is incompressible: cross the limit and the kernel OOM-kills the container with exit code 137 (128+9, SIGKILL), often before the logs finish flushing. CPU is compressible: crossing the limit only throttles the process, which keeps running but slower, showing up as a degraded P99 rather than a missing process. \"The app did not crash but suddenly got slow\" and \"the app was killed\" therefore point in different directions.\n\nThe `QoS class` is derived, not declared. The kubelet computes it from requests and limits: every container declaring both cpu and memory with requests equal to limits is `Guaranteed`; declaring nothing is `BestEffort`; anything else is `Burstable`. That class decides who is evicted first when a node runs short of memory: BestEffort first, then Burstable pods exceeding their own requests, and Guaranteed last.\n\nThis creates an easy dead end. A container gets OOM-killed, so you remove the limit and it stops being killed. True, but it has also become BestEffort and is now first in line for eviction: one way of dying traded for another. The right move is to measure actual usage and set numbers from that. Production adds the VPA recommender to compute them and a LimitRange to give the namespace sane defaults."
+        }
+      },
+      {
+        "id": "gateway-migration",
+        "title": {
+          "zh": "从 Ingress 迁到 Gateway API",
+          "en": "Migrate from Ingress to Gateway API"
+        },
+        "goal": {
+          "zh": "      门户的对外入口还挂在 ingress-nginx 上，而这个项目已经在 2026 年 3 月退役了 ——\n      镜像从仓库里下架，控制器起不来，Ingress 一直没有地址，门户从办公网访问不了。\n\n      平台组已经把 Envoy Gateway 装好了，也提供了两个 GatewayClass：\n      `envoy-internal`（只暴露到办公网）和 `envoy-public`（暴露到公网）。\n      **门户是内部系统，不能上公网。**\n\n      ## 通关标准\n\n      1. 建一个 Gateway（用对 class）和一条 HTTPRoute，把\n         `portal.corp.internal` 指到 `portal` 这个 Service；\n      2. Gateway 的 `Programmed` 是 True，拿到了地址；\n      3. 从跳板机（办公网）访问得到，返回 200；\n      4. **从公网访问不到**；\n      5. 老的 Ingress 与 ingress-nginx 的 Deployment 都删掉 —— 留着不只是脏，\n         还会让下一个人以为它还在起作用。\n\n      ## 会用到的命令\n\n      ```bash\n      kubectl get ingress,pods -n payments\n      kubectl get gatewayclass\n      kubectl apply -f infra/gateway.yaml\n      kubectl get gateway corp-gw -n payments -o yaml\n      kubectl describe httproute portal -n payments\n      curl -s -o /dev/null -w '%{http_code}\n' \\\n        --resolve portal.corp.internal:80:<Gateway 的地址> http://portal.corp.internal/\n      ```\n\n      跳板机上没有配 `portal.corp.internal` 的解析，直接用 Gateway 拿到的\n      地址访问就行。\n",
+          "en": "      The portal's external entrypoint still runs on ingress-nginx, a project that\n      was retired in March 2026. The image was pulled from the registry, the\n      controller cannot start, the Ingress never got an address, and the portal is\n      unreachable from the office network.\n\n      The platform team has already installed Envoy Gateway and offers two\n      GatewayClasses: `envoy-internal` (office network only) and `envoy-public`\n      (public internet). **The portal is an internal system and must not be public.**\n\n      ## Done when\n\n      1. a Gateway (with the right class) and an HTTPRoute send\n         `portal.corp.internal` to the `portal` Service;\n      2. the Gateway reports `Programmed` True and has an address;\n      3. it answers 200 from the jump host (office network);\n      4. **it is not reachable from the internet**;\n      5. the old Ingress and the ingress-nginx Deployment are both deleted. Leaving\n         them is not just untidy: the next person will assume they still do something.\n\n      ## Commands you will need\n\n      ```bash\n      kubectl get ingress,pods -n payments\n      kubectl get gatewayclass\n      kubectl apply -f infra/gateway.yaml\n      kubectl get gateway corp-gw -n payments -o yaml\n      kubectl describe httproute portal -n payments\n      curl -s -o /dev/null -w '%{http_code}\n' \\\n        --resolve portal.corp.internal:80:<gateway address> http://portal.corp.internal/\n      ```\n"
+        },
+        "checklist": [
+          {
+            "zh": "Gateway 与 HTTPRoute 建好并生效",
+            "en": "Gateway and HTTPRoute created and effective"
+          },
+          {
+            "zh": "办公网访问得到、公网访问不到",
+            "en": "Reachable from the office network, not from the internet"
+          },
+          {
+            "zh": "老的 Ingress 与 ingress-nginx 都下线",
+            "en": "The old Ingress and ingress-nginx are gone"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`kubectl get gatewayclass` 会列出平台提供了哪几个 class，名字里就写着内外网。",
+            "en": "`kubectl get gatewayclass` lists what the platform offers; the names say internal or public."
+          },
+          {
+            "zh": "Gateway 的 `status.addresses` 里就是访问地址。`kubectl get gateway -o wide` 也看得到。",
+            "en": "The address is in the Gateway’s `status.addresses`; `kubectl get gateway -o wide` shows it too."
+          },
+          {
+            "zh": "路由不生效时先看 `kubectl describe httproute` 里的 `ResolvedRefs`，它会直接说是后端不存在还是别的。",
+            "en": "When a route does not work, check `ResolvedRefs` in `kubectl describe httproute`; it names the actual problem."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用了 `envoy-public` 那个 class。门户能访问了，但同时也暴露到了公网上 —— 判定会挂在这一条，现实里则是一次事故。",
+            "en": "Using the `envoy-public` class. The portal works, and is also on the public internet. The grader catches it; production would not."
+          },
+          {
+            "zh": "只删 Ingress 不删 ingress-nginx 的 Deployment。那个 Pod 还在那儿 CrashLoop，占着资源，还会让下一个人以为入口是它在管。",
+            "en": "Deleting the Ingress but not the ingress-nginx Deployment. The pod keeps crash-looping, burning resources and misleading the next person."
+          },
+          {
+            "zh": "HTTPRoute 的 `hostnames` 和 Gateway listener 的 `hostname` 对不上，两边都写了但不一样，结果是永远 404。",
+            "en": "Mismatched `hostnames` between the HTTPRoute and the Gateway listener: both set, both different, permanent 404."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ingress-nginx-controller",
+                "namespace": "ingress-nginx",
+                "labels": {
+                  "app.kubernetes.io/name": "ingress-nginx"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "ingress-nginx"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "ingress-nginx"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/ingress-nginx/controller:v1.13.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/ingress.yaml": "apiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: portal\n  namespace: payments\n  annotations:\n    nginx.ingress.kubernetes.io/rewrite-target: /\nspec:\n  ingressClassName: nginx\n  rules:\n  - host: portal.corp.internal\n    http:\n      paths:\n      - path: /\n        pathType: Prefix\n        backend:\n          service:\n            name: portal\n            port:\n              number: 80\n",
+            "/root/infra/gateway.yaml": "# 在这里写 Gateway 与 HTTPRoute\n"
+          },
+          "referenceFiles": {
+            "/root/infra/gateway.yaml": "apiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: corp-gw\n  namespace: payments\nspec:\n  gatewayClassName: envoy-internal\n  listeners:\n  - name: http\n    port: 80\n    protocol: HTTP\n    hostname: portal.corp.internal\n    allowedRoutes:\n      namespaces:\n        from: Same\n---\napiVersion: gateway.networking.k8s.io/v1\nkind: HTTPRoute\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  parentRefs:\n  - name: corp-gw\n  hostnames:\n  - portal.corp.internal\n  rules:\n  - matches:\n    - path:\n        type: PathPrefix\n        value: /\n    backendRefs:\n    - name: portal\n      port: 80\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/ingress.yaml",
+            "kubectl apply -f /root/infra/gateway.yaml",
+            "kubectl delete ingress portal -n payments",
+            "kubectl delete deployment ingress-nginx-controller -n ingress-nginx",
+            "rm -f /root/infra/ingress.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "gateway-migration.spec.ts",
+            "content": "import { get, list, sh, world } from '@ops/lab';\n\nfunction conditionOf(object, type) {\n  return ((object.status || {}).conditions || []).find((entry) => entry.type === type);\n}\n\ndescribe('从 Ingress 迁到 Gateway API', () => {\n  it('Gateway 建出来了，而且被 program 了', () => {\n    const gateways = list('Gateway', { namespace: 'payments' });\n    expect(gateways.length).toBe(1);\n    expect(conditionOf(gateways[0], 'Programmed').status).toBe('True');\n    expect(gateways[0].status.addresses.length).toBe(1);\n  });\n\n  it('用的是内网 class，不是公网那个', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    expect(gateway.spec.gatewayClassName).toBe('envoy-internal');\n  });\n\n  it('HTTPRoute 的后端解析得到', () => {\n    const routes = list('HTTPRoute', { namespace: 'payments' });\n    expect(routes.length).toBe(1);\n    const parent = routes[0].status.parents[0];\n    const resolved = parent.conditions.find((entry) => entry.type === 'ResolvedRefs');\n    expect(resolved.status).toBe('True');\n  });\n\n  it('办公网访问得到，返回 200', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    // DNS 还没改过来，用 --resolve 直连 Gateway 的地址\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:80:' + address\n      + ' http://portal.corp.internal/'\n    );\n    expect(result.code).toBe(0);\n    expect(result.stdout).toBe('200');\n  });\n\n  it('公网访问不到', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    const outcome = world.cluster.network.connect(\n      { zone: 'internet', label: 'outside', ip: '203.0.113.9' },\n      { host: 'portal.corp.internal', address, headerHost: 'portal.corp.internal', port: 80, path: '/' }\n    );\n    expect(outcome.kind).toBe('no-route');\n  });\n\n  it('老的 Ingress 下线了', () => {\n    expect(list('Ingress', { namespace: 'payments' }).length).toBe(0);\n  });\n\n  it('ingress-nginx 的控制器也下线了', () => {\n    const left = list('Deployment', { namespace: 'ingress-nginx' });\n    expect(left.length).toBe(0);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "Gateway API 相对 Ingress 最大的改进是**角色分离**：GatewayClass 归平台，\nGateway 归集群管理员（决定端口、证书、暴露到哪个网段），HTTPRoute 归应用\n团队。Ingress 时代所有这些都挤在一个对象和一堆 annotation 里，\n于是「谁能改什么」根本没法划清。\n\n这一关里「内网还是公网」由 GatewayClass 背后的 EnvoyProxy 参数决定，\n应用团队写 HTTPRoute 时碰不到它 —— 这正是分离的价值：\n应用团队不可能不小心把自己暴露到公网上。\n",
+          "en": "The biggest improvement Gateway API makes over Ingress is **role separation**:\nGatewayClass belongs to the platform, Gateway to the cluster administrator\n(ports, certificates, which network it is exposed on), and HTTPRoute to the\napplication team. Under Ingress all of that was crammed into one object and a\npile of annotations, so \"who may change what\" could not be drawn at all.\n\nHere, internal-versus-public is decided by the EnvoyProxy parameters behind the\nGatewayClass, and the application team never touches it while writing an\nHTTPRoute. That is the point of the separation: an application team cannot\naccidentally publish itself to the internet.\n"
+        },
+        "primer": {
+          "zh": "集群里的服务默认只能在集群内部访问。要让外面进得来，需要一个`入口`。早年的做法是 `Ingress`：一个对象里写着域名、路径和后端 Service，再由某个 Ingress 控制器（nginx、traefik 之类）把它翻译成真正的反向代理配置。Ingress 的规范只覆盖了最基础的 HTTP 路由，超出的部分全靠 annotation，于是每家控制器一套写法，配置无法在实现之间迁移。\n\n`Gateway API` 是它的继任者，2023 年 GA。最大的变化是把一个对象拆成三个，按`角色`分开：`GatewayClass` 由平台方提供，声明「这套入口由哪个控制器实现」；`Gateway` 由集群管理员建，决定监听哪些端口、用什么证书、暴露到哪个网段；`HTTPRoute` 由应用团队自己写，只管路径怎么分发到哪个 Service。谁能改什么，从此在 RBAC 上划得清。\n\n一条请求进来要经过两层匹配。先看 Gateway 的 `listener`：端口对不对、`hostname` 对不对。再看挂在这个 Gateway 上的 HTTPRoute：`hostnames` 对不对、`rules.matches` 里的路径对不对。两层都过了才转给 `backendRefs` 指的 Service。任何一层没匹配上，Gateway 会回 404 而不是拒绝连接，因为 Gateway 本身是活着的。这个区别决定了排查方向：404 去查路由，连不上去查 Gateway。\n\n状态写在两处，都值得先看。Gateway 的 `Programmed` 条件说明控制器有没有把配置下发下去，`status.addresses` 里是真正的访问地址。HTTPRoute 的 `status.parents[].conditions` 里有 `Accepted` 和 `ResolvedRefs`，后者会直接说出后端 Service 是不是不存在，省掉一轮猜测。",
+          "en": "Services in a cluster are only reachable from inside it by default. Letting outside traffic in requires an `ingress point`. The original mechanism was `Ingress`: one object holding hostnames, paths, and backend Services, translated into real reverse-proxy configuration by some Ingress controller (nginx, traefik, and others). The Ingress spec only covered basic HTTP routing, so everything beyond it lived in annotations, every controller invented its own, and configuration could not move between implementations.\n\n`Gateway API` is the successor, GA since 2023. Its central change is splitting that one object into three along `role` lines. `GatewayClass` is offered by the platform and names the controller implementing it. `Gateway` is created by the cluster administrator and decides which ports to listen on, which certificates to use, and which network it is exposed on. `HTTPRoute` is written by the application team and only says which path goes to which Service. Who may change what is finally expressible in RBAC.\n\nAn incoming request passes two matching layers. First the Gateway `listener`: correct port, correct `hostname`. Then the HTTPRoutes attached to that Gateway: correct `hostnames`, correct path in `rules.matches`. Only if both pass does traffic go to the Service in `backendRefs`. If either fails, the Gateway returns 404 rather than refusing the connection, because the Gateway itself is alive. That distinction sets the direction of an investigation: a 404 means look at routing, a refused connection means look at the Gateway.\n\nStatus lives in two places and both are worth reading first. The Gateway `Programmed` condition says whether the controller pushed configuration down, and `status.addresses` holds the real address. An HTTPRoute carries `Accepted` and `ResolvedRefs` in `status.parents[].conditions`, and the latter states outright whether the backend Service is missing, saving a round of guessing."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1147,6 +1147,21 @@ const primers = {
       )
     ),
 
+    'gateway-migration': t(
+      p(
+        '集群里的服务默认只能在集群内部访问。要让外面进得来，需要一个`入口`。早年的做法是 `Ingress`：一个对象里写着域名、路径和后端 Service，再由某个 Ingress 控制器（nginx、traefik 之类）把它翻译成真正的反向代理配置。Ingress 的规范只覆盖了最基础的 HTTP 路由，超出的部分全靠 annotation，于是每家控制器一套写法，配置无法在实现之间迁移。',
+        '`Gateway API` 是它的继任者，2023 年 GA。最大的变化是把一个对象拆成三个，按`角色`分开：`GatewayClass` 由平台方提供，声明「这套入口由哪个控制器实现」；`Gateway` 由集群管理员建，决定监听哪些端口、用什么证书、暴露到哪个网段；`HTTPRoute` 由应用团队自己写，只管路径怎么分发到哪个 Service。谁能改什么，从此在 RBAC 上划得清。',
+        '一条请求进来要经过两层匹配。先看 Gateway 的 `listener`：端口对不对、`hostname` 对不对。再看挂在这个 Gateway 上的 HTTPRoute：`hostnames` 对不对、`rules.matches` 里的路径对不对。两层都过了才转给 `backendRefs` 指的 Service。任何一层没匹配上，Gateway 会回 404 而不是拒绝连接，因为 Gateway 本身是活着的。这个区别决定了排查方向：404 去查路由，连不上去查 Gateway。',
+        '状态写在两处，都值得先看。Gateway 的 `Programmed` 条件说明控制器有没有把配置下发下去，`status.addresses` 里是真正的访问地址。HTTPRoute 的 `status.parents[].conditions` 里有 `Accepted` 和 `ResolvedRefs`，后者会直接说出后端 Service 是不是不存在，省掉一轮猜测。'
+      ),
+      p(
+        'Services in a cluster are only reachable from inside it by default. Letting outside traffic in requires an `ingress point`. The original mechanism was `Ingress`: one object holding hostnames, paths, and backend Services, translated into real reverse-proxy configuration by some Ingress controller (nginx, traefik, and others). The Ingress spec only covered basic HTTP routing, so everything beyond it lived in annotations, every controller invented its own, and configuration could not move between implementations.',
+        '`Gateway API` is the successor, GA since 2023. Its central change is splitting that one object into three along `role` lines. `GatewayClass` is offered by the platform and names the controller implementing it. `Gateway` is created by the cluster administrator and decides which ports to listen on, which certificates to use, and which network it is exposed on. `HTTPRoute` is written by the application team and only says which path goes to which Service. Who may change what is finally expressible in RBAC.',
+        'An incoming request passes two matching layers. First the Gateway `listener`: correct port, correct `hostname`. Then the HTTPRoutes attached to that Gateway: correct `hostnames`, correct path in `rules.matches`. Only if both pass does traffic go to the Service in `backendRefs`. If either fails, the Gateway returns 404 rather than refusing the connection, because the Gateway itself is alive. That distinction sets the direction of an investigation: a 404 means look at routing, a refused connection means look at the Gateway.',
+        'Status lives in two places and both are worth reading first. The Gateway `Programmed` condition says whether the controller pushed configuration down, and `status.addresses` holds the real address. An HTTPRoute carries `Accepted` and `ResolvedRefs` in `status.parents[].conditions`, and the latter states outright whether the backend Service is missing, saving a round of guessing.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -241,6 +241,17 @@ export interface OpsWorldSpec {
   /** 集群外的名字：`git.corp.internal` -> ['10.10.0.30'] */
   externalHosts?: Record<string, string[]>;
   /**
+   * 负载均衡地址池。
+   *
+   * `loadBalancerClass` 决定从哪个池子分地址，也决定这个地址能被谁访问到。
+   * 「内网入口」与「公网入口」的分野在这里。
+   */
+  addressPools?: Array<{
+    loadBalancerClass: string;
+    cidrPrefix: string;
+    zones: Array<'office' | 'internet'>;
+  }>;
+  /**
    * 哪些主机名解析得到 apiserver。
    *
    * 不填就是 `apiserver.opslab`。写错 server 的 kubeconfig 应该连不上，

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -27,7 +27,10 @@ import {
   SchedulerController,
 } from './workloads';
 import type { ImageBehavior, RegistryAuth } from './runtime';
-import { Network, createNetwork } from '../net';
+import { Network, createNetwork, type Zone } from '../net';
+import {
+  AddressPool, GATEWAY_RESOURCES, GatewayController, LoadBalancerController, resolveGateway,
+} from '../gateway';
 
 export interface NodeSpec {
   name: string;
@@ -53,8 +56,13 @@ export interface ClusterOptions {
   resolveImage?: (image: string) => ImageSpec | undefined;
   /** 集群外的名字，`harbor.corp.internal` 之类 */
   externalHosts?: Record<string, string[]>;
-  /** 哪些地址暴露到了哪些分区（Gateway / LoadBalancer 往这里加） */
-  exposure?: (address: string) => import('../net').Zone[];
+  /**
+   * 负载均衡地址池。
+   *
+   * `loadBalancerClass` 决定从哪个池子分地址，也决定这个地址被暴露到哪个网段。
+   * 内网入口与公网入口的分野在这里，不在 Gateway 自己身上。
+   */
+  addressPools?: AddressPool[];
   /**
    * 集群「已经跑了多久」。
    *
@@ -65,6 +73,11 @@ export interface ClusterOptions {
   clusterAgeMs?: number;
   extraResources?: ResourceDefinition[];
 }
+
+/** 不声明地址池时，只有一个内网池 —— 默认不该把东西暴露到公网 */
+const DEFAULT_POOLS: AddressPool[] = [
+  { loadBalancerClass: 'corp.internal/office-lb', cidrPrefix: '10.10.8', zones: ['office'] },
+];
 
 export class Cluster {
   readonly kernel: Kernel;
@@ -88,7 +101,9 @@ export class Cluster {
     const now = () => startTime + this.kernel.now() - this.backdate;
 
     this.store = createStore();
-    this.scheme = createScheme([...CORE_RESOURCES, ...(options.extraResources ?? [])]);
+    this.scheme = createScheme([
+      ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...(options.extraResources ?? []),
+    ]);
     this.registry = new Registry({
       store: this.store,
       scheme: this.scheme,
@@ -100,12 +115,35 @@ export class Cluster {
       registry: this.registry,
       scheme: this.scheme,
       externalHosts: options.externalHosts,
-      exposure: options.exposure,
+      exposure: (address) => this.zonesOf(address),
+      gatewayRoute: (address, request) =>
+        resolveGateway({ registry: this.registry, scheme: this.scheme }, address, request),
       imageOf: (image) => this.imageBehaviorOf(image),
       now,
     });
 
     this.seed();
+  }
+
+  /**
+   * 这个地址被暴露到了哪些网段。
+   *
+   * 读的是 LoadBalancer Service 的 `spec.loadBalancerClass` —— 也就是说
+   * 「内网还是公网」是集群里的一个对象说了算的，不是宿主写死的。
+   */
+  private zonesOf(address: string): Zone[] {
+    const services = this.scheme.get({ group: '', version: 'v1', resource: 'services' });
+    if (!services) return [];
+    for (const service of this.registry.list(services).items) {
+      const ingress = ((service.status ?? {}) as any)?.loadBalancer?.ingress ?? [];
+      if (!ingress.some((entry: any) => entry.ip === address)) continue;
+      const className = ((service.spec ?? {}) as any).loadBalancerClass;
+      const pool = (this.options.addressPools ?? []).find(
+        (item) => item.loadBalancerClass === className
+      ) ?? (this.options.addressPools ?? [])[0];
+      return (pool?.zones ?? ['office']) as Zone[];
+    }
+    return [];
   }
 
   /** 这个镜像的运行时行为：端口、路由、内存。网络与 kubelet 共用同一份。 */
@@ -246,6 +284,9 @@ export class Cluster {
       new ReplicaSetController(context),
       new DeploymentController(context),
       new EndpointsController(context),
+      // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
+      new GatewayController(context),
+      new LoadBalancerController(context, this.options.addressPools ?? DEFAULT_POOLS),
       ...this.nodeSpecs.flatMap((node) => [
         new KubeletController(context, node.name, {
           images: this.options.images,

--- a/src/lib/opslab/gateway/controller.ts
+++ b/src/lib/opslab/gateway/controller.ts
@@ -17,7 +17,7 @@
  * ResolvedRefs=False 会直接说出是后端 Service 不存在还是端口对不上。
  */
 import { Priority } from '../kernel';
-import type { KubeObject } from '../apiserver';
+import type { KubeObject, ResourceDefinition } from '../apiserver';
 import {
   Controller, ControllerContext, Informer, isConflict, isNotFound, objectKey, splitKey,
 } from '../controllers/framework';
@@ -80,10 +80,10 @@ export class GatewayController extends Controller {
     try {
       gateway = this.registry.get(GATEWAYS, namespace, name);
     } catch (error) {
-      if (isNotFound(error)) return;
+      if (isNotFound(error)) { this.removeService(namespace, name); return; }
       throw error;
     }
-    if (gateway.metadata.deletionTimestamp) return;
+    if (gateway.metadata.deletionTimestamp) { this.removeService(namespace, name); return; }
 
     const spec = (gateway.spec ?? {}) as any;
     const owned = this.classes.list().find(
@@ -125,6 +125,20 @@ export class GatewayController extends Controller {
     for (const route of this.routesFor(gateway)) this.setRouteStatus(route, gateway);
   }
 
+  /**
+   * Gateway 没了，它的 Service 也要跟着走。
+   *
+   * 不清的话地址还挂在那儿，`resolveGateway` 会一直返回 503，
+   * 看起来像「入口坏了」而不是「入口被删了」。
+   */
+  private removeService(namespace: string | undefined, name: string): void {
+    try {
+      this.registry.delete(SERVICES, 'envoy-gateway-system', `envoy-${namespace}-${name}`);
+    } catch (error) {
+      if (!isNotFound(error) && !isConflict(error)) throw error;
+    }
+  }
+
   /** 每个 Gateway 对应一个 LoadBalancer Service，真 Envoy Gateway 也是这么干的 */
   private ensureService(gateway: KubeObject, gatewayClass: KubeObject): KubeObject | undefined {
     const namespace = 'envoy-gateway-system';
@@ -141,6 +155,14 @@ export class GatewayController extends Controller {
           'gateway.envoyproxy.io/owning-gateway-namespace': gateway.metadata.namespace ?? '',
         },
         annotations: parameters.annotations,
+        // 属主关系写清楚，`kubectl get svc -o yaml` 里看得出这个 Service 是谁生的
+        ownerReferences: [{
+          apiVersion: 'gateway.networking.k8s.io/v1',
+          kind: 'Gateway',
+          name: gateway.metadata.name,
+          uid: gateway.metadata.uid,
+          controller: true,
+        }],
       },
       spec: {
         type: 'LoadBalancer',
@@ -257,7 +279,7 @@ export class GatewayController extends Controller {
     });
   }
 
-  private writeStatus(definition: typeof GATEWAYS, object: KubeObject, status: unknown): void {
+  private writeStatus(definition: ResourceDefinition, object: KubeObject, status: unknown): void {
     if (JSON.stringify(object.status ?? null) === JSON.stringify(status)) return;
     try {
       const latest = this.registry.get(definition, object.metadata.namespace, object.metadata.name);
@@ -298,6 +320,17 @@ export class LoadBalancerController extends Controller {
       ((service.spec as any)?.type === 'LoadBalancer' ? key : null));
   }
 
+  /** 从池子里挑一个还没被占的地址 */
+  private pick(pool: AddressPool, key: string): string {
+    const taken = new Set(this.assigned.values());
+    const start = hash(key) % 200;
+    for (let offset = 0; offset < 200; offset += 1) {
+      const candidate = `${pool.cidrPrefix}.${((start + offset) % 200) + 20}`;
+      if (!taken.has(candidate)) return candidate;
+    }
+    throw new Error(`地址池 ${pool.loadBalancerClass} 用完了`);
+  }
+
   protected async reconcile(key: string): Promise<void> {
     const { namespace, name } = splitKey(key);
     let service: KubeObject;
@@ -314,8 +347,13 @@ export class LoadBalancerController extends Controller {
       ?? this.pools[0];
     if (!pool) return;
 
-    // 地址按 key 派生，不用计数器 —— 同一个世界重放两次要分到同一个地址
-    const address = this.assigned.get(key) ?? `${pool.cidrPrefix}.${(hash(key) % 200) + 20}`;
+    /**
+     * 地址按 key 派生，不用计数器 —— 同一个世界重放两次要分到同一个地址。
+     *
+     * 但派生会撞：两个 Service 抢到同一个地址的话，路由会串到别人身上。
+     * 撞了就往后顺延，顺延也是确定的。
+     */
+    const address = this.assigned.get(key) ?? this.pick(pool, key);
     this.assigned.set(key, address);
 
     const status = { loadBalancer: { ingress: [{ ip: address }] } };

--- a/src/lib/opslab/gateway/controller.ts
+++ b/src/lib/opslab/gateway/controller.ts
@@ -1,0 +1,361 @@
+/**
+ * Envoy Gateway 控制器
+ *
+ * 它是**跑在集群里的一个工作负载**，不是宿主特判出来的东西：reconcile 之前
+ * 先确认自己那个 Deployment 还在、还可用。学员把它卸载掉，Gateway 就不再被
+ * program —— 第 8 关最后一步「旧控制器彻底下线」之所以能判定，靠的就是这条。
+ *
+ * 它干的事和真 Envoy Gateway 一样：
+ *  1. 认领 controllerName 指向自己的 GatewayClass；
+ *  2. 给每个 Gateway 建一个 LoadBalancer Service（真的会在
+ *     envoy-gateway-system 里建出来，名字是 `envoy-<ns>-<name>`）；
+ *  3. 把 Service 拿到的地址写回 Gateway 的 status.addresses；
+ *  4. 校验 HTTPRoute 的 parentRefs 与 backendRefs，写 status.parents 里的
+ *     Accepted / ResolvedRefs 条件。
+ *
+ * 第 4 步是排查的关键：路由不生效时，`kubectl describe httproute` 里的
+ * ResolvedRefs=False 会直接说出是后端 Service 不存在还是端口对不上。
+ */
+import { Priority } from '../kernel';
+import type { KubeObject } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isConflict, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS, SERVICES } from '../controllers/resources';
+import { GATEWAYCLASSES, GATEWAYS, HTTPROUTES, ENVOYPROXIES } from './resources';
+
+export const ENVOY_CONTROLLER = 'gateway.envoyproxy.io/gatewayclass-controller';
+/** 控制器自己那个 Deployment 靠这个标签认出来 */
+export const ENVOY_LABEL = { key: 'app.kubernetes.io/name', value: 'envoy-gateway' };
+
+export interface GatewayControllerOptions {
+  /** 认哪个 controllerName。默认就是 Envoy Gateway 的那个。 */
+  controllerName?: string;
+}
+
+export class GatewayController extends Controller {
+  private gateways: Informer;
+  private routes: Informer;
+  private classes: Informer;
+  private deployments: Informer;
+  private services: Informer;
+  private readonly controllerName: string;
+
+  constructor(context: ControllerContext, options: GatewayControllerOptions = {}) {
+    super(context, 'envoy-gateway');
+    this.controllerName = options.controllerName ?? ENVOY_CONTROLLER;
+
+    this.gateways = new Informer(this.registry, GATEWAYS);
+    this.routes = this.track(new Informer(this.registry, HTTPROUTES));
+    this.classes = this.track(new Informer(this.registry, GATEWAYCLASSES));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.services = this.track(new Informer(this.registry, SERVICES));
+
+    this.watch(this.gateways);
+    // 路由、class、自己的部署、后端 Service 变了，相关的 Gateway 都要重看
+    for (const informer of [this.routes, this.classes, this.deployments, this.services]) {
+      informer.onChange(() => {
+        for (const gateway of this.gateways.list()) this.queue.add(objectKey(gateway));
+      });
+    }
+  }
+
+  /**
+   * 控制器自己在不在。
+   *
+   * 这是「组件是工作负载」这条约束的兑现处：没有可用的 Deployment，
+   * 什么都不做，Gateway 会一直停在 Programmed=Unknown。
+   */
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[ENVOY_LABEL.key] !== ENVOY_LABEL.value) return false;
+      const status = (deployment.status ?? {}) as { availableReplicas?: number };
+      return (status.availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let gateway: KubeObject;
+    try {
+      gateway = this.registry.get(GATEWAYS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (gateway.metadata.deletionTimestamp) return;
+
+    const spec = (gateway.spec ?? {}) as any;
+    const owned = this.classes.list().find(
+      (item) => item.metadata.name === spec.gatewayClassName
+        && ((item.spec ?? {}) as any).controllerName === this.controllerName
+    );
+    if (!owned) return;   // 别人的 class，不插手
+
+    if (!this.installed()) {
+      this.setGatewayStatus(gateway, {
+        accepted: 'Unknown', programmed: 'Unknown',
+        message: 'Waiting for controller',
+        addresses: [],
+      });
+      return;
+    }
+
+    // 给这个 Gateway 建（或更新）它的 LoadBalancer Service
+    const service = this.ensureService(gateway, owned);
+    const address = ((service?.status ?? {}) as any)?.loadBalancer?.ingress?.[0]?.ip;
+
+    this.setGatewayStatus(gateway, {
+      accepted: 'True',
+      programmed: address ? 'True' : 'Unknown',
+      message: address ? 'Sending translated configuration to Envoy' : 'Waiting for address',
+      addresses: address ? [{ type: 'IPAddress', value: address }] : [],
+      listeners: listenersOf(spec).map((listener) => ({
+        name: listener.name,
+        supportedKinds: [{ group: 'gateway.networking.k8s.io', kind: 'HTTPRoute' }],
+        attachedRoutes: this.routesFor(gateway, listener).length,
+        conditions: [
+          condition('Accepted', 'True', 'Accepted', 'Sending translated configuration to Envoy', this.context.now()),
+          condition('Programmed', address ? 'True' : 'Unknown', 'Programmed', 'Listener is ready', this.context.now()),
+          condition('ResolvedRefs', 'True', 'ResolvedRefs', 'Listener references resolved', this.context.now()),
+        ],
+      })),
+    });
+
+    for (const route of this.routesFor(gateway)) this.setRouteStatus(route, gateway);
+  }
+
+  /** 每个 Gateway 对应一个 LoadBalancer Service，真 Envoy Gateway 也是这么干的 */
+  private ensureService(gateway: KubeObject, gatewayClass: KubeObject): KubeObject | undefined {
+    const namespace = 'envoy-gateway-system';
+    const name = `envoy-${gateway.metadata.namespace}-${gateway.metadata.name}`;
+    const parameters = this.parametersOf(gatewayClass);
+    const listeners = listenersOf((gateway.spec ?? {}) as any);
+
+    const desired = {
+      apiVersion: 'v1', kind: 'Service',
+      metadata: {
+        name, namespace,
+        labels: {
+          'gateway.envoyproxy.io/owning-gateway-name': gateway.metadata.name,
+          'gateway.envoyproxy.io/owning-gateway-namespace': gateway.metadata.namespace ?? '',
+        },
+        annotations: parameters.annotations,
+      },
+      spec: {
+        type: 'LoadBalancer',
+        loadBalancerClass: parameters.loadBalancerClass,
+        selector: { 'app.kubernetes.io/name': 'envoy', 'gateway.envoyproxy.io/owning-gateway-name': gateway.metadata.name },
+        ports: listeners.map((listener) => ({
+          name: listener.name,
+          port: listener.port,
+          targetPort: listener.port,
+          protocol: 'TCP',
+        })),
+      },
+    } as unknown as KubeObject;
+
+    const existing = this.services.list().find(
+      (item) => item.metadata.namespace === namespace && item.metadata.name === name
+    );
+    try {
+      if (!existing) return this.registry.create(SERVICES, namespace, desired);
+      const merged = { ...existing, spec: { ...(existing.spec as any), ...(desired.spec as any) } };
+      if (JSON.stringify(merged.spec) === JSON.stringify(existing.spec)) return existing;
+      return this.registry.update(SERVICES, namespace, name, merged);
+    } catch (error) {
+      if (isConflict(error) || isNotFound(error)) return existing;
+      throw error;
+    }
+  }
+
+  /** GatewayClass -> EnvoyProxy -> LoadBalancer Service 长什么样 */
+  private parametersOf(gatewayClass: KubeObject): {
+    loadBalancerClass?: string;
+    annotations?: Record<string, string>;
+  } {
+    const ref = ((gatewayClass.spec ?? {}) as any).parametersRef;
+    if (!ref?.name) return {};
+    try {
+      const proxy = this.registry.get(ENVOYPROXIES, ref.namespace ?? 'envoy-gateway-system', ref.name);
+      const service = ((proxy.spec ?? {}) as any)?.provider?.kubernetes?.envoyService ?? {};
+      return { loadBalancerClass: service.loadBalancerClass, annotations: service.annotations };
+    } catch (error) {
+      if (isNotFound(error)) return {};
+      throw error;
+    }
+  }
+
+  /** 挂在这个 Gateway 上的 HTTPRoute */
+  private routesFor(gateway: KubeObject, listener?: { name: string }): KubeObject[] {
+    return this.routes.list().filter((route) => {
+      const parents = ((route.spec ?? {}) as any).parentRefs ?? [];
+      return parents.some((parent: any) =>
+        parent.name === gateway.metadata.name
+        && (parent.namespace ?? route.metadata.namespace) === gateway.metadata.namespace
+        && (!listener || !parent.sectionName || parent.sectionName === listener.name)
+      );
+    });
+  }
+
+  /**
+   * HTTPRoute 的状态。
+   *
+   * `ResolvedRefs=False` 是排查路由不生效时最有用的一条：它会直接说出
+   * 后端 Service 不存在，而不是让人去猜。
+   */
+  private setRouteStatus(route: KubeObject, gateway: KubeObject): void {
+    const backends = ((route.spec ?? {}) as any).rules?.flatMap((rule: any) => rule.backendRefs ?? []) ?? [];
+    const missing = backends.filter((backend: any) => {
+      const namespace = backend.namespace ?? route.metadata.namespace;
+      return !this.services.list().some(
+        (item) => item.metadata.namespace === namespace && item.metadata.name === backend.name
+      );
+    });
+
+    const now = this.context.now();
+    const parents = [{
+      parentRef: {
+        group: 'gateway.networking.k8s.io',
+        kind: 'Gateway',
+        name: gateway.metadata.name,
+        namespace: gateway.metadata.namespace,
+      },
+      controllerName: this.controllerName,
+      conditions: [
+        condition('Accepted', 'True', 'Accepted', 'Route is accepted', now),
+        missing.length === 0
+          ? condition('ResolvedRefs', 'True', 'ResolvedRefs', 'Resolved all the Object references for the Route', now)
+          : condition(
+            'ResolvedRefs', 'False', 'BackendNotFound',
+            `Service ${route.metadata.namespace}/${missing[0].name} not found`,
+            now
+          ),
+      ],
+    }];
+    this.writeStatus(HTTPROUTES, route, { parents });
+  }
+
+  private setGatewayStatus(
+    gateway: KubeObject,
+    input: {
+      accepted: string;
+      programmed: string;
+      message: string;
+      addresses: Array<{ type: string; value: string }>;
+      listeners?: unknown[];
+    }
+  ): void {
+    const now = this.context.now();
+    this.writeStatus(GATEWAYS, gateway, {
+      addresses: input.addresses,
+      conditions: [
+        condition('Accepted', input.accepted, 'Accepted', 'The Gateway has been scheduled by Envoy Gateway', now),
+        condition('Programmed', input.programmed, 'Programmed', input.message, now),
+      ],
+      listeners: input.listeners ?? [],
+    });
+  }
+
+  private writeStatus(definition: typeof GATEWAYS, object: KubeObject, status: unknown): void {
+    if (JSON.stringify(object.status ?? null) === JSON.stringify(status)) return;
+    try {
+      const latest = this.registry.get(definition, object.metadata.namespace, object.metadata.name);
+      if (JSON.stringify(latest.status ?? null) === JSON.stringify(status)) return;
+      this.registry.updateStatus(definition, object.metadata.namespace, object.metadata.name, {
+        ...latest, status,
+      });
+    } catch (error) {
+      if (!isConflict(error) && !isNotFound(error)) throw error;
+    }
+  }
+}
+
+/**
+ * 给 LoadBalancer Service 分地址。
+ *
+ * 相当于云厂商的 controller，或者内网里那台 MetalLB。地址从哪个池子里出，
+ * 由 `spec.loadBalancerClass` 决定 —— 内网入口和公网入口的分野就在这里，
+ * 而不是在 Gateway 自己身上。
+ */
+export interface AddressPool {
+  /** `corp.internal/office-lb` */
+  loadBalancerClass: string;
+  /** 从哪个网段分 */
+  cidrPrefix: string;
+  /** 这个池子里的地址，谁能访问到 */
+  zones: Array<'office' | 'internet'>;
+}
+
+export class LoadBalancerController extends Controller {
+  private services: Informer;
+  private assigned = new Map<string, string>();
+
+  constructor(context: ControllerContext, private readonly pools: AddressPool[]) {
+    super(context, 'load-balancer');
+    this.services = new Informer(this.registry, SERVICES);
+    this.watch(this.services, (service, key) =>
+      ((service.spec as any)?.type === 'LoadBalancer' ? key : null));
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let service: KubeObject;
+    try {
+      service = this.registry.get(SERVICES, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) { this.assigned.delete(key); return; }
+      throw error;
+    }
+    const spec = (service.spec ?? {}) as any;
+    if (spec.type !== 'LoadBalancer' || service.metadata.deletionTimestamp) return;
+
+    const pool = this.pools.find((item) => item.loadBalancerClass === spec.loadBalancerClass)
+      ?? this.pools[0];
+    if (!pool) return;
+
+    // 地址按 key 派生，不用计数器 —— 同一个世界重放两次要分到同一个地址
+    const address = this.assigned.get(key) ?? `${pool.cidrPrefix}.${(hash(key) % 200) + 20}`;
+    this.assigned.set(key, address);
+
+    const status = { loadBalancer: { ingress: [{ ip: address }] } };
+    if (JSON.stringify(service.status ?? null) === JSON.stringify(status)) return;
+    this.kernel.setTimeout(() => {
+      try {
+        const latest = this.registry.get(SERVICES, namespace, name);
+        if (JSON.stringify(latest.status ?? null) === JSON.stringify(status)) return;
+        this.registry.updateStatus(SERVICES, namespace, name, { ...latest, status });
+      } catch (error) {
+        if (!isConflict(error) && !isNotFound(error)) throw error;
+      }
+    }, 300, { priority: Priority.CONTROLLER, label: `load-balancer:${key}` });
+  }
+}
+
+/* ------------------------------------------------------------------ */
+
+function listenersOf(spec: any): Array<{ name: string; port: number; protocol: string; hostname?: string }> {
+  return (spec.listeners ?? []).map((listener: any) => ({
+    name: listener.name,
+    port: Number(listener.port),
+    protocol: listener.protocol ?? 'HTTP',
+    hostname: listener.hostname,
+  }));
+}
+
+function condition(type: string, status: string, reason: string, message: string, now: number) {
+  return {
+    type, status, reason, message,
+    observedGeneration: 1,
+    lastTransitionTime: new Date(now).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+  };
+}
+
+function hash(value: string): number {
+  let result = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    result ^= value.charCodeAt(i);
+    result = Math.imul(result, 16777619) >>> 0;
+  }
+  return result >>> 0;
+}

--- a/src/lib/opslab/gateway/index.ts
+++ b/src/lib/opslab/gateway/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Gateway API 与 Envoy Gateway
+ */
+export {
+  GATEWAYCLASSES, GATEWAYS, HTTPROUTES, GRPCROUTES, BACKENDTLSPOLICIES, ENVOYPROXIES,
+  GATEWAY_RESOURCES,
+} from './resources';
+export {
+  GatewayController, LoadBalancerController, ENVOY_CONTROLLER, ENVOY_LABEL,
+  type GatewayControllerOptions, type AddressPool,
+} from './controller';
+export { resolveGateway, hostnameMatches, type GatewayDecision, type GatewayLookup } from './routing';

--- a/src/lib/opslab/gateway/resources.ts
+++ b/src/lib/opslab/gateway/resources.ts
@@ -1,0 +1,63 @@
+/**
+ * Gateway API 的资源定义
+ *
+ * ingress-nginx 在 2026-03-24 退役之后，Gateway API 是入口的事实标准。
+ * 它和 Ingress 最大的区别是**角色分离**：GatewayClass 由平台方提供，
+ * Gateway 由集群管理员建（决定监听哪些端口、用什么证书、暴露到哪个网段），
+ * HTTPRoute 由应用团队自己写（决定路径怎么分发）。
+ *
+ * 这个分离是第 8 关的骨架：学员要能说清楚哪一层归谁管。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+const GROUP = 'gateway.networking.k8s.io';
+const VERSION = 'v1';
+
+export const GATEWAYCLASSES: ResourceDefinition = {
+  group: GROUP, version: VERSION, resource: 'gatewayclasses',
+  singular: 'gatewayclass', kind: 'GatewayClass', namespaced: false,
+  shortNames: ['gc'], subresources: ['status'],
+};
+
+export const GATEWAYS: ResourceDefinition = {
+  group: GROUP, version: VERSION, resource: 'gateways',
+  singular: 'gateway', kind: 'Gateway', namespaced: true,
+  shortNames: ['gtw'], subresources: ['status'],
+};
+
+export const HTTPROUTES: ResourceDefinition = {
+  group: GROUP, version: VERSION, resource: 'httproutes',
+  singular: 'httproute', kind: 'HTTPRoute', namespaced: true,
+  shortNames: [], subresources: ['status'],
+};
+
+export const GRPCROUTES: ResourceDefinition = {
+  group: GROUP, version: VERSION, resource: 'grpcroutes',
+  singular: 'grpcroute', kind: 'GRPCRoute', namespaced: true,
+  shortNames: [], subresources: ['status'],
+};
+
+/** BackendTLSPolicy 在 v1alpha3，第 9 关要用 */
+export const BACKENDTLSPOLICIES: ResourceDefinition = {
+  group: GROUP, version: 'v1alpha3', resource: 'backendtlspolicies',
+  singular: 'backendtlspolicy', kind: 'BackendTLSPolicy', namespaced: true,
+  shortNames: ['btlspolicy'], subresources: ['status'],
+};
+
+/**
+ * Envoy Gateway 自己的参数对象。
+ *
+ * GatewayClass 通过 `parametersRef` 指到它，里面写着「给这个 class 的 Gateway
+ * 建出来的 LoadBalancer Service 长什么样」—— 用哪个 loadBalancerClass，
+ * 也就决定了它被暴露到哪个网段。内网入口和公网入口的区别就在这一处，
+ * 不在 Gateway 自己身上。
+ */
+export const ENVOYPROXIES: ResourceDefinition = {
+  group: 'gateway.envoyproxy.io', version: 'v1alpha1', resource: 'envoyproxies',
+  singular: 'envoyproxy', kind: 'EnvoyProxy', namespaced: true,
+  shortNames: [], subresources: ['status'],
+};
+
+export const GATEWAY_RESOURCES: ResourceDefinition[] = [
+  GATEWAYCLASSES, GATEWAYS, HTTPROUTES, GRPCROUTES, BACKENDTLSPOLICIES, ENVOYPROXIES,
+];

--- a/src/lib/opslab/gateway/routing.ts
+++ b/src/lib/opslab/gateway/routing.ts
@@ -1,0 +1,157 @@
+/**
+ * Gateway 的转发决策
+ *
+ * 一个请求打到 Gateway 的地址上之后，要按 listener 的 hostname、HTTPRoute 的
+ * hostnames 与 matches 一层层挑出后端。挑不到任何一条就是 404 —— 而**不是**
+ * 连接失败：Gateway 是活的，只是没有路由匹配上。这个区别很重要，
+ * 学员看到 404 就该去查路由，看到 connection refused 才去查 Gateway 本身。
+ */
+import type { KubeObject, Registry, Scheme } from '../apiserver';
+import { GATEWAYS, HTTPROUTES } from './resources';
+
+export interface GatewayLookup {
+  registry: Registry;
+  scheme: Scheme;
+}
+
+export interface GatewayDecision {
+  /** 命中的 Gateway 与路由，写进包路径里 */
+  gateway: string;
+  route?: string;
+  /** 转给哪个 Service */
+  backend?: { namespace: string; name: string; port: number };
+  /** 没有路由匹配，或者后端解析不了 */
+  status?: number;
+  detail: string;
+}
+
+/**
+ * 这个地址是不是某个 Gateway 的，如果是，这个请求该转到哪。
+ *
+ * 返回 undefined 表示「这个地址不归任何 Gateway 管」，调用方按普通地址处理。
+ */
+export function resolveGateway(
+  lookup: GatewayLookup,
+  address: string,
+  request: { host: string; port: number; path: string }
+): GatewayDecision | undefined {
+  const services = list(lookup, { group: '', version: 'v1', resource: 'services' });
+  const owner = services.find((service) =>
+    ((service.status ?? {}) as any)?.loadBalancer?.ingress?.some((entry: any) => entry.ip === address)
+    && service.metadata.labels?.['gateway.envoyproxy.io/owning-gateway-name']
+  );
+  if (!owner) return undefined;
+
+  const gatewayName = owner.metadata.labels!['gateway.envoyproxy.io/owning-gateway-name'];
+  const gatewayNamespace = owner.metadata.labels!['gateway.envoyproxy.io/owning-gateway-namespace'];
+  const reference = `gateway/${gatewayNamespace}/${gatewayName}`;
+
+  let gateway: KubeObject;
+  try {
+    gateway = lookup.registry.get(GATEWAYS, gatewayNamespace, gatewayName);
+  } catch {
+    return { gateway: reference, status: 503, detail: 'Gateway 已经不在了' };
+  }
+
+  // Gateway 得先被 program 过。控制器没起来的话这里就停住。
+  const programmed = ((gateway.status ?? {}) as any).conditions
+    ?.find((entry: any) => entry.type === 'Programmed');
+  if (programmed?.status !== 'True') {
+    return { gateway: reference, status: 503, detail: 'Gateway 还没有被 program' };
+  }
+
+  const listener = ((gateway.spec ?? {}) as any).listeners?.find((entry: any) =>
+    Number(entry.port) === request.port
+    && (!entry.hostname || hostnameMatches(entry.hostname, request.host)));
+  if (!listener) {
+    return { gateway: reference, status: 404, detail: `${request.port} 端口上没有匹配的 listener` };
+  }
+
+  const routes = list(lookup, HTTPROUTES).filter((route) =>
+    ((route.spec ?? {}) as any).parentRefs?.some((parent: any) =>
+      parent.name === gatewayName
+      && (parent.namespace ?? route.metadata.namespace) === gatewayNamespace
+      && (!parent.sectionName || parent.sectionName === listener.name)));
+
+  for (const route of sortByName(routes)) {
+    const spec = (route.spec ?? {}) as any;
+    const hostnames: string[] = spec.hostnames ?? [];
+    if (hostnames.length > 0 && !hostnames.some((entry) => hostnameMatches(entry, request.host))) continue;
+
+    for (const rule of bestFirst(spec.rules ?? [])) {
+      if (!ruleMatches(rule, request.path)) continue;
+      const backend = (rule.backendRefs ?? [])[0];
+      if (!backend) {
+        return {
+          gateway: reference, route: routeRef(route), status: 500,
+          detail: '规则匹配上了但没有 backendRef',
+        };
+      }
+      return {
+        gateway: reference,
+        route: routeRef(route),
+        backend: {
+          namespace: backend.namespace ?? route.metadata.namespace ?? 'default',
+          name: backend.name,
+          port: Number(backend.port),
+        },
+        detail: `${request.path} -> ${backend.name}:${backend.port}`,
+      };
+    }
+  }
+
+  return {
+    gateway: reference, status: 404,
+    detail: `没有 HTTPRoute 匹配 ${request.host}${request.path}`,
+  };
+}
+
+/** `*.corp.internal` 这种通配前缀，规则和 Gateway API 一样：只能整段通配 */
+export function hostnameMatches(pattern: string, host: string): boolean {
+  if (pattern === host) return true;
+  if (!pattern.startsWith('*.')) return false;
+  const suffix = pattern.slice(1);
+  return host.endsWith(suffix) && host.slice(0, host.length - suffix.length).length > 0;
+}
+
+function ruleMatches(rule: any, path: string): boolean {
+  const matches = rule.matches ?? [{ path: { type: 'PathPrefix', value: '/' } }];
+  return matches.some((match: any) => {
+    const spec = match.path ?? { type: 'PathPrefix', value: '/' };
+    const value = spec.value ?? '/';
+    if (spec.type === 'Exact') return path === value;
+    if (spec.type === 'RegularExpression') {
+      try { return new RegExp(value).test(path); } catch { return false; }
+    }
+    // PathPrefix 按「路径段」比，`/apix` 不该被 `/api` 匹配上
+    return path === value || path.startsWith(value.endsWith('/') ? value : `${value}/`);
+  });
+}
+
+/** 前缀长的规则优先，和 Gateway API 的优先级规则一致 */
+function bestFirst(rules: any[]): any[] {
+  return [...rules].sort((a, b) => prefixLengthOf(b) - prefixLengthOf(a));
+}
+
+function prefixLengthOf(rule: any): number {
+  const matches = rule.matches ?? [];
+  return Math.max(0, ...matches.map((match: any) => String(match.path?.value ?? '').length));
+}
+
+function sortByName(routes: KubeObject[]): KubeObject[] {
+  // 顺序稳定，同样的世界每次挑出同一条
+  return [...routes].sort((a, b) => routeRef(a) < routeRef(b) ? -1 : 1);
+}
+
+function routeRef(route: KubeObject): string {
+  return `${route.metadata.namespace}/${route.metadata.name}`;
+}
+
+function list(
+  lookup: GatewayLookup,
+  definition: { group: string; version: string; resource: string }
+): KubeObject[] {
+  const found = lookup.scheme.get(definition);
+  if (!found) return [];
+  return lookup.registry.list(found).items;
+}

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -80,6 +80,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
       ])),
       ...(spec.externalHosts ?? {}),
     },
+    addressPools: spec.addressPools,
   });
 
   const machineSpec = spec.machine ?? {};

--- a/src/lib/opslab/net/network.ts
+++ b/src/lib/opslab/net/network.ts
@@ -33,6 +33,18 @@ export interface NetworkDeps {
    * 不在表里的地址，办公网与外网都够不到 —— Pod IP 天然如此。
    */
   exposure?(address: string): Zone[];
+  /**
+   * 这个地址归不归某个 Gateway 管、这个请求该转到哪。
+   *
+   * 由集群注入，网络层自己不认识 Gateway 的 CRD —— 数据面只管「转给谁」。
+   */
+  gatewayRoute?(address: string, request: { host: string; port: number; path: string }): {
+    gateway: string;
+    route?: string;
+    backend?: { namespace: string; name: string; port: number };
+    status?: number;
+    detail: string;
+  } | undefined;
 }
 
 /** 连一次要多久（虚拟毫秒）。超时按 kube-proxy 的默认行为算。 */
@@ -66,9 +78,17 @@ export class Network {
     const hops: Hop[] = [];
     let elapsed = 0;
 
-    // 1. 名字解析
+    // 1. 名字解析。`--resolve` 指定了地址就跳过这一步。
     let addresses: string[];
-    if (isIpv4(target.host)) {
+    if (target.address) {
+      addresses = [target.address];
+      hops.push({
+        at: 'dns',
+        detail: `${target.host} -> ${target.address}（--resolve，没查 DNS）`,
+        verdict: 'forward',
+        elapsedMs: 0,
+      });
+    } else if (isIpv4(target.host)) {
       addresses = [target.host];
     } else {
       const answer = this.resolve(target.host, source);
@@ -104,10 +124,48 @@ export class Network {
       return { kind: 'no-route', hops, elapsedMs: elapsed, blockedBy: 'no route to host' };
     }
 
-    // 3. 目标是 Service 还是 Pod
-    const service = this.serviceByClusterIp(address);
+    // 3. 这个地址归不归某个 Gateway 管
+    const gateway = this.deps.gatewayRoute?.(address, {
+      host: target.headerHost ?? target.host,
+      port: target.port,
+      path: target.path ?? '/',
+    });
+    let serviceOverride: KubeObject | undefined;
+    let portOverride: number | undefined;
+    if (gateway) {
+      elapsed += LATENCY.hop;
+      hops.push({
+        at: gateway.route ? `${gateway.gateway} -> httproute/${gateway.route}` : gateway.gateway,
+        detail: gateway.detail,
+        verdict: gateway.backend ? 'forward' : 'reject',
+        elapsedMs: LATENCY.hop,
+      });
+      if (!gateway.backend) {
+        // Gateway 活着，只是没有路由匹配上 —— 是 404 不是连不上
+        return {
+          kind: 'ok',
+          status: gateway.status ?? 404,
+          body: `${gateway.status ?? 404} ${gateway.detail}\n`,
+          hops,
+          elapsedMs: elapsed,
+        };
+      }
+      serviceOverride = this.serviceByName(gateway.backend.namespace, gateway.backend.name);
+      portOverride = gateway.backend.port;
+      if (!serviceOverride) {
+        return {
+          kind: 'ok', status: 503,
+          body: '503 backend service not found\n',
+          hops, elapsedMs: elapsed,
+        };
+      }
+    }
+
+    // 4. 目标是 Service 还是 Pod
+    const service = serviceOverride ?? this.serviceByClusterIp(address);
+    const servicePort = portOverride ?? target.port;
     const backends = service
-      ? this.backendsOf(service, target.port)
+      ? this.backendsOf(service, servicePort)
       : this.podByIp(address)
         ? [{ pod: this.podByIp(address)!, port: target.port }]
         : [];
@@ -117,8 +175,8 @@ export class Network {
       hops.push({
         at: `svc/${service.metadata.namespace}/${service.metadata.name}`,
         detail: backends.length
-          ? `ClusterIP ${address}:${target.port} -> ${backends.length} 个后端`
-          : `ClusterIP ${address}:${target.port} 没有后端（Endpoints 为空）`,
+          ? `${service.metadata.name}:${servicePort} -> ${backends.length} 个后端`
+          : `${service.metadata.name}:${servicePort} 没有后端（Endpoints 为空）`,
         verdict: backends.length ? 'forward' : 'reject',
         elapsedMs: LATENCY.hop,
       });
@@ -134,7 +192,7 @@ export class Network {
       return { kind: 'no-route', hops, elapsedMs: elapsed, blockedBy: 'no route to host' };
     }
 
-    // 4. 网络策略。两端都要放行，被拒绝表现为丢包 -> 超时。
+    // 5. 网络策略。两端都要放行，被拒绝表现为丢包 -> 超时。
     const chosen = backends[0];
     const decision = evaluate(this.policies(), {
       source: this.peerOf(source),
@@ -168,7 +226,7 @@ export class Network {
       });
     }
 
-    // 5. 端口上有没有人听、应用怎么答
+    // 6. 端口上有没有人听、应用怎么答
     return this.deliver(chosen.pod, chosen.port, target, hops, elapsed);
   }
 
@@ -251,6 +309,10 @@ export class Network {
       },
       external: (name) => this.deps.externalHosts?.[name],
     };
+  }
+
+  private serviceByName(namespace: string, name: string): KubeObject | undefined {
+    return this.list('services', namespace).find((item) => item.metadata.name === name);
   }
 
   private serviceByClusterIp(ip: string): KubeObject | undefined {

--- a/src/lib/opslab/net/tools.ts
+++ b/src/lib/opslab/net/tools.ts
@@ -46,10 +46,17 @@ interface CurlFlags {
   url?: string;
   method?: string;
   verbose: boolean;
+  /** `-H 'Host: x'` */
+  hostHeader?: string;
+  /** `--resolve host:port:addr` */
+  resolveTo: Array<{ host: string; port: number; address: string }>;
 }
 
 function parseCurl(argv: string[]): CurlFlags {
-  const flags: CurlFlags = { silent: false, headOnly: false, failOnError: false, include: false, verbose: false };
+  const flags: CurlFlags = {
+    silent: false, headOnly: false, failOnError: false, include: false, verbose: false,
+    resolveTo: [],
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
@@ -64,6 +71,20 @@ function parseCurl(argv: string[]): CurlFlags {
       case '-X': case '--request': flags.method = argv[++i]; break;
       case '-m': case '--max-time': flags.maxTimeMs = Number(argv[++i]) * 1000; break;
       case '--connect-timeout': flags.maxTimeMs = Number(argv[++i]) * 1000; break;
+      case '-H': case '--header': {
+        const header = argv[++i] ?? '';
+        const match = /^\s*host\s*:\s*(\S+)\s*$/i.exec(header);
+        if (match) flags.hostHeader = match[1];
+        break;
+      }
+      case '--resolve': {
+        // host:port:address
+        const parts = (argv[++i] ?? '').split(':');
+        if (parts.length >= 3) {
+          flags.resolveTo.push({ host: parts[0], port: Number(parts[1]), address: parts[2] });
+        }
+        break;
+      }
       case '-k': case '--insecure': break;
       case '-L': case '--location': break;
       default:
@@ -104,6 +125,11 @@ function curl(argv: string[], options: NetToolsOptions): CommandResult {
   if (!target) return { stderr: `curl: (3) URL rejected: Bad hostname\n`, code: 3 };
   if (flags.method) target.method = flags.method;
   if (flags.headOnly) target.method = 'HEAD';
+  if (flags.hostHeader) target.headerHost = flags.hostHeader;
+  const override = flags.resolveTo.find(
+    (entry) => entry.host === target.host && entry.port === target.port
+  );
+  if (override) target.address = override.address;
 
   const result = options.network.connect(options.source(), target);
   const spent = flags.maxTimeMs !== undefined

--- a/src/lib/opslab/net/types.ts
+++ b/src/lib/opslab/net/types.ts
@@ -66,6 +66,15 @@ export interface Target {
   tls?: boolean;
   /** TLS 时的 SNI，缺省用 host */
   serverName?: string;
+  /**
+   * 直接连这个地址，不查 DNS。
+   *
+   * `curl --resolve host:port:addr` 就是这么干的：DNS 还没改过来的时候，
+   * 拿它先把路由验通。
+   */
+  address?: string;
+  /** Host 头。Gateway 与 HTTPRoute 匹配的是它，不是连过去的那个地址。 */
+  headerHost?: string;
 }
 
 /** DNS 查出来的东西 */

--- a/tests/opslab/gateway.test.ts
+++ b/tests/opslab/gateway.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Gateway API 与 Envoy Gateway
+ *
+ * 两件事要成立：
+ *  1. 控制器是**集群里的一个工作负载**。把它卸载掉，Gateway 就不再被 program。
+ *     第 8 关最后一步「旧控制器彻底下线」之所以判定得了，靠的就是这条。
+ *  2. 内网入口与公网入口的分野在 `loadBalancerClass` 上，不在 Gateway 自己身上。
+ */
+import { createCluster } from '../../src/lib/opslab/controllers';
+import { hostnameMatches } from '../../src/lib/opslab/gateway';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+import type { Source } from '../../src/lib/opslab/net';
+
+const IMAGE = 'harbor.corp.internal/team/portal:1.4.0';
+const OFFICE: Source = { zone: 'office', label: 'jump-01', ip: '10.10.1.5' };
+const INTERNET: Source = { zone: 'internet', label: 'outside', ip: '203.0.113.9' };
+
+const POOLS = [
+  { loadBalancerClass: 'corp.internal/office-lb', cidrPrefix: '10.10.8', zones: ['office'] as const },
+  { loadBalancerClass: 'corp.internal/public-lb', cidrPrefix: '203.0.113', zones: ['office', 'internet'] as const },
+];
+
+/** Envoy Gateway 自己：一个跑在 envoy-gateway-system 里的 Deployment */
+const controllerDeployment = () => ({
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: {
+    name: 'envoy-gateway', namespace: 'envoy-gateway-system',
+    labels: { 'app.kubernetes.io/name': 'envoy-gateway' },
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'envoy-gateway' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'envoy-gateway' } },
+      spec: { containers: [{ name: 'controller', image: IMAGE }] },
+    },
+  },
+} as unknown as KubeObject);
+
+const envoyProxy = (name: string, loadBalancerClass: string) => ({
+  apiVersion: 'gateway.envoyproxy.io/v1alpha1', kind: 'EnvoyProxy',
+  metadata: { name, namespace: 'envoy-gateway-system' },
+  spec: { provider: { kubernetes: { envoyService: { loadBalancerClass } } } },
+} as unknown as KubeObject);
+
+const gatewayClass = (name: string, parameters: string) => ({
+  apiVersion: 'gateway.networking.k8s.io/v1', kind: 'GatewayClass',
+  metadata: { name },
+  spec: {
+    controllerName: 'gateway.envoyproxy.io/gatewayclass-controller',
+    parametersRef: {
+      group: 'gateway.envoyproxy.io', kind: 'EnvoyProxy',
+      name: parameters, namespace: 'envoy-gateway-system',
+    },
+  },
+} as unknown as KubeObject);
+
+const gateway = (name: string, className: string, hostname?: string) => ({
+  apiVersion: 'gateway.networking.k8s.io/v1', kind: 'Gateway',
+  metadata: { name, namespace: 'payments' },
+  spec: {
+    gatewayClassName: className,
+    listeners: [{ name: 'http', port: 80, protocol: 'HTTP', hostname }],
+  },
+} as unknown as KubeObject);
+
+const httpRoute = (name: string, options: {
+  hostnames?: string[];
+  rules: Array<{ path?: string; backend: string; port: number }>;
+}) => ({
+  apiVersion: 'gateway.networking.k8s.io/v1', kind: 'HTTPRoute',
+  metadata: { name, namespace: 'payments' },
+  spec: {
+    parentRefs: [{ name: 'corp-gw', namespace: 'payments' }],
+    hostnames: options.hostnames,
+    rules: options.rules.map((rule) => ({
+      matches: [{ path: { type: 'PathPrefix', value: rule.path ?? '/' } }],
+      backendRefs: [{ name: rule.backend, port: rule.port }],
+    })),
+  },
+} as unknown as KubeObject);
+
+const app = (name: string) => [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name, namespace: 'payments' },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: name } },
+      template: {
+        metadata: { labels: { app: name } },
+        spec: { containers: [{ name: 'web', image: IMAGE, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name, namespace: 'payments' },
+    spec: { clusterIP: `10.96.1.${name.length}`, selector: { app: name }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+] as unknown as KubeObject[];
+
+async function world(objects: KubeObject[]) {
+  const cluster = createCluster({
+    namespaces: ['default', 'kube-system', 'payments', 'envoy-gateway-system'],
+    images: { [IMAGE]: { listens: [8080], routes: { '/': 200, '/healthz': 200, '/api/orders': 200 } } },
+    addressPools: POOLS as never,
+  });
+  cluster.start();
+  for (const object of objects) {
+    const [group, version] = object.apiVersion.includes('/')
+      ? object.apiVersion.split('/')
+      : ['', object.apiVersion];
+    const definition = cluster.scheme.resolveKind(group, version, object.kind)!;
+    if (!definition) throw new Error(`未注册：${object.apiVersion} ${object.kind}`);
+    cluster.registry.create(
+      definition,
+      definition.namespaced ? object.metadata.namespace ?? 'default' : undefined,
+      object
+    );
+  }
+  await cluster.settle();
+  return cluster;
+}
+
+function gatewayStatus(cluster: Awaited<ReturnType<typeof world>>) {
+  return cluster.registry.get(
+    cluster.scheme.mustGet({ group: 'gateway.networking.k8s.io', version: 'v1', resource: 'gateways' }),
+    'payments', 'corp-gw'
+  ).status as any;
+}
+
+describe('控制器是集群里的一个工作负载', () => {
+  it('控制器没装：Gateway 停在 Programmed=Unknown，没有地址', async () => {
+    const cluster = await world([
+      envoyProxy('office', 'corp.internal/office-lb'),
+      gatewayClass('envoy-internal', 'office'),
+      gateway('corp-gw', 'envoy-internal'),
+    ]);
+    const status = gatewayStatus(cluster);
+    expect(status.addresses).toEqual([]);
+    expect(status.conditions.find((c: any) => c.type === 'Programmed').status).toBe('Unknown');
+  });
+
+  it('装上控制器之后被 program，并且拿到一个内网地址', async () => {
+    const cluster = await world([
+      controllerDeployment(),
+      envoyProxy('office', 'corp.internal/office-lb'),
+      gatewayClass('envoy-internal', 'office'),
+      gateway('corp-gw', 'envoy-internal'),
+    ]);
+    const status = gatewayStatus(cluster);
+    expect(status.conditions.find((c: any) => c.type === 'Programmed').status).toBe('True');
+    expect(status.addresses[0].value).toMatch(/^10\.10\.8\./);
+  });
+
+  it('把控制器删掉，Gateway 退回 Programmed=Unknown', async () => {
+    const cluster = await world([
+      controllerDeployment(),
+      envoyProxy('office', 'corp.internal/office-lb'),
+      gatewayClass('envoy-internal', 'office'),
+      gateway('corp-gw', 'envoy-internal'),
+    ]);
+    expect(gatewayStatus(cluster).conditions.find((c: any) => c.type === 'Programmed').status).toBe('True');
+
+    cluster.registry.delete(
+      cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' }),
+      'envoy-gateway-system', 'envoy-gateway'
+    );
+    await cluster.settle();
+    expect(gatewayStatus(cluster).conditions.find((c: any) => c.type === 'Programmed').status).toBe('Unknown');
+  });
+
+  it('别人的 GatewayClass 不插手', async () => {
+    const cluster = await world([
+      controllerDeployment(),
+      {
+        apiVersion: 'gateway.networking.k8s.io/v1', kind: 'GatewayClass',
+        metadata: { name: 'nginx' },
+        spec: { controllerName: 'k8s.io/ingress-nginx' },
+      } as unknown as KubeObject,
+      gateway('corp-gw', 'nginx'),
+    ]);
+    expect(gatewayStatus(cluster)).toBeUndefined();
+  });
+});
+
+describe('内网入口与公网入口', () => {
+  const base = (loadBalancerClass: string) => [
+    controllerDeployment(),
+    envoyProxy('params', loadBalancerClass),
+    gatewayClass('envoy-class', 'params'),
+    gateway('corp-gw', 'envoy-class'),
+    ...app('portal'),
+    httpRoute('portal', { rules: [{ backend: 'portal', port: 80 }] }),
+  ];
+
+  it('内网 class：办公网通、外网不通', async () => {
+    const cluster = await world(base('corp.internal/office-lb'));
+    const address = gatewayStatus(cluster).addresses[0].value;
+
+    expect(cluster.network.connect(OFFICE, { host: address, port: 80, path: '/' }).kind).toBe('ok');
+    expect(cluster.network.connect(INTERNET, { host: address, port: 80, path: '/' }).kind).toBe('no-route');
+  });
+
+  it('公网 class：两边都通', async () => {
+    const cluster = await world(base('corp.internal/public-lb'));
+    const address = gatewayStatus(cluster).addresses[0].value;
+    expect(address).toMatch(/^203\.0\.113\./);
+
+    expect(cluster.network.connect(OFFICE, { host: address, port: 80, path: '/' }).kind).toBe('ok');
+    expect(cluster.network.connect(INTERNET, { host: address, port: 80, path: '/' }).kind).toBe('ok');
+  });
+});
+
+describe('路由', () => {
+  async function routed(routes: KubeObject[]) {
+    const cluster = await world([
+      controllerDeployment(),
+      envoyProxy('office', 'corp.internal/office-lb'),
+      gatewayClass('envoy-internal', 'office'),
+      gateway('corp-gw', 'envoy-internal'),
+      ...app('portal'),
+      ...app('orders'),
+      ...routes,
+    ]);
+    return { cluster, address: gatewayStatus(cluster).addresses[0].value };
+  }
+
+  it('按路径前缀分发，长前缀优先', async () => {
+    const { cluster, address } = await routed([
+      httpRoute('portal', {
+        rules: [
+          { path: '/', backend: 'portal', port: 80 },
+          { path: '/api', backend: 'orders', port: 80 },
+        ],
+      }),
+    ]);
+    const root = cluster.network.connect(OFFICE, { host: address, port: 80, path: '/' });
+    expect(root.hops.some((hop) => hop.detail.includes('portal:80'))).toBe(true);
+
+    const api = cluster.network.connect(OFFICE, { host: address, port: 80, path: '/api/orders' });
+    expect(api.hops.some((hop) => hop.detail.includes('orders:80'))).toBe(true);
+  });
+
+  it('没有路由匹配是 404，不是连不上 —— 这两种要分得开', async () => {
+    const { cluster, address } = await routed([
+      httpRoute('portal', { hostnames: ['portal.corp.internal'], rules: [{ backend: 'portal', port: 80 }] }),
+    ]);
+    const wrongHost = cluster.network.connect(OFFICE, { host: address, port: 80, path: '/' });
+    expect(wrongHost.kind).toBe('ok');
+    expect(wrongHost.status).toBe(404);
+  });
+
+  it('后端 Service 不存在时，HTTPRoute 的 ResolvedRefs 说得清清楚楚', async () => {
+    const { cluster } = await routed([
+      httpRoute('broken', { rules: [{ backend: 'ghost', port: 80 }] }),
+    ]);
+    const route = cluster.registry.get(
+      cluster.scheme.mustGet({ group: 'gateway.networking.k8s.io', version: 'v1', resource: 'httproutes' }),
+      'payments', 'broken'
+    );
+    const resolved = ((route.status as any).parents[0].conditions as any[])
+      .find((entry) => entry.type === 'ResolvedRefs');
+    expect(resolved.status).toBe('False');
+    expect(resolved.reason).toBe('BackendNotFound');
+    expect(resolved.message).toContain('ghost');
+  });
+
+  it('listener 上挂了几条路由，写在 Gateway 的 status 里', async () => {
+    const { cluster } = await routed([
+      httpRoute('a', { rules: [{ backend: 'portal', port: 80 }] }),
+      httpRoute('b', { rules: [{ path: '/api', backend: 'orders', port: 80 }] }),
+    ]);
+    expect(gatewayStatus(cluster).listeners[0].attachedRoutes).toBe(2);
+  });
+});
+
+describe('hostname 通配', () => {
+  it.each([
+    ['portal.corp.internal', 'portal.corp.internal', true],
+    ['*.corp.internal', 'portal.corp.internal', true],
+    ['*.corp.internal', 'corp.internal', false],
+    ['*.corp.internal', 'a.b.corp.internal', true],
+    ['portal.corp.internal', 'other.corp.internal', false],
+  ])('%s 匹配 %s', (pattern, host, expected) => {
+    expect(hostnameMatches(pattern, host)).toBe(expected);
+  });
+});

--- a/tests/opslab/gateway.test.ts
+++ b/tests/opslab/gateway.test.ts
@@ -185,6 +185,49 @@ describe('控制器是集群里的一个工作负载', () => {
   });
 });
 
+describe('地址与清理', () => {
+  it('两个 Gateway 拿到不同的地址 —— 撞了路由会串到别人身上', async () => {
+    const cluster = await world([
+      controllerDeployment(),
+      envoyProxy('office', 'corp.internal/office-lb'),
+      gatewayClass('envoy-internal', 'office'),
+      gateway('corp-gw', 'envoy-internal'),
+      {
+        apiVersion: 'gateway.networking.k8s.io/v1', kind: 'Gateway',
+        metadata: { name: 'other-gw', namespace: 'payments' },
+        spec: {
+          gatewayClassName: 'envoy-internal',
+          listeners: [{ name: 'http', port: 80, protocol: 'HTTP' }],
+        },
+      } as unknown as KubeObject,
+    ]);
+    const gateways = cluster.registry.list(
+      cluster.scheme.mustGet({ group: 'gateway.networking.k8s.io', version: 'v1', resource: 'gateways' })
+    ).items;
+    const addresses = gateways.map((item) => (item.status as any).addresses[0].value);
+    expect(addresses).toHaveLength(2);
+    expect(new Set(addresses).size).toBe(2);
+  });
+
+  it('Gateway 删掉之后，它的 Service 也不在了', async () => {
+    const cluster = await world([
+      controllerDeployment(),
+      envoyProxy('office', 'corp.internal/office-lb'),
+      gatewayClass('envoy-internal', 'office'),
+      gateway('corp-gw', 'envoy-internal'),
+    ]);
+    const services = cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'services' });
+    expect(cluster.registry.list(services, { namespace: 'envoy-gateway-system' }).items).toHaveLength(1);
+
+    cluster.registry.delete(
+      cluster.scheme.mustGet({ group: 'gateway.networking.k8s.io', version: 'v1', resource: 'gateways' }),
+      'payments', 'corp-gw'
+    );
+    await cluster.settle();
+    expect(cluster.registry.list(services, { namespace: 'envoy-gateway-system' }).items).toHaveLength(0);
+  });
+});
+
 describe('内网入口与公网入口', () => {
   const base = (loadBalancerClass: string) => [
     controllerDeployment(),

--- a/tests/opslab/net.test.ts
+++ b/tests/opslab/net.test.ts
@@ -475,6 +475,20 @@ describe('网络工具的输出与退出码', () => {
     expect(result.stderr).toContain('nc -z');
   });
 
+  it('curl --resolve 跳过 DNS，-H Host 改的是 Host 头', async () => {
+    const world = await jumpHost();
+    // DNS 里没有这个名字，但 --resolve 指定了地址就不查 DNS 了
+    const resolved = await world.run(
+      'curl -s --resolve portal.corp.internal:80:10.96.1.10 http://portal.corp.internal/'
+    );
+    // 办公网到不了 ClusterIP，所以是 no route 而不是解析失败 —— 说明确实跳过了 DNS
+    expect(resolved.code).toBe(7);
+    expect(resolved.stderr).toContain('No route to host');
+
+    const unresolved = await world.run('curl -s http://portal.corp.internal/');
+    expect(unresolved.code).toBe(6);
+  });
+
   it('curl -w %{http_code} 与 -o /dev/null', async () => {
     const world = await jumpHost();
     // 办公网到不了集群，但格式本身要对：先验一个能到的外部地址上的失败路径


### PR DESCRIPTION
第 2 期第二片。

## 控制器是集群里的一个工作负载

这是这一片最要紧的架构点。`GatewayController.reconcile` 的第一件事是确认自己那个 Deployment 还在、还可用；不在就什么都不做，Gateway 停在 `Programmed=Unknown`。

于是第 8 关最后一步「把旧控制器彻底下线」是可判定的，而且删掉 Envoy Gateway 会真的让入口失效 —— 宿主没有为它开任何后门。

## 内网还是公网，由集群里的对象说了算

```
GatewayClass → parametersRef → EnvoyProxy → envoyService.loadBalancerClass
                                              ↓
                                    corp.internal/office-lb  → 只有办公网到得了
                                    corp.internal/public-lb  → 办公网 + 公网
```

Gateway 自己身上没有这个开关。应用团队写 HTTPRoute 时碰不到它，所以**不可能不小心把自己暴露到公网**。这正是 Gateway API 角色分离的价值，第 8 关考的就是它。

## 一个刻意保留的区别

路由没匹配上是 **404，不是连不上**。Gateway 是活着的，只是没有路由认领这个请求。学员看到 404 该去查路由，看到 connection refused 才去查 Gateway 本身。

`HTTPRoute` 的 `ResolvedRefs=False` 会直接写出 `Service payments/ghost not found`，不用猜。

## curl --resolve

迁入口时 DNS 通常还没改过来，标准动作是 `curl --resolve host:port:addr` 先把路由验通。这一片给 curl 加上了它和 `-H 'Host:'`。参考解就这么写。

（第一版的参考解直接 curl Gateway 的 IP，结果是 404 —— Host 头是 IP，匹配不上 listener 的 hostname。这个失败本身很说明问题，所以留在了 pitfalls 里。）

## 第 8 关

门户还挂在 2026-03 退役的 ingress-nginx 上：镜像下架 → 控制器 ImagePullBackOff → Ingress 一直没地址 → 办公网访问不了。学员要迁到 Gateway API、用对内网 class、确认公网确实到不了、再把老的 Ingress 与 Deployment 都下线。

## 验证

`npx jest tests/opslab` → 439 用例（新增 19）；第 8 关反向验证通过（参考解全绿、什么都不做挂）；`npm test` 8/8；`npm run build` 通过。