### PR TITLE
feat(opslab): kubectl exec 走真 WebSocket 通道进 Pod

### DIFF
--- a/public/projects.json
+++ b/public/projects.json
@@ -5612,7 +5612,10 @@
         "namespaces": [
           "default",
           "kube-system",
-          "payments"
+          "payments",
+          "envoy-gateway-system",
+          "ingress-nginx",
+          "cert-manager"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5631,6 +5634,22 @@
             "handlesSigterm": true,
             "runAsUser": 10001
           },
+          "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "listens": [
+              18000
+            ]
+          },
+          "quay.io/jetstack/cert-manager-controller:v1.19.1": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "listens": [
+              9402
+            ]
+          },
           "harbor.corp.internal/team/reports:2.1.0": {
             "pullMs": 500,
             "startupMs": 800,
@@ -5647,6 +5666,55 @@
         "baseImages": {
           "node:22-alpine": "node"
         },
+        "pki": {
+          "roots": [
+            {
+              "name": "corp-root-ca",
+              "namespace": "cert-manager",
+              "commonName": "Corp Root CA"
+            }
+          ],
+          "intermediates": [
+            {
+              "name": "corp-issuing-ca",
+              "namespace": "cert-manager",
+              "commonName": "Corp Issuing CA",
+              "signedBy": "corp-root-ca"
+            }
+          ],
+          "serverCertificates": [
+            {
+              "name": "portal-tls-manual",
+              "namespace": "payments",
+              "commonName": "portal.corp.internal",
+              "dnsNames": [
+                "portal.corp.internal"
+              ],
+              "signedBy": "corp-issuing-ca",
+              "leafOnly": true
+            }
+          ],
+          "trust": [
+            "corp-root-ca"
+          ]
+        },
+        "addressPools": [
+          {
+            "loadBalancerClass": "corp.internal/office-lb",
+            "cidrPrefix": "10.10.8",
+            "zones": [
+              "office"
+            ]
+          },
+          {
+            "loadBalancerClass": "corp.internal/public-lb",
+            "cidrPrefix": "203.0.113",
+            "zones": [
+              "office",
+              "internet"
+            ]
+          }
+        ],
         "registries": [
           {
             "host": "harbor.corp.internal",
@@ -6249,6 +6317,613 @@
         "primer": {
           "zh": "容器声明资源有两个字段，管的是两件事。`requests` 是给调度器看的：调度器按它做装箱，把 Pod 放到「已承诺容量」还够的节点上。`limits` 是运行时的硬约束，落到 cgroup 上。两者可以不相等，也可以只写一个，不同的写法会得到不同的后果。\n\n内存和 CPU 的超限行为完全不同。内存是不可压缩资源：用量超过 limit，内核直接 OOMKill 这个容器，退出码 137（128+9，SIGKILL），日志经常来不及写完。CPU 是可压缩资源：超过 limit 只是被限流，进程继续跑，只是变慢，表现为 P99 变差而不是进程消失。所以「应用没崩但突然变慢了」和「应用被杀了」要往两个方向查。\n\n`QoS 等级`不是自己填的，是 kubelet 根据 requests 与 limits 推出来的：每个容器的 cpu 和 memory 都写了且 requests 等于 limits，是 `Guaranteed`；一个都没写，是 `BestEffort`；其余是 `Burstable`。这个等级决定节点内存不够时谁先被赶走：BestEffort 最先，然后是用量超过自己 requests 的 Burstable，Guaranteed 最后。\n\n于是有一个很容易走进去的死胡同：容器被 OOMKill 了，把 limits 删掉「就不会被杀了」。确实不会，但它同时变成了 BestEffort，节点一紧张第一个被驱逐，只是把一种死法换成了另一种。正确的做法是先量出实际用量再设定数字。生产里有 VPA 的 recommender 帮忙算，以及 LimitRange 给命名空间兜一个默认值。",
           "en": "A container declares resources with two fields that govern two different things. `requests` is for the scheduler: it bin-packs by requests, placing pods on nodes that still have promised capacity. `limits` is a runtime constraint enforced by cgroups. The two need not be equal, and either may be omitted, with different consequences.\n\nMemory and CPU behave completely differently when exceeded. Memory is incompressible: cross the limit and the kernel OOM-kills the container with exit code 137 (128+9, SIGKILL), often before the logs finish flushing. CPU is compressible: crossing the limit only throttles the process, which keeps running but slower, showing up as a degraded P99 rather than a missing process. \"The app did not crash but suddenly got slow\" and \"the app was killed\" therefore point in different directions.\n\nThe `QoS class` is derived, not declared. The kubelet computes it from requests and limits: every container declaring both cpu and memory with requests equal to limits is `Guaranteed`; declaring nothing is `BestEffort`; anything else is `Burstable`. That class decides who is evicted first when a node runs short of memory: BestEffort first, then Burstable pods exceeding their own requests, and Guaranteed last.\n\nThis creates an easy dead end. A container gets OOM-killed, so you remove the limit and it stops being killed. True, but it has also become BestEffort and is now first in line for eviction: one way of dying traded for another. The right move is to measure actual usage and set numbers from that. Production adds the VPA recommender to compute them and a LimitRange to give the namespace sane defaults."
+        }
+      },
+      {
+        "id": "gateway-migration",
+        "title": {
+          "zh": "从 Ingress 迁到 Gateway API",
+          "en": "Migrate from Ingress to Gateway API"
+        },
+        "goal": {
+          "zh": "      门户的对外入口还挂在 ingress-nginx 上，而这个项目已经在 2026 年 3 月退役了 ——\n      镜像从仓库里下架，控制器起不来，Ingress 一直没有地址，门户从办公网访问不了。\n\n      平台组已经把 Envoy Gateway 装好了，也提供了两个 GatewayClass：\n      `envoy-internal`（只暴露到办公网）和 `envoy-public`（暴露到公网）。\n      **门户是内部系统，不能上公网。**\n\n      ## 通关标准\n\n      1. 建一个 Gateway（用对 class）和一条 HTTPRoute，把\n         `portal.corp.internal` 指到 `portal` 这个 Service；\n      2. Gateway 的 `Programmed` 是 True，拿到了地址；\n      3. 从跳板机（办公网）访问得到，返回 200；\n      4. **从公网访问不到**；\n      5. 老的 Ingress 与 ingress-nginx 的 Deployment 都删掉 —— 留着不只是脏，\n         还会让下一个人以为它还在起作用。\n\n      ## 会用到的命令\n\n      ```bash\n      kubectl get ingress,pods -n payments\n      kubectl get gatewayclass\n      kubectl apply -f infra/gateway.yaml\n      kubectl get gateway corp-gw -n payments -o yaml\n      kubectl describe httproute portal -n payments\n      curl -s -o /dev/null -w '%{http_code}\n' \\\n        --resolve portal.corp.internal:80:<Gateway 的地址> http://portal.corp.internal/\n      ```\n\n      跳板机上没有配 `portal.corp.internal` 的解析，直接用 Gateway 拿到的\n      地址访问就行。\n",
+          "en": "      The portal's external entrypoint still runs on ingress-nginx, a project that\n      was retired in March 2026. The image was pulled from the registry, the\n      controller cannot start, the Ingress never got an address, and the portal is\n      unreachable from the office network.\n\n      The platform team has already installed Envoy Gateway and offers two\n      GatewayClasses: `envoy-internal` (office network only) and `envoy-public`\n      (public internet). **The portal is an internal system and must not be public.**\n\n      ## Done when\n\n      1. a Gateway (with the right class) and an HTTPRoute send\n         `portal.corp.internal` to the `portal` Service;\n      2. the Gateway reports `Programmed` True and has an address;\n      3. it answers 200 from the jump host (office network);\n      4. **it is not reachable from the internet**;\n      5. the old Ingress and the ingress-nginx Deployment are both deleted. Leaving\n         them is not just untidy: the next person will assume they still do something.\n\n      ## Commands you will need\n\n      ```bash\n      kubectl get ingress,pods -n payments\n      kubectl get gatewayclass\n      kubectl apply -f infra/gateway.yaml\n      kubectl get gateway corp-gw -n payments -o yaml\n      kubectl describe httproute portal -n payments\n      curl -s -o /dev/null -w '%{http_code}\n' \\\n        --resolve portal.corp.internal:80:<gateway address> http://portal.corp.internal/\n      ```\n"
+        },
+        "checklist": [
+          {
+            "zh": "Gateway 与 HTTPRoute 建好并生效",
+            "en": "Gateway and HTTPRoute created and effective"
+          },
+          {
+            "zh": "办公网访问得到、公网访问不到",
+            "en": "Reachable from the office network, not from the internet"
+          },
+          {
+            "zh": "老的 Ingress 与 ingress-nginx 都下线",
+            "en": "The old Ingress and ingress-nginx are gone"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`kubectl get gatewayclass` 会列出平台提供了哪几个 class，名字里就写着内外网。",
+            "en": "`kubectl get gatewayclass` lists what the platform offers; the names say internal or public."
+          },
+          {
+            "zh": "Gateway 的 `status.addresses` 里就是访问地址。`kubectl get gateway -o wide` 也看得到。",
+            "en": "The address is in the Gateway’s `status.addresses`; `kubectl get gateway -o wide` shows it too."
+          },
+          {
+            "zh": "路由不生效时先看 `kubectl describe httproute` 里的 `ResolvedRefs`，它会直接说是后端不存在还是别的。",
+            "en": "When a route does not work, check `ResolvedRefs` in `kubectl describe httproute`; it names the actual problem."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用了 `envoy-public` 那个 class。门户能访问了，但同时也暴露到了公网上 —— 判定会挂在这一条，现实里则是一次事故。",
+            "en": "Using the `envoy-public` class. The portal works, and is also on the public internet. The grader catches it; production would not."
+          },
+          {
+            "zh": "只删 Ingress 不删 ingress-nginx 的 Deployment。那个 Pod 还在那儿 CrashLoop，占着资源，还会让下一个人以为入口是它在管。",
+            "en": "Deleting the Ingress but not the ingress-nginx Deployment. The pod keeps crash-looping, burning resources and misleading the next person."
+          },
+          {
+            "zh": "HTTPRoute 的 `hostnames` 和 Gateway listener 的 `hostname` 对不上，两边都写了但不一样，结果是永远 404。",
+            "en": "Mismatched `hostnames` between the HTTPRoute and the Gateway listener: both set, both different, permanent 404."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ingress-nginx-controller",
+                "namespace": "ingress-nginx",
+                "labels": {
+                  "app.kubernetes.io/name": "ingress-nginx"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "ingress-nginx"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "ingress-nginx"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/ingress-nginx/controller:v1.13.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/ingress.yaml": "apiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: portal\n  namespace: payments\n  annotations:\n    nginx.ingress.kubernetes.io/rewrite-target: /\nspec:\n  ingressClassName: nginx\n  rules:\n  - host: portal.corp.internal\n    http:\n      paths:\n      - path: /\n        pathType: Prefix\n        backend:\n          service:\n            name: portal\n            port:\n              number: 80\n",
+            "/root/infra/gateway.yaml": "# 在这里写 Gateway 与 HTTPRoute\n"
+          },
+          "referenceFiles": {
+            "/root/infra/gateway.yaml": "apiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: corp-gw\n  namespace: payments\nspec:\n  gatewayClassName: envoy-internal\n  listeners:\n  - name: http\n    port: 80\n    protocol: HTTP\n    hostname: portal.corp.internal\n    allowedRoutes:\n      namespaces:\n        from: Same\n---\napiVersion: gateway.networking.k8s.io/v1\nkind: HTTPRoute\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  parentRefs:\n  - name: corp-gw\n  hostnames:\n  - portal.corp.internal\n  rules:\n  - matches:\n    - path:\n        type: PathPrefix\n        value: /\n    backendRefs:\n    - name: portal\n      port: 80\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/ingress.yaml",
+            "kubectl apply -f /root/infra/gateway.yaml",
+            "kubectl delete ingress portal -n payments",
+            "kubectl delete deployment ingress-nginx-controller -n ingress-nginx",
+            "rm -f /root/infra/ingress.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "gateway-migration.spec.ts",
+            "content": "import { get, list, sh, world } from '@ops/lab';\n\nfunction conditionOf(object, type) {\n  return ((object.status || {}).conditions || []).find((entry) => entry.type === type);\n}\n\ndescribe('从 Ingress 迁到 Gateway API', () => {\n  it('Gateway 建出来了，而且被 program 了', () => {\n    const gateways = list('Gateway', { namespace: 'payments' });\n    expect(gateways.length).toBe(1);\n    expect(conditionOf(gateways[0], 'Programmed').status).toBe('True');\n    expect(gateways[0].status.addresses.length).toBe(1);\n  });\n\n  it('用的是内网 class，不是公网那个', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    expect(gateway.spec.gatewayClassName).toBe('envoy-internal');\n  });\n\n  it('HTTPRoute 的后端解析得到', () => {\n    const routes = list('HTTPRoute', { namespace: 'payments' });\n    expect(routes.length).toBe(1);\n    const parent = routes[0].status.parents[0];\n    const resolved = parent.conditions.find((entry) => entry.type === 'ResolvedRefs');\n    expect(resolved.status).toBe('True');\n  });\n\n  it('办公网访问得到，返回 200', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    // DNS 还没改过来，用 --resolve 直连 Gateway 的地址\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:80:' + address\n      + ' http://portal.corp.internal/'\n    );\n    expect(result.code).toBe(0);\n    expect(result.stdout).toBe('200');\n  });\n\n  it('公网访问不到', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    const outcome = world.cluster.network.connect(\n      { zone: 'internet', label: 'outside', ip: '203.0.113.9' },\n      { host: 'portal.corp.internal', address, headerHost: 'portal.corp.internal', port: 80, path: '/' }\n    );\n    expect(outcome.kind).toBe('no-route');\n  });\n\n  it('老的 Ingress 下线了', () => {\n    expect(list('Ingress', { namespace: 'payments' }).length).toBe(0);\n  });\n\n  it('ingress-nginx 的控制器也下线了', () => {\n    const left = list('Deployment', { namespace: 'ingress-nginx' });\n    expect(left.length).toBe(0);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "Gateway API 相对 Ingress 最大的改进是**角色分离**：GatewayClass 归平台，\nGateway 归集群管理员（决定端口、证书、暴露到哪个网段），HTTPRoute 归应用\n团队。Ingress 时代所有这些都挤在一个对象和一堆 annotation 里，\n于是「谁能改什么」根本没法划清。\n\n这一关里「内网还是公网」由 GatewayClass 背后的 EnvoyProxy 参数决定，\n应用团队写 HTTPRoute 时碰不到它 —— 这正是分离的价值：\n应用团队不可能不小心把自己暴露到公网上。\n",
+          "en": "The biggest improvement Gateway API makes over Ingress is **role separation**:\nGatewayClass belongs to the platform, Gateway to the cluster administrator\n(ports, certificates, which network it is exposed on), and HTTPRoute to the\napplication team. Under Ingress all of that was crammed into one object and a\npile of annotations, so \"who may change what\" could not be drawn at all.\n\nHere, internal-versus-public is decided by the EnvoyProxy parameters behind the\nGatewayClass, and the application team never touches it while writing an\nHTTPRoute. That is the point of the separation: an application team cannot\naccidentally publish itself to the internet.\n"
+        },
+        "primer": {
+          "zh": "集群里的服务默认只能在集群内部访问。要让外面进得来，需要一个`入口`。早年的做法是 `Ingress`：一个对象里写着域名、路径和后端 Service，再由某个 Ingress 控制器（nginx、traefik 之类）把它翻译成真正的反向代理配置。Ingress 的规范只覆盖了最基础的 HTTP 路由，超出的部分全靠 annotation，于是每家控制器一套写法，配置无法在实现之间迁移。\n\n`Gateway API` 是它的继任者，2023 年 GA。最大的变化是把一个对象拆成三个，按`角色`分开：`GatewayClass` 由平台方提供，声明「这套入口由哪个控制器实现」；`Gateway` 由集群管理员建，决定监听哪些端口、用什么证书、暴露到哪个网段；`HTTPRoute` 由应用团队自己写，只管路径怎么分发到哪个 Service。谁能改什么，从此在 RBAC 上划得清。\n\n一条请求进来要经过两层匹配。先看 Gateway 的 `listener`：端口对不对、`hostname` 对不对。再看挂在这个 Gateway 上的 HTTPRoute：`hostnames` 对不对、`rules.matches` 里的路径对不对。两层都过了才转给 `backendRefs` 指的 Service。任何一层没匹配上，Gateway 会回 404 而不是拒绝连接，因为 Gateway 本身是活着的。这个区别决定了排查方向：404 去查路由，连不上去查 Gateway。\n\n状态写在两处，都值得先看。Gateway 的 `Programmed` 条件说明控制器有没有把配置下发下去，`status.addresses` 里是真正的访问地址。HTTPRoute 的 `status.parents[].conditions` 里有 `Accepted` 和 `ResolvedRefs`，后者会直接说出后端 Service 是不是不存在，省掉一轮猜测。",
+          "en": "Services in a cluster are only reachable from inside it by default. Letting outside traffic in requires an `ingress point`. The original mechanism was `Ingress`: one object holding hostnames, paths, and backend Services, translated into real reverse-proxy configuration by some Ingress controller (nginx, traefik, and others). The Ingress spec only covered basic HTTP routing, so everything beyond it lived in annotations, every controller invented its own, and configuration could not move between implementations.\n\n`Gateway API` is the successor, GA since 2023. Its central change is splitting that one object into three along `role` lines. `GatewayClass` is offered by the platform and names the controller implementing it. `Gateway` is created by the cluster administrator and decides which ports to listen on, which certificates to use, and which network it is exposed on. `HTTPRoute` is written by the application team and only says which path goes to which Service. Who may change what is finally expressible in RBAC.\n\nAn incoming request passes two matching layers. First the Gateway `listener`: correct port, correct `hostname`. Then the HTTPRoutes attached to that Gateway: correct `hostnames`, correct path in `rules.matches`. Only if both pass does traffic go to the Service in `backendRefs`. If either fails, the Gateway returns 404 rather than refusing the connection, because the Gateway itself is alive. That distinction sets the direction of an investigation: a 404 means look at routing, a refused connection means look at the Gateway.\n\nStatus lives in two places and both are worth reading first. The Gateway `Programmed` condition says whether the controller pushed configuration down, and `status.addresses` holds the real address. An HTTPRoute carries `Accepted` and `ResolvedRefs` in `status.parents[].conditions`, and the latter states outright whether the backend Service is missing, saving a round of guessing."
+        }
+      },
+      {
+        "id": "certificates-and-pki",
+        "title": {
+          "zh": "证书与 PKI",
+          "en": "Certificates and PKI"
+        },
+        "goal": {
+          "zh": "门户要上 HTTPS。前任已经在 Gateway 上配了 443，用的是他手工造的一张证书\n（Secret `portal-tls-manual`）。但从跳板机访问的时候 curl 直接失败了，\n而他坚称「证书是对的，浏览器里能打开」。\n\n公司有自己的 PKI：一个根 CA `Corp Root CA`，下面一个签发用的中间 CA\n`Corp Issuing CA`。cert-manager 已经装好，ClusterIssuer `corp-ca`\n指向那个中间 CA。根 CA 已经装进这台跳板机的信任库了。\n\n## 通关标准\n\n1. 先搞清楚手工那张证书到底哪里不对（`openssl x509` 与 `openssl verify`\n   能把话说明白）；\n2. 用 cert-manager 签一张，Certificate 的 `Ready` 是 True；\n3. Gateway 的 443 用上新证书；\n4. **不加 `-k`** 的 `curl https://portal.corp.internal/` 返回 200；\n5. 证书有效期至少还剩 60 天。\n\n## 会用到的命令\n\n```bash\nkubectl get secret portal-tls-manual -n payments -o jsonpath='{.data.tls.crt}' | base64 -d > /tmp/manual.pem\nopenssl x509 -in /tmp/manual.pem -noout -text\nopenssl verify -CAfile /etc/ssl/certs/ca-certificates.crt /tmp/manual.pem\nkubectl get clusterissuer\nkubectl apply -f infra/tls.yaml\nkubectl describe certificate portal -n payments\ncurl -v --resolve portal.corp.internal:443:<Gateway 地址> https://portal.corp.internal/\n```\n",
+          "en": "The portal needs HTTPS. Your predecessor already configured port 443 on the\nGateway using a certificate he made by hand (Secret `portal-tls-manual`).\ncurl from the jump host fails outright, and he insists the certificate is fine\nbecause \"it opens in the browser\".\n\nThe company runs its own PKI: a root CA `Corp Root CA` with an issuing\nintermediate `Corp Issuing CA` under it. cert-manager is installed and the\nClusterIssuer `corp-ca` points at that intermediate. The root is already in\nthis jump host's trust store.\n\n## Done when\n\n1. you work out what is actually wrong with the hand-made certificate\n   (`openssl x509` and `openssl verify` will say it plainly);\n2. cert-manager issues a replacement and the Certificate reports `Ready` True;\n3. the Gateway's port 443 uses the new certificate;\n4. `curl https://portal.corp.internal/` returns 200 **without `-k`**;\n5. the certificate has at least 60 days of validity left.\n\n## Commands you will need\n\n```bash\nkubectl get secret portal-tls-manual -n payments -o jsonpath='{.data.tls.crt}' | base64 -d > /tmp/manual.pem\nopenssl x509 -in /tmp/manual.pem -noout -text\nopenssl verify -CAfile /etc/ssl/certs/ca-certificates.crt /tmp/manual.pem\nkubectl get clusterissuer\nkubectl apply -f infra/tls.yaml\nkubectl describe certificate portal -n payments\ncurl -v --resolve portal.corp.internal:443:<gateway address> https://portal.corp.internal/\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "看懂手工证书哪里不对",
+            "en": "Diagnose the hand-made certificate"
+          },
+          {
+            "zh": "cert-manager 签出新证书并被 Gateway 用上",
+            "en": "cert-manager issues one and the Gateway uses it"
+          },
+          {
+            "zh": "不加 -k 也能通，有效期充足",
+            "en": "Works without -k, with plenty of validity left"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`openssl verify` 会直接说 `unable to get local issuer certificate` —— 意思是「顺着这张证书往上找不到签它的那一级」。",
+            "en": "`openssl verify` says `unable to get local issuer certificate` outright: it cannot find the certificate that signed this one."
+          },
+          {
+            "zh": "根 CA 在信任库里，签这张证书的却是中间 CA。`tls.crt` 里应该是**叶子 + 中间**两张，前任只放了一张。",
+            "en": "The root is trusted, but this certificate was signed by the intermediate. `tls.crt` should hold **leaf + intermediate**; your predecessor put in only one."
+          },
+          {
+            "zh": "cert-manager 签发时会自动把签发链接在叶子后面，所以用它就不会犯这个错。",
+            "en": "cert-manager appends the issuing chain after the leaf automatically, so using it avoids the mistake entirely."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "「浏览器里能打开」不能作为证据。浏览器可能缓存过那张中间证书，或者会主动去补齐（AIA chasing）；curl、Go 写的服务、Java 写的服务都不会。这类「我这儿好好的」正是链不完整最典型的表现。",
+            "en": "\"It opens in my browser\" is not evidence. Browsers may have cached the intermediate or fetch it themselves (AIA chasing); curl, Go services, and Java services will not. \"Works on my machine\" is the signature symptom of an incomplete chain."
+          },
+          {
+            "zh": "加 `-k` 让它通过。那不是修好了，是把校验关掉了 —— 中间人攻击也一起放进来了。判定明确要求不加 `-k`。",
+            "en": "Adding `-k` makes it pass. That is not a fix, it is disabling verification, and it lets a man-in-the-middle in too. The grader requires no `-k`."
+          },
+          {
+            "zh": "把中间 CA 也塞进跳板机的信任库。这样确实能通，但你只修好了自己这一台 —— 集群里的服务、别人的机器全都还是坏的。证书链应该由服务端提供完整。",
+            "en": "Adding the intermediate to this jump host’s trust store. It works here and nowhere else: other machines and in-cluster callers still fail. The server is responsible for presenting a complete chain."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/tls.yaml": "apiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: corp-gw\n  namespace: payments\nspec:\n  gatewayClassName: envoy-internal\n  listeners:\n  - name: https\n    port: 443\n    protocol: HTTPS\n    hostname: portal.corp.internal\n    tls:\n      mode: Terminate\n      certificateRefs:\n      - name: portal-tls-manual\n  - name: http\n    port: 80\n    protocol: HTTP\n    hostname: portal.corp.internal\n"
+          },
+          "referenceFiles": {
+            "/root/infra/tls.yaml": "apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  secretName: portal-tls\n  duration: 2160h\n  renewBefore: 720h\n  commonName: portal.corp.internal\n  dnsNames:\n  - portal.corp.internal\n  issuerRef:\n    name: corp-ca\n    kind: ClusterIssuer\n---\napiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: corp-gw\n  namespace: payments\nspec:\n  gatewayClassName: envoy-internal\n  listeners:\n  - name: https\n    port: 443\n    protocol: HTTPS\n    hostname: portal.corp.internal\n    tls:\n      mode: Terminate\n      certificateRefs:\n      - name: portal-tls\n  - name: http\n    port: 80\n    protocol: HTTP\n    hostname: portal.corp.internal\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/tls.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "certificates-and-pki.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst DAY = 24 * 60 * 60 * 1000;\n\ndescribe('证书与 PKI', () => {\n  it('cert-manager 签出了证书，Ready 是 True', () => {\n    const certificates = list('Certificate', { namespace: 'payments' });\n    expect(certificates.length).toBe(1);\n    const ready = certificates[0].status.conditions\n      .find((entry) => entry.type === 'Ready');\n    expect(ready.status).toBe('True');\n  });\n\n  it('Gateway 的 443 用的是 cert-manager 签的那张', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const https = gateway.spec.listeners.find((entry) => entry.protocol === 'HTTPS');\n    expect(https).toBeTruthy();\n\n    const reference = https.tls.certificateRefs[0].name;\n    const certificate = list('Certificate', { namespace: 'payments' })[0];\n    expect(reference).toBe(certificate.spec.secretName);\n  });\n\n  it('不加 -k 也能通，返回 200', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address\n      + ' https://portal.corp.internal/'\n    );\n    expect(result.code).toBe(0);\n    expect(result.stdout).toBe('200');\n  });\n\n  it('证书有效期至少还剩 60 天', () => {\n    const certificate = list('Certificate', { namespace: 'payments' })[0];\n    const notAfter = Date.parse(certificate.status.notAfter);\n    const remaining = (notAfter - Date.parse('2026-03-02T09:00:00Z')) / DAY;\n    expect(remaining >= 60).toBe(true);\n  });\n\n  it('没有靠把中间 CA 塞进本机信任库来蒙过去', async () => {\n    // 信任库里只该有根，多出来的中间 CA 说明修的是自己这一台\n    const bundle = await sh('grep -c BEGIN /etc/ssl/certs/ca-certificates.crt');\n    expect(bundle.stdout.trim()).toBe('1');\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "「链不完整」之所以难查，是因为它**不是必然失败**。浏览器缓存过那张中间\n证书、或者按证书里的 AIA 扩展自己去下载，都会让它看起来是好的；而 curl、\nGo 与 Java 写的服务不会做这些事。于是现象是「我这儿好好的，你那儿不行」。\n\n判断的办法只有一个：把服务端实际发出来的那串证书拿出来看。\n`openssl s_client -connect host:443 -showcerts` 会把它们全打出来，\n数一数有几张，就知道链有没有断。\n",
+          "en": "An incomplete chain is hard to diagnose precisely because it does not always\nfail. A browser may have cached the intermediate, or fetch it itself through the\nAIA extension; curl, Go services, and Java services do neither. The result is\n\"it works here and not there\".\n\nThere is only one reliable check: look at the certificates the server actually\nsends. `openssl s_client -connect host:443 -showcerts` prints all of them, and\ncounting them tells you whether the chain is complete.\n"
+        },
+        "primer": {
+          "zh": "HTTPS 的信任建立在一条`证书链`上。服务端出示一张`叶子证书`，上面写着它是谁（`Subject`）、能代表哪些域名（`SAN`，Subject Alternative Name）、有效期、以及公钥。这张证书由某个`证书颁发机构`（CA）用私钥签过名。客户端手里有一份`信任库`，里面是它信任的根 CA。验证的过程就是从叶子往上找签它的那一级，一级级找到信任库里的某个根为止。\n\n实际的 PKI 很少只有一层。通常是一个离线保存的根 CA，签出若干个`中间 CA`，日常签发全用中间 CA 做。好处是根的私钥可以锁在保险柜里，中间 CA 泄漏了也能单独吊销。代价是**服务端必须把中间证书一起发给客户端**：客户端信任库里只有根，它不认识那张中间 CA，链就断在那里。\n\n这个坑之所以难查，是因为它不是必然失败。浏览器可能之前访问别的站点时缓存过同一张中间证书，或者按证书里的 AIA 扩展自己去下载补齐；而 curl、Go 与 Java 写的服务都不做这些事。于是现象是「浏览器能打开，服务之间调不通」。判断的办法只有一个：看服务端实际发出来的是几张证书。\n\n`SAN` 是另一处常见问题。2017 年之后所有主流验证器都不再看 `CN` 字段，只认 SAN。一张 CN 写对但 SAN 里没有这个名字的证书会被拒绝，报错是「certificate is valid for A, not B」。Kubernetes 里这些事通常交给 `cert-manager`：`Issuer` 声明用哪个 CA，`Certificate` 声明要签什么，控制器把签好的叶子**连同签发链**一起写进一个 `kubernetes.io/tls` 类型的 Secret，链不完整这个错自然就不会犯。",
+          "en": "HTTPS trust rests on a `certificate chain`. A server presents a `leaf certificate` stating who it is (`Subject`), which names it may represent (`SAN`, Subject Alternative Name), how long it is valid, and its public key. That certificate is signed by some `certificate authority` (CA). The client holds a `trust store` of root CAs it trusts, and verification walks upward from the leaf, level by level, until it reaches one of those roots.\n\nReal PKIs rarely have a single level. The usual shape is an offline root CA that signs several `intermediate CAs`, with day-to-day issuance done by an intermediate. The root private key can then live in a safe, and a compromised intermediate can be revoked on its own. The price is that **the server must send the intermediate along with the leaf**: the client only trusts the root, does not recognise the intermediate, and the chain breaks there.\n\nThis is hard to diagnose because it does not always fail. A browser may have cached the same intermediate from another site, or fetch it itself via the AIA extension in the certificate; curl, Go services, and Java services do neither. The symptom is \"the browser opens it, service-to-service calls fail\". There is one reliable check: look at how many certificates the server actually sends.\n\n`SAN` is the other frequent problem. Since 2017 no mainstream verifier reads the `CN` field; only SAN counts. A certificate with the right CN but a SAN that omits the name is rejected with \"certificate is valid for A, not B\". In Kubernetes this is normally handled by `cert-manager`: an `Issuer` names the CA, a `Certificate` describes what to issue, and the controller writes the leaf **together with its issuing chain** into a `kubernetes.io/tls` Secret, which makes the incomplete-chain mistake impossible to commit."
         }
       }
     ]

--- a/scripts/opslab-wasm-patches.sh
+++ b/scripts/opslab-wasm-patches.sh
@@ -310,4 +310,200 @@ if old not in source:
 open(path, "w").write(source.replace(old, new))
 PYEOF
 
+# --- 6. websocket：让 gorilla 通过宿主提供的通道拨号 ----------------------
+#
+# `kubectl exec` / `logs -f` / `port-forward` 走的是 WebSocket（v5.channel.k8s.io）。
+# 上层全是真的 client-go remotecommand，问题只在最底下一层：gorilla 要一个
+# net.Conn，而 js/wasm 里没有 socket。
+#
+# 好在 gorilla 的 Dialer 有 NetDialContext 钩子。补一个由宿主 JS 提供的
+# net.Conn 进去，握手、分帧、子协议协商就全都还是真的走一遍。
+cat > "$V/k8s.io/client-go/transport/websocket/opslab_dial_js.go" <<'EOF'
+//go:build js
+
+package websocket
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall/js"
+	"time"
+)
+
+// opslabConn 是一条由宿主 JS 提供的双向字节通道。
+//
+// 宿主那边是一个内存里的 WebSocket 服务端，所以 gorilla 照常做握手与分帧，
+// 只是字节没有真的过网卡。
+type opslabConn struct {
+	handle  js.Value
+	incoming chan []byte
+	pending []byte
+	closed  chan struct{}
+	onData  js.Func
+	onClose js.Func
+}
+
+func opslabDial(ctx context.Context, network, address string) (net.Conn, error) {
+	dial := js.Global().Get("__opslabDial")
+	if !dial.Truthy() {
+		return nil, errors.New("opslab: 宿主没有提供 __opslabDial")
+	}
+	handle := dial.Invoke(address)
+	if !handle.Truthy() {
+		return nil, errors.New("opslab: 连不上 " + address)
+	}
+
+	conn := &opslabConn{
+		handle:   handle,
+		incoming: make(chan []byte, 64),
+		closed:   make(chan struct{}),
+	}
+	conn.onData = js.FuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) == 0 {
+			return nil
+		}
+		buffer := make([]byte, args[0].Get("length").Int())
+		js.CopyBytesToGo(buffer, args[0])
+		select {
+		case conn.incoming <- buffer:
+		case <-conn.closed:
+		}
+		return nil
+	})
+	conn.onClose = js.FuncOf(func(this js.Value, args []js.Value) any {
+		conn.shutdown()
+		return nil
+	})
+	handle.Set("onData", conn.onData)
+	handle.Set("onClose", conn.onClose)
+	return conn, nil
+}
+
+func (c *opslabConn) Read(p []byte) (int, error) {
+	if len(c.pending) == 0 {
+		select {
+		case chunk, ok := <-c.incoming:
+			if !ok {
+				return 0, io.EOF
+			}
+			c.pending = chunk
+		case <-c.closed:
+			return 0, io.EOF
+		}
+	}
+	n := copy(p, c.pending)
+	c.pending = c.pending[n:]
+	return n, nil
+}
+
+func (c *opslabConn) Write(p []byte) (int, error) {
+	select {
+	case <-c.closed:
+		return 0, io.ErrClosedPipe
+	default:
+	}
+	buffer := js.Global().Get("Uint8Array").New(len(p))
+	js.CopyBytesToJS(buffer, p)
+	c.handle.Call("send", buffer)
+	return len(p), nil
+}
+
+func (c *opslabConn) Close() error {
+	if c.handle.Truthy() {
+		c.handle.Call("close")
+	}
+	c.shutdown()
+	return nil
+}
+
+func (c *opslabConn) shutdown() {
+	select {
+	case <-c.closed:
+		return
+	default:
+	}
+	close(c.closed)
+	c.onData.Release()
+	c.onClose.Release()
+}
+
+type opslabAddr struct{}
+
+func (opslabAddr) Network() string { return "opslab" }
+func (opslabAddr) String() string  { return "opslab" }
+
+func (c *opslabConn) LocalAddr() net.Addr                { return opslabAddr{} }
+func (c *opslabConn) RemoteAddr() net.Addr               { return opslabAddr{} }
+func (c *opslabConn) SetDeadline(t time.Time) error      { return nil }
+func (c *opslabConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *opslabConn) SetWriteDeadline(t time.Time) error { return nil }
+EOF
+
+# 把钩子挂到 Dialer 上
+python3 - "$V" <<'PYEOF'
+import sys
+path = f"{sys.argv[1]}/k8s.io/client-go/transport/websocket/roundtripper.go"
+source = open(path).read()
+old = """	dialer := gwebsocket.Dialer{
+		Proxy:           rt.Proxier,"""
+new = """	dialer := gwebsocket.Dialer{
+		// opslab: js/wasm 里没有 socket，走宿主提供的内存通道。
+		// 握手、分帧、子协议协商仍然是 gorilla 真的做一遍。
+		NetDialContext:  opslabDialContext,
+		Proxy:           rt.Proxier,"""
+if old not in source:
+    raise SystemExit("websocket RoundTrip 的样子变了，补丁要重写")
+source = source.replace(old, new)
+
+# 通道本身就是宿主提供的内存管道，没有网卡也没有 TLS 记录层。
+# 不改这里的话 gorilla 会对着 https 的 kubeconfig 选 wss，然后在我们的
+# 管道上发一个 ClientHello 等 ServerHello —— 永远等不到，整条 exec 卡死。
+# fetch 那条路同样没有真 TLS，两边保持一致。
+old_scheme = (
+    '\tswitch request.URL.Scheme {\n'
+    '\tcase "https":\n'
+    '\t\trequest.URL.Scheme = "wss"\n'
+    '\tcase "http":\n'
+    '\t\trequest.URL.Scheme = "ws"\n'
+)
+new_scheme = (
+    '\tswitch request.URL.Scheme {\n'
+    '\tcase "https", "http":\n'
+    '\t\t// opslab: 通道是宿主给的内存管道，没有 TLS 记录层，统一走 ws\n'
+    '\t\trequest.URL.Scheme = "ws"\n'
+)
+if old_scheme not in source:
+    raise SystemExit("websocket 的 scheme 切换变了，补丁要重写")
+open(path, "w").write(source.replace(old_scheme, new_scheme))
+PYEOF
+
+# 非 js 平台上钩子是空的，保持可编译
+cat > "$V/k8s.io/client-go/transport/websocket/opslab_dial_other.go" <<'EOF'
+//go:build !js
+
+package websocket
+
+import (
+	"context"
+	"net"
+)
+
+var opslabDialContext func(ctx context.Context, network, address string) (net.Conn, error)
+EOF
+
+cat > "$V/k8s.io/client-go/transport/websocket/opslab_dial_hook_js.go" <<'EOF'
+//go:build js
+
+package websocket
+
+import (
+	"context"
+	"net"
+)
+
+var opslabDialContext func(ctx context.Context, network, address string) (net.Conn, error) = opslabDial
+EOF
+
 echo "js/wasm 补丁已应用"

--- a/src/lib/opslab/apiserver/exec.ts
+++ b/src/lib/opslab/apiserver/exec.ts
@@ -1,0 +1,121 @@
+/**
+ * `kubectl exec` 的服务端
+ *
+ * 走的是 k8s 的通道协议（`v5.channel.k8s.io`）：WebSocket 上的每一帧，
+ * 第一个字节是通道号，剩下是数据。
+ *
+ *   0 stdin   1 stdout   2 stderr   3 error（一个 metav1.Status 的 JSON）
+ *   4 resize  255 close
+ *
+ * 退出码走的是 3 号通道里的 Status —— 不是 HTTP 状态码。所以
+ * `kubectl exec ... && echo ok` 这种写法能不能对，全看这一段。
+ */
+import type { StreamSession, UpgradeRequest } from '../net';
+import { OPCODE } from '../net';
+
+export const CHANNEL = { STDIN: 0, STDOUT: 1, STDERR: 2, ERROR: 3, RESIZE: 4, CLOSE: 255 } as const;
+export const EXEC_PROTOCOL = 'v5.channel.k8s.io';
+
+export interface ExecRequest {
+  namespace: string;
+  pod: string;
+  container?: string;
+  command: string[];
+  stdin: boolean;
+  tty: boolean;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export type ExecHandler = (request: ExecRequest, stdin: string) => Promise<ExecResult>;
+
+/** 从 `/api/v1/namespaces/x/pods/y/exec?command=...&stdout=true` 解出请求 */
+export function parseExecRequest(request: UpgradeRequest): ExecRequest | undefined {
+  const match = /^\/api\/v1\/namespaces\/([^/]+)\/pods\/([^/]+)\/exec/.exec(request.path);
+  if (!match) return undefined;
+  const query = new URLSearchParams(request.path.split('?')[1] ?? '');
+  return {
+    namespace: match[1],
+    pod: decodeURIComponent(match[2].split('?')[0]),
+    container: query.get('container') ?? undefined,
+    command: query.getAll('command'),
+    stdin: query.get('stdin') === 'true',
+    tty: query.get('tty') === 'true',
+  };
+}
+
+/**
+ * 一次 exec 会话。
+ *
+ * 命令是异步跑的（里面可能有 curl，要等虚拟时钟推进），跑完把 stdout/stderr
+ * 分通道写回去，最后在 3 号通道上写一个 Status 表示退出码，再关掉连接。
+ */
+export function createExecSession(request: ExecRequest, handler: ExecHandler): StreamSession {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let stdin = '';
+
+  return {
+    protocol: EXEC_PROTOCOL,
+
+    onFrame(opcode, payload) {
+      if (opcode !== OPCODE.BINARY || payload.length === 0) return;
+      if (payload[0] === CHANNEL.STDIN) stdin += decoder.decode(payload.subarray(1));
+    },
+
+    start(send, close) {
+      const write = (channel: number, text: string) => {
+        if (!text) return;
+        const body = encoder.encode(text);
+        const frame = new Uint8Array(body.length + 1);
+        frame[0] = channel;
+        frame.set(body, 1);
+        send(OPCODE.BINARY, frame);
+      };
+
+      // stdin 是流式送来的，但我们的命令是一次性执行的：
+      // 等一个微任务批次，让已经在路上的 stdin 帧先落地
+      void Promise.resolve().then(async () => {
+        let result: ExecResult;
+        try {
+          result = await handler(request, stdin);
+        } catch (error) {
+          result = { stdout: '', stderr: `${(error as Error).message}\n`, code: 1 };
+        }
+        write(CHANNEL.STDOUT, result.stdout);
+        write(CHANNEL.STDERR, result.stderr);
+        write(CHANNEL.ERROR, JSON.stringify(statusOf(result.code, request)));
+        close();
+      });
+    },
+  };
+}
+
+/**
+ * 3 号通道上那个 Status。
+ *
+ * 成功是 `status: Success`；失败要带上 `reason: NonZeroExitCode` 与
+ * `ExitCode` 这个 cause，kubectl 就是从这里取退出码的。少一个字段，
+ * `kubectl exec ... ; echo $?` 就永远是 0。
+ */
+export function statusOf(code: number, request: ExecRequest): unknown {
+  if (code === 0) {
+    return { metadata: {}, status: 'Success' };
+  }
+  return {
+    metadata: {},
+    status: 'Failure',
+    message: `command terminated with exit code ${code}`,
+    reason: 'NonZeroExitCode',
+    details: {
+      causes: [
+        { reason: 'ExitCode', message: String(code) },
+        { reason: 'Command', message: request.command.join(' ') },
+      ],
+    },
+  };
+}

--- a/src/lib/opslab/apiserver/exec.ts
+++ b/src/lib/opslab/apiserver/exec.ts
@@ -40,7 +40,7 @@ export function parseExecRequest(request: UpgradeRequest): ExecRequest | undefin
   const query = new URLSearchParams(request.path.split('?')[1] ?? '');
   return {
     namespace: match[1],
-    pod: decodeURIComponent(match[2].split('?')[0]),
+    pod: decodeURIComponent(match[2]),
     container: query.get('container') ?? undefined,
     command: query.getAll('command'),
     stdin: query.get('stdin') === 'true',
@@ -58,6 +58,7 @@ export function createExecSession(request: ExecRequest, handler: ExecHandler): S
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   let stdin = '';
+  let launch: (() => void) | undefined;
 
   return {
     protocol: EXEC_PROTOCOL,
@@ -65,6 +66,18 @@ export function createExecSession(request: ExecRequest, handler: ExecHandler): S
     onFrame(opcode, payload) {
       if (opcode !== OPCODE.BINARY || payload.length === 0) return;
       if (payload[0] === CHANNEL.STDIN) stdin += decoder.decode(payload.subarray(1));
+      /**
+       * 255 通道是 v5 加的「某条流关了」。
+       *
+       * `-i` 的时候要等 stdin 关掉才开跑：我们的命令是一次性执行的，
+       * 提前跑就等于把 stdin 当成空的 —— `kubectl exec -i pod -- cat`
+       * 会静默输出空，比报错还难查。
+       */
+      if (payload[0] === CHANNEL.CLOSE && payload[1] === CHANNEL.STDIN) {
+        const start = launch;
+        launch = undefined;
+        start?.();
+      }
     },
 
     start(send, close) {
@@ -77,9 +90,7 @@ export function createExecSession(request: ExecRequest, handler: ExecHandler): S
         send(OPCODE.BINARY, frame);
       };
 
-      // stdin 是流式送来的，但我们的命令是一次性执行的：
-      // 等一个微任务批次，让已经在路上的 stdin 帧先落地
-      void Promise.resolve().then(async () => {
+      const run = async () => {
         let result: ExecResult;
         try {
           result = await handler(request, stdin);
@@ -90,7 +101,16 @@ export function createExecSession(request: ExecRequest, handler: ExecHandler): S
         write(CHANNEL.STDERR, result.stderr);
         write(CHANNEL.ERROR, JSON.stringify(statusOf(result.code, request)));
         close();
-      });
+      };
+
+      // 不带 -i 时没人会送 stdin，等一个微任务批次就开跑
+      if (request.stdin) launch = () => { void run(); };
+      else void Promise.resolve().then(run);
+    },
+
+    onClose() {
+      // 连接先断了：stdin 不会再来了，别把会话晾在那儿
+      launch = undefined;
     },
   };
 }

--- a/src/lib/opslab/apiserver/http.ts
+++ b/src/lib/opslab/apiserver/http.ts
@@ -22,9 +22,18 @@ export interface ApiServerDeps {
   now: () => number;
   /** 集群版本，出现在 /version 与 discovery 里 */
   version?: { major: string; minor: string; gitVersion: string };
+  /**
+   * `kubectl exec` 真正执行命令的地方。
+   *
+   * apiserver 只负责协议，命令跑在哪、怎么跑，由集群那边说了算 ——
+   * 和真集群把它转给 kubelet 是同一个分工。
+   */
+  exec?: ExecHandler;
 }
 import { openApiDocument, openApiRoot } from './openapi';
 import type { PatchType } from './patch';
+import { createExecSession, parseExecRequest, type ExecHandler } from './exec';
+import type { StreamSession, UpgradeRequest } from '../net';
 
 interface ParsedPath {
   group: string;
@@ -128,6 +137,7 @@ export class ApiServer {
   private readonly scheme: Scheme;
   private readonly now: () => number;
   private readonly version: { major: string; minor: string; gitVersion: string };
+  private readonly exec?: ExecHandler;
   /** 收到的请求，调试与测试用 */
   readonly requestLog: string[] = [];
 
@@ -136,6 +146,34 @@ export class ApiServer {
     this.scheme = deps.scheme;
     this.now = deps.now;
     this.version = deps.version ?? { major: '1', minor: '36', gitVersion: 'v1.36.0' };
+    this.exec = deps.exec;
+  }
+
+  /**
+   * WebSocket 升级请求。
+   *
+   * `kubectl exec` 走的不是 fetch 而是这条路：真 gorilla 在 wasm 里做握手，
+   * 宿主这边把它接到会话上。
+   */
+  openStream(request: UpgradeRequest): StreamSession | { status: number; reason: string; body: string } | undefined {
+    const parsed = parseExecRequest(request);
+    if (!parsed) {
+      return { status: 404, reason: 'Not Found', body: JSON.stringify(toStatus(notFound('pods', '', ''))) };
+    }
+    if (!this.exec) {
+      return {
+        status: 400, reason: 'Bad Request',
+        body: JSON.stringify({ kind: 'Status', status: 'Failure', message: 'exec is not supported by this server' }),
+      };
+    }
+    if (parsed.command.length === 0) {
+      return {
+        status: 400, reason: 'Bad Request',
+        body: JSON.stringify({ kind: 'Status', status: 'Failure', message: 'you must specify at least one command for the container' }),
+      };
+    }
+    this.requestLog.push(`WS ${request.path}`);
+    return createExecSession(parsed, this.exec);
   }
 
   /** fetch 兼容的入口 —— 真 kubectl 就是通过它打进来的 */

--- a/src/lib/opslab/apiserver/index.ts
+++ b/src/lib/opslab/apiserver/index.ts
@@ -13,7 +13,7 @@ export {
   parseFieldSelector,
   parseLabelSelector,
 } from './registry';
-export type { RegistryDeps } from './registry';
+export type { Defaulter, RegistryDeps } from './registry';
 export { Scheme, createScheme, storageKey, storagePrefix } from './scheme';
 export { ApiServer, createApiServer, parsePath } from './http';
 export type { ApiServerDeps } from './http';
@@ -48,3 +48,7 @@ export type {
   UpdateOptions,
   WatchEventOut,
 } from './types';
+export {
+  createExecSession, parseExecRequest, statusOf, CHANNEL, EXEC_PROTOCOL,
+  type ExecRequest, type ExecResult, type ExecHandler,
+} from './exec';

--- a/src/lib/opslab/apiserver/registry.ts
+++ b/src/lib/opslab/apiserver/registry.ts
@@ -35,6 +35,19 @@ import type {
 export const FOREGROUND_DELETION = 'foregroundDeletion';
 export const ORPHAN_DEPENDENTS = 'orphan';
 
+/**
+ * 创建时补默认值的钩子。
+ *
+ * 真 apiserver 里这是 defaulting + 分配器：Service 的 ClusterIP 就是在这一层
+ * 从 service CIDR 里分出来的，不是哪个控制器事后补的 —— 所以 `kubectl create svc`
+ * 之后紧跟着 `kubectl get svc`，IP 已经在那儿了。
+ */
+export interface Defaulter {
+  matches(definition: ResourceDefinition): boolean;
+  /** existing 是整体替换时的旧对象；不可变字段要从它那里带过来 */
+  apply(object: KubeObject, definition: ResourceDefinition, existing?: KubeObject): void;
+}
+
 export interface RegistryDeps {
   store: Store;
   scheme: Scheme;
@@ -42,6 +55,7 @@ export interface RegistryDeps {
   now: () => number;
   /** 生成 uid，来自确定性随机数 */
   uid: () => string;
+  defaulters?: Defaulter[];
 }
 
 function clone<T>(value: T): T {
@@ -167,7 +181,21 @@ export class Registry {
   private readonly now: () => number;
   private readonly nextUid: () => string;
 
+  private readonly defaulters: Defaulter[];
+
+  /** 装一个 defaulter。集群起来的时候把 ClusterIP 分配器装在这里。 */
+  addDefaulter(defaulter: Defaulter): void {
+    this.defaulters.push(defaulter);
+  }
+
+  private applyDefaults(definition: ResourceDefinition, object: KubeObject, existing?: KubeObject): void {
+    for (const defaulter of this.defaulters) {
+      if (defaulter.matches(definition)) defaulter.apply(object, definition, existing);
+    }
+  }
+
   constructor(deps: RegistryDeps) {
+    this.defaulters = [...(deps.defaulters ?? [])];
     this.store = deps.store;
     this.scheme = deps.scheme;
     this.now = deps.now;
@@ -289,6 +317,8 @@ export class Registry {
     delete meta.resourceVersion;
     delete meta.deletionTimestamp;
 
+    this.applyDefaults(definition, candidate);
+
     if (options.dryRun) return this.decorate(candidate, this.store.revision);
 
     const kv = this.store.put(key, candidate);
@@ -339,6 +369,8 @@ export class Registry {
     next.kind = definition.kind;
     // status 归 status 子资源管
     next.status = existing.status;
+
+    this.applyDefaults(definition, next, existing);
 
     const specChanged = JSON.stringify(next.spec ?? null) !== JSON.stringify(existing.spec ?? null);
     meta.generation = (existing.metadata.generation ?? 1) + (specChanged ? 1 : 0);

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -16,6 +16,7 @@ import {
   Scheme,
 } from '../apiserver';
 import { Controller, ControllerContext } from './framework';
+import { createServiceIpDefaulter } from './serviceip';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -58,6 +59,10 @@ export interface ClusterOptions {
   resolveImage?: (image: string) => ImageSpec | undefined;
   /** 集群外的名字，`harbor.corp.internal` 之类 */
   externalHosts?: Record<string, string[]>;
+  /** Service 的 VIP 从哪个网段分。默认 10.96.0.0/12，和真集群一样。 */
+  serviceCidr?: string;
+  /** `kubectl exec` 落到哪。不给就是这个集群不支持 exec。 */
+  exec?: import('../apiserver').ExecHandler;
   /** 客户端信任哪些根。办公网的机器读自己的 ca-certificates.crt。 */
   trustBundle?: (source: import('../net').Source) => Certificate[];
   /**
@@ -92,6 +97,8 @@ export class Cluster {
   /** 网络：DNS、Service 转发、NetworkPolicy 判定，全都读 apiserver 里的对象 */
   readonly network: Network;
 
+  /** 由外面装上（createOpsWorld 会接一个 Pod 里的 shell 进来） */
+  execHandler?: import('../apiserver').ExecHandler;
   private controllers: Controller[] = [];
   private uidSeq = 0;
   private started = false;
@@ -115,7 +122,13 @@ export class Cluster {
       now,
       uid: () => `uid-${String(++this.uidSeq).padStart(6, '0')}`,
     });
-    this.apiServer = createApiServer({ registry: this.registry, scheme: this.scheme, now });
+    this.apiServer = createApiServer({
+      registry: this.registry, scheme: this.scheme, now,
+      exec: (request, stdin) => {
+        if (!this.execHandler) throw new Error('exec 没有接上');
+        return this.execHandler(request, stdin);
+      },
+    });
     this.network = createNetwork({
       registry: this.registry,
       scheme: this.scheme,
@@ -128,6 +141,12 @@ export class Cluster {
       imageOf: (image) => this.imageBehaviorOf(image),
       now,
     });
+
+    // ClusterIP 在 apiserver 这一层分，不是控制器事后补的 ——
+    // 这样 `kubectl expose` 之后紧跟 `kubectl get svc`，IP 已经在那儿了
+    this.registry.addDefaulter(createServiceIpDefaulter({
+      registry: this.registry, scheme: this.scheme, cidr: options.serviceCidr,
+    }));
 
     this.seed();
   }

--- a/src/lib/opslab/controllers/index.ts
+++ b/src/lib/opslab/controllers/index.ts
@@ -26,3 +26,4 @@ export type {
 } from './runtime';
 export { Cluster, createCluster } from './cluster';
 export type { ClusterOptions, NodeSpec } from './cluster';
+export { createServiceIpDefaulter, DEFAULT_SERVICE_CIDR } from './serviceip';

--- a/src/lib/opslab/controllers/serviceip.ts
+++ b/src/lib/opslab/controllers/serviceip.ts
@@ -1,0 +1,110 @@
+/**
+ * ClusterIP 分配
+ *
+ * 真集群里这件事发生在 apiserver 里，不是某个控制器事后补的 —— 所以
+ * `kubectl expose` 之后紧接着 `kubectl get svc`，IP 已经在那儿了。
+ * 我们也放在同一层（Registry 的 defaulter），行为才对得上。
+ *
+ * 三种 Service 不分配：
+ *  - `clusterIP: None`（headless，DNS 直接回后端 Pod 的地址）
+ *  - `type: ExternalName`（就是个 CNAME）
+ *  - 已经写死了 IP 的（关卡里手写的对象）
+ */
+import type { Defaulter, KubeObject, Registry, ResourceDefinition, Scheme } from '../apiserver';
+
+/** k8s 默认的 service CIDR */
+export const DEFAULT_SERVICE_CIDR = '10.96.0.0/12';
+
+function hash(text: string): number {
+  let value = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    value ^= text.charCodeAt(i);
+    value = Math.imul(value, 16777619) >>> 0;
+  }
+  return value >>> 0;
+}
+
+function parseCidr(cidr: string): { base: number; size: number } {
+  const [address, bitsText] = cidr.split('/');
+  const bits = Number(bitsText);
+  const octets = address.split('.').map(Number);
+  const value = ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0;
+  const size = 2 ** (32 - bits);
+  return { base: (value & (size === 4294967296 ? 0 : ~(size - 1))) >>> 0, size };
+}
+
+function formatIp(value: number): string {
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff].join('.');
+}
+
+export interface ServiceIpOptions {
+  registry: Registry;
+  scheme: Scheme;
+  cidr?: string;
+}
+
+/**
+ * 名字决定 IP，冲突就线性往后探。
+ *
+ * 不用计数器是因为要可复现：同一个世界重放两遍，同一个 Service 必须拿到
+ * 同一个 IP，哪怕中间创建顺序被别的东西影响过。
+ */
+export function createServiceIpDefaulter(options: ServiceIpOptions): Defaulter {
+  const { base, size } = parseCidr(options.cidr ?? DEFAULT_SERVICE_CIDR);
+  // .0 是网络地址，.1 留给 kubernetes 这个 Service，从 2 开始分
+  const usable = size - 2;
+
+  const taken = (): Set<string> => {
+    const definition = options.scheme.get({ group: '', version: 'v1', resource: 'services' });
+    if (!definition) return new Set();
+    const used = new Set<string>();
+    for (const service of options.registry.list(definition).items) {
+      const ip = ((service.spec ?? {}) as { clusterIP?: string }).clusterIP;
+      if (ip && ip !== 'None') used.add(ip);
+    }
+    return used;
+  };
+
+  return {
+    matches: (definition: ResourceDefinition) =>
+      definition.group === '' && definition.resource === 'services',
+
+    apply(object: KubeObject, _definition, existing?: KubeObject) {
+      const spec = (object.spec ?? (object.spec = {})) as {
+        clusterIP?: string; clusterIPs?: string[]; type?: string;
+      };
+      if (spec.type === 'ExternalName') return;
+
+      // ClusterIP 是不可变字段：整体替换时没写就沿用旧的，
+      // 不然 `kubectl replace -f` 会让一个在用的 Service 换掉 VIP
+      if (!spec.clusterIP && existing) {
+        const previous = ((existing.spec ?? {}) as { clusterIP?: string }).clusterIP;
+        if (previous) {
+          spec.clusterIP = previous;
+          spec.clusterIPs = previous === 'None' ? undefined : [previous];
+          return;
+        }
+      }
+      if (spec.clusterIP === 'None') {
+        spec.clusterIPs = ['None'];
+        return;
+      }
+      if (spec.clusterIP) {
+        spec.clusterIPs = spec.clusterIPs ?? [spec.clusterIP];
+        return;
+      }
+
+      const used = taken();
+      const seed = hash(`${object.metadata.namespace ?? ''}/${object.metadata.name ?? ''}`);
+      for (let probe = 0; probe < usable; probe += 1) {
+        const candidate = formatIp((base + 2 + ((seed + probe) % usable)) >>> 0);
+        if (!used.has(candidate)) {
+          spec.clusterIP = candidate;
+          spec.clusterIPs = [candidate];
+          return;
+        }
+      }
+      // CIDR 满了。真 apiserver 报的是 InternalError，实验里到不了这一步。
+    },
+  };
+}

--- a/src/lib/opslab/controllers/serviceip.ts
+++ b/src/lib/opslab/controllers/serviceip.ts
@@ -51,8 +51,9 @@ export interface ServiceIpOptions {
  */
 export function createServiceIpDefaulter(options: ServiceIpOptions): Defaulter {
   const { base, size } = parseCidr(options.cidr ?? DEFAULT_SERVICE_CIDR);
-  // .0 是网络地址，.1 留给 kubernetes 这个 Service，从 2 开始分
-  const usable = size - 2;
+  // .0 是网络地址，.1 留给 kubernetes 这个 Service，最后一个也不用，
+  // 所以可分的是 [base+2, base+size-2]
+  const usable = size - 3;
 
   const taken = (): Set<string> => {
     const definition = options.scheme.get({ group: '', version: 'v1', resource: 'services' });

--- a/src/lib/opslab/crypto/sha1.ts
+++ b/src/lib/opslab/crypto/sha1.ts
@@ -1,0 +1,46 @@
+/**
+ * SHA-1
+ *
+ * 只为一件事存在：WebSocket 握手要算 `Sec-WebSocket-Accept`，而那一步的算法
+ * 就是写死的 SHA-1。除此之外别处都不该用它。
+ */
+export function sha1(input: Uint8Array | string): Uint8Array {
+  const bytes = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+  const bitLength = bytes.length * 8;
+
+  const padded = new Uint8Array(((bytes.length + 9 + 63) >> 6) << 6);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padded.length - 8, Math.floor(bitLength / 0x100000000));
+  view.setUint32(padded.length - 4, bitLength >>> 0);
+
+  const h = new Uint32Array([0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0]);
+  const w = new Uint32Array(80);
+  const rotl = (value: number, bits: number) => (value << bits) | (value >>> (32 - bits));
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let i = 0; i < 16; i += 1) w[i] = view.getUint32(offset + i * 4);
+    for (let i = 16; i < 80; i += 1) w[i] = rotl(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+
+    let [a, b, c, d, e] = h;
+    for (let i = 0; i < 80; i += 1) {
+      let f: number;
+      let k: number;
+      if (i < 20) { f = (b & c) | (~b & d); k = 0x5a827999; }
+      else if (i < 40) { f = b ^ c ^ d; k = 0x6ed9eba1; }
+      else if (i < 60) { f = (b & c) | (b & d) | (c & d); k = 0x8f1bbcdc; }
+      else { f = b ^ c ^ d; k = 0xca62c1d6; }
+
+      const temp = (rotl(a, 5) + f + e + k + w[i]) >>> 0;
+      e = d; d = c; c = rotl(b, 30); b = a; a = temp;
+    }
+    h[0] = (h[0] + a) >>> 0; h[1] = (h[1] + b) >>> 0; h[2] = (h[2] + c) >>> 0;
+    h[3] = (h[3] + d) >>> 0; h[4] = (h[4] + e) >>> 0;
+  }
+
+  const out = new Uint8Array(20);
+  const outView = new DataView(out.buffer);
+  for (let i = 0; i < 5; i += 1) outView.setUint32(i * 4, h[i]);
+  return out;
+}

--- a/src/lib/opslab/lab/index.ts
+++ b/src/lib/opslab/lab/index.ts
@@ -11,3 +11,4 @@ export {
 } from './view';
 
 export { toolchainFor, baseImageOf, type ToolchainName } from './toolchains';
+export { createExecHandler, normalizeCommand } from './podshell';

--- a/src/lib/opslab/lab/podshell.ts
+++ b/src/lib/opslab/lab/podshell.ts
@@ -1,0 +1,144 @@
+/**
+ * Pod 里面那个 shell
+ *
+ * `kubectl exec` 落到这里。容器里能跑什么，取决于镜像给了什么：
+ * 一个基础的 rootfs、coreutils、以及网络工具 —— 而这些工具发起的连接，
+ * 源是**这个 Pod**，不是跳板机。第 10、11 关整两关都建立在这个区别上：
+ * 同一条 curl，从跳板机发和从 Pod 里发，结果完全不同。
+ */
+import type { KubeObject } from '../apiserver';
+import type { Cluster } from '../controllers';
+import { COREUTILS, createShell, createVfs } from '../machine';
+import { createNetTools } from '../net';
+import type { ExecRequest, ExecResult } from '../apiserver';
+
+/**
+ * 容器里那套最小的根文件系统。
+ *
+ * 真容器里有什么取决于基础镜像，这里给的是「一个能排查问题的容器」应该有的
+ * 那点东西。`/etc/resolv.conf` 尤其重要：第 10 关要学员自己去看 ndots。
+ */
+function rootfsFor(pod: KubeObject, cluster: Cluster): Record<string, string> {
+  const namespace = pod.metadata.namespace ?? 'default';
+  const status = (pod.status ?? {}) as { podIP?: string };
+  return {
+    '/etc/resolv.conf': cluster.network.resolvConfOf(namespace),
+    '/etc/hosts': [
+      '127.0.0.1\tlocalhost',
+      `${status.podIP ?? '127.0.0.1'}\t${pod.metadata.name}`,
+      '',
+    ].join('\n'),
+    '/etc/hostname': `${pod.metadata.name}\n`,
+    '/var/run/secrets/kubernetes.io/serviceaccount/namespace': namespace,
+  };
+}
+
+export function createExecHandler(cluster: Cluster) {
+  return async (request: ExecRequest, stdin: string): Promise<ExecResult> => {
+    const pods = cluster.scheme.get({ group: '', version: 'v1', resource: 'pods' });
+    if (!pods) return { stdout: '', stderr: 'pods resource not registered\n', code: 1 };
+
+    let pod: KubeObject;
+    try {
+      pod = cluster.registry.get(pods, request.namespace, request.pod);
+    } catch {
+      return {
+        stdout: '',
+        stderr: `Error from server (NotFound): pods "${request.pod}" not found\n`,
+        code: 1,
+      };
+    }
+
+    const status = (pod.status ?? {}) as { phase?: string };
+    if (status.phase !== 'Running') {
+      // 真 apiserver 在这种情况下报的是「连不上后端」，不是「Pod 不存在」
+      return {
+        stdout: '',
+        stderr: `error: unable to upgrade connection: container not found ("${
+          request.container ?? containersOf(pod)[0]?.name ?? 'app'
+        }")\n`,
+        code: 1,
+      };
+    }
+
+    const containers = containersOf(pod);
+    const container = request.container
+      ? containers.find((entry) => entry.name === request.container)
+      : containers[0];
+    if (!container) {
+      return {
+        stdout: '',
+        stderr: `Error from server (BadRequest): container ${request.container} is not valid for pod ${request.pod}\n`,
+        code: 1,
+      };
+    }
+
+    const vfs = createVfs(() => cluster.wallClock());
+    vfs.populate(rootfsFor(pod, cluster));
+    for (const directory of ['/bin', '/usr/bin', '/tmp', '/app']) vfs.mkdirp(directory);
+
+    const source = {
+      zone: 'cluster' as const,
+      namespace: request.namespace,
+      podName: request.pod,
+      ip: ((pod.status ?? {}) as { podIP?: string }).podIP,
+      label: request.pod,
+    };
+
+    const shell = createShell({
+      vfs,
+      cwd: '/',
+      hostname: request.pod,
+      user: 'root',
+      env: {
+        HOSTNAME: request.pod,
+        KUBERNETES_SERVICE_HOST: 'kubernetes.default.svc',
+        KUBERNETES_SERVICE_PORT: '443',
+        ...envOf(container),
+      },
+      commands: {
+        ...COREUTILS,
+        ...createNetTools({
+          network: cluster.network,
+          source: () => source,
+          advance: (ms) => { void cluster.advanceBy(ms); },
+        }),
+      },
+    });
+
+    // `kubectl exec pod -- sh -c '...'` 与 `kubectl exec pod -- curl x` 都要能跑
+    const command = normalizeCommand(request.command);
+    const result = await shell.run(command);
+    void stdin;
+    return { stdout: result.stdout, stderr: result.stderr, code: result.code };
+  };
+}
+
+/**
+ * argv 拼回一行。
+ *
+ * `sh -c 'curl x'` 里那一段本来就是一整条命令，直接拿它；其余情况把参数
+ * 用引号包好再拼，免得参数里的空格被 shell 再拆一次。
+ */
+export function normalizeCommand(argv: string[]): string {
+  if ((argv[0] === 'sh' || argv[0] === 'bash') && argv[1] === '-c' && argv[2] !== undefined) {
+    return argv.slice(2).join(' ');
+  }
+  return argv.map(quote).join(' ');
+}
+
+function quote(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function containersOf(pod: KubeObject): Array<{ name: string; env?: Array<{ name: string; value?: string }> }> {
+  return ((pod.spec ?? {}) as any).containers ?? [];
+}
+
+function envOf(container: { env?: Array<{ name: string; value?: string }> }): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of container.env ?? []) {
+    if (entry.value !== undefined) out[entry.name] = entry.value;
+  }
+  return out;
+}

--- a/src/lib/opslab/lab/podshell.ts
+++ b/src/lib/opslab/lab/podshell.ts
@@ -108,8 +108,7 @@ export function createExecHandler(cluster: Cluster) {
 
     // `kubectl exec pod -- sh -c '...'` 与 `kubectl exec pod -- curl x` 都要能跑
     const command = normalizeCommand(request.command);
-    const result = await shell.run(command);
-    void stdin;
+    const result = await shell.run(command, stdin);
     return { stdout: result.stdout, stderr: result.stderr, code: result.code };
   };
 }

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -20,6 +20,7 @@ import { createNetTools } from '../net';
 import { parseChain } from '../crypto';
 import { createOpensslCommand } from './openssl';
 import { materializePki } from './pki';
+import { createExecHandler } from './podshell';
 import { CliRuntime, installClusterCli } from '../wasm';
 import type { KubeObject } from '../apiserver';
 
@@ -163,6 +164,9 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
       return undefined;
     }
   };
+
+  // `kubectl exec` 落到 Pod 里那个 shell 上
+  cluster.execHandler = createExecHandler(cluster);
 
   // 镜像解析装好之后才让控制器跑起来，免得先起来的 kubelet 查到一张空表
   cluster.start();

--- a/src/lib/opslab/machine/shell/shell.ts
+++ b/src/lib/opslab/machine/shell/shell.ts
@@ -116,8 +116,8 @@ export class Shell {
     ].sort();
   }
 
-  /** 跑一行（或一段）脚本 */
-  async run(source: string): Promise<RunResult> {
+  /** 跑一行（或一段）脚本。stdin 是喂给第一段命令的输入。 */
+  async run(source: string, stdin = ''): Promise<RunResult> {
     let node: Node | null;
     try {
       node = await parseShell(source);
@@ -135,7 +135,7 @@ export class Shell {
     this.errSink = (text) => err.push(text);
     let code = 0;
     try {
-      code = await this.exec(node, '', (s) => out.push(s), (s) => err.push(s));
+      code = await this.exec(node, stdin, (s) => out.push(s), (s) => err.push(s));
     } catch (error) {
       if (error instanceof ExitSignal || error instanceof ReturnSignal) code = error.code;
       else throw error;

--- a/src/lib/opslab/net/index.ts
+++ b/src/lib/opslab/net/index.ts
@@ -11,3 +11,8 @@ export {
 } from './policy';
 export type { ConnectResult, ConnectKind, Hop, Resolution, Source, Target, Zone } from './types';
 export { createNetTools, parseUrl, type NetToolsOptions } from './tools';
+export {
+  WebSocketConnection, parseUpgrade, upgradeResponse, rejectResponse,
+  readFrame, writeFrame, OPCODE,
+  type UpgradeRequest, type StreamSession, type StreamServer, type Frame,
+} from './websocket';

--- a/src/lib/opslab/net/websocket.ts
+++ b/src/lib/opslab/net/websocket.ts
@@ -1,0 +1,249 @@
+/**
+ * 内存里的 WebSocket 服务端
+ *
+ * `kubectl exec` / `logs -f` / `port-forward` 走的都是 WebSocket。客户端那边
+ * 是真的 gorilla + 真的 client-go remotecommand，所以这一侧必须把协议真的实现：
+ * 握手要算对 `Sec-WebSocket-Accept`，帧要真的分（客户端发来的帧带掩码，
+ * 服务端回的不带）。
+ *
+ * 只做够用的那部分：文本/二进制帧、close、ping/pong，不做分片续帧
+ * （k8s 的通道协议不会用到）。
+ */
+import { sha1 } from '../crypto/sha1';
+
+const MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+export interface UpgradeRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  /** 客户端要求的子协议，按优先级 */
+  protocols: string[];
+}
+
+/** 把 HTTP 升级请求解出来。收到的字节不完整就返回 undefined，等下一批。 */
+export function parseUpgrade(text: string): UpgradeRequest | undefined {
+  const end = text.indexOf('\r\n\r\n');
+  if (end < 0) return undefined;
+
+  const lines = text.slice(0, end).split('\r\n');
+  const [method, path] = lines[0].split(' ');
+  const headers: Record<string, string> = {};
+  for (const line of lines.slice(1)) {
+    const index = line.indexOf(':');
+    if (index < 0) continue;
+    headers[line.slice(0, index).trim().toLowerCase()] = line.slice(index + 1).trim();
+  }
+  return {
+    method,
+    path,
+    headers,
+    protocols: (headers['sec-websocket-protocol'] ?? '')
+      .split(',').map((entry) => entry.trim()).filter(Boolean),
+  };
+}
+
+/** 101 响应。`Sec-WebSocket-Accept` 算错的话 gorilla 会直接拒绝握手。 */
+export function upgradeResponse(request: UpgradeRequest, protocol?: string): string {
+  const accept = base64(sha1(`${request.headers['sec-websocket-key'] ?? ''}${MAGIC}`));
+  return [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${accept}`,
+    ...(protocol ? [`Sec-WebSocket-Protocol: ${protocol}`] : []),
+    '', '',
+  ].join('\r\n');
+}
+
+export function rejectResponse(status: number, reason: string, body: string): string {
+  return [
+    `HTTP/1.1 ${status} ${reason}`,
+    'Content-Type: application/json',
+    `Content-Length: ${body.length}`,
+    '', body,
+  ].join('\r\n');
+}
+
+export const OPCODE = { CONTINUATION: 0x0, TEXT: 0x1, BINARY: 0x2, CLOSE: 0x8, PING: 0x9, PONG: 0xa } as const;
+
+export interface Frame {
+  opcode: number;
+  payload: Uint8Array;
+  fin: boolean;
+}
+
+/** 从缓冲区里拆出一帧。不够一帧就返回 undefined。 */
+export function readFrame(buffer: Uint8Array): { frame: Frame; consumed: number } | undefined {
+  if (buffer.length < 2) return undefined;
+  const fin = (buffer[0] & 0x80) !== 0;
+  const opcode = buffer[0] & 0x0f;
+  const masked = (buffer[1] & 0x80) !== 0;
+  let length = buffer[1] & 0x7f;
+  let offset = 2;
+
+  if (length === 126) {
+    if (buffer.length < offset + 2) return undefined;
+    length = (buffer[offset] << 8) | buffer[offset + 1];
+    offset += 2;
+  } else if (length === 127) {
+    if (buffer.length < offset + 8) return undefined;
+    // 高 4 字节我们不会用到（帧不会大到 4GB）
+    length = 0;
+    for (let i = 4; i < 8; i += 1) length = (length << 8) | buffer[offset + i];
+    offset += 8;
+  }
+
+  const maskStart = offset;
+  if (masked) offset += 4;
+  if (buffer.length < offset + length) return undefined;
+
+  const payload = buffer.slice(offset, offset + length);
+  if (masked) {
+    for (let i = 0; i < payload.length; i += 1) payload[i] ^= buffer[maskStart + (i % 4)];
+  }
+  return { frame: { opcode, payload, fin }, consumed: offset + length };
+}
+
+/** 服务端发出去的帧不带掩码 */
+export function writeFrame(opcode: number, payload: Uint8Array): Uint8Array {
+  const header: number[] = [0x80 | opcode];
+  if (payload.length < 126) header.push(payload.length);
+  else if (payload.length < 65536) header.push(126, (payload.length >> 8) & 0xff, payload.length & 0xff);
+  else {
+    header.push(127, 0, 0, 0, 0,
+      (payload.length >>> 24) & 0xff, (payload.length >>> 16) & 0xff,
+      (payload.length >>> 8) & 0xff, payload.length & 0xff);
+  }
+  const out = new Uint8Array(header.length + payload.length);
+  out.set(header);
+  out.set(payload, header.length);
+  return out;
+}
+
+function base64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/* ------------------------------------------------------------------ */
+/* 一条连接                                                            */
+/* ------------------------------------------------------------------ */
+
+export interface StreamSession {
+  /** 服务端选中的子协议 */
+  protocol?: string;
+  /** 客户端发来的一帧 */
+  onFrame?(opcode: number, payload: Uint8Array): void;
+  /** 握手完成，可以往回推数据了 */
+  start?(send: (opcode: number, payload: Uint8Array) => void, close: () => void): void;
+  /** 连接断了 */
+  onClose?(): void;
+}
+
+export interface StreamServer {
+  /** 收到升级请求。返回 undefined 表示拒绝（会回一个 HTTP 错误）。 */
+  open(request: UpgradeRequest): StreamSession | { status: number; reason: string; body: string } | undefined;
+}
+
+/**
+ * 宿主这边的一条 WebSocket 连接。
+ *
+ * 客户端（wasm 里的 gorilla）把字节写进来，这里做握手与分帧，再把 payload
+ * 交给会话。会话往回写的东西同样要打成帧。
+ */
+export class WebSocketConnection {
+  private buffer = new Uint8Array(0);
+  private session?: StreamSession;
+  private upgraded = false;
+  private closed = false;
+  private closeSent = false;
+
+  constructor(
+    private readonly server: StreamServer,
+    private readonly emit: (bytes: Uint8Array) => void,
+    private readonly onClosed: () => void
+  ) {}
+
+  /** 客户端写进来的字节 */
+  receive(bytes: Uint8Array): void {
+    if (this.closed) return;
+    this.buffer = concatBytes(this.buffer, bytes);
+    if (!this.upgraded) {
+      this.tryUpgrade();
+      return;
+    }
+    this.drainFrames();
+  }
+
+  /**
+   * 收尾。
+   *
+   * 必须先发一个 CLOSE 帧再断。直接断链的话对端看到的是 1006
+   * abnormal closure —— kubectl 会把它当成「连接出问题了」报错，
+   * 而不是「命令跑完了」，退出码也就丢了。
+   */
+  close(code = 1000): void {
+    if (this.closed) return;
+    if (this.upgraded && !this.closeSent) {
+      this.closeSent = true;
+      this.emit(writeFrame(OPCODE.CLOSE, Uint8Array.from([(code >> 8) & 0xff, code & 0xff])));
+    }
+    this.closed = true;
+    this.session?.onClose?.();
+    this.onClosed();
+  }
+
+  private tryUpgrade(): void {
+    const text = new TextDecoder().decode(this.buffer);
+    const request = parseUpgrade(text);
+    if (!request) return;
+
+    const outcome = this.server.open(request);
+    if (!outcome || 'status' in outcome) {
+      const error = outcome ?? { status: 404, reason: 'Not Found', body: '{}' };
+      this.emit(new TextEncoder().encode(rejectResponse(error.status, error.reason, error.body)));
+      this.close();
+      return;
+    }
+
+    this.session = outcome;
+    this.upgraded = true;
+    this.buffer = this.buffer.subarray(text.indexOf('\r\n\r\n') + 4);
+    this.emit(new TextEncoder().encode(upgradeResponse(request, outcome.protocol)));
+
+    outcome.start?.(
+      (opcode, payload) => { if (!this.closed) this.emit(writeFrame(opcode, payload)); },
+      () => this.close()
+    );
+    this.drainFrames();
+  }
+
+  private drainFrames(): void {
+    for (;;) {
+      const next = readFrame(this.buffer);
+      if (!next) return;
+      this.buffer = this.buffer.subarray(next.consumed);
+
+      const { opcode, payload } = next.frame;
+      if (opcode === OPCODE.CLOSE) {
+        // 对端先关：把它的状态码原样回过去，这是 RFC 6455 的握手收尾
+        this.emit(writeFrame(OPCODE.CLOSE, payload));
+        this.closeSent = true;
+        this.close();
+        return;
+      }
+      if (opcode === OPCODE.PING) { this.emit(writeFrame(OPCODE.PONG, payload)); continue; }
+      if (opcode === OPCODE.PONG) continue;
+      this.session?.onFrame?.(opcode, payload);
+    }
+  }
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a);
+  out.set(b, a.length);
+  return out;
+}

--- a/src/lib/opslab/wasm/install.ts
+++ b/src/lib/opslab/wasm/install.ts
@@ -7,13 +7,21 @@
  */
 import { Machine } from '../machine/machine';
 import { CliRuntime, CliRunOptions, FetchLike } from './runtime';
+import type { StreamServer, UpgradeRequest } from '../net/websocket';
 import { DEFAULT_KUBECONFIG_PATH, KubeconfigSpec, defaultKubeconfig, renderKubeconfig } from './kubeconfig';
 
 export interface InstallCliOptions {
   machine: Machine;
   runtime: CliRuntime;
-  /** client-go 的请求打到哪 —— 通常是 cluster.apiServer.handle */
-  apiServer: { handle: (url: string, init?: never) => Promise<Response> };
+  /**
+   * client-go 的请求打到哪 —— 通常是 cluster.apiServer。
+   *
+   * `handle` 走普通请求，`openStream` 走 `kubectl exec` 那条 WebSocket。
+   */
+  apiServer: {
+    handle: (url: string, init?: never) => Promise<Response>;
+    openStream?: (request: UpgradeRequest) => ReturnType<StreamServer['open']>;
+  };
   /** 装哪些 applet。不传就问二进制本人。 */
   applets?: string[];
   /** 不传就写一份单集群的默认配置；已经有配置文件时用 false 保留它 */
@@ -58,6 +66,20 @@ export async function installClusterCli(options: InstallCliOptions): Promise<str
     }
     return options.apiServer.handle(url, init as never);
   };
+  /**
+   * exec 的通道。
+   *
+   * gorilla dial 的是 `host:port`，主机名这一关和 fetch 那边同一套判断 ——
+   * 不然 context 选错集群时，普通命令连不上而 exec 却能连上。
+   */
+  const stream: StreamServer | undefined = options.apiServer.openStream
+    ? { open: (request) => options.apiServer.openStream!(request) }
+    : undefined;
+  const dial = (address: string) => {
+    const host = address.replace(/:\d+$/, '').replace(/^\[|\]$/g, '');
+    return endpoints.includes(host) ? stream : undefined;
+  };
+
   const applets = options.applets ?? (await runtime.applets());
 
   for (const applet of applets) {
@@ -66,6 +88,7 @@ export async function installClusterCli(options: InstallCliOptions): Promise<str
         vfs, cwd, stdin,
         env: { KUBECONFIG: path, ...env },
         fetch: fetchImpl,
+        dial,
         now: options.now,
       };
       const result = await runtime.run(applet, argv, run);

--- a/src/lib/opslab/wasm/runtime.ts
+++ b/src/lib/opslab/wasm/runtime.ts
@@ -13,6 +13,7 @@
  */
 import { Vfs, createVfs } from '../machine/vfs';
 import { createGoFs } from './gofs';
+import { WebSocketConnection, type StreamServer } from '../net/websocket';
 import { CacheEntry, ModuleCache, createIndexedDbCache, remoteSignature } from './cache';
 
 export const CLI_WASM_URL = '/opslab/opslab-cli.wasm';
@@ -39,8 +40,23 @@ export interface CliRunOptions {
   stdin?: string;
   /** client-go 在 js 上统一走 fetch —— 把它指到内存里的 apiserver */
   fetch: FetchLike;
+  /**
+   * `kubectl exec` / `port-forward` 要的双向通道。
+   *
+   * fetch 撑不起 WebSocket，所以这条路单开：Go 那边 dial 出来的 net.Conn
+   * 就接在这里。不给就是这次运行不支持 exec，Go 会报「宿主没有提供」。
+   */
+  dial?: (address: string) => StreamServer | undefined;
   /** 虚拟墙钟 */
   now?: () => number;
+}
+
+/** 交给 Go 的那个句柄。字段名是 opslab_dial_js.go 认的那几个。 */
+interface DialHandle {
+  send(bytes: Uint8Array): void;
+  close(): void;
+  onData?: (bytes: Uint8Array) => void;
+  onClose?: () => void;
 }
 
 export interface CliResult {
@@ -156,7 +172,14 @@ export class CliRuntime {
     };
 
     const host = globalThis as Record<string, unknown>;
-    const saved = { fs: host.fs, fetch: host.fetch, process: host.process, path: host.path };
+    const saved = {
+      fs: host.fs, fetch: host.fetch, process: host.process, path: host.path,
+      dial: host.__opslabDial,
+    };
+    const openConnections: WebSocketConnection[] = [];
+    // Go 退出之后再 resume 就是 "Go program has already exited"。
+    // 收尾时先把这面旗子立起来，排在队里的字节直接丢掉。
+    let finished = false;
 
     host.fs = fs;
     host.path = { resolve: (...parts: string[]) => parts.join('/') };
@@ -166,6 +189,36 @@ export class CliRuntime {
       env, on: () => {},
     };
     host.fetch = (url: unknown, init: unknown) => options.fetch(String(url), init);
+    host.__opslabDial = (address: unknown): DialHandle | null => {
+      const server = options.dial?.(String(address));
+      if (!server) return null;
+      const handle: DialHandle = {
+        send: (bytes) => connection.receive(bytes),
+        close: () => connection.close(),
+      };
+      /**
+       * 回给 Go 的字节必须晚一拍。
+       *
+       * `handle.send` 是在 Go 的 Write 里同步调过来的；这时候直接回调
+       * `onData`，wasm_exec 会在 Go 还没出栈的时候再 `resume()` 一次 ——
+       * Go 的调度器不支持这种重入，整个实例就卡死在那里，连 panic 都没有。
+       * 排到微任务里，等 Go 让出控制权再送。
+       */
+      const defer = (fn: () => void) => {
+        queueMicrotask(() => {
+          // Go 已经退出的话，队里剩下的字节没人要了 —— 再 resume 一次会抛
+          if (finished || (go as { exited?: boolean } | undefined)?.exited) return;
+          fn();
+        });
+      };
+      const connection = new WebSocketConnection(
+        server,
+        (bytes) => defer(() => handle.onData?.(bytes)),
+        () => defer(() => handle.onClose?.()),
+      );
+      openConnections.push(connection);
+      return handle;
+    };
 
     const go = new (host.Go as new () => GoInstance)();
     go.argv = [applet, ...args];
@@ -185,6 +238,11 @@ export class CliRuntime {
       host.fetch = saved.fetch;
       host.process = saved.process;
       host.path = saved.path;
+      host.__opslabDial = saved.dial;
+      // Go 正常退出时自己会 Close；异常退出时别把连接留着，
+      // 不然下一条命令跑起来还有上一条的会话在往一个已经没人听的口子写
+      finished = true;
+      for (const connection of openConnections) connection.close();
     }
 
     return { stdout, stderr, code };

--- a/tests/opslab/controllers.test.ts
+++ b/tests/opslab/controllers.test.ts
@@ -374,3 +374,84 @@ describe('确定性', () => {
     for (let i = 0; i < 19; i += 1) expect(await run()).toBe(first);
   }, 60_000);
 });
+
+/**
+ * ClusterIP 的分配
+ *
+ * 这件事发生在 apiserver 里，不是控制器事后补的 —— 学员 `kubectl expose`
+ * 完马上 `kubectl get svc`，IP 必须已经在那儿。
+ */
+describe('ClusterIP 分配器', () => {
+  function svc(name: string, extra: Record<string, unknown> = {}) {
+    return {
+      apiVersion: 'v1', kind: 'Service',
+      metadata: { name, namespace: 'default' },
+      spec: { selector: { app: name }, ports: [{ port: 80 }], ...extra },
+    };
+  }
+
+  function fresh() {
+    const cluster = createCluster();
+    cluster.start();
+    return cluster;
+  }
+
+  it('创建时就有 IP，而且在 service CIDR 里', () => {
+    const cluster = fresh();
+    const created = cluster.registry.create(SERVICES, 'default', svc('portal') as never);
+    const ip = (created.spec as { clusterIP: string }).clusterIP;
+    expect(ip).toMatch(/^10\.(9[6-9]|10\d|11\d)\.\d+\.\d+$/);
+    expect((created.spec as { clusterIPs: string[] }).clusterIPs).toEqual([ip]);
+  });
+
+  it('同一个名字在两个世界里拿到同一个 IP —— 重放要可复现', () => {
+    const a = fresh();
+    const b = fresh();
+    const ipA = (a.registry.create(SERVICES, 'default', svc('portal') as never).spec as any).clusterIP;
+    const ipB = (b.registry.create(SERVICES, 'default', svc('portal') as never).spec as any).clusterIP;
+    expect(ipA).toBe(ipB);
+  });
+
+  it('不同 Service 不撞车', () => {
+    const cluster = fresh();
+    const seen = new Set<string>();
+    for (const name of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
+      const created = cluster.registry.create(SERVICES, 'default', svc(name) as never);
+      seen.add((created.spec as any).clusterIP);
+    }
+    expect(seen.size).toBe(8);
+  });
+
+  it('headless 不分配', () => {
+    const cluster = fresh();
+    const created = cluster.registry.create(SERVICES, 'default', svc('db', { clusterIP: 'None' }) as never);
+    expect((created.spec as any).clusterIP).toBe('None');
+  });
+
+  it('ExternalName 不分配 —— 它就是个 CNAME', () => {
+    const cluster = fresh();
+    const created = cluster.registry.create(
+      SERVICES, 'default',
+      { apiVersion: 'v1', kind: 'Service', metadata: { name: 'legacy', namespace: 'default' },
+        spec: { type: 'ExternalName', externalName: 'legacy.corp.internal' } } as never
+    );
+    expect((created.spec as any).clusterIP).toBeUndefined();
+  });
+
+  it('关卡写死的 IP 不被改掉', () => {
+    const cluster = fresh();
+    const created = cluster.registry.create(SERVICES, 'default', svc('portal', { clusterIP: '10.96.1.10' }) as never);
+    expect((created.spec as any).clusterIP).toBe('10.96.1.10');
+  });
+
+  it('整体替换时不换 VIP —— ClusterIP 是不可变字段', () => {
+    const cluster = fresh();
+    const created = cluster.registry.create(SERVICES, 'default', svc('portal') as never);
+    const ip = (created.spec as any).clusterIP;
+    const replaced = cluster.registry.update(SERVICES, 'default', 'portal', {
+      apiVersion: 'v1', kind: 'Service', metadata: { name: 'portal', namespace: 'default' },
+      spec: { selector: { app: 'portal' }, ports: [{ port: 8080 }] },
+    } as never);
+    expect((replaced.spec as any).clusterIP).toBe(ip);
+  });
+});

--- a/tests/opslab/controllers.test.ts
+++ b/tests/opslab/controllers.test.ts
@@ -400,7 +400,7 @@ describe('ClusterIP 分配器', () => {
     const cluster = fresh();
     const created = cluster.registry.create(SERVICES, 'default', svc('portal') as never);
     const ip = (created.spec as { clusterIP: string }).clusterIP;
-    expect(ip).toMatch(/^10\.(9[6-9]|10\d|11\d)\.\d+\.\d+$/);
+    expect(ip).toMatch(/^10\.(9[6-9]|10\d|11[01])\.\d+\.\d+$/);
     expect((created.spec as { clusterIPs: string[] }).clusterIPs).toEqual([ip]);
   });
 

--- a/tests/opslab/exec.test.ts
+++ b/tests/opslab/exec.test.ts
@@ -1,0 +1,309 @@
+/**
+ * kubectl exec 的通道
+ *
+ * 分三层：WebSocket 本身（握手 + 分帧）、k8s 的通道协议（v5.channel.k8s.io）、
+ * 以及 Pod 里那个真的会跑命令的 shell。
+ *
+ * 真 kubectl 打进来的那一遍在 kubectl-integration.test.ts —— 这里证明的是
+ * 「协议写对了」，那里证明的是「kubectl 接受」。
+ */
+import {
+  OPCODE, WebSocketConnection, parseUpgrade, readFrame, upgradeResponse, writeFrame,
+  type StreamServer,
+} from '../../src/lib/opslab/net';
+import { CHANNEL, EXEC_PROTOCOL, parseExecRequest, statusOf } from '../../src/lib/opslab/apiserver';
+import { createExecHandler, normalizeCommand } from '../../src/lib/opslab/lab';
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function handshake(path = '/api/v1/namespaces/default/pods/web/exec?command=echo&command=hi'): string {
+  return [
+    `GET ${path} HTTP/1.1`,
+    'Host: apiserver.opslab:6443',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+    'Sec-WebSocket-Version: 13',
+    `Sec-WebSocket-Protocol: ${EXEC_PROTOCOL}`,
+    '', '',
+  ].join('\r\n');
+}
+
+describe('WebSocket 握手', () => {
+  it('Sec-WebSocket-Accept 是 RFC 6455 里那个值', () => {
+    const request = parseUpgrade(handshake())!;
+    expect(request).toBeDefined();
+    const response = upgradeResponse(request, EXEC_PROTOCOL);
+    // RFC 6455 §1.3 的例子：key dGhlIHNhbXBsZSBub25jZQ== 对应这个 accept
+    expect(response).toContain('Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=');
+    expect(response.startsWith('HTTP/1.1 101 Switching Protocols\r\n')).toBe(true);
+    expect(response).toContain(`Sec-WebSocket-Protocol: ${EXEC_PROTOCOL}`);
+  });
+
+  it('请求没收全时先不动 —— 半个头不能当成握手失败', () => {
+    expect(parseUpgrade('GET /x HTTP/1.1\r\nHost: a\r\n')).toBeUndefined();
+  });
+});
+
+describe('分帧', () => {
+  it('服务端发出去的帧不带掩码', () => {
+    const frame = writeFrame(OPCODE.BINARY, encoder.encode('hi'));
+    expect(frame[0]).toBe(0x82);
+    expect(frame[1] & 0x80).toBe(0); // MASK 位是 0
+    expect(frame[1] & 0x7f).toBe(2);
+  });
+
+  it('客户端发来的帧要解掩码', () => {
+    const payload = encoder.encode('hello world');
+    const mask = Uint8Array.from([0x1a, 0x2b, 0x3c, 0x4d]);
+    const frame = new Uint8Array(6 + payload.length);
+    frame[0] = 0x80 | OPCODE.BINARY;
+    frame[1] = 0x80 | payload.length;
+    frame.set(mask, 2);
+    for (let i = 0; i < payload.length; i += 1) frame[6 + i] = payload[i] ^ mask[i % 4];
+
+    const read = readFrame(frame)!;
+    expect(read.consumed).toBe(frame.length);
+    expect(decoder.decode(read.frame.payload)).toBe('hello world');
+  });
+
+  it('126~65535 字节用两字节长度', () => {
+    const frame = writeFrame(OPCODE.BINARY, new Uint8Array(300));
+    expect(frame[1] & 0x7f).toBe(126);
+    expect((frame[2] << 8) | frame[3]).toBe(300);
+    expect(readFrame(frame)!.frame.payload.length).toBe(300);
+  });
+
+  it('字节没到齐就返回 undefined，等下一批', () => {
+    const frame = writeFrame(OPCODE.BINARY, encoder.encode('abcdef'));
+    expect(readFrame(frame.subarray(0, 4))).toBeUndefined();
+  });
+});
+
+describe('exec 请求的解析', () => {
+  it('命名空间、Pod、容器、命令都从 URL 里来', () => {
+    const request = parseExecRequest({
+      method: 'GET', path: '/api/v1/namespaces/shop/pods/web-1/exec?container=app&command=sh&command=-c&command=ls+%2Ftmp&stdout=true&stderr=true',
+      headers: {}, protocols: [],
+    })!;
+    expect(request).toMatchObject({
+      namespace: 'shop', pod: 'web-1', container: 'app',
+      command: ['sh', '-c', 'ls /tmp'], stdin: false, tty: false,
+    });
+  });
+
+  it('不是 exec 的路径不认', () => {
+    expect(parseExecRequest({
+      method: 'GET', path: '/api/v1/namespaces/shop/pods/web-1/log', headers: {}, protocols: [],
+    })).toBeUndefined();
+  });
+});
+
+describe('3 号通道上的 Status', () => {
+  const request = { namespace: 'default', pod: 'web', command: ['false'], stdin: false, tty: false };
+
+  it('成功是 Success', () => {
+    expect(statusOf(0, request)).toMatchObject({ status: 'Success' });
+  });
+
+  it('失败要带 NonZeroExitCode 和 ExitCode —— 少了退出码就永远是 0', () => {
+    const status = statusOf(3, request) as any;
+    expect(status.status).toBe('Failure');
+    expect(status.reason).toBe('NonZeroExitCode');
+    expect(status.details.causes).toContainEqual({ reason: 'ExitCode', message: '3' });
+  });
+});
+
+describe('一整条连接', () => {
+  /** 一个照着 gorilla 的样子说话的假客户端 */
+  function connect(server: StreamServer) {
+    const inbound: Uint8Array[] = [];
+    let closed = false;
+    const connection = new WebSocketConnection(server, (bytes) => inbound.push(bytes), () => { closed = true; });
+    connection.receive(encoder.encode(handshake()));
+    return {
+      connection,
+      get closed() { return closed; },
+      /** 已经收到的东西：握手响应 + 之后的帧 */
+      drain() {
+        let all = new Uint8Array(0);
+        for (const chunk of inbound) {
+          const next = new Uint8Array(all.length + chunk.length);
+          next.set(all); next.set(chunk, all.length);
+          all = next;
+        }
+        const text = decoder.decode(all);
+        const split = text.indexOf('\r\n\r\n');
+        const head = text.slice(0, split + 4);
+        let rest = all.subarray(encoder.encode(head).length);
+        const frames: Array<{ channel: number; text: string }> = [];
+        let closeCode: number | undefined;
+        for (;;) {
+          const read = readFrame(rest);
+          if (!read) break;
+          rest = rest.subarray(read.consumed);
+          if (read.frame.opcode === OPCODE.CLOSE) {
+            closeCode = (read.frame.payload[0] << 8) | read.frame.payload[1];
+            continue;
+          }
+          frames.push({ channel: read.frame.payload[0], text: decoder.decode(read.frame.payload.subarray(1)) });
+        }
+        return { head, frames, closeCode };
+      },
+    };
+  }
+
+  it('stdout / stderr / Status 分在 1、2、3 号通道上', async () => {
+    const server: StreamServer = {
+      open: () => ({
+        protocol: EXEC_PROTOCOL,
+        start(send, close) {
+          const write = (channel: number, text: string) => {
+            const body = encoder.encode(text);
+            const frame = new Uint8Array(body.length + 1);
+            frame[0] = channel; frame.set(body, 1);
+            send(OPCODE.BINARY, frame);
+          };
+          write(CHANNEL.STDOUT, 'out');
+          write(CHANNEL.STDERR, 'err');
+          write(CHANNEL.ERROR, JSON.stringify({ status: 'Success' }));
+          close();
+        },
+      }),
+    };
+    const client = connect(server);
+    const { head, frames, closeCode } = client.drain();
+    expect(head).toContain('101 Switching Protocols');
+    expect(frames).toEqual([
+      { channel: CHANNEL.STDOUT, text: 'out' },
+      { channel: CHANNEL.STDERR, text: 'err' },
+      { channel: CHANNEL.ERROR, text: '{"status":"Success"}' },
+    ]);
+    // 收尾要发 CLOSE 帧。直接断链的话对端看到 1006 abnormal closure，
+    // kubectl 会当成「连接坏了」报错，Status 里的退出码就丢了。
+    expect(closeCode).toBe(1000);
+    expect(client.closed).toBe(true);
+  });
+
+  it('服务端拒绝时回的是 HTTP 错误，不是 101', () => {
+    const server: StreamServer = {
+      open: () => ({ status: 404, reason: 'Not Found', body: '{"kind":"Status"}' }),
+    };
+    const client = connect(server);
+    expect(client.drain().head).toContain('HTTP/1.1 404 Not Found');
+    expect(client.closed).toBe(true);
+  });
+});
+
+describe('argv 拼回一行', () => {
+  it('sh -c 里那段本来就是一整条命令', () => {
+    expect(normalizeCommand(['sh', '-c', 'curl -s portal | head -1'])).toBe('curl -s portal | head -1');
+  });
+
+  it('带空格的参数要包引号，不能被再拆一次', () => {
+    expect(normalizeCommand(['echo', 'a b'])).toBe("echo 'a b'");
+  });
+
+  it('普通参数不加多余的引号', () => {
+    expect(normalizeCommand(['curl', '-s', 'http://portal.shop.svc/health'])).toBe('curl -s http://portal.shop.svc/health');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Pod 里那个 shell                                                    */
+/* ------------------------------------------------------------------ */
+
+const WORLD: OpsWorldSpec = {
+  namespaces: ['shop'],
+  baseImages: { 'registry.corp.internal/portal:2.1': 'node' },
+  objects: [
+    {
+      apiVersion: 'apps/v1', kind: 'Deployment',
+      metadata: { name: 'portal', namespace: 'shop' },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: { app: 'portal' } },
+        template: {
+          metadata: { labels: { app: 'portal' } },
+          spec: { containers: [{
+            name: 'app', image: 'registry.corp.internal/portal:2.1',
+            ports: [{ containerPort: 8080 }], env: [{ name: 'TIER', value: 'web' }],
+          }] },
+        },
+      },
+    },
+    {
+      apiVersion: 'v1', kind: 'Service',
+      metadata: { name: 'portal', namespace: 'shop' },
+      spec: { selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+    },
+  ],
+};
+
+async function podWorld() {
+  const world = await createOpsWorld({ world: WORLD });
+  await world.cluster.advanceBy(30_000);
+  const pods = world.cluster.registry.list(
+    world.cluster.scheme.get({ group: '', version: 'v1', resource: 'pods' })!, { namespace: 'shop' }
+  );
+  return { world, pod: pods.items[0] };
+}
+
+describe('Pod 里的 shell', () => {
+  it('容器里能看到自己的 resolv.conf 和 hostname', async () => {
+    const { world, pod } = await podWorld();
+    const exec = createExecHandler(world.cluster);
+    const result = await exec(
+      { namespace: 'shop', pod: pod.metadata.name!, command: ['cat', '/etc/resolv.conf'], stdin: false, tty: false },
+      ''
+    );
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('search shop.svc.cluster.local svc.cluster.local cluster.local');
+    expect(result.stdout).toContain('options ndots:5');
+  });
+
+  it('容器的 env 进得来', async () => {
+    const { world, pod } = await podWorld();
+    const exec = createExecHandler(world.cluster);
+    const result = await exec(
+      { namespace: 'shop', pod: pod.metadata.name!, command: ['sh', '-c', 'echo $TIER'], stdin: false, tty: false },
+      ''
+    );
+    expect(result.stdout.trim()).toBe('web');
+  });
+
+  it('从 Pod 里 curl 同命名空间的短名 —— 这条从跳板机上是打不通的', async () => {
+    const { world, pod } = await podWorld();
+    const exec = createExecHandler(world.cluster);
+    const result = await exec(
+      { namespace: 'shop', pod: pod.metadata.name!, command: ['curl', '-s', '-o', '/dev/null', '-w', '%{http_code}', 'http://portal'], stdin: false, tty: false },
+      ''
+    );
+    expect(result.stdout).toBe('200');
+    expect(result.code).toBe(0);
+  });
+
+  it('Pod 不存在时报的是 NotFound', async () => {
+    const { world } = await podWorld();
+    const exec = createExecHandler(world.cluster);
+    const result = await exec(
+      { namespace: 'shop', pod: 'nope', command: ['echo', 'hi'], stdin: false, tty: false },
+      ''
+    );
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('pods "nope" not found');
+  });
+
+  it('指定了不存在的容器要报出来，不能悄悄换一个', async () => {
+    const { world, pod } = await podWorld();
+    const exec = createExecHandler(world.cluster);
+    const result = await exec(
+      { namespace: 'shop', pod: pod.metadata.name!, container: 'sidecar', command: ['echo', 'hi'], stdin: false, tty: false },
+      ''
+    );
+    expect(result.stderr).toContain('container sidecar is not valid for pod');
+  });
+});

--- a/tests/opslab/exec.test.ts
+++ b/tests/opslab/exec.test.ts
@@ -265,6 +265,16 @@ describe('Pod 里的 shell', () => {
     expect(result.stdout).toContain('options ndots:5');
   });
 
+  it('stdin 喂得进去', async () => {
+    const { world, pod } = await podWorld();
+    const exec = createExecHandler(world.cluster);
+    const result = await exec(
+      { namespace: 'shop', pod: pod.metadata.name!, command: ['cat'], stdin: true, tty: false },
+      'from outside\n'
+    );
+    expect(result.stdout).toBe('from outside\n');
+  });
+
   it('容器的 env 进得来', async () => {
     const { world, pod } = await podWorld();
     const exec = createExecHandler(world.cluster);

--- a/tests/opslab/kubectl-integration.test.ts
+++ b/tests/opslab/kubectl-integration.test.ts
@@ -276,6 +276,20 @@ describeIfBuilt('真 kubectl exec 走 WebSocket 通道', () => {
     expect(result.code).toBe(127);
   });
 
+  it('kubectl exec -i —— stdin 从 0 号通道进去', async () => {
+    const { server } = buildWorld();
+    const vfs = createVfs(() => VIRTUAL_NOW);
+    vfs.writeFile('/root/.kube/config', renderKubeconfig(defaultKubeconfig()));
+    const result = await runtime().run('kubectl', ['exec', '-i', 'payments-7f4-2xk', '--', 'cat'], {
+      vfs, cwd: '/root', stdin: 'from the outside\n',
+      fetch: (url, init) => server.handle(url, init as never),
+      dial: () => ({ open: (request) => server.openStream(request) }),
+      now: () => VIRTUAL_NOW,
+    });
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('from the outside\n');
+  });
+
   it('宿主不给通道时报的是升级失败，不是「Pod 不存在」', async () => {
     const { server } = buildWorld();
     const vfs = createVfs(() => VIRTUAL_NOW);
@@ -345,6 +359,13 @@ describeIfBuilt('跳板机 -> Pod -> 集群网络', () => {
     );
     expect(result.stderr).toBe('');
     expect(result.stdout).toBe('200');
+  });
+
+  it('管道能穿过 kubectl exec -i 进到容器里', async () => {
+    const world = await createOpsWorld({ world: WORLD as never, runtime: runtime() });
+    const result = await world.run("echo 'hello from jump-01' | kubectl exec -i -n shop deploy/portal -- cat");
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('hello from jump-01\n');
   });
 
   it('同一条 curl 在跳板机上打不通 —— 办公网够不到 ClusterIP', async () => {

--- a/tests/opslab/kubectl-integration.test.ts
+++ b/tests/opslab/kubectl-integration.test.ts
@@ -20,7 +20,9 @@ import {
   ResourceDefinition,
 } from '../../src/lib/opslab/apiserver';
 import { createVfs } from '../../src/lib/opslab/machine';
+import type { ExecRequest } from '../../src/lib/opslab/apiserver';
 import { CliRuntime, createCliRuntime, defaultKubeconfig, renderKubeconfig } from '../../src/lib/opslab/wasm';
+import { createOpsWorld } from '../../src/lib/opslab/lab';
 
 const WASM_PATH = path.join(__dirname, '../../public/opslab/opslab-cli.wasm');
 const WASM_EXEC = path.join(__dirname, '../../public/opslab/wasm_exec.js');
@@ -53,7 +55,21 @@ function buildWorld() {
     now: () => Date.parse('2026-01-01T00:00:00Z'),
     uid: () => `uid-${++uid}`,
   });
-  const server = createApiServer({ registry, scheme, now: () => VIRTUAL_NOW });
+  const execLog: ExecRequest[] = [];
+  const server = createApiServer({
+    registry, scheme, now: () => VIRTUAL_NOW,
+    exec: async (request, stdin) => {
+      execLog.push(request);
+      const [command, ...rest] = request.command;
+      if (command === 'echo') return { stdout: `${rest.join(' ')}\n`, stderr: '', code: 0 };
+      if (command === 'cat') return { stdout: stdin, stderr: '', code: 0 };
+      if (command === 'false') return { stdout: '', stderr: '', code: 1 };
+      if (command === 'curl') {
+        return { stdout: '', stderr: 'curl: (7) Failed to connect to portal port 80\n', code: 7 };
+      }
+      return { stdout: '', stderr: `sh: ${command}: not found\n`, code: 127 };
+    },
+  });
 
   registry.create(NAMESPACES, undefined, {
     apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'default' }, status: { phase: 'Active' },
@@ -70,7 +86,7 @@ function buildWorld() {
     spec: { nodeName: 'node-2', containers: [{ name: 'app', image: 'registry.corp.internal/portal:2.1' }] },
     status: { phase: 'Running', podIP: '10.42.2.3', containerStatuses: [{ name: 'app', ready: true, restartCount: 2 }] },
   });
-  return { registry, server, scheme };
+  return { registry, server, scheme, execLog };
 }
 
 let shared: CliRuntime | null = null;
@@ -96,6 +112,7 @@ async function runKubectl(
     vfs,
     cwd: '/root',
     fetch: (url, init) => server.handle(url, init as never),
+    dial: () => ({ open: (request) => server.openStream(request) }),
     now: () => VIRTUAL_NOW,
   });
 }
@@ -203,5 +220,137 @@ describe('kubectl 集成测试的前提', () => {
   it(HAS_ARTIFACT ? '产物已就绪' : '产物缺失，整组跳过（先跑 scripts/build-opslab-wasm.sh）', () => {
     // 这一条永远通过，只是把跳过的原因写进测试报告，免得「没跑」被误读成「跑过了」
     expect(true).toBe(true);
+  });
+});
+
+/**
+ * `kubectl exec`
+ *
+ * 这一组是唯一能证明通道协议对的地方。exec 不走 fetch：kubectl 会先尝试
+ * WebSocket（`v5.channel.k8s.io`），握手、分帧、子协议协商全是 gorilla 真做的，
+ * 我们只提供一条内存里的字节通道。退出码走的是 3 号通道里那个 Status，
+ * 不是 HTTP 状态码 —— 少一个字段，`kubectl exec ...; echo $?` 就永远是 0。
+ */
+describeIfBuilt('真 kubectl exec 走 WebSocket 通道', () => {
+  jest.setTimeout(120_000);
+
+  it('stdout 从 1 号通道回来', async () => {
+    const { server } = buildWorld();
+    const result = await runKubectl(server, ['exec', 'payments-7f4-2xk', '--', 'echo', 'hello']);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('hello\n');
+    expect(result.code).toBe(0);
+  });
+
+  it('exec 打的是 pods/exec 子资源，命令按 argv 分开传', async () => {
+    const { server, execLog } = buildWorld();
+    await runKubectl(server, ['exec', '-n', 'default', 'portal-6c9-abc', '-c', 'app', '--', 'echo', 'a b']);
+    expect(execLog).toHaveLength(1);
+    expect(execLog[0]).toMatchObject({
+      namespace: 'default', pod: 'portal-6c9-abc', container: 'app',
+      command: ['echo', 'a b'],
+    });
+    expect(server.requestLog.some((entry) => entry.startsWith('WS /api/v1/namespaces/default/pods/portal-6c9-abc/exec'))).toBe(true);
+  });
+
+  it('stderr 从 2 号通道回来，和 stdout 不混在一起', async () => {
+    const { server } = buildWorld();
+    const result = await runKubectl(server, ['exec', 'payments-7f4-2xk', '--', 'curl', 'portal']);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('curl: (7) Failed to connect to portal port 80');
+  });
+
+  it('非零退出码经 3 号通道的 Status 传回来', async () => {
+    const { server } = buildWorld();
+    const result = await runKubectl(server, ['exec', 'payments-7f4-2xk', '--', 'false']);
+    expect(result.code).toBe(1);
+    // Status 里的 message 会被 kubectl 原样打到 stderr 上，
+    // 所以「命令失败了」在终端上是看得见的，不只是一个退出码
+    expect(result.stderr).toBe('command terminated with exit code 1\n');
+  });
+
+  it('127 也原样传回来 —— 容器里没这个命令和执行失败要分得开', async () => {
+    const { server } = buildWorld();
+    const result = await runKubectl(server, ['exec', 'payments-7f4-2xk', '--', 'jq', '.']);
+    expect(result.stderr).toContain('sh: jq: not found');
+    expect(result.code).toBe(127);
+  });
+
+  it('宿主不给通道时报的是升级失败，不是「Pod 不存在」', async () => {
+    const { server } = buildWorld();
+    const vfs = createVfs(() => VIRTUAL_NOW);
+    vfs.writeFile('/root/.kube/config', renderKubeconfig(defaultKubeconfig()));
+    const result = await runtime().run('kubectl', ['exec', 'payments-7f4-2xk', '--', 'echo', 'hi'], {
+      vfs, cwd: '/root',
+      fetch: (url, init) => server.handle(url, init as never),
+      now: () => VIRTUAL_NOW,
+    });
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toBe('');
+  });
+});
+
+/**
+ * 整条链路：跳板机上的 kubectl exec 进 Pod，再从 Pod 里发请求
+ *
+ * 这是第 10 关往后所有网络题的地基。同一条 curl 从跳板机发是打不通的
+ * （办公网够不到 ClusterIP），从 Pod 里发才行 —— 学员必须能自己走进去看。
+ */
+describeIfBuilt('跳板机 -> Pod -> 集群网络', () => {
+  jest.setTimeout(120_000);
+
+  const WORLD = {
+    namespaces: ['shop'],
+    images: {
+      'registry.corp.internal/portal:2.1': {},
+      'registry.corp.internal/payments:1.4': {},
+    },
+    objects: [
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'portal', namespace: 'shop' },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: 'portal' } },
+          template: {
+            metadata: { labels: { app: 'portal' } },
+            spec: { containers: [{ name: 'app', image: 'registry.corp.internal/portal:2.1', ports: [{ containerPort: 8080 }] }] },
+          },
+        },
+      },
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'payments', namespace: 'shop' },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: 'payments' } },
+          template: {
+            metadata: { labels: { app: 'payments' } },
+            spec: { containers: [{ name: 'app', image: 'registry.corp.internal/payments:1.4', ports: [{ containerPort: 8080 }] }] },
+          },
+        },
+      },
+      {
+        apiVersion: 'v1', kind: 'Service',
+        metadata: { name: 'payments', namespace: 'shop' },
+        spec: { selector: { app: 'payments' }, ports: [{ port: 80, targetPort: 8080 }] },
+      },
+    ],
+  };
+
+  it('kubectl exec deploy/portal -- curl payments —— 从 Pod 里打得通', async () => {
+    const world = await createOpsWorld({ world: WORLD as never, runtime: runtime() });
+    const result = await world.run(
+      "kubectl exec -n shop deploy/portal -- curl -s -o /dev/null -w '%{http_code}' http://payments"
+    );
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('200');
+  });
+
+  it('同一条 curl 在跳板机上打不通 —— 办公网够不到 ClusterIP', async () => {
+    const world = await createOpsWorld({ world: WORLD as never, runtime: runtime() });
+    const direct = await world.run('curl -s -m 5 http://payments.shop.svc.cluster.local');
+    expect(direct.code).not.toBe(0);
+    expect(direct.stdout).toBe('');
   });
 });


### PR DESCRIPTION
## 做了什么

`kubectl exec` 是第 10 关往后所有网络题的地基：同一条 `curl`，从跳板机发和从 Pod 里发结果必须不同，学员得能自己走进去看。

它不走 fetch —— 要一条双向字节流。kubectl 首选 WebSocket（`v5.channel.k8s.io`），失败才退回 SPDY，而 SPDY 在 fetch 之上做不出来。所以这一片把 WebSocket 那条路做通。

### Go 侧（`scripts/opslab-wasm-patches.sh` 补丁 6）

- 给 gorilla 的 `Dialer` 挂 `NetDialContext`，`net.Conn` 由宿主的 `__opslabDial` 提供。握手、分帧、子协议协商仍然是 gorilla 真的做一遍，只是字节没过网卡。
- **新补一条**：https 的 kubeconfig 会让 gorilla 选 `wss`，然后对着我们的内存管道发 ClientHello 等 ServerHello —— 永远等不到，整条 exec 卡死且不报错。管道本来就没有 TLS 记录层（fetch 那条路同样没有），统一走 `ws`。

### 宿主侧

| 文件 | 干什么 |
| --- | --- |
| `net/websocket.ts` | 握手（SHA-1 + magic GUID）、分帧、一条连接的状态机 |
| `crypto/sha1.ts` | 只为了 `Sec-WebSocket-Accept` |
| `apiserver/exec.ts` | k8s 的通道协议：0 stdin / 1 stdout / 2 stderr / 3 error |
| `lab/podshell.ts` | exec 落到 Pod 里一个真的 shell |
| `controllers/serviceip.ts` | ClusterIP 分配 |

两个容易漏的点，都用测试钉住了：

- **收尾必须发 CLOSE 帧**。直接断链的话对端看到 1006 abnormal closure，kubectl 会把它当成连接故障而不是命令结束，Status 里的退出码就丢了。
- **退出码在 3 号通道的 Status 里**，不是 HTTP 状态码。少 `reason: NonZeroExitCode` 或 `ExitCode` 这个 cause，`kubectl exec ...; echo \$?` 就永远是 0。

### 顺带修的洞：Service 没写 clusterIP 就没有 VIP

不修的话学员一 `kubectl expose`，DNS 解析到 Pod IP 上，端口对不上，看起来像「Service 坏了」。现在和真 apiserver 一样在同一层分配（Registry 多了一个 defaulter 钩子），所以 `kubectl expose` 之后紧接着 `kubectl get svc`，IP 已经在那儿。名字决定 IP + 线性探测，重放可复现。

## 验证

- 真 kubectl 的 6 个 exec 用例（stdout/stderr 分通道、退出码、127、宿主不给通道时报升级失败而不是「Pod 不存在」）
- 跳板机 → Pod → 集群网络 2 个用例：`kubectl exec deploy/portal -- curl payments` 通，同一条 curl 在跳板机上不通
- 全量 1309 个用例通过

WASM 产物：142,253,608 字节，比上一版 **少 164 字节**（只改了一个 switch 分支）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)