### PR TITLE
feat(opslab): git —— 内容寻址的对象库 + 够用的 CLI

### DIFF
--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -200,6 +200,20 @@ export interface OpsImageSpec {
   needsEnv?: string[];
 }
 
+/** 内网 Git 服务上的一个仓库 */
+export interface OpsGitRepositorySpec {
+  /** 完整 URL，如 `https://git.corp.internal/platform/apps` */
+  url: string;
+  /** 默认分支，不写就是 main */
+  branch?: string;
+  /** 初始内容：仓库内相对路径 -> 文件内容 */
+  files?: Record<string, string>;
+  /** 首次提交的说明 */
+  message?: string;
+  /** 只读的仓库 push 会被 403 拒掉 */
+  readOnly?: boolean;
+}
+
 /** 一个私有镜像仓库 */
 export interface OpsRegistrySpec {
   host: string;
@@ -217,6 +231,8 @@ export interface OpsMachineSpec {
   cwd?: string;
   /** 开局就在磁盘上的文件 */
   files?: Record<string, string>;
+  /** `git commit` 的署名。真机上来自 ~/.gitconfig。 */
+  gitIdentity?: { name: string; email: string };
 }
 
 /** 这家公司的内网长什么样 */
@@ -237,6 +253,8 @@ export interface OpsWorldSpec {
    */
   baseImages?: Record<string, 'node' | 'python' | 'static'>;
   registries?: OpsRegistrySpec[];
+  /** 内网的 Git 仓库。GitOps 里那份 YAML 就住在这儿。 */
+  gitRepositories?: OpsGitRepositorySpec[];
   machine?: OpsMachineSpec;
   /** 集群外的名字：`git.corp.internal` -> ['10.10.0.30'] */
   externalHosts?: Record<string, string[]>;

--- a/src/lib/opslab/crypto/sha1.ts
+++ b/src/lib/opslab/crypto/sha1.ts
@@ -44,3 +44,8 @@ export function sha1(input: Uint8Array | string): Uint8Array {
   for (let i = 0; i < 5; i += 1) outView.setUint32(i * 4, h[i]);
   return out;
 }
+
+/** 十六进制的摘要。git 的对象 id 就是这个。 */
+export function sha1Hex(input: Uint8Array | string): string {
+  return Array.from(sha1(input), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/src/lib/opslab/git/command.ts
+++ b/src/lib/opslab/git/command.ts
@@ -1,0 +1,492 @@
+/**
+ * `git`
+ *
+ * 覆盖到「能在 GitOps 里干活」为止：init / clone / add / commit / status /
+ * log / diff / branch / checkout / remote / push / pull / rev-parse /
+ * cat-file / hash-object / show / ls-files。
+ *
+ * 输出照抄真 git —— 学员在这里练出来的读法要能带走。
+ */
+import type { CommandHandler } from '../machine/shell/shell';
+import type { Vfs } from '../machine/vfs';
+import { GitNetwork, type BareRepository } from './remote';
+import { DEFAULT_BRANCH, Repository, statusOf } from './repository';
+import { hashObject, readTree } from './objects';
+
+export interface GitCommandOptions {
+  network: GitNetwork;
+  now: () => number;
+  /** 提交人。真 git 从 ~/.gitconfig 读，这里由世界给。 */
+  identity?: { name: string; email: string };
+  /** 哪些主机解析得到。不在里面的 URL 表现为 DNS 失败。 */
+  resolves?(host: string): boolean;
+}
+
+const USAGE = `usage: git [--version] [--help] <command> [<args>]\n`;
+
+export function createGitCommand(options: GitCommandOptions): CommandHandler {
+  const identity = options.identity ?? { name: 'ops', email: 'ops@corp.internal' };
+
+  return ({ argv, cwd, vfs }) => {
+    // 这里的 argv 已经不含命令名了（和 curl / docker 那些一致）
+    const [subcommand, ...rest] = argv;
+    if (!subcommand) return { stderr: USAGE, code: 1 };
+
+    const open = (): Repository | undefined => Repository.find(vfs, cwd, options.now);
+    const notARepo = {
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git\n',
+      code: 128,
+    };
+
+    switch (subcommand) {
+      case '--version':
+      case 'version':
+        return { stdout: 'git version 2.51.0\n' };
+
+      case 'init': {
+        const target = rest[0] ? resolve(cwd, rest[0]) : cwd;
+        vfs.mkdirp(target);
+        if (vfs.exists(`${target}/.git/HEAD`)) {
+          return { stdout: `Reinitialized existing Git repository in ${target}/.git/\n` };
+        }
+        new Repository(vfs, target, options.now).init();
+        return { stdout: `Initialized empty Git repository in ${target}/.git/\n` };
+      }
+
+      case 'clone': return clone(vfs, cwd, rest, options);
+
+      case 'config': {
+        // 只认 `git config user.name X` 这种最常用的形式，读的时候回默认值
+        if (rest.length >= 2) return {};
+        if (rest[0] === 'user.name') return { stdout: `${identity.name}\n` };
+        if (rest[0] === 'user.email') return { stdout: `${identity.email}\n` };
+        return {};
+      }
+
+      case 'add': {
+        const repository = open();
+        if (!repository) return notARepo;
+        const paths = rest.filter((entry) => !entry.startsWith('-'));
+        if (paths.length === 0) return { stderr: 'Nothing specified, nothing added.\n', code: 1 };
+        const { missing } = repository.add(paths);
+        if (missing.length > 0) {
+          return {
+            stderr: `fatal: pathspec '${missing[0]}' did not match any files\n`,
+            code: 128,
+          };
+        }
+        return {};
+      }
+
+      case 'status': return status(open(), rest) ?? notARepo;
+      case 'log': return log(open(), rest) ?? notARepo;
+      case 'diff': return diff(open(), rest) ?? notARepo;
+
+      case 'commit': {
+        const repository = open();
+        if (!repository) return notARepo;
+        if (rest.includes('-a') || rest.includes('--all')) repository.add(['.']);
+        const message = messageOf(rest);
+        if (!message) {
+          return { stderr: 'Aborting commit due to empty commit message.\n', code: 1 };
+        }
+        const state = statusOf(repository);
+        if (state.staged.length === 0) {
+          const branch = repository.currentBranch() ?? DEFAULT_BRANCH;
+          const lines = [`On branch ${branch}`];
+          if (state.unstaged.length > 0 || state.untracked.length > 0) {
+            lines.push('Changes not staged for commit:', '  (use "git add <file>..." to update what will be committed)');
+          } else {
+            lines.push('nothing to commit, working tree clean');
+          }
+          return { stdout: `${lines.join('\n')}\n`, code: 1 };
+        }
+        const hash = repository.createCommit(message, identity);
+        const branch = repository.currentBranch() ?? DEFAULT_BRANCH;
+        const files = state.staged.length;
+        return {
+          stdout: `[${branch} ${hash.slice(0, 7)}] ${message.split('\n')[0]}\n`
+            + ` ${files} file${files === 1 ? '' : 's'} changed\n`,
+        };
+      }
+
+      case 'branch': {
+        const repository = open();
+        if (!repository) return notARepo;
+        const name = rest.find((entry) => !entry.startsWith('-'));
+        if (name) {
+          const head = repository.headCommit();
+          if (!head) return { stderr: `fatal: not a valid object name: '${name}'\n`, code: 128 };
+          repository.setRef(name, head);
+          return {};
+        }
+        const current = repository.currentBranch();
+        return {
+          stdout: repository.branches()
+            .map((branch) => `${branch === current ? '*' : ' '} ${branch}\n`).join(''),
+        };
+      }
+
+      case 'checkout':
+      case 'switch': {
+        const repository = open();
+        if (!repository) return notARepo;
+        const create = rest.includes('-b') || rest.includes('-c');
+        const name = rest.find((entry) => !entry.startsWith('-'));
+        if (!name) return { stderr: 'fatal: you must specify a branch name\n', code: 128 };
+        if (!create && !repository.ref(name)) {
+          return { stderr: `error: pathspec '${name}' did not match any file(s) known to git\n`, code: 1 };
+        }
+        repository.checkout(name, create);
+        return {
+          stderr: create ? `Switched to a new branch '${name}'\n` : `Switched to branch '${name}'\n`,
+        };
+      }
+
+      case 'remote': {
+        const repository = open();
+        if (!repository) return notARepo;
+        if (rest[0] === 'add' && rest[1] && rest[2]) {
+          repository.setRemote(rest[1], rest[2]);
+          return {};
+        }
+        if (rest[0] === '-v' || rest.length === 0) {
+          const config = repository.config();
+          const names = Object.keys(config)
+            .filter((key) => key.endsWith('.url'))
+            .map((key) => key.slice('remote.'.length, -'.url'.length));
+          if (rest[0] !== '-v') return { stdout: names.map((name) => `${name}\n`).join('') };
+          return {
+            stdout: names.flatMap((name) => [
+              `${name}\t${config[`remote.${name}.url`]} (fetch)\n`,
+              `${name}\t${config[`remote.${name}.url`]} (push)\n`,
+            ]).join(''),
+          };
+        }
+        return {};
+      }
+
+      case 'push': return push(open(), rest, options) ?? notARepo;
+      case 'pull':
+      case 'fetch': return pull(open(), rest, options, subcommand === 'pull') ?? notARepo;
+
+      case 'rev-parse': {
+        const repository = open();
+        if (!repository) return notARepo;
+        const target = rest.find((entry) => !entry.startsWith('-')) ?? 'HEAD';
+        if (rest.includes('--abbrev-ref')) return { stdout: `${repository.currentBranch() ?? 'HEAD'}\n` };
+        const hash = target === 'HEAD' ? repository.headCommit() : repository.ref(target);
+        if (!hash) return { stderr: `fatal: ambiguous argument '${target}'\n`, code: 128 };
+        return { stdout: `${hash}\n` };
+      }
+
+      case 'hash-object': {
+        const path = rest.find((entry) => !entry.startsWith('-'));
+        if (!path) return { stderr: 'fatal: no file given\n', code: 128 };
+        const full = resolve(cwd, path);
+        if (!vfs.exists(full)) return { stderr: `fatal: could not open '${path}'\n`, code: 128 };
+        return { stdout: `${hashObject('blob', vfs.readFile(full))}\n` };
+      }
+
+      case 'cat-file': {
+        const repository = open();
+        if (!repository) return notARepo;
+        const hash = rest[rest.length - 1];
+        const object = repository.objects.get(hash);
+        if (!object) return { stderr: `fatal: Not a valid object name ${hash}\n`, code: 128 };
+        if (rest.includes('-t')) return { stdout: `${object.type}\n` };
+        if (rest.includes('-s')) return { stdout: `${new TextEncoder().encode(object.body).length}\n` };
+        return { stdout: object.body.endsWith('\n') ? object.body : `${object.body}\n` };
+      }
+
+      case 'show': {
+        const repository = open();
+        if (!repository) return notARepo;
+        const hash = rest.find((entry) => !entry.startsWith('-')) ?? repository.headCommit();
+        if (!hash) return { stderr: 'fatal: bad revision\n', code: 128 };
+        const commit = repository.commit(hash);
+        if (!commit) return { stderr: `fatal: bad object ${hash}\n`, code: 128 };
+        return {
+          stdout: `commit ${hash}\nAuthor: ${commit.author}\nDate:   ${formatDate(commit.timestamp)}\n\n`
+            + `    ${commit.message.split('\n').join('\n    ')}\n`,
+        };
+      }
+
+      case 'ls-files': {
+        const repository = open();
+        if (!repository) return notARepo;
+        return { stdout: Object.keys(repository.index()).sort().map((path) => `${path}\n`).join('') };
+      }
+
+      default:
+        return { stderr: `git: '${subcommand}' is not a git command. See 'git --help'.\n`, code: 1 };
+    }
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* 各个子命令                                                          */
+/* ------------------------------------------------------------------ */
+
+function status(repository: Repository | undefined, argv: string[]) {
+  if (!repository) return undefined;
+  const state = statusOf(repository);
+  const branch = repository.currentBranch() ?? 'HEAD (detached)';
+
+  if (argv.includes('--porcelain') || argv.includes('-s')) {
+    const lines: string[] = [];
+    for (const entry of state.staged) lines.push(`${letter(entry.state)}  ${entry.path}`);
+    for (const entry of state.unstaged) lines.push(` ${letter(entry.state)} ${entry.path}`);
+    for (const path of state.untracked) lines.push(`?? ${path}`);
+    return { stdout: lines.length ? `${lines.join('\n')}\n` : '' };
+  }
+
+  const lines = [`On branch ${branch}`];
+  if (state.staged.length) {
+    lines.push('', 'Changes to be committed:', '  (use "git restore --staged <file>..." to unstage)');
+    for (const entry of state.staged) lines.push(`\t${label(entry.state)}   ${entry.path}`);
+  }
+  if (state.unstaged.length) {
+    lines.push('', 'Changes not staged for commit:', '  (use "git add <file>..." to update what will be committed)');
+    for (const entry of state.unstaged) lines.push(`\t${label(entry.state)}   ${entry.path}`);
+  }
+  if (state.untracked.length) {
+    lines.push('', 'Untracked files:', '  (use "git add <file>..." to include in what will be committed)');
+    for (const path of state.untracked) lines.push(`\t${path}`);
+  }
+  if (!state.staged.length && !state.unstaged.length && !state.untracked.length) {
+    lines.push('', 'nothing to commit, working tree clean');
+  }
+  return { stdout: `${lines.join('\n')}\n` };
+}
+
+function log(repository: Repository | undefined, argv: string[]) {
+  if (!repository) return undefined;
+  const history = repository.history();
+  if (history.length === 0) {
+    const branch = repository.currentBranch() ?? DEFAULT_BRANCH;
+    return {
+      stderr: `fatal: your current branch '${branch}' does not have any commits yet\n`,
+      code: 128,
+    };
+  }
+  const limit = limitOf(argv) ?? history.length;
+  const shown = history.slice(0, limit);
+  if (argv.includes('--oneline')) {
+    return {
+      stdout: shown.map(({ hash, commit }) =>
+        `${hash.slice(0, 7)} ${commit.message.split('\n')[0]}\n`).join(''),
+    };
+  }
+  return {
+    stdout: shown.map(({ hash, commit }) =>
+      `commit ${hash}\nAuthor: ${commit.author}\nDate:   ${formatDate(commit.timestamp)}\n\n`
+      + `    ${commit.message.split('\n').join('\n    ')}\n`).join('\n'),
+  };
+}
+
+function diff(repository: Repository | undefined, argv: string[]) {
+  if (!repository) return undefined;
+  const cached = argv.includes('--cached') || argv.includes('--staged');
+  const left = cached ? repository.committed() : repository.staged();
+  const right = cached ? repository.staged() : repository.worktree();
+  const paths = [...new Set([...Object.keys(left), ...Object.keys(right)])].sort();
+
+  if (argv.includes('--name-only')) {
+    return {
+      stdout: paths.filter((path) => left[path] !== right[path]).map((path) => `${path}\n`).join(''),
+    };
+  }
+
+  const out: string[] = [];
+  for (const path of paths) {
+    if (left[path] === right[path]) continue;
+    out.push(`diff --git a/${path} b/${path}`);
+    if (!(path in left)) out.push('new file mode 100644', '--- /dev/null', `+++ b/${path}`);
+    else if (!(path in right)) out.push('deleted file mode 100644', `--- a/${path}`, '+++ /dev/null');
+    else out.push(`--- a/${path}`, `+++ b/${path}`);
+    out.push(...unified(left[path] ?? '', right[path] ?? ''));
+  }
+  return { stdout: out.length ? `${out.join('\n')}\n` : '' };
+}
+
+/**
+ * 最朴素的逐行差异。
+ *
+ * 真 git 用 Myers 算法给出最小编辑脚本；这里整段删、整段加。
+ * 读起来一样能看出改了什么，而「diff 算法」不是这个项目要教的东西。
+ */
+function unified(before: string, after: string): string[] {
+  const a = before.split('\n');
+  const b = after.split('\n');
+  if (a[a.length - 1] === '') a.pop();
+  if (b[b.length - 1] === '') b.pop();
+  let head = 0;
+  while (head < a.length && head < b.length && a[head] === b[head]) head += 1;
+  let tail = 0;
+  while (tail < a.length - head && tail < b.length - head
+    && a[a.length - 1 - tail] === b[b.length - 1 - tail]) tail += 1;
+
+  const removed = a.slice(head, a.length - tail);
+  const added = b.slice(head, b.length - tail);
+  const lines = [`@@ -${head + 1},${removed.length} +${head + 1},${added.length} @@`];
+  for (const line of removed) lines.push(`-${line}`);
+  for (const line of added) lines.push(`+${line}`);
+  return lines;
+}
+
+function clone(vfs: Vfs, cwd: string, argv: string[], options: GitCommandOptions) {
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  const url = positional[0];
+  if (!url) return { stderr: 'fatal: You must specify a repository to clone.\n', code: 128 };
+
+  const host = GitNetwork.hostOf(url);
+  if (host && options.resolves && !options.resolves(host)) {
+    return {
+      stderr: `fatal: unable to access '${url}': Could not resolve host: ${host}\n`,
+      code: 128,
+    };
+  }
+  const bare = options.network.get(url);
+  if (!bare) {
+    return {
+      stderr: `fatal: repository '${url}' not found\n`,
+      code: 128,
+    };
+  }
+
+  const name = positional[1] ?? GitNetwork.normalize(url).split('/').pop()!;
+  const target = resolve(cwd, name);
+  if (vfs.exists(`${target}/.git/HEAD`)) {
+    return { stderr: `fatal: destination path '${name}' already exists and is not an empty directory.\n`, code: 128 };
+  }
+
+  const repository = new Repository(vfs, target, options.now);
+  repository.init(bare.head);
+  repository.setRemote('origin', url);
+  for (const [branch, hash] of Object.entries(bare.refs)) {
+    bare.objects.copyTo(repository.objects, hash);
+    repository.setRef(branch, hash);
+  }
+  const head = bare.refs[bare.head];
+  if (head) repository.restoreWorktree(head);
+
+  // git 把进度打在 stderr 上，stdout 留给能被管道接走的东西
+  const empty = !head || Object.keys(readTree(repository.objects, repository.commit(head)!.tree)).length === 0;
+  const notice = empty ? 'warning: You appear to have cloned an empty repository.\n' : '';
+  return { stderr: `Cloning into '${name}'...\n${notice}`, code: 0 };
+}
+
+function push(repository: Repository | undefined, argv: string[], options: GitCommandOptions) {
+  if (!repository) return undefined;
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  const remoteName = positional[0] ?? 'origin';
+  const branch = positional[1] ?? repository.currentBranch() ?? DEFAULT_BRANCH;
+  const url = repository.remote(remoteName);
+  if (!url) return { stderr: `fatal: '${remoteName}' does not appear to be a git repository\n`, code: 128 };
+
+  const bare = resolveRemote(url, options);
+  if ('stderr' in bare) return bare;
+  if (bare.repository.readOnly) {
+    return {
+      stderr: `remote: You are not allowed to push code to this project.\nfatal: unable to access '${url}': The requested URL returned error: 403\n`,
+      code: 128,
+    };
+  }
+
+  const hash = repository.ref(branch);
+  if (!hash) return { stderr: `error: src refspec ${branch} does not match any\n`, code: 1 };
+  const before = bare.repository.refs[branch];
+  if (before === hash) return { stdout: 'Everything up-to-date\n' };
+
+  repository.objects.copyTo(bare.repository.objects, hash);
+  bare.repository.refs[branch] = hash;
+  const range = before ? `${before.slice(0, 7)}..${hash.slice(0, 7)}` : `[new branch]      ${branch}`;
+  return {
+    stderr: `To ${url}\n   ${range}  ${branch} -> ${branch}\n`,
+  };
+}
+
+function pull(
+  repository: Repository | undefined,
+  argv: string[],
+  options: GitCommandOptions,
+  checkout: boolean
+) {
+  if (!repository) return undefined;
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  const remoteName = positional[0] ?? 'origin';
+  const branch = positional[1] ?? repository.currentBranch() ?? DEFAULT_BRANCH;
+  const url = repository.remote(remoteName);
+  if (!url) return { stderr: `fatal: '${remoteName}' does not appear to be a git repository\n`, code: 128 };
+
+  const bare = resolveRemote(url, options);
+  if ('stderr' in bare) return bare;
+
+  const hash = bare.repository.refs[branch];
+  if (!hash) return { stderr: `fatal: couldn't find remote ref ${branch}\n`, code: 128 };
+  if (repository.ref(branch) === hash) return { stdout: 'Already up to date.\n' };
+
+  bare.repository.objects.copyTo(repository.objects, hash);
+  repository.setRef(branch, hash);
+  if (checkout && repository.currentBranch() === branch) repository.restoreWorktree(hash);
+  return { stdout: `Updating ${branch}\nFast-forward\n` };
+}
+
+function resolveRemote(url: string, options: GitCommandOptions):
+  { repository: BareRepository } | { stderr: string; code: number } {
+  const host = GitNetwork.hostOf(url);
+  if (host && options.resolves && !options.resolves(host)) {
+    return { stderr: `fatal: unable to access '${url}': Could not resolve host: ${host}\n`, code: 128 };
+  }
+  const repository = options.network.get(url);
+  if (!repository) return { stderr: `fatal: repository '${url}' not found\n`, code: 128 };
+  return { repository };
+}
+
+/* ------------------------------------------------------------------ */
+
+function messageOf(argv: string[]): string | undefined {
+  const index = argv.findIndex((entry) => entry === '-m' || entry === '--message');
+  if (index >= 0 && argv[index + 1] !== undefined) return argv[index + 1];
+  const inline = argv.find((entry) => entry.startsWith('-m'));
+  return inline && inline.length > 2 ? inline.slice(2) : undefined;
+}
+
+function limitOf(argv: string[]): number | undefined {
+  const flag = argv.find((entry) => /^-\d+$/.test(entry));
+  if (flag) return Number(flag.slice(1));
+  const index = argv.indexOf('-n');
+  return index >= 0 ? Number(argv[index + 1]) : undefined;
+}
+
+function letter(state: 'added' | 'modified' | 'deleted'): string {
+  return state === 'added' ? 'A' : state === 'deleted' ? 'D' : 'M';
+}
+
+function label(state: 'added' | 'modified' | 'deleted'): string {
+  return state === 'added' ? 'new file:' : state === 'deleted' ? 'deleted:' : 'modified:';
+}
+
+/** git 的日期格式：`Mon Mar 2 09:00:00 2026 +0000` */
+function formatDate(seconds: number): string {
+  const date = new Date(seconds * 1000);
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${days[date.getUTCDay()]} ${months[date.getUTCMonth()]} ${date.getUTCDate()} `
+    + `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())} `
+    + `${date.getUTCFullYear()} +0000`;
+}
+
+function resolve(cwd: string, path: string): string {
+  if (path.startsWith('/')) return path.replace(/\/+$/, '') || '/';
+  const parts = `${cwd}/${path}`.split('/');
+  const out: string[] = [];
+  for (const part of parts) {
+    if (!part || part === '.') continue;
+    if (part === '..') out.pop();
+    else out.push(part);
+  }
+  return `/${out.join('/')}`;
+}

--- a/src/lib/opslab/git/command.ts
+++ b/src/lib/opslab/git/command.ts
@@ -85,7 +85,7 @@ export function createGitCommand(options: GitCommandOptions): CommandHandler {
       case 'commit': {
         const repository = open();
         if (!repository) return notARepo;
-        if (rest.includes('-a') || rest.includes('--all')) repository.add(['.']);
+        if (rest.includes('-a') || rest.includes('--all')) repository.restageTracked();
         const message = messageOf(rest);
         if (!message) {
           return { stderr: 'Aborting commit due to empty commit message.\n', code: 1 };
@@ -398,6 +398,21 @@ function push(repository: Repository | undefined, argv: string[], options: GitCo
   if (!hash) return { stderr: `error: src refspec ${branch} does not match any\n`, code: 1 };
   const before = bare.repository.refs[branch];
   if (before === hash) return { stdout: 'Everything up-to-date\n' };
+  /**
+   * 非快进的推送要拒。
+   *
+   * 别人先推了一版而你手上是旧的，直接覆盖等于把那次提交抹掉 ——
+   * 真 git 在这里拦一道，GitOps 里这一拦尤其重要：远端就是期望状态。
+   */
+  if (before && !repository.isAncestor(before, hash)) {
+    return {
+      stderr: `To ${url}\n ! [rejected]        ${branch} -> ${branch} (fetch first)\n`
+        + `error: failed to push some refs to '${url}'\n`
+        + `hint: Updates were rejected because the remote contains work that you do not\n`
+        + `hint: have locally. Integrate the remote changes before pushing again.\n`,
+      code: 1,
+    };
+  }
 
   repository.objects.copyTo(bare.repository.objects, hash);
   bare.repository.refs[branch] = hash;
@@ -425,9 +440,18 @@ function pull(
 
   const hash = bare.repository.refs[branch];
   if (!hash) return { stderr: `fatal: couldn't find remote ref ${branch}\n`, code: 128 };
-  if (repository.ref(branch) === hash) return { stdout: 'Already up to date.\n' };
+  const local = repository.ref(branch);
+  if (local === hash) return { stdout: 'Already up to date.\n' };
 
   bare.repository.objects.copyTo(repository.objects, hash);
+  // 本地有远端没有的提交 = 分叉了。这里不做 merge，如实说出来。
+  if (local && !repository.isAncestor(local, hash)) {
+    return {
+      stderr: `fatal: Not possible to fast-forward, and merging is not supported here.\n`
+        + `hint: ${branch} has diverged from ${remoteName}/${branch}.\n`,
+      code: 128,
+    };
+  }
   repository.setRef(branch, hash);
   if (checkout && repository.currentBranch() === branch) repository.restoreWorktree(hash);
   return { stdout: `Updating ${branch}\nFast-forward\n` };

--- a/src/lib/opslab/git/index.ts
+++ b/src/lib/opslab/git/index.ts
@@ -1,0 +1,17 @@
+/**
+ * git —— 内容寻址的对象库 + 一个够用的 CLI
+ *
+ * 第 11 关往后的 GitOps 全建立在这上面：仓库里那份 YAML 才是「期望状态」，
+ * 集群里的对象只是它的一个投影。
+ */
+export {
+  ObjectStore, hashObject, encodeTree, parseTree, encodeCommit, parseCommit,
+  writeTree, readTree,
+} from './objects';
+export type { Commit, FileMap, GitObjectType, TreeEntry } from './objects';
+export { Repository, statusOf, DEFAULT_BRANCH } from './repository';
+export type { GitIdentity, StatusEntry } from './repository';
+export { GitNetwork, seedRepository } from './remote';
+export type { BareRepository } from './remote';
+export { createGitCommand } from './command';
+export type { GitCommandOptions } from './command';

--- a/src/lib/opslab/git/objects.ts
+++ b/src/lib/opslab/git/objects.ts
@@ -1,0 +1,192 @@
+/**
+ * Git 的对象库
+ *
+ * 三种对象，都按 `<type> <length>\0<content>` 编码之后取 SHA-1 —— 和真 git
+ * 一模一样，所以这里算出来的 hash 拿到真 git 里也对得上。这不是为了炫技：
+ * 「同样的内容永远是同一个 hash」正是 GitOps 敢拿 commit sha 当部署凭据的原因，
+ * 学员应该能自己 `git cat-file` 验证这件事。
+ *
+ * 不做的部分：packfile、delta 压缩、submodule、merge。这些是存储与协作的
+ * 优化，不影响「内容寻址」这个要教的东西。
+ */
+import { sha1Hex } from '../crypto/sha1';
+
+export type GitObjectType = 'blob' | 'tree' | 'commit';
+
+export interface TreeEntry {
+  mode: string;
+  name: string;
+  hash: string;
+  type: 'blob' | 'tree';
+}
+
+export interface Commit {
+  tree: string;
+  parents: string[];
+  author: string;
+  committer: string;
+  message: string;
+  /** 秒级 epoch，来自虚拟时钟 */
+  timestamp: number;
+}
+
+/** 一个对象库。真 git 放在 `.git/objects` 下，我们放在内存里，写盘的是索引。 */
+export class ObjectStore {
+  private readonly objects = new Map<string, { type: GitObjectType; body: string }>();
+
+  put(type: GitObjectType, body: string): string {
+    const hash = hashObject(type, body);
+    if (!this.objects.has(hash)) this.objects.set(hash, { type, body });
+    return hash;
+  }
+
+  get(hash: string): { type: GitObjectType; body: string } | undefined {
+    return this.objects.get(hash);
+  }
+
+  has(hash: string): boolean {
+    return this.objects.has(hash);
+  }
+
+  /**
+   * 拷贝一批对象过去。push / pull / clone 都是这个动作。
+   *
+   * 两边都走 `get` / `put` 而不是直接动内部的 Map —— 子类可能把对象落在
+   * 磁盘上（`.git/objects`），绕过去的话对象只存在于内存里，
+   * 下一条命令换一个实例就全丢了。
+   */
+  copyTo(other: ObjectStore, root: string): void {
+    const seen = new Set<string>();
+    const walk = (hash: string) => {
+      if (!hash || seen.has(hash)) return;
+      seen.add(hash);
+      const object = this.get(hash);
+      if (!object) return;
+      other.put(object.type, object.body);
+      if (object.type === 'commit') {
+        const commit = parseCommit(object.body);
+        walk(commit.tree);
+        for (const parent of commit.parents) walk(parent);
+      } else if (object.type === 'tree') {
+        for (const entry of parseTree(object.body)) walk(entry.hash);
+      }
+    };
+    walk(root);
+  }
+
+  get size(): number {
+    return this.objects.size;
+  }
+}
+
+/** 真 git 的对象 id：`sha1("<type> <len>\0" + content)` */
+export function hashObject(type: GitObjectType, body: string): string {
+  return sha1Hex(`${type} ${byteLength(body)}\0${body}`);
+}
+
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+/* ------------------------------------------------------------------ */
+/* tree                                                                */
+/* ------------------------------------------------------------------ */
+
+/**
+ * tree 的编码。
+ *
+ * 真 git 用二进制（20 字节裸 hash），我们用一行一条的文本 —— 唯一的代价是
+ * tree 对象的 hash 和真 git 不一致，blob 与「同内容同 hash」都还是真的。
+ * 换来的是 `git cat-file -p` 打出来人能读，教学上更划算。
+ */
+export function encodeTree(entries: TreeEntry[]): string {
+  return [...entries]
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .map((entry) => `${entry.mode} ${entry.type} ${entry.hash}\t${entry.name}`)
+    .join('\n') + (entries.length ? '\n' : '');
+}
+
+export function parseTree(body: string): TreeEntry[] {
+  return body.split('\n').filter(Boolean).map((line) => {
+    const [meta, name] = line.split('\t');
+    const [mode, type, hash] = meta.split(' ');
+    return { mode, type: type as 'blob' | 'tree', hash, name };
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* commit                                                              */
+/* ------------------------------------------------------------------ */
+
+export function encodeCommit(commit: Commit): string {
+  const lines = [`tree ${commit.tree}`];
+  for (const parent of commit.parents) lines.push(`parent ${parent}`);
+  lines.push(`author ${commit.author} ${commit.timestamp} +0000`);
+  lines.push(`committer ${commit.committer} ${commit.timestamp} +0000`);
+  lines.push('');
+  lines.push(commit.message.replace(/\n*$/, ''));
+  return lines.join('\n') + '\n';
+}
+
+export function parseCommit(body: string): Commit {
+  const [head, ...rest] = body.split('\n\n');
+  const commit: Commit = {
+    tree: '', parents: [], author: '', committer: '', message: rest.join('\n\n').replace(/\n$/, ''),
+    timestamp: 0,
+  };
+  for (const line of head.split('\n')) {
+    if (line.startsWith('tree ')) commit.tree = line.slice(5).trim();
+    else if (line.startsWith('parent ')) commit.parents.push(line.slice(7).trim());
+    else if (line.startsWith('author ')) {
+      const match = /^author (.*) (\d+) [+-]\d{4}$/.exec(line);
+      if (match) { commit.author = match[1]; commit.timestamp = Number(match[2]); }
+    } else if (line.startsWith('committer ')) {
+      const match = /^committer (.*) (\d+) [+-]\d{4}$/.exec(line);
+      if (match) commit.committer = match[1];
+    }
+  }
+  return commit;
+}
+
+/* ------------------------------------------------------------------ */
+/* 文件表 <-> tree                                                     */
+/* ------------------------------------------------------------------ */
+
+/** 一棵工作树：相对路径 -> 内容 */
+export type FileMap = Record<string, string>;
+
+export function writeTree(store: ObjectStore, files: FileMap): string {
+  const root: Record<string, unknown> = {};
+  for (const [path, content] of Object.entries(files)) {
+    const parts = path.split('/').filter(Boolean);
+    let node = root;
+    for (const part of parts.slice(0, -1)) {
+      node[part] = (node[part] as Record<string, unknown>) ?? {};
+      node = node[part] as Record<string, unknown>;
+    }
+    node[parts[parts.length - 1]] = content;
+  }
+  const build = (node: Record<string, unknown>): string => {
+    const entries: TreeEntry[] = Object.entries(node).map(([name, value]) =>
+      typeof value === 'string'
+        ? { mode: '100644', type: 'blob', name, hash: store.put('blob', value) }
+        : { mode: '040000', type: 'tree', name, hash: build(value as Record<string, unknown>) });
+    return store.put('tree', encodeTree(entries));
+  };
+  return build(root);
+}
+
+export function readTree(store: ObjectStore, hash: string, prefix = ''): FileMap {
+  const object = store.get(hash);
+  if (!object || object.type !== 'tree') return {};
+  const files: FileMap = {};
+  for (const entry of parseTree(object.body)) {
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.type === 'blob') {
+      files[path] = store.get(entry.hash)?.body ?? '';
+    } else {
+      Object.assign(files, readTree(store, entry.hash, path));
+    }
+  }
+  return files;
+}

--- a/src/lib/opslab/git/remote.ts
+++ b/src/lib/opslab/git/remote.ts
@@ -56,11 +56,20 @@ export class GitNetwork {
   }
 }
 
-/** 往裸仓库里塞一份初始内容，返回 commit id */
+/**
+ * 往裸仓库里塞一次提交，返回 commit id。
+ *
+ * 分支上已经有东西时默认接在它后面 —— 不然造出来的是一次根提交，
+ * 对面 pull 下来会被判成分叉。
+ */
 export function seedRepository(
   repository: BareRepository,
   files: FileMap,
-  options: { branch?: string; message?: string; author?: string; timestamp?: number } = {}
+  options: {
+    branch?: string; message?: string; author?: string; timestamp?: number;
+    /** 接在哪次提交后面。不给就是一次根提交。 */
+    parent?: string;
+  } = {}
 ): string {
   // 这里刻意不复用 Repository：裸仓库没有工作树，只有对象与引用
   const store = repository.objects;
@@ -68,8 +77,10 @@ export function seedRepository(
   const branch = options.branch ?? repository.head;
   const author = options.author ?? 'Platform Team <platform@corp.internal>';
   const timestamp = Math.floor((options.timestamp ?? 0) / 1000);
+  const parent = options.parent ?? repository.refs[branch];
   const body = [
     `tree ${tree}`,
+    ...(parent ? [`parent ${parent}`] : []),
     `author ${author} ${timestamp} +0000`,
     `committer ${author} ${timestamp} +0000`,
     '',

--- a/src/lib/opslab/git/remote.ts
+++ b/src/lib/opslab/git/remote.ts
@@ -1,0 +1,82 @@
+/**
+ * 内网的 Git 服务
+ *
+ * 一个 URL 对应一个裸仓库。push / pull / clone 就是在两个对象库之间搬对象、
+ * 然后动一下引用 —— 真 git 也是这么回事，只是中间隔着 smart HTTP 协议。
+ *
+ * 认证做成和镜像仓库一样：URL 里的主机得在网络里存在，仓库得存在。
+ * 「clone 不下来」和「push 被拒」是两件不同的事，学员应该分得清。
+ */
+import { ObjectStore, writeTree, type FileMap } from './objects';
+
+export interface BareRepository {
+  /** 默认分支 */
+  head: string;
+  refs: Record<string, string>;
+  objects: ObjectStore;
+  /** 只读的仓库：push 会被拒 */
+  readOnly?: boolean;
+}
+
+export class GitNetwork {
+  private readonly repositories = new Map<string, BareRepository>();
+
+  /** URL 归一化：去掉结尾的斜杠与 `.git` */
+  static normalize(url: string): string {
+    return url.replace(/\/+$/, '').replace(/\.git$/, '');
+  }
+
+  create(url: string, options: { head?: string; readOnly?: boolean } = {}): BareRepository {
+    const repository: BareRepository = {
+      head: options.head ?? 'main',
+      refs: {},
+      objects: new ObjectStore(),
+      readOnly: options.readOnly,
+    };
+    this.repositories.set(GitNetwork.normalize(url), repository);
+    return repository;
+  }
+
+  get(url: string): BareRepository | undefined {
+    return this.repositories.get(GitNetwork.normalize(url));
+  }
+
+  has(url: string): boolean {
+    return this.repositories.has(GitNetwork.normalize(url));
+  }
+
+  list(): string[] {
+    return [...this.repositories.keys()].sort();
+  }
+
+  /** 主机名 —— 网络层判断解析得到解析不到时要用 */
+  static hostOf(url: string): string | undefined {
+    const match = /^[a-z+]+:\/\/([^/@]+@)?([^/:]+)/.exec(url);
+    return match?.[2];
+  }
+}
+
+/** 往裸仓库里塞一份初始内容，返回 commit id */
+export function seedRepository(
+  repository: BareRepository,
+  files: FileMap,
+  options: { branch?: string; message?: string; author?: string; timestamp?: number } = {}
+): string {
+  // 这里刻意不复用 Repository：裸仓库没有工作树，只有对象与引用
+  const store = repository.objects;
+  const tree = writeTree(store, files);
+  const branch = options.branch ?? repository.head;
+  const author = options.author ?? 'Platform Team <platform@corp.internal>';
+  const timestamp = Math.floor((options.timestamp ?? 0) / 1000);
+  const body = [
+    `tree ${tree}`,
+    `author ${author} ${timestamp} +0000`,
+    `committer ${author} ${timestamp} +0000`,
+    '',
+    options.message ?? 'initial commit',
+    '',
+  ].join('\n');
+  const hash = store.put('commit', body);
+  repository.refs[branch] = hash;
+  return hash;
+}

--- a/src/lib/opslab/git/repository.ts
+++ b/src/lib/opslab/git/repository.ts
@@ -1,0 +1,311 @@
+/**
+ * 一个仓库
+ *
+ * 对象、引用、索引全都落在 `.git/` 下面 —— 不是为了好看：世界要能快照回放，
+ * 而快照的是文件系统。把仓库状态藏在内存里，回放就对不上了。
+ * 顺带的好处是 `find .git/objects` 真的能翻，`cat .git/HEAD` 真的有东西。
+ */
+import type { Vfs } from '../machine/vfs';
+import {
+  Commit, FileMap, ObjectStore, encodeCommit, parseCommit, readTree, writeTree,
+  type GitObjectType,
+} from './objects';
+
+export const DEFAULT_BRANCH = 'main';
+
+/** 把 `.git/objects` 当成对象库来读写 */
+class VfsObjectStore extends ObjectStore {
+  constructor(private readonly vfs: Vfs, private readonly gitDir: string) {
+    super();
+  }
+
+  put(type: GitObjectType, body: string): string {
+    const hash = super.put(type, body);
+    const path = `${this.gitDir}/objects/${hash.slice(0, 2)}/${hash.slice(2)}`;
+    if (!this.vfs.exists(path)) this.vfs.writeFile(path, `${type}\n${body}`);
+    return hash;
+  }
+
+  get(hash: string): { type: GitObjectType; body: string } | undefined {
+    const cached = super.get(hash);
+    if (cached) return cached;
+    const path = `${this.gitDir}/objects/${hash.slice(0, 2)}/${hash.slice(2)}`;
+    if (!this.vfs.exists(path)) return undefined;
+    const raw = this.vfs.readFile(path);
+    const split = raw.indexOf('\n');
+    const object = { type: raw.slice(0, split) as GitObjectType, body: raw.slice(split + 1) };
+    super.put(object.type, object.body);
+    return object;
+  }
+
+  has(hash: string): boolean {
+    return this.get(hash) !== undefined;
+  }
+}
+
+export interface GitIdentity {
+  name: string;
+  email: string;
+}
+
+export class Repository {
+  readonly objects: ObjectStore;
+
+  constructor(
+    private readonly vfs: Vfs,
+    /** 工作树的根，如 `/root/platform` */
+    readonly root: string,
+    private readonly now: () => number
+  ) {
+    this.objects = new VfsObjectStore(vfs, this.gitDir);
+  }
+
+  get gitDir(): string {
+    return `${this.root}/.git`;
+  }
+
+  static find(vfs: Vfs, cwd: string, now: () => number): Repository | undefined {
+    let current = cwd;
+    for (;;) {
+      if (vfs.exists(`${current}/.git/HEAD`)) return new Repository(vfs, current, now);
+      const parent = current.replace(/\/[^/]*$/, '');
+      if (!parent || parent === current) return undefined;
+      current = parent;
+    }
+  }
+
+  init(branch = DEFAULT_BRANCH): void {
+    this.vfs.mkdirp(`${this.gitDir}/objects`);
+    this.vfs.mkdirp(`${this.gitDir}/refs/heads`);
+    this.vfs.writeFile(`${this.gitDir}/HEAD`, `ref: refs/heads/${branch}\n`);
+    this.vfs.writeFile(`${this.gitDir}/index`, '{}\n');
+  }
+
+  /* ---------------- 引用 ---------------- */
+
+  head(): string {
+    return this.vfs.readFile(`${this.gitDir}/HEAD`).trim();
+  }
+
+  currentBranch(): string | undefined {
+    const head = this.head();
+    return head.startsWith('ref: refs/heads/') ? head.slice('ref: refs/heads/'.length) : undefined;
+  }
+
+  branches(): string[] {
+    const dir = `${this.gitDir}/refs/heads`;
+    return this.vfs.exists(dir) ? this.vfs.readDir(dir).sort() : [];
+  }
+
+  ref(branch: string): string | undefined {
+    const path = `${this.gitDir}/refs/heads/${branch}`;
+    return this.vfs.exists(path) ? this.vfs.readFile(path).trim() : undefined;
+  }
+
+  setRef(branch: string, hash: string): void {
+    this.vfs.writeFile(`${this.gitDir}/refs/heads/${branch}`, `${hash}\n`);
+  }
+
+  /** HEAD 指向的 commit。空仓库返回 undefined。 */
+  headCommit(): string | undefined {
+    const branch = this.currentBranch();
+    if (branch) return this.ref(branch);
+    return this.head() || undefined;
+  }
+
+  checkout(branch: string, create = false): void {
+    if (create) {
+      const current = this.headCommit();
+      if (current) this.setRef(branch, current);
+      else this.vfs.mkdirp(`${this.gitDir}/refs/heads`);
+    }
+    this.vfs.writeFile(`${this.gitDir}/HEAD`, `ref: refs/heads/${branch}\n`);
+    const target = this.ref(branch);
+    if (target) this.restoreWorktree(target);
+  }
+
+  /* ---------------- 索引与工作树 ---------------- */
+
+  index(): Record<string, string> {
+    const path = `${this.gitDir}/index`;
+    if (!this.vfs.exists(path)) return {};
+    try {
+      return JSON.parse(this.vfs.readFile(path)) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+
+  private writeIndex(index: Record<string, string>): void {
+    const ordered = Object.fromEntries(Object.entries(index).sort(([a], [b]) => (a < b ? -1 : 1)));
+    this.vfs.writeFile(`${this.gitDir}/index`, `${JSON.stringify(ordered, null, 2)}\n`);
+  }
+
+  /** 工作树上的文件（不含 .git） */
+  worktree(): FileMap {
+    const files: FileMap = {};
+    for (const path of this.vfs.walkAll(this.root)) {
+      if (!this.vfs.isFile(path)) continue;
+      const relative = path.slice(this.root.length + 1);
+      if (relative.startsWith('.git/') || relative === '.git') continue;
+      files[relative] = this.vfs.readFile(path);
+    }
+    return files;
+  }
+
+  /** HEAD 那次提交的内容 */
+  committed(): FileMap {
+    const head = this.headCommit();
+    if (!head) return {};
+    const commit = this.commit(head);
+    return commit ? readTree(this.objects, commit.tree) : {};
+  }
+
+  add(paths: string[]): { added: string[]; missing: string[] } {
+    const worktree = this.worktree();
+    const index = this.index();
+    const added: string[] = [];
+    const missing: string[] = [];
+    for (const raw of paths) {
+      const wanted = raw === '.' || raw === './' ? '' : raw.replace(/^\.\//, '').replace(/\/$/, '');
+      const matched = Object.keys(worktree).filter(
+        (file) => wanted === '' || file === wanted || file.startsWith(`${wanted}/`)
+      );
+      if (matched.length === 0) { missing.push(raw); continue; }
+      for (const file of matched) {
+        index[file] = this.objects.put('blob', worktree[file]);
+        added.push(file);
+      }
+    }
+    // 暂存过、现在工作树里没有了 = 删除也要进暂存区
+    for (const file of Object.keys(index)) {
+      if (!(file in worktree)) delete index[file];
+    }
+    this.writeIndex(index);
+    return { added, missing };
+  }
+
+  /** 暂存区的内容（路径 -> 内容） */
+  staged(): FileMap {
+    const files: FileMap = {};
+    for (const [path, hash] of Object.entries(this.index())) {
+      files[path] = this.objects.get(hash)?.body ?? '';
+    }
+    return files;
+  }
+
+  createCommit(message: string, identity: GitIdentity): string {
+    const who = `${identity.name} <${identity.email}>`;
+    const parent = this.headCommit();
+    const tree = writeTree(this.objects, this.staged());
+    const commit: Commit = {
+      tree,
+      parents: parent ? [parent] : [],
+      author: who,
+      committer: who,
+      message,
+      timestamp: Math.floor(this.now() / 1000),
+    };
+    const hash = this.objects.put('commit', encodeCommit(commit));
+    const branch = this.currentBranch() ?? DEFAULT_BRANCH;
+    this.setRef(branch, hash);
+    return hash;
+  }
+
+  commit(hash: string): Commit | undefined {
+    const object = this.objects.get(hash);
+    return object?.type === 'commit' ? parseCommit(object.body) : undefined;
+  }
+
+  /** 从新到旧 */
+  history(from = this.headCommit()): Array<{ hash: string; commit: Commit }> {
+    const out: Array<{ hash: string; commit: Commit }> = [];
+    let cursor = from;
+    while (cursor) {
+      const commit = this.commit(cursor);
+      if (!commit) break;
+      out.push({ hash: cursor, commit });
+      cursor = commit.parents[0];
+    }
+    return out;
+  }
+
+  /** 把某次提交的内容铺回工作树 */
+  restoreWorktree(hash: string): void {
+    const commit = this.commit(hash);
+    if (!commit) return;
+    const wanted = readTree(this.objects, commit.tree);
+    for (const path of Object.keys(this.worktree())) {
+      if (!(path in wanted)) this.vfs.remove(`${this.root}/${path}`);
+    }
+    for (const [path, content] of Object.entries(wanted)) {
+      this.vfs.writeFile(`${this.root}/${path}`, content);
+    }
+    const index: Record<string, string> = {};
+    for (const [path, content] of Object.entries(wanted)) index[path] = this.objects.put('blob', content);
+    this.writeIndex(index);
+  }
+
+  /* ---------------- 远端 ---------------- */
+
+  config(): Record<string, string> {
+    const path = `${this.gitDir}/config`;
+    if (!this.vfs.exists(path)) return {};
+    try {
+      return JSON.parse(this.vfs.readFile(path)) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+
+  setRemote(name: string, url: string): void {
+    const config = this.config();
+    config[`remote.${name}.url`] = url;
+    this.vfs.writeFile(`${this.gitDir}/config`, `${JSON.stringify(config, null, 2)}\n`);
+  }
+
+  remote(name: string): string | undefined {
+    return this.config()[`remote.${name}.url`];
+  }
+}
+
+/** 状态：工作树 / 暂存区 / HEAD 三者的差 */
+export interface StatusEntry {
+  path: string;
+  state: 'added' | 'modified' | 'deleted';
+}
+
+export function statusOf(repository: Repository): {
+  staged: StatusEntry[];
+  unstaged: StatusEntry[];
+  untracked: string[];
+} {
+  const head = repository.committed();
+  const index = repository.staged();
+  const worktree = repository.worktree();
+
+  const staged: StatusEntry[] = [];
+  for (const path of union(head, index)) {
+    if (!(path in head)) staged.push({ path, state: 'added' });
+    else if (!(path in index)) staged.push({ path, state: 'deleted' });
+    else if (head[path] !== index[path]) staged.push({ path, state: 'modified' });
+  }
+
+  const unstaged: StatusEntry[] = [];
+  const untracked: string[] = [];
+  for (const path of union(index, worktree)) {
+    if (!(path in index)) { untracked.push(path); continue; }
+    if (!(path in worktree)) { unstaged.push({ path, state: 'deleted' }); continue; }
+    if (index[path] !== worktree[path]) unstaged.push({ path, state: 'modified' });
+  }
+
+  return { staged: sortBy(staged), unstaged: sortBy(unstaged), untracked: untracked.sort() };
+}
+
+function union(a: FileMap, b: FileMap): string[] {
+  return [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+}
+
+function sortBy(entries: StatusEntry[]): StatusEntry[] {
+  return [...entries].sort((a, b) => (a.path < b.path ? -1 : 1));
+}

--- a/src/lib/opslab/git/repository.ts
+++ b/src/lib/opslab/git/repository.ts
@@ -161,6 +161,12 @@ export class Repository {
     return commit ? readTree(this.objects, commit.tree) : {};
   }
 
+  /**
+   * `git add`
+   *
+   * 只动 pathspec 覆盖到的那些路径。删除同样要进暂存区，但**也只限这些路径** ——
+   * `git add b.yaml` 不该顺手把别处删掉的文件也暂存了。
+   */
   add(paths: string[]): { added: string[]; missing: string[] } {
     const worktree = this.worktree();
     const index = this.index();
@@ -168,21 +174,35 @@ export class Repository {
     const missing: string[] = [];
     for (const raw of paths) {
       const wanted = raw === '.' || raw === './' ? '' : raw.replace(/^\.\//, '').replace(/\/$/, '');
-      const matched = Object.keys(worktree).filter(
-        (file) => wanted === '' || file === wanted || file.startsWith(`${wanted}/`)
-      );
-      if (matched.length === 0) { missing.push(raw); continue; }
+      const covers = (file: string) => wanted === '' || file === wanted || file.startsWith(`${wanted}/`);
+      const matched = Object.keys(worktree).filter(covers);
+      const removed = Object.keys(index).filter((file) => covers(file) && !(file in worktree));
+      if (matched.length === 0 && removed.length === 0) { missing.push(raw); continue; }
       for (const file of matched) {
         index[file] = this.objects.put('blob', worktree[file]);
         added.push(file);
       }
-    }
-    // 暂存过、现在工作树里没有了 = 删除也要进暂存区
-    for (const file of Object.keys(index)) {
-      if (!(file in worktree)) delete index[file];
+      for (const file of removed) delete index[file];
     }
     this.writeIndex(index);
     return { added, missing };
+  }
+
+  /** `git commit -a`：只重新暂存已跟踪的文件，不碰未跟踪的 */
+  restageTracked(): void {
+    this.add(Object.keys(this.index()));
+  }
+
+  /** ancestor 是不是 descendant 的祖先（快进判断） */
+  isAncestor(ancestor: string, descendant: string): boolean {
+    let cursor: string | undefined = descendant;
+    const seen = new Set<string>();
+    while (cursor && !seen.has(cursor)) {
+      if (cursor === ancestor) return true;
+      seen.add(cursor);
+      cursor = this.commit(cursor)?.parents[0];
+    }
+    return false;
   }
 
   /** 暂存区的内容（路径 -> 内容） */

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -20,6 +20,7 @@ import { createNetTools } from '../net';
 import { parseChain } from '../crypto';
 import { createOpensslCommand } from './openssl';
 import { materializePki } from './pki';
+import { GitNetwork, createGitCommand, seedRepository } from '../git';
 import { createExecHandler } from './podshell';
 import { CliRuntime, installClusterCli } from '../wasm';
 import type { KubeObject } from '../apiserver';
@@ -36,6 +37,8 @@ export interface OpsWorld {
   machine: Machine;
   images: ImageStore;
   registries: RegistryNetwork;
+  /** 内网 Git 服务 */
+  git: GitNetwork;
   /** 装上的真 CLI 名字，如 ['kubectl','helm'] */
   applets: string[];
   /** 敲一条命令，然后让世界自己往前走到静止 */
@@ -61,6 +64,23 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   // 先声明，下面 createCluster 要用；仓库对象在它之后才建得出来
   let lookupPushedImage: (image: string) => ReturnType<typeof behaviorOfImage> | undefined = () => undefined;
 
+  /**
+   * 内网服务的名字。
+   *
+   * 私有仓库、Git 服务这些，办公网与集群都该解析得到；不在这张表里的
+   * 名字表现和真的 DNS 失败一样 —— 「写错了域名」和「服务挂了」要分得开。
+   */
+  const externalHosts: Record<string, string[]> = {
+    ...Object.fromEntries((spec.registries ?? []).map((registry, index) => [
+      registry.host, [`10.10.0.${20 + index}`],
+    ])),
+    ...Object.fromEntries((spec.gitRepositories ?? []).flatMap((repository, index) => {
+      const host = GitNetwork.hostOf(repository.url);
+      return host ? [[host, [`10.10.0.${40 + index}`]] as [string, string[]]] : [];
+    })),
+    ...(spec.externalHosts ?? {}),
+  };
+
   const cluster = createCluster({
     seed: spec.seed ?? 1,
     startTime: Date.parse(spec.startTime ?? DEFAULT_START),
@@ -77,13 +97,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     ])),
     clusterAgeMs,
     resolveImage: (image) => lookupPushedImage(image),
-    externalHosts: {
-      // 私有仓库这些内网服务，办公网与集群都该解析得到
-      ...Object.fromEntries((spec.registries ?? []).map((registry, index) => [
-        registry.host, [`10.10.0.${20 + index}`],
-      ])),
-      ...(spec.externalHosts ?? {}),
-    },
+    externalHosts,
     addressPools: spec.addressPools,
     /**
      * 跳板机信任哪些根。
@@ -112,6 +126,23 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   });
 
   const images = new ImageStore();
+
+  // 内网的 Git 服务。关卡声明里那些仓库在世界起来之前就该在了。
+  const git = new GitNetwork();
+  for (const repository of spec.gitRepositories ?? []) {
+    const bare = git.create(repository.url, {
+      head: repository.branch ?? 'main',
+      readOnly: repository.readOnly,
+    });
+    if (repository.files) {
+      seedRepository(bare, repository.files, {
+        message: repository.message ?? 'initial commit',
+        // 仓库是「本来就在」的东西，提交时间按集群年龄之前算
+        timestamp: cluster.wallClock() - DEFAULT_OBJECT_AGE_MS,
+      });
+    }
+  }
+
   const registries = new RegistryNetwork();
   for (const registry of spec.registries ?? []) {
     registries.add(new ImageRegistry({
@@ -138,6 +169,14 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   }
 
   machine.install('openssl', createOpensslCommand());
+
+  machine.install('git', createGitCommand({
+    network: git,
+    now: () => cluster.wallClock(),
+    identity: spec.machine?.gitIdentity ?? { name: 'ops', email: 'ops@corp.internal' },
+    // 名字解析不到的远端，表现和真的 DNS 失败一样
+    resolves: (host) => Boolean(externalHosts[host]),
+  }));
 
   machine.install('docker', createDockerCommand({
     store: images,
@@ -209,6 +248,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     machine,
     images,
     registries,
+    git,
     applets,
     now: () => cluster.wallClock(),
     async run(command: string) {

--- a/src/lib/opslab/machine/shell/parser.ts
+++ b/src/lib/opslab/machine/shell/parser.ts
@@ -372,9 +372,19 @@ function collectRedirects(node: TsNode): Redirect[] {
   return redirects;
 }
 
-/** 把重定向挂到该挂的地方：单命令直接包一层，管道分别挂在首尾两段 */
+/**
+ * 把重定向挂到该挂的地方。
+ *
+ * 单命令直接包一层；管道分别挂在首尾两段；`a && b > f` 只重定向 `b`。
+ * 最后这条不是吹毛求疵：整段包起来的话，重定向的目标路径会在 `a` 跑之前
+ * 就解析掉，于是 `cd sub && echo x > f` 把文件写到了 cd 之前的目录里 ——
+ * 命令全部成功，文件出现在错误的地方，没有任何报错。
+ */
 function attachRedirects(body: Node, redirects: Redirect[]): Node {
   if (redirects.length === 0) return body;
+  if (body.type === 'list') {
+    return { ...body, right: attachRedirects(body.right, redirects) };
+  }
   if (body.type === 'pipeline' && body.commands.length > 0) {
     const commands = [...body.commands];
     const inbound = redirects.filter((r) => r.kind === 'in' || r.kind === 'heredoc');

--- a/tests/opslab/git.test.ts
+++ b/tests/opslab/git.test.ts
@@ -242,6 +242,53 @@ describe('git 命令', () => {
     expect(w.machine.vfs.readFile('/root/apps/apps/portal.yaml')).toContain('replicas: 5');
   });
 
+  it('别人先推了、你手上是旧的 —— push 要被拒，不能悄悄覆盖', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    // 你在本地改了一版
+    await w.run("cd /root/apps && sed -i 's/replicas: 2/replicas: 3/' apps/portal.yaml");
+    await w.run("cd /root/apps && git add . && git commit -m 'mine'");
+    // 与此同时平台组推了另一版
+    const bare = w.git.get('https://git.corp.internal/platform/apps')!;
+    seedRepository(bare, { 'apps/portal.yaml': 'kind: Deployment\nreplicas: 9\n' }, {
+      message: 'theirs', timestamp: w.now(),
+    });
+
+    const pushed = await w.run('cd /root/apps && git push origin main');
+    expect(pushed.code).toBe(1);
+    expect(pushed.stderr).toContain('[rejected]');
+    expect(pushed.stderr).toContain('fetch first');
+    // 远端那次提交没被抹掉
+    const tree = parseCommit(bare.objects.get(bare.refs.main)!.body).tree;
+    expect(readTree(bare.objects, tree)['apps/portal.yaml']).toContain('replicas: 9');
+  });
+
+  it('分叉之后 pull 如实说分叉了，不假装 merge 成功', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    await w.run("cd /root/apps && sed -i 's/replicas: 2/replicas: 3/' apps/portal.yaml");
+    await w.run("cd /root/apps && git add . && git commit -m 'mine'");
+    const bare = w.git.get('https://git.corp.internal/platform/apps')!;
+    seedRepository(bare, { 'apps/portal.yaml': 'kind: Deployment\nreplicas: 9\n' }, {
+      message: 'theirs', timestamp: w.now(),
+    });
+
+    const pulled = await w.run('cd /root/apps && git pull origin main');
+    expect(pulled.code).toBe(128);
+    expect(pulled.stderr).toContain('diverged');
+  });
+
+  it('git add 只动指到的路径 —— 别处删掉的文件不该被顺手暂存', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    await w.run('cd /root/apps && rm README.md && echo x > new.yaml');
+    await w.run('cd /root/apps && git add new.yaml');
+    const status = await w.run('cd /root/apps && git status --porcelain');
+    expect(status.stdout).toContain('A  new.yaml');
+    // README.md 的删除还留在工作区，没有被带进暂存区
+    expect(status.stdout).toContain(' D README.md');
+  });
+
   it('git log --oneline 与 rev-parse HEAD 对得上', async () => {
     const w = await world();
     await w.run('git clone https://git.corp.internal/platform/apps');

--- a/tests/opslab/git.test.ts
+++ b/tests/opslab/git.test.ts
@@ -1,0 +1,266 @@
+/**
+ * git
+ *
+ * 要证明的是两件事：
+ *  1. **内容寻址是真的** —— 这里算出来的 blob hash 和真 git 一致；
+ *  2. **CLI 的行为对得上** —— 输出、退出码、失败时说的话都能带走。
+ *
+ * 第 11 关往后的 GitOps 全建立在这上面：仓库里那份 YAML 才是期望状态。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import {
+  GitNetwork, Repository, hashObject, parseCommit, readTree, seedRepository, statusOf, writeTree,
+  ObjectStore,
+} from '../../src/lib/opslab/git';
+import { createVfs } from '../../src/lib/opslab/machine';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+const NOW = Date.parse('2026-03-02T09:00:00Z');
+
+describe('对象库', () => {
+  it('blob 的 hash 和真 git 逐位一致', () => {
+    // 这两个值是 `git hash-object` 出来的，不是我们算的
+    expect(hashObject('blob', 'hello\n')).toBe('ce013625030ba8dba906f756967f9e9ca394464a');
+    expect(hashObject('blob', '')).toBe('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391');
+  });
+
+  it('同样的内容永远是同一个 hash —— GitOps 敢拿 sha 当凭据就是因为这个', () => {
+    const store = new ObjectStore();
+    const a = writeTree(store, { 'a/b.yaml': 'x: 1\n', 'c.yaml': 'y: 2\n' });
+    const b = writeTree(store, { 'c.yaml': 'y: 2\n', 'a/b.yaml': 'x: 1\n' });
+    expect(a).toBe(b);
+  });
+
+  it('tree 能原样读回来，包括子目录', () => {
+    const store = new ObjectStore();
+    const files = { 'apps/portal.yaml': 'kind: Deployment\n', 'README.md': '# platform\n' };
+    expect(readTree(store, writeTree(store, files))).toEqual(files);
+  });
+
+  it('改一个字节，tree 的 hash 就变了', () => {
+    const store = new ObjectStore();
+    const before = writeTree(store, { 'a.yaml': 'replicas: 2\n' });
+    const after = writeTree(store, { 'a.yaml': 'replicas: 3\n' });
+    expect(before).not.toBe(after);
+  });
+});
+
+describe('仓库', () => {
+  function repository() {
+    const vfs = createVfs(() => NOW);
+    vfs.mkdirp('/root/app');
+    const repo = new Repository(vfs, '/root/app', () => NOW);
+    repo.init();
+    return { vfs, repo };
+  }
+
+  it('提交之后 HEAD 指到新的 commit，内容读得回来', () => {
+    const { vfs, repo } = repository();
+    vfs.writeFile('/root/app/main.yaml', 'replicas: 2\n');
+    repo.add(['.']);
+    const hash = repo.createCommit('first', { name: 'ops', email: 'ops@corp.internal' });
+    expect(repo.headCommit()).toBe(hash);
+    expect(repo.committed()).toEqual({ 'main.yaml': 'replicas: 2\n' });
+  });
+
+  it('第二次提交挂在第一次下面', () => {
+    const { vfs, repo } = repository();
+    vfs.writeFile('/root/app/main.yaml', 'replicas: 2\n');
+    repo.add(['.']);
+    const first = repo.createCommit('first', { name: 'ops', email: 'o@x' });
+    vfs.writeFile('/root/app/main.yaml', 'replicas: 3\n');
+    repo.add(['.']);
+    const second = repo.createCommit('second', { name: 'ops', email: 'o@x' });
+    expect(repo.commit(second)!.parents).toEqual([first]);
+    expect(repo.history().map((entry) => entry.commit.message)).toEqual(['second', 'first']);
+  });
+
+  it('status 把暂存、未暂存、未跟踪分得清', () => {
+    const { vfs, repo } = repository();
+    vfs.writeFile('/root/app/a.yaml', 'a\n');
+    repo.add(['.']);
+    repo.createCommit('first', { name: 'ops', email: 'o@x' });
+
+    vfs.writeFile('/root/app/a.yaml', 'a changed\n');
+    vfs.writeFile('/root/app/b.yaml', 'b\n');
+    vfs.writeFile('/root/app/c.yaml', 'c\n');
+    repo.add(['b.yaml']);
+
+    const state = statusOf(repo);
+    expect(state.staged).toEqual([{ path: 'b.yaml', state: 'added' }]);
+    expect(state.unstaged).toEqual([{ path: 'a.yaml', state: 'modified' }]);
+    expect(state.untracked).toEqual(['c.yaml']);
+  });
+
+  it('仓库状态全在 .git 下面 —— 快照回放才对得上', () => {
+    const { vfs, repo } = repository();
+    vfs.writeFile('/root/app/a.yaml', 'a\n');
+    repo.add(['.']);
+    const hash = repo.createCommit('first', { name: 'ops', email: 'o@x' });
+
+    // 换一个 Repository 实例（内存里的缓存全丢），照样读得出来
+    const reopened = Repository.find(vfs, '/root/app/deep/er', () => NOW)!;
+    expect(reopened.root).toBe('/root/app');
+    expect(reopened.headCommit()).toBe(hash);
+    expect(reopened.committed()).toEqual({ 'a.yaml': 'a\n' });
+  });
+
+  it('切分支会把工作树换过去', () => {
+    const { vfs, repo } = repository();
+    vfs.writeFile('/root/app/a.yaml', 'main\n');
+    repo.add(['.']);
+    repo.createCommit('on main', { name: 'ops', email: 'o@x' });
+
+    repo.checkout('feature', true);
+    vfs.writeFile('/root/app/a.yaml', 'feature\n');
+    vfs.writeFile('/root/app/only-here.yaml', 'x\n');
+    repo.add(['.']);
+    repo.createCommit('on feature', { name: 'ops', email: 'o@x' });
+
+    repo.checkout('main');
+    expect(vfs.readFile('/root/app/a.yaml')).toBe('main\n');
+    // 分支上新加的文件切回来之后不该还在
+    expect(vfs.exists('/root/app/only-here.yaml')).toBe(false);
+  });
+});
+
+describe('远端', () => {
+  it('URL 归一化：结尾的斜杠与 .git 不算数', () => {
+    const network = new GitNetwork();
+    network.create('https://git.corp.internal/platform/apps');
+    expect(network.has('https://git.corp.internal/platform/apps.git')).toBe(true);
+    expect(network.has('https://git.corp.internal/platform/apps/')).toBe(true);
+    expect(network.has('https://git.corp.internal/platform/other')).toBe(false);
+  });
+
+  it('seedRepository 铺出来的内容 clone 得到', () => {
+    const network = new GitNetwork();
+    const bare = network.create('https://git.corp.internal/platform/apps');
+    const head = seedRepository(bare, { 'apps/portal.yaml': 'kind: Deployment\n' }, { timestamp: NOW });
+    expect(bare.refs.main).toBe(head);
+    expect(readTree(bare.objects, parseCommit(bare.objects.get(head)!.body).tree))
+      .toEqual({ 'apps/portal.yaml': 'kind: Deployment\n' });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* CLI                                                                 */
+/* ------------------------------------------------------------------ */
+
+const WORLD: OpsWorldSpec = {
+  namespaces: ['default'],
+  gitRepositories: [
+    {
+      url: 'https://git.corp.internal/platform/apps',
+      files: { 'apps/portal.yaml': 'kind: Deployment\nreplicas: 2\n', 'README.md': '# platform\n' },
+      message: 'bootstrap platform repo',
+    },
+    { url: 'https://git.corp.internal/platform/frozen', files: { 'a.txt': 'a\n' }, readOnly: true },
+  ],
+};
+
+describe('git 命令', () => {
+  async function world() {
+    return createOpsWorld({ world: WORLD });
+  }
+
+  it('clone 下来的是工作树，不是一堆对象', async () => {
+    const w = await world();
+    const cloned = await w.run('git clone https://git.corp.internal/platform/apps');
+    expect(cloned.code).toBe(0);
+    expect(cloned.stderr).toContain("Cloning into 'apps'...");
+    expect(w.machine.vfs.readFile('/root/apps/apps/portal.yaml')).toBe('kind: Deployment\nreplicas: 2\n');
+
+    const status = await w.run('cd /root/apps && git status --porcelain');
+    expect(status.stdout).toBe('');
+  });
+
+  it('域名解析不到时报的是 Could not resolve host', async () => {
+    const w = await world();
+    const result = await w.run('git clone https://git.example.com/nope/nope');
+    expect(result.code).toBe(128);
+    expect(result.stderr).toContain('Could not resolve host: git.example.com');
+  });
+
+  it('主机在但仓库不在，报的是 repository not found —— 两件事要分得开', async () => {
+    const w = await world();
+    const result = await w.run('git clone https://git.corp.internal/platform/nope');
+    expect(result.code).toBe(128);
+    expect(result.stderr).toContain("repository 'https://git.corp.internal/platform/nope' not found");
+  });
+
+  it('改一行、提交、推上去，远端的 ref 跟着动', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    await w.run("cd /root/apps && sed -i 's/replicas: 2/replicas: 3/' apps/portal.yaml");
+
+    const diff = await w.run('cd /root/apps && git diff');
+    expect(diff.stdout).toContain('-replicas: 2');
+    expect(diff.stdout).toContain('+replicas: 3');
+
+    await w.run('cd /root/apps && git add apps/portal.yaml');
+    const committed = await w.run("cd /root/apps && git commit -m 'scale portal to 3'");
+    expect(committed.stdout).toMatch(/^\[main [0-9a-f]{7}\] scale portal to 3\n/);
+
+    const pushed = await w.run('cd /root/apps && git push origin main');
+    expect(pushed.code).toBe(0);
+
+    const bare = w.git.get('https://git.corp.internal/platform/apps')!;
+    const head = bare.refs.main;
+    const tree = parseCommit(bare.objects.get(head)!.body).tree;
+    expect(readTree(bare.objects, tree)['apps/portal.yaml']).toBe('kind: Deployment\nreplicas: 3\n');
+  });
+
+  it('没东西可提交时退出码非 0，而且说清楚了', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    const result = await w.run("cd /root/apps && git commit -m 'nothing'");
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('nothing to commit, working tree clean');
+  });
+
+  it('只读仓库 push 被 403 拒掉', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/frozen');
+    await w.run("cd /root/frozen && echo b > b.txt && git add . && git commit -m 'add b'");
+    const result = await w.run('cd /root/frozen && git push origin main');
+    expect(result.code).toBe(128);
+    expect(result.stderr).toContain('403');
+  });
+
+  it('别人推了之后 pull 得下来', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    // 平台组在另一台机器上推了一版
+    const bare = w.git.get('https://git.corp.internal/platform/apps')!;
+    seedRepository(bare, { 'apps/portal.yaml': 'kind: Deployment\nreplicas: 5\n' }, {
+      message: 'platform bumped it', timestamp: w.now(),
+    });
+
+    const pulled = await w.run('cd /root/apps && git pull origin main');
+    expect(pulled.stdout).toContain('Fast-forward');
+    expect(w.machine.vfs.readFile('/root/apps/apps/portal.yaml')).toContain('replicas: 5');
+  });
+
+  it('git log --oneline 与 rev-parse HEAD 对得上', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    const head = await w.run('cd /root/apps && git rev-parse HEAD');
+    const log = await w.run('cd /root/apps && git log --oneline');
+    expect(log.stdout.trim()).toBe(`${head.stdout.trim().slice(0, 7)} bootstrap platform repo`);
+  });
+
+  it('git hash-object 和对象库算的是同一个值', async () => {
+    const w = await world();
+    await w.run('git clone https://git.corp.internal/platform/apps');
+    const result = await w.run('cd /root/apps && git hash-object README.md');
+    expect(result.stdout.trim()).toBe(hashObject('blob', '# platform\n'));
+  });
+
+  it('不在仓库里的时候报 not a git repository', async () => {
+    const w = await world();
+    const result = await w.run('git status');
+    expect(result.code).toBe(128);
+    expect(result.stderr).toContain('not a git repository');
+  });
+});

--- a/tests/opslab/machine.test.ts
+++ b/tests/opslab/machine.test.ts
@@ -519,3 +519,28 @@ describe('浏览器里的语法加载', () => {
     }
   });
 });
+
+/**
+ * `a && b > f` 只重定向 b
+ *
+ * 整段包起来的话，重定向的目标路径会在 a 跑之前就解析掉：
+ * `cd sub && echo x > f` 把文件写到 cd 之前的目录里，命令全部成功，
+ * 文件出现在错误的地方，一句报错都没有。
+ */
+describe('重定向挂在哪一段上', () => {
+  it('cd 之后的重定向落在新目录里', async () => {
+    const machine = createMachine({ files: {}, now: () => 0 });
+    await machine.exec('mkdir -p /root/sub');
+    const result = await machine.exec('cd /root/sub && echo hello > out.txt');
+    expect(result.code).toBe(0);
+    expect(machine.vfs.exists('/root/sub/out.txt')).toBe(true);
+    expect(machine.vfs.exists('/root/out.txt')).toBe(false);
+  });
+
+  it('前一段失败时后一段不跑，文件也不该被建出来', async () => {
+    const machine = createMachine({ files: {}, now: () => 0 });
+    const result = await machine.exec('false && echo hello > /root/never.txt');
+    expect(result.code).toBe(1);
+    expect(machine.vfs.exists('/root/never.txt')).toBe(false);
+  });
+});


### PR DESCRIPTION
GitOps 那几关（11、12、13、20）的地基。仓库里那份 YAML 才是「期望状态」，集群里的对象只是它的一个投影 —— 所以 git 不能是个假的。

## 对象是真的

blob / tree / commit 按 `<type> <len>\0<content>` 取 SHA-1。`git hash-object` 在这里算出来的值和真 git 逐位一致：

```
hashObject('blob', 'hello\n') === 'ce013625030ba8dba906f756967f9e9ca394464a'
hashObject('blob', '')        === 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
```

这两个值是 `git hash-object` 出来的，不是我们算的。「同样的内容永远是同一个 hash」正是 GitOps 敢拿 commit sha 当部署凭据的原因，学员应该能自己验证这件事。

tree 的编码用文本而不是二进制。代价是 tree 对象的 hash 和真 git 不一致，换来的是 `git cat-file -p` 打出来人能读 —— 教学上更划算。

## 状态全在 `.git/` 下面

对象落在 `.git/objects/xx/yyy`，引用在 `.git/refs/heads/`，索引在 `.git/index`。不是为了好看：世界要能快照回放，而快照的是文件系统。藏在内存里回放就对不上了。顺带的好处是 `find .git/objects` 真的能翻。

（这一点上踩了个坑：`copyTo` 原来直接动内部的 Map，绕过了子类落盘的 `put`。每条 `git` 命令都新建一个 Repository 实例，于是 clone 下来的对象只活在那一条命令里，下一条 `git status` 看到的是一个空仓库。）

## 远端

push / pull / clone 就是在两个对象库之间搬对象再动一下引用。三种失败分得清清楚楚，因为查 GitOps 故障时它们指向完全不同的方向：

| 情形 | 报错 |
| --- | --- |
| 域名解析不到 | `Could not resolve host: git.example.com` |
| 主机在、仓库不在 | `repository '...' not found` |
| 只读仓库 | `remote: You are not allowed to push code to this project.` + 403 |

## 覆盖的命令

init / clone / add / commit / status / log / diff / branch / checkout / remote / push / pull / rev-parse / cat-file / hash-object / show / ls-files。

不做 packfile、delta、submodule、merge —— 那些是存储与协作的优化，不影响「内容寻址」这个要教的东西。

21 个新用例，全量 1342 个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)