### PR TITLE
feat(opslab): 第 11 关 —— GitOps，让仓库说了算

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -25,6 +25,7 @@ const LEDGER_IMAGE = 'harbor.corp.internal/team/ledger:3.2.1';
 // 集群现在的 CNI。它不实现 NetworkPolicy —— 第 10 关整关都建立在这一点上。
 const FLANNEL_IMAGE = 'docker.io/flannel/flannel:v0.28.0';
 const CILIUM_IMAGE = 'quay.io/cilium/cilium:v1.19.2';
+const ARGOCD_IMAGE = 'quay.io/argoproj/argocd:v3.2.4';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -81,6 +82,45 @@ const HANDOVER = code`
   第一件事：确认三台节点都是 Ready，把结果记到 handover/nodes.txt 里。
 `;
 
+/** 平台仓库里门户的那份 manifest。集群里跑的应该和它一致。 */
+const PORTAL_GITOPS_MANIFEST = code`
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        app: portal
+    template:
+      metadata:
+        labels:
+          app: portal
+      spec:
+        containers:
+        - name: web
+          image: ${PORTAL_IMAGE}
+          ports:
+          - containerPort: 8080
+`;
+
+const PORTAL_GITOPS_SERVICE = code`
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    clusterIP: 10.96.1.10
+    selector:
+      app: portal
+    ports:
+    - port: 80
+      targetPort: 8080
+`;
+
 const WORLD = {
   seed: 1,
   startTime: '2026-03-02T09:00:00Z',
@@ -91,7 +131,7 @@ const WORLD = {
   ],
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
-    'envoy-gateway-system', 'ingress-nginx', 'cert-manager',
+    'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -123,6 +163,7 @@ const WORLD = {
       listens: [9962],
       enforcesNetworkPolicy: true,
     },
+    [ARGOCD_IMAGE]: { pullMs: 500, startupMs: 700, readyAfterMs: 300, listens: [8080] },
     // 财务的报表任务：吃 900Mi，limits 写小了就会被 OOMKill
     [REPORTS_IMAGE]: {
       pullMs: 500, startupMs: 800, readyAfterMs: 200,
@@ -161,6 +202,25 @@ const WORLD = {
       users: { ci: 'Harbor@2026' },
       projects: ['team', 'library'],
       anonymousPull: false,
+    },
+  ],
+  // 内网的 Git 服务。平台仓库是「本来就在」的东西，第 11 关往后都从它来。
+  gitRepositories: [
+    {
+      url: 'https://git.corp.internal/platform/apps',
+      branch: 'main',
+      message: 'bootstrap platform repo',
+      files: {
+        'README.md': [
+          '# platform/apps',
+          '',
+          '集群里跑什么，以这个仓库为准。',
+          '手工 kubectl apply 出来的东西迟早会被同步回来。',
+          '',
+        ].join('\n'),
+        'apps/portal/deployment.yaml': PORTAL_GITOPS_MANIFEST,
+        'apps/portal/service.yaml': PORTAL_GITOPS_SERVICE,
+      },
     },
   ],
   // 只有生产那套解析得到；legacy 与 staging 会像真的 DNS 失败一样连不上
@@ -538,6 +598,49 @@ const PREDECESSOR_POLICY = {
     egress: [],
   },
 };
+
+/** 第 10 关之后集群里跑的是 Cilium */
+const CNI_CILIUM = {
+  apiVersion: 'apps/v1', kind: 'DaemonSet',
+  metadata: {
+    name: 'cilium', namespace: 'kube-system',
+    labels: { 'app.kubernetes.io/name': 'cilium' },
+  },
+  spec: {
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'cilium' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'cilium' } },
+      spec: { containers: [{ name: 'cilium-agent', image: CILIUM_IMAGE, ports: [{ containerPort: 9962 }] }] },
+    },
+  },
+};
+
+/** Argo CD：application controller 同样是集群里的一个工作负载 */
+const ARGOCD_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'argocd-application-controller', namespace: 'argocd',
+      labels: { 'app.kubernetes.io/name': 'argocd-application-controller' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'argocd-application-controller' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'argocd-application-controller' } },
+        spec: { containers: [{ name: 'controller', image: ARGOCD_IMAGE, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'argoproj.io/v1alpha1', kind: 'AppProject',
+    metadata: { name: 'default', namespace: 'argocd' },
+    spec: {
+      sourceRepos: ['*'],
+      destinations: [{ namespace: '*', server: 'https://kubernetes.default.svc' }],
+    },
+  },
+];
 
 /* ------------------------------------------------------------------ */
 /* 第 2 关                                                             */
@@ -2785,6 +2888,265 @@ const stage10 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 11 关                                                            */
+/* ------------------------------------------------------------------ */
+
+/** 前任手工改的那份：副本数被临时调到 5，从来没回写仓库 */
+const DRIFTED_PORTAL = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name: 'portal', namespace: 'payments' },
+  spec: {
+    replicas: 5,
+    selector: { matchLabels: { app: 'portal' } },
+    template: {
+      metadata: { labels: { app: 'portal' } },
+      spec: { containers: [{ name: 'web', image: PORTAL_IMAGE, ports: [{ containerPort: 8080 }] }] },
+    },
+  },
+};
+
+const APPLICATION_STARTER = code`
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    name: portal
+    namespace: argocd
+  spec:
+    project: default
+    source:
+      repoURL: https://git.corp.internal/platform/apps
+      path: apps/portal
+      targetRevision: main
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: payments
+`;
+
+const APPLICATION_REFERENCE = code`
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    name: portal
+    namespace: argocd
+  spec:
+    project: default
+    source:
+      repoURL: https://git.corp.internal/platform/apps
+      path: apps/portal
+      targetRevision: main
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: payments
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+`;
+
+const stage11 = {
+  id: 'gitops-with-argocd',
+  title: t('GitOps：让仓库说了算', 'GitOps: Let the Repository Decide'),
+  goal: t(
+    code`
+      平台组要求所有服务改走 GitOps：集群里跑什么，以仓库
+      \`https://git.corp.internal/platform/apps\` 为准。Argo CD 已经装好了。
+
+      现在的状况是：仓库里门户写的是 2 个副本，集群里跑着 5 个 ——
+      某次大促前任手工 \`kubectl scale\` 上去的，没回写仓库。谁也说不清
+      还有多少这种改动。
+
+      \`/root/infra/application.yaml\` 里是一份 Application 的草稿。
+
+      ## 通关标准
+
+      1. 门户由 Argo CD 管起来，\`kubectl get app -n argocd\` 里 \`Synced\` + \`Healthy\`；
+      2. 集群里的副本数回到仓库写的那个；
+      3. 之后再有人手工改，会被自己改回来（不需要人介入）；
+      4. 想把副本数改成 3，得**通过仓库**改 —— 直接 kubectl 不算；
+      5. 仓库里删掉的东西，集群里也要跟着消失。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      git clone https://git.corp.internal/platform/apps
+      kubectl apply -f /root/infra/application.yaml
+      kubectl get app -n argocd
+      kubectl describe app portal -n argocd
+      kubectl patch app portal -n argocd --type merge -p '{"operation":{"sync":{}}}'
+      \`\`\`
+    `,
+    code`
+      The platform team wants every service on GitOps: what runs in the cluster is
+      whatever \`https://git.corp.internal/platform/apps\` says. Argo CD is already
+      installed.
+
+      Right now the repository says two replicas for the portal and the cluster runs
+      five, hand-scaled before a sale and never written back. Nobody knows how many
+      other changes like that are out there.
+
+      \`/root/infra/application.yaml\` holds a draft Application.
+
+      ## Done when
+
+      1. the portal is managed by Argo CD and \`kubectl get app -n argocd\` shows
+         \`Synced\` and \`Healthy\`;
+      2. the live replica count matches what the repository says;
+      3. later hand edits get reverted automatically, with nobody in the loop;
+      4. changing the count to three happens **through the repository**, not with
+         kubectl;
+      5. what is deleted from the repository disappears from the cluster.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      git clone https://git.corp.internal/platform/apps
+      kubectl apply -f /root/infra/application.yaml
+      kubectl get app -n argocd
+      kubectl describe app portal -n argocd
+      kubectl patch app portal -n argocd --type merge -p '{"operation":{"sync":{}}}'
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('Application 建起来，Synced + Healthy', 'Application created, Synced and Healthy'),
+    t('漂移被纠正，而且以后会自己纠正', 'Drift corrected, and stays corrected on its own'),
+    t('改配置走仓库这条路', 'Configuration changes go through the repository'),
+  ],
+  hints: [
+    t(
+      '光建一个 Application 只会让它去**比对**，不会动手。\`kubectl get app\` 会显示 OutOfSync —— 那说明它看见了差异，在等你发话。',
+      'Creating an Application only makes Argo CD **compare**; it will not act. `kubectl get app` shows OutOfSync, meaning it sees the difference and is waiting for you.'
+    ),
+    t(
+      '自动同步分两层：\`syncPolicy.automated\` 让它在仓库变化时自己 apply；再加 \`selfHeal: true\` 才会把集群里的手改拉回来；\`prune: true\` 才会删掉仓库里已经没有的对象。三个开关管三件事。',
+      'Automated sync has layers: `syncPolicy.automated` applies repository changes; `selfHeal: true` also pulls hand edits back; `prune: true` deletes objects that no longer exist in the repository. Three switches, three behaviours.'
+    ),
+    t(
+      'Argo CD 看的是**远端仓库**。在跳板机上改完不 push，它什么都看不到。',
+      'Argo CD reads the **remote** repository. Edits on the jump host that are not pushed are invisible to it.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '把副本数用 \`kubectl scale\` 改成 3 就交差。开了 selfHeal 之后这个改动活不过一轮同步；没开的话它会一直挂着 OutOfSync，下一个人看到的仍然是「仓库和现实不一致」。GitOps 的意思就是这条路被堵死了。',
+      'Scaling to three with `kubectl scale` and calling it done. With selfHeal on, the change does not survive one sync; with it off, the app sits OutOfSync and the next person still sees "repository and reality disagree". GitOps means that path is closed.'
+    ),
+    t(
+      '在本地 commit 了但没 push。Argo CD 连的是远端 —— 本地仓库里的提交对它不存在。这个错很难自查，因为 \`git log\` 看起来一切正常。',
+      'Committing locally without pushing. Argo CD talks to the remote, so a local commit does not exist as far as it is concerned. It is hard to spot because `git log` looks perfectly fine.'
+    ),
+    t(
+      '看到 OutOfSync 就当成故障。它只说明现状和仓库不一致，服务可能好好的 —— 健康与否是 \`status.health\` 那一栏。两栏分别代表两件事，混在一起看会把「配置漂移」当成「服务挂了」。',
+      'Treating OutOfSync as an outage. It only means live state differs from the repository; the service may be perfectly fine. Health is a separate column, and conflating the two turns "configuration drift" into "the service is down".'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM, ...ARGOCD_PLATFORM,
+      DRIFTED_PORTAL,
+      {
+        apiVersion: 'v1', kind: 'Service',
+        metadata: { name: 'portal', namespace: 'payments' },
+        spec: { clusterIP: '10.96.1.10', selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+      },
+      PORTAL_ROUTE,
+    ],
+    files: {
+      '/root/infra/application.yaml': APPLICATION_STARTER,
+    },
+    referenceFiles: { '/root/infra/application.yaml': APPLICATION_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/application.yaml',
+    ],
+  },
+  specs: [
+    spec('gitops-with-argocd.spec.ts', code`
+      import { get, list, sh } from '@ops/lab';
+
+      const REPO = 'https://git.corp.internal/platform/apps';
+
+      describe('GitOps', () => {
+        it('门户归 Argo CD 管，Synced + Healthy', () => {
+          const application = get('Application', 'portal', 'argocd');
+          expect(application).toBeTruthy();
+          expect(application.status.sync.status).toBe('Synced');
+          expect(application.status.health.status).toBe('Healthy');
+        });
+
+        it('集群里的副本数和仓库一致', async () => {
+          const cloned = await sh('rm -rf /tmp/check && git clone ' + REPO + ' /tmp/check');
+          expect(cloned.code).toBe(0);
+          const manifest = await sh('grep -E "^  replicas:" /tmp/check/apps/portal/deployment.yaml');
+          const wanted = Number(manifest.stdout.split(':')[1].trim());
+
+          const deployment = get('Deployment', 'portal', 'payments');
+          expect(deployment.spec.replicas).toBe(wanted);
+        });
+
+        it('手改会被改回去 —— 不需要人介入', async () => {
+          await sh('kubectl scale deploy/portal -n payments --replicas=11');
+          const deployment = get('Deployment', 'portal', 'payments');
+          expect(deployment.spec.replicas).not.toBe(11);
+        });
+
+        it('仓库里删掉的对象，集群里也会消失', async () => {
+          await sh('rm -rf /tmp/prune && git clone ' + REPO + ' /tmp/prune');
+          await sh('cd /tmp/prune && rm apps/portal/service.yaml && git add -A'
+            + ' && git commit -m "drop the service" && git push origin main');
+
+          const services = list('Service', { namespace: 'payments' })
+            .map((item) => item.metadata.name);
+          expect(services).not.toContain('portal');
+        });
+
+        it('Argo CD 认的是远端仓库，不是跳板机上那个克隆', () => {
+          const application = get('Application', 'portal', 'argocd');
+          expect(application.spec.source.repoURL).toBe(REPO);
+          // revision 是一个真的 commit sha，不是分支名
+          expect(application.status.sync.revision).toMatch(/^[0-9a-f]{40}$/);
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'maintainability'],
+  extension: t(
+    code`
+      GitOps 真正改变的不是部署方式，是**「现在到底跑着什么」这个问题的答案从哪里来**。
+      在此之前答案只能从集群里问，而集群会被任何一个有权限的人改动，改动不留痕；
+      之后答案在仓库里，有历史、有审核、能回滚。
+
+      代价是那条手工通道被堵死了。开了 selfHeal 之后，\`kubectl edit\` 改的东西
+      活不过一轮同步 —— 这对救火的人是个不小的调整。真集群里的做法是给
+      Application 加 \`ignoreDifferences\`（哪些字段不比对，比如 HPA 管的副本数），
+      而不是把 selfHeal 关掉。
+
+      还有一个容易忽略的点：Argo CD 自己也应该由 Argo CD 管（app-of-apps）。
+      不然升级 Argo CD 这件事本身就还是手工的，而它恰恰是最不该漂移的组件。
+    `,
+    code`
+      What GitOps really changes is not how you deploy but **where the answer to
+      "what is running right now" comes from**. Before, you could only ask the
+      cluster, and the cluster can be changed by anyone with access, leaving no trace.
+      After, the answer lives in a repository with history, review, and rollback.
+
+      The price is that the manual path is closed. With selfHeal on, anything
+      \`kubectl edit\` changes does not survive a sync, which is a real adjustment for
+      whoever is firefighting. The production answer is to add
+      \`ignoreDifferences\` to the Application for fields owned by something else
+      (replica counts managed by an HPA, for instance) rather than turning selfHeal
+      off.
+
+      One more thing that is easy to miss: Argo CD should manage Argo CD (app of
+      apps). Otherwise upgrading it stays a manual operation, and it is exactly the
+      component that should never drift.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -2827,5 +3189,8 @@ module.exports = {
   ),
   workspace: { kind: 'ops', world: WORLD },
   files: [],
-  stages: [stage1, stage2, stage3, stage4, stage5, stage6, stage7, stage8, stage9, stage10],
+  stages: [
+    stage1, stage2, stage3, stage4, stage5, stage6,
+    stage7, stage8, stage9, stage10, stage11,
+  ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5616,7 +5616,8 @@
           "analytics",
           "envoy-gateway-system",
           "ingress-nginx",
-          "cert-manager"
+          "cert-manager",
+          "argocd"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5678,6 +5679,14 @@
               9962
             ],
             "enforcesNetworkPolicy": true
+          },
+          "quay.io/argoproj/argocd:v3.2.4": {
+            "pullMs": 500,
+            "startupMs": 700,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
+            ]
           },
           "harbor.corp.internal/team/reports:2.1.0": {
             "pullMs": 500,
@@ -5755,6 +5764,18 @@
               "library"
             ],
             "anonymousPull": false
+          }
+        ],
+        "gitRepositories": [
+          {
+            "url": "https://git.corp.internal/platform/apps",
+            "branch": "main",
+            "message": "bootstrap platform repo",
+            "files": {
+              "README.md": "# platform/apps\n\n集群里跑什么，以这个仓库为准。\n手工 kubectl apply 出来的东西迟早会被同步回来。\n",
+              "apps/portal/deployment.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  replicas: 2\n  selector:\n    matchLabels:\n      app: portal\n  template:\n    metadata:\n      labels:\n        app: portal\n    spec:\n      containers:\n      - name: web\n        image: harbor.corp.internal/team/portal:1.4.0\n        ports:\n        - containerPort: 8080\n",
+              "apps/portal/service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  clusterIP: 10.96.1.10\n  selector:\n    app: portal\n  ports:\n  - port: 80\n    targetPort: 8080\n"
+            }
           }
         ],
         "endpoints": [
@@ -7496,6 +7517,481 @@
         "primer": {
           "zh": "集群里的 Pod 默认可以互相访问，不分命名空间。`NetworkPolicy` 是收紧这件事的对象：它按标签选中一批 Pod，然后声明这批 Pod 的入向（`ingress`）和出向（`egress`）允许什么。没有任何策略选中某个 Pod 时，这个 Pod 完全开放；一旦被选中，对应方向就变成默认拒绝，只有明确写出来的才放行。\n\n有两件事经常被搞混。第一，`policyTypes` 决定这条策略管哪个方向：写了 `Egress` 却不写任何 egress 规则，等于「这批 Pod 什么都出不去」，包括查 DNS。第二，`from` 和 `to` 里的每一个元素是「或」的关系，但同一个元素内部的 `podSelector` 和 `namespaceSelector` 是「与」。写成两个元素就是「这个命名空间的所有 Pod，或者任何命名空间里叫这个名字的 Pod」，比想要的宽得多。另外，只写 `podSelector` 不写 `namespaceSelector` 时，它只在策略自己所在的命名空间里找。\n\n最关键、也最容易踩的一点：`NetworkPolicy` 只是一个被 apiserver 收下的对象，真正拦不拦包取决于 CNI。flannel 这类只做网络连通的插件根本不看这些对象，策略写得再对也是一张废纸；Cilium、Calico 这类才会把它翻译成数据面规则。所以「加了策略但行为没变」时，第一个要确认的不是策略写得对不对，而是集群里到底有没有人在执行它。\n\n被策略拒绝的连接表现为`超时`，不是`拒绝`。丢包意味着对端不会回 RST，客户端只能等到自己的超时时间。这个区别很有用：`Connection refused` 说明包已经到了对端而那里没有进程在听，和策略无关；`timeout` 才值得去看策略、路由和防火墙。",
           "en": "Pods can reach each other freely by default, across namespaces. `NetworkPolicy` is how you tighten that: it selects pods by label and declares what their inbound (`ingress`) and outbound (`egress`) traffic may be. A pod that no policy selects stays fully open; once selected, that direction becomes deny-by-default and only what you spell out gets through.\n\nTwo details cause most of the confusion. First, `policyTypes` decides which directions the policy governs: listing `Egress` without writing any egress rule means \"these pods may not reach anything\", DNS lookups included. Second, entries in `from` and `to` are ORed together, but `podSelector` and `namespaceSelector` inside a single entry are ANDed. Writing them as two entries means \"every pod in that namespace, or any pod with that label in any namespace\", which is far wider than intended. And a bare `podSelector` with no `namespaceSelector` only matches within the policy own namespace.\n\nThe most important point, and the easiest to miss: a `NetworkPolicy` is only an object the apiserver accepts. Whether packets get dropped depends on the CNI. Plugins like flannel provide connectivity and never read these objects, so a perfectly correct policy does nothing at all; Cilium and Calico translate them into real data plane rules. When a policy changes no behaviour, the first thing to check is not the policy but whether anything is enforcing it.\n\nA connection denied by policy shows up as a `timeout`, not a `refusal`. Dropping a packet means no RST comes back, so the client waits out its own deadline. That distinction is useful: `Connection refused` means the packet arrived and no process was listening, which has nothing to do with policy, while a `timeout` is what sends you looking at policies, routing, and firewalls."
+        }
+      },
+      {
+        "id": "gitops-with-argocd",
+        "title": {
+          "zh": "GitOps：让仓库说了算",
+          "en": "GitOps: Let the Repository Decide"
+        },
+        "goal": {
+          "zh": "平台组要求所有服务改走 GitOps：集群里跑什么，以仓库\n`https://git.corp.internal/platform/apps` 为准。Argo CD 已经装好了。\n\n现在的状况是：仓库里门户写的是 2 个副本，集群里跑着 5 个 ——\n某次大促前任手工 `kubectl scale` 上去的，没回写仓库。谁也说不清\n还有多少这种改动。\n\n`/root/infra/application.yaml` 里是一份 Application 的草稿。\n\n## 通关标准\n\n1. 门户由 Argo CD 管起来，`kubectl get app -n argocd` 里 `Synced` + `Healthy`；\n2. 集群里的副本数回到仓库写的那个；\n3. 之后再有人手工改，会被自己改回来（不需要人介入）；\n4. 想把副本数改成 3，得**通过仓库**改 —— 直接 kubectl 不算；\n5. 仓库里删掉的东西，集群里也要跟着消失。\n\n## 会用到的命令\n\n```bash\ngit clone https://git.corp.internal/platform/apps\nkubectl apply -f /root/infra/application.yaml\nkubectl get app -n argocd\nkubectl describe app portal -n argocd\nkubectl patch app portal -n argocd --type merge -p '{\"operation\":{\"sync\":{}}}'\n```\n",
+          "en": "The platform team wants every service on GitOps: what runs in the cluster is\nwhatever `https://git.corp.internal/platform/apps` says. Argo CD is already\ninstalled.\n\nRight now the repository says two replicas for the portal and the cluster runs\nfive, hand-scaled before a sale and never written back. Nobody knows how many\nother changes like that are out there.\n\n`/root/infra/application.yaml` holds a draft Application.\n\n## Done when\n\n1. the portal is managed by Argo CD and `kubectl get app -n argocd` shows\n   `Synced` and `Healthy`;\n2. the live replica count matches what the repository says;\n3. later hand edits get reverted automatically, with nobody in the loop;\n4. changing the count to three happens **through the repository**, not with\n   kubectl;\n5. what is deleted from the repository disappears from the cluster.\n\n## Commands you will need\n\n```bash\ngit clone https://git.corp.internal/platform/apps\nkubectl apply -f /root/infra/application.yaml\nkubectl get app -n argocd\nkubectl describe app portal -n argocd\nkubectl patch app portal -n argocd --type merge -p '{\"operation\":{\"sync\":{}}}'\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "Application 建起来，Synced + Healthy",
+            "en": "Application created, Synced and Healthy"
+          },
+          {
+            "zh": "漂移被纠正，而且以后会自己纠正",
+            "en": "Drift corrected, and stays corrected on its own"
+          },
+          {
+            "zh": "改配置走仓库这条路",
+            "en": "Configuration changes go through the repository"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "光建一个 Application 只会让它去**比对**，不会动手。`kubectl get app` 会显示 OutOfSync —— 那说明它看见了差异，在等你发话。",
+            "en": "Creating an Application only makes Argo CD **compare**; it will not act. `kubectl get app` shows OutOfSync, meaning it sees the difference and is waiting for you."
+          },
+          {
+            "zh": "自动同步分两层：`syncPolicy.automated` 让它在仓库变化时自己 apply；再加 `selfHeal: true` 才会把集群里的手改拉回来；`prune: true` 才会删掉仓库里已经没有的对象。三个开关管三件事。",
+            "en": "Automated sync has layers: `syncPolicy.automated` applies repository changes; `selfHeal: true` also pulls hand edits back; `prune: true` deletes objects that no longer exist in the repository. Three switches, three behaviours."
+          },
+          {
+            "zh": "Argo CD 看的是**远端仓库**。在跳板机上改完不 push，它什么都看不到。",
+            "en": "Argo CD reads the **remote** repository. Edits on the jump host that are not pushed are invisible to it."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "把副本数用 `kubectl scale` 改成 3 就交差。开了 selfHeal 之后这个改动活不过一轮同步；没开的话它会一直挂着 OutOfSync，下一个人看到的仍然是「仓库和现实不一致」。GitOps 的意思就是这条路被堵死了。",
+            "en": "Scaling to three with `kubectl scale` and calling it done. With selfHeal on, the change does not survive one sync; with it off, the app sits OutOfSync and the next person still sees \"repository and reality disagree\". GitOps means that path is closed."
+          },
+          {
+            "zh": "在本地 commit 了但没 push。Argo CD 连的是远端 —— 本地仓库里的提交对它不存在。这个错很难自查，因为 `git log` 看起来一切正常。",
+            "en": "Committing locally without pushing. Argo CD talks to the remote, so a local commit does not exist as far as it is concerned. It is hard to spot because `git log` looks perfectly fine."
+          },
+          {
+            "zh": "看到 OutOfSync 就当成故障。它只说明现状和仓库不一致，服务可能好好的 —— 健康与否是 `status.health` 那一栏。两栏分别代表两件事，混在一起看会把「配置漂移」当成「服务挂了」。",
+            "en": "Treating OutOfSync as an outage. It only means live state differs from the repository; the service may be perfectly fine. Health is a separate column, and conflating the two turns \"configuration drift\" into \"the service is down\"."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argocd-application-controller",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argocd-application-controller"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argocd-application-controller"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argocd-application-controller"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argocd:v3.2.4",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "AppProject",
+              "metadata": {
+                "name": "default",
+                "namespace": "argocd"
+              },
+              "spec": {
+                "sourceRepos": [
+                  "*"
+                ],
+                "destinations": [
+                  {
+                    "namespace": "*",
+                    "server": "https://kubernetes.default.svc"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 5,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/application.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: portal\n  namespace: argocd\nspec:\n  project: default\n  source:\n    repoURL: https://git.corp.internal/platform/apps\n    path: apps/portal\n    targetRevision: main\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: payments\n"
+          },
+          "referenceFiles": {
+            "/root/infra/application.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: portal\n  namespace: argocd\nspec:\n  project: default\n  source:\n    repoURL: https://git.corp.internal/platform/apps\n    path: apps/portal\n    targetRevision: main\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: payments\n  syncPolicy:\n    automated:\n      prune: true\n      selfHeal: true\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/application.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "gitops-with-argocd.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst REPO = 'https://git.corp.internal/platform/apps';\n\ndescribe('GitOps', () => {\n  it('门户归 Argo CD 管，Synced + Healthy', () => {\n    const application = get('Application', 'portal', 'argocd');\n    expect(application).toBeTruthy();\n    expect(application.status.sync.status).toBe('Synced');\n    expect(application.status.health.status).toBe('Healthy');\n  });\n\n  it('集群里的副本数和仓库一致', async () => {\n    const cloned = await sh('rm -rf /tmp/check && git clone ' + REPO + ' /tmp/check');\n    expect(cloned.code).toBe(0);\n    const manifest = await sh('grep -E \"^  replicas:\" /tmp/check/apps/portal/deployment.yaml');\n    const wanted = Number(manifest.stdout.split(':')[1].trim());\n\n    const deployment = get('Deployment', 'portal', 'payments');\n    expect(deployment.spec.replicas).toBe(wanted);\n  });\n\n  it('手改会被改回去 —— 不需要人介入', async () => {\n    await sh('kubectl scale deploy/portal -n payments --replicas=11');\n    const deployment = get('Deployment', 'portal', 'payments');\n    expect(deployment.spec.replicas).not.toBe(11);\n  });\n\n  it('仓库里删掉的对象，集群里也会消失', async () => {\n    await sh('rm -rf /tmp/prune && git clone ' + REPO + ' /tmp/prune');\n    await sh('cd /tmp/prune && rm apps/portal/service.yaml && git add -A'\n      + ' && git commit -m \"drop the service\" && git push origin main');\n\n    const services = list('Service', { namespace: 'payments' })\n      .map((item) => item.metadata.name);\n    expect(services).not.toContain('portal');\n  });\n\n  it('Argo CD 认的是远端仓库，不是跳板机上那个克隆', () => {\n    const application = get('Application', 'portal', 'argocd');\n    expect(application.spec.source.repoURL).toBe(REPO);\n    // revision 是一个真的 commit sha，不是分支名\n    expect(application.status.sync.revision).toMatch(/^[0-9a-f]{40}$/);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "GitOps 真正改变的不是部署方式，是**「现在到底跑着什么」这个问题的答案从哪里来**。\n在此之前答案只能从集群里问，而集群会被任何一个有权限的人改动，改动不留痕；\n之后答案在仓库里，有历史、有审核、能回滚。\n\n代价是那条手工通道被堵死了。开了 selfHeal 之后，`kubectl edit` 改的东西\n活不过一轮同步 —— 这对救火的人是个不小的调整。真集群里的做法是给\nApplication 加 `ignoreDifferences`（哪些字段不比对，比如 HPA 管的副本数），\n而不是把 selfHeal 关掉。\n\n还有一个容易忽略的点：Argo CD 自己也应该由 Argo CD 管（app-of-apps）。\n不然升级 Argo CD 这件事本身就还是手工的，而它恰恰是最不该漂移的组件。\n",
+          "en": "What GitOps really changes is not how you deploy but **where the answer to\n\"what is running right now\" comes from**. Before, you could only ask the\ncluster, and the cluster can be changed by anyone with access, leaving no trace.\nAfter, the answer lives in a repository with history, review, and rollback.\n\nThe price is that the manual path is closed. With selfHeal on, anything\n`kubectl edit` changes does not survive a sync, which is a real adjustment for\nwhoever is firefighting. The production answer is to add\n`ignoreDifferences` to the Application for fields owned by something else\n(replica counts managed by an HPA, for instance) rather than turning selfHeal\noff.\n\nOne more thing that is easy to miss: Argo CD should manage Argo CD (app of\napps). Otherwise upgrading it stays a manual operation, and it is exactly the\ncomponent that should never drift.\n"
+        },
+        "primer": {
+          "zh": "`GitOps` 把「集群里应该跑什么」这个答案从集群搬到了仓库。一个 Git 仓库存着全部 manifest，一个控制器不停地把仓库和集群比对，不一致就补齐。改配置的方式从「敲 kubectl」变成「提交一次代码」，于是每一次变更天然有作者、有时间、有 review、能回滚。\n\n`Argo CD` 是最常见的实现。它的核心对象是 `Application`：`spec.source` 指到仓库的某个路径与某个分支，`spec.destination` 指到集群的某个命名空间。控制器把那个路径下的 YAML 渲染出来，和集群里的现状比一比，结果写进 `status`。要强调的是它读的是**远端仓库**：本地 commit 了没 push，对它来说等于什么都没发生。\n\n`status` 里有两栏，代表两件完全不同的事，混在一起看会误判。`sync.status` 是 `Synced` 还是 `OutOfSync`，说的是「现状和仓库一不一致」；`health.status` 是 `Healthy` / `Progressing` / `Degraded`，说的是「服务好不好」。一个刚被人手工扩容过的服务是 OutOfSync 但 Healthy；一个刚同步完但镜像拉不下来的服务是 Synced 但 Degraded。\n\n同步行为由 `syncPolicy` 上三个独立的开关决定，各管各的：不写 `automated` 时它只比对、只报告，什么都不动；写了 `automated` 之后仓库一变就自动 apply；再加 `selfHeal: true`，集群里的手工改动也会被拉回仓库的样子；再加 `prune: true`，仓库里删掉的对象才会在集群里被删除。想手动触发一次同步，写 `operation` 字段就行，`argocd app sync` 做的正是这件事。",
+          "en": "`GitOps` moves the answer to \"what should be running\" out of the cluster and into a repository. One Git repository holds all the manifests, a controller continuously compares repository against cluster, and reconciles any difference. Changing configuration becomes committing code, so every change comes with an author, a timestamp, a review, and a way back.\n\n`Argo CD` is the common implementation. Its central object is the `Application`: `spec.source` points at a path and revision in a repository, `spec.destination` at a namespace in a cluster. The controller renders the YAML under that path, compares it with live state, and writes the outcome into `status`. Note that it reads the **remote** repository: a local commit that was never pushed may as well not exist.\n\nTwo fields in `status` mean two entirely different things, and conflating them causes misdiagnosis. `sync.status` (`Synced` or `OutOfSync`) says whether live state matches the repository. `health.status` (`Healthy`, `Progressing`, `Degraded`) says whether the workload is well. A service someone just hand-scaled is OutOfSync but Healthy; a freshly synced service whose image will not pull is Synced but Degraded.\n\nSync behaviour comes from three independent switches under `syncPolicy`. Without `automated`, the controller only compares and reports, never acts. With `automated`, repository changes get applied. Adding `selfHeal: true` also pulls hand edits in the cluster back to what the repository says. Adding `prune: true` deletes objects that no longer exist in the repository. To trigger one sync by hand, write the `operation` field, which is exactly what `argocd app sync` does."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1192,6 +1192,21 @@ const primers = {
       )
     ),
 
+    'gitops-with-argocd': t(
+      p(
+        '`GitOps` 把「集群里应该跑什么」这个答案从集群搬到了仓库。一个 Git 仓库存着全部 manifest，一个控制器不停地把仓库和集群比对，不一致就补齐。改配置的方式从「敲 kubectl」变成「提交一次代码」，于是每一次变更天然有作者、有时间、有 review、能回滚。',
+        '`Argo CD` 是最常见的实现。它的核心对象是 `Application`：`spec.source` 指到仓库的某个路径与某个分支，`spec.destination` 指到集群的某个命名空间。控制器把那个路径下的 YAML 渲染出来，和集群里的现状比一比，结果写进 `status`。要强调的是它读的是**远端仓库**：本地 commit 了没 push，对它来说等于什么都没发生。',
+        '`status` 里有两栏，代表两件完全不同的事，混在一起看会误判。`sync.status` 是 `Synced` 还是 `OutOfSync`，说的是「现状和仓库一不一致」；`health.status` 是 `Healthy` / `Progressing` / `Degraded`，说的是「服务好不好」。一个刚被人手工扩容过的服务是 OutOfSync 但 Healthy；一个刚同步完但镜像拉不下来的服务是 Synced 但 Degraded。',
+        '同步行为由 `syncPolicy` 上三个独立的开关决定，各管各的：不写 `automated` 时它只比对、只报告，什么都不动；写了 `automated` 之后仓库一变就自动 apply；再加 `selfHeal: true`，集群里的手工改动也会被拉回仓库的样子；再加 `prune: true`，仓库里删掉的对象才会在集群里被删除。想手动触发一次同步，写 `operation` 字段就行，`argocd app sync` 做的正是这件事。'
+      ),
+      p(
+        '`GitOps` moves the answer to "what should be running" out of the cluster and into a repository. One Git repository holds all the manifests, a controller continuously compares repository against cluster, and reconciles any difference. Changing configuration becomes committing code, so every change comes with an author, a timestamp, a review, and a way back.',
+        '`Argo CD` is the common implementation. Its central object is the `Application`: `spec.source` points at a path and revision in a repository, `spec.destination` at a namespace in a cluster. The controller renders the YAML under that path, compares it with live state, and writes the outcome into `status`. Note that it reads the **remote** repository: a local commit that was never pushed may as well not exist.',
+        'Two fields in `status` mean two entirely different things, and conflating them causes misdiagnosis. `sync.status` (`Synced` or `OutOfSync`) says whether live state matches the repository. `health.status` (`Healthy`, `Progressing`, `Degraded`) says whether the workload is well. A service someone just hand-scaled is OutOfSync but Healthy; a freshly synced service whose image will not pull is Synced but Degraded.',
+        'Sync behaviour comes from three independent switches under `syncPolicy`. Without `automated`, the controller only compares and reports, never acts. With `automated`, repository changes get applied. Adding `selfHeal: true` also pulls hand edits in the cluster back to what the repository says. Adding `prune: true` deletes objects that no longer exist in the repository. To trigger one sync by hand, write the `operation` field, which is exactly what `argocd app sync` does.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5616,7 +5616,8 @@
           "analytics",
           "envoy-gateway-system",
           "ingress-nginx",
-          "cert-manager"
+          "cert-manager",
+          "argocd"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5678,6 +5679,14 @@
               9962
             ],
             "enforcesNetworkPolicy": true
+          },
+          "quay.io/argoproj/argocd:v3.2.4": {
+            "pullMs": 500,
+            "startupMs": 700,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
+            ]
           },
           "harbor.corp.internal/team/reports:2.1.0": {
             "pullMs": 500,
@@ -5755,6 +5764,18 @@
               "library"
             ],
             "anonymousPull": false
+          }
+        ],
+        "gitRepositories": [
+          {
+            "url": "https://git.corp.internal/platform/apps",
+            "branch": "main",
+            "message": "bootstrap platform repo",
+            "files": {
+              "README.md": "# platform/apps\n\n集群里跑什么，以这个仓库为准。\n手工 kubectl apply 出来的东西迟早会被同步回来。\n",
+              "apps/portal/deployment.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  replicas: 2\n  selector:\n    matchLabels:\n      app: portal\n  template:\n    metadata:\n      labels:\n        app: portal\n    spec:\n      containers:\n      - name: web\n        image: harbor.corp.internal/team/portal:1.4.0\n        ports:\n        - containerPort: 8080\n",
+              "apps/portal/service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  clusterIP: 10.96.1.10\n  selector:\n    app: portal\n  ports:\n  - port: 80\n    targetPort: 8080\n"
+            }
           }
         ],
         "endpoints": [
@@ -7496,6 +7517,481 @@
         "primer": {
           "zh": "集群里的 Pod 默认可以互相访问，不分命名空间。`NetworkPolicy` 是收紧这件事的对象：它按标签选中一批 Pod，然后声明这批 Pod 的入向（`ingress`）和出向（`egress`）允许什么。没有任何策略选中某个 Pod 时，这个 Pod 完全开放；一旦被选中，对应方向就变成默认拒绝，只有明确写出来的才放行。\n\n有两件事经常被搞混。第一，`policyTypes` 决定这条策略管哪个方向：写了 `Egress` 却不写任何 egress 规则，等于「这批 Pod 什么都出不去」，包括查 DNS。第二，`from` 和 `to` 里的每一个元素是「或」的关系，但同一个元素内部的 `podSelector` 和 `namespaceSelector` 是「与」。写成两个元素就是「这个命名空间的所有 Pod，或者任何命名空间里叫这个名字的 Pod」，比想要的宽得多。另外，只写 `podSelector` 不写 `namespaceSelector` 时，它只在策略自己所在的命名空间里找。\n\n最关键、也最容易踩的一点：`NetworkPolicy` 只是一个被 apiserver 收下的对象，真正拦不拦包取决于 CNI。flannel 这类只做网络连通的插件根本不看这些对象，策略写得再对也是一张废纸；Cilium、Calico 这类才会把它翻译成数据面规则。所以「加了策略但行为没变」时，第一个要确认的不是策略写得对不对，而是集群里到底有没有人在执行它。\n\n被策略拒绝的连接表现为`超时`，不是`拒绝`。丢包意味着对端不会回 RST，客户端只能等到自己的超时时间。这个区别很有用：`Connection refused` 说明包已经到了对端而那里没有进程在听，和策略无关；`timeout` 才值得去看策略、路由和防火墙。",
           "en": "Pods can reach each other freely by default, across namespaces. `NetworkPolicy` is how you tighten that: it selects pods by label and declares what their inbound (`ingress`) and outbound (`egress`) traffic may be. A pod that no policy selects stays fully open; once selected, that direction becomes deny-by-default and only what you spell out gets through.\n\nTwo details cause most of the confusion. First, `policyTypes` decides which directions the policy governs: listing `Egress` without writing any egress rule means \"these pods may not reach anything\", DNS lookups included. Second, entries in `from` and `to` are ORed together, but `podSelector` and `namespaceSelector` inside a single entry are ANDed. Writing them as two entries means \"every pod in that namespace, or any pod with that label in any namespace\", which is far wider than intended. And a bare `podSelector` with no `namespaceSelector` only matches within the policy own namespace.\n\nThe most important point, and the easiest to miss: a `NetworkPolicy` is only an object the apiserver accepts. Whether packets get dropped depends on the CNI. Plugins like flannel provide connectivity and never read these objects, so a perfectly correct policy does nothing at all; Cilium and Calico translate them into real data plane rules. When a policy changes no behaviour, the first thing to check is not the policy but whether anything is enforcing it.\n\nA connection denied by policy shows up as a `timeout`, not a `refusal`. Dropping a packet means no RST comes back, so the client waits out its own deadline. That distinction is useful: `Connection refused` means the packet arrived and no process was listening, which has nothing to do with policy, while a `timeout` is what sends you looking at policies, routing, and firewalls."
+        }
+      },
+      {
+        "id": "gitops-with-argocd",
+        "title": {
+          "zh": "GitOps：让仓库说了算",
+          "en": "GitOps: Let the Repository Decide"
+        },
+        "goal": {
+          "zh": "平台组要求所有服务改走 GitOps：集群里跑什么，以仓库\n`https://git.corp.internal/platform/apps` 为准。Argo CD 已经装好了。\n\n现在的状况是：仓库里门户写的是 2 个副本，集群里跑着 5 个 ——\n某次大促前任手工 `kubectl scale` 上去的，没回写仓库。谁也说不清\n还有多少这种改动。\n\n`/root/infra/application.yaml` 里是一份 Application 的草稿。\n\n## 通关标准\n\n1. 门户由 Argo CD 管起来，`kubectl get app -n argocd` 里 `Synced` + `Healthy`；\n2. 集群里的副本数回到仓库写的那个；\n3. 之后再有人手工改，会被自己改回来（不需要人介入）；\n4. 想把副本数改成 3，得**通过仓库**改 —— 直接 kubectl 不算；\n5. 仓库里删掉的东西，集群里也要跟着消失。\n\n## 会用到的命令\n\n```bash\ngit clone https://git.corp.internal/platform/apps\nkubectl apply -f /root/infra/application.yaml\nkubectl get app -n argocd\nkubectl describe app portal -n argocd\nkubectl patch app portal -n argocd --type merge -p '{\"operation\":{\"sync\":{}}}'\n```\n",
+          "en": "The platform team wants every service on GitOps: what runs in the cluster is\nwhatever `https://git.corp.internal/platform/apps` says. Argo CD is already\ninstalled.\n\nRight now the repository says two replicas for the portal and the cluster runs\nfive, hand-scaled before a sale and never written back. Nobody knows how many\nother changes like that are out there.\n\n`/root/infra/application.yaml` holds a draft Application.\n\n## Done when\n\n1. the portal is managed by Argo CD and `kubectl get app -n argocd` shows\n   `Synced` and `Healthy`;\n2. the live replica count matches what the repository says;\n3. later hand edits get reverted automatically, with nobody in the loop;\n4. changing the count to three happens **through the repository**, not with\n   kubectl;\n5. what is deleted from the repository disappears from the cluster.\n\n## Commands you will need\n\n```bash\ngit clone https://git.corp.internal/platform/apps\nkubectl apply -f /root/infra/application.yaml\nkubectl get app -n argocd\nkubectl describe app portal -n argocd\nkubectl patch app portal -n argocd --type merge -p '{\"operation\":{\"sync\":{}}}'\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "Application 建起来，Synced + Healthy",
+            "en": "Application created, Synced and Healthy"
+          },
+          {
+            "zh": "漂移被纠正，而且以后会自己纠正",
+            "en": "Drift corrected, and stays corrected on its own"
+          },
+          {
+            "zh": "改配置走仓库这条路",
+            "en": "Configuration changes go through the repository"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "光建一个 Application 只会让它去**比对**，不会动手。`kubectl get app` 会显示 OutOfSync —— 那说明它看见了差异，在等你发话。",
+            "en": "Creating an Application only makes Argo CD **compare**; it will not act. `kubectl get app` shows OutOfSync, meaning it sees the difference and is waiting for you."
+          },
+          {
+            "zh": "自动同步分两层：`syncPolicy.automated` 让它在仓库变化时自己 apply；再加 `selfHeal: true` 才会把集群里的手改拉回来；`prune: true` 才会删掉仓库里已经没有的对象。三个开关管三件事。",
+            "en": "Automated sync has layers: `syncPolicy.automated` applies repository changes; `selfHeal: true` also pulls hand edits back; `prune: true` deletes objects that no longer exist in the repository. Three switches, three behaviours."
+          },
+          {
+            "zh": "Argo CD 看的是**远端仓库**。在跳板机上改完不 push，它什么都看不到。",
+            "en": "Argo CD reads the **remote** repository. Edits on the jump host that are not pushed are invisible to it."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "把副本数用 `kubectl scale` 改成 3 就交差。开了 selfHeal 之后这个改动活不过一轮同步；没开的话它会一直挂着 OutOfSync，下一个人看到的仍然是「仓库和现实不一致」。GitOps 的意思就是这条路被堵死了。",
+            "en": "Scaling to three with `kubectl scale` and calling it done. With selfHeal on, the change does not survive one sync; with it off, the app sits OutOfSync and the next person still sees \"repository and reality disagree\". GitOps means that path is closed."
+          },
+          {
+            "zh": "在本地 commit 了但没 push。Argo CD 连的是远端 —— 本地仓库里的提交对它不存在。这个错很难自查，因为 `git log` 看起来一切正常。",
+            "en": "Committing locally without pushing. Argo CD talks to the remote, so a local commit does not exist as far as it is concerned. It is hard to spot because `git log` looks perfectly fine."
+          },
+          {
+            "zh": "看到 OutOfSync 就当成故障。它只说明现状和仓库不一致，服务可能好好的 —— 健康与否是 `status.health` 那一栏。两栏分别代表两件事，混在一起看会把「配置漂移」当成「服务挂了」。",
+            "en": "Treating OutOfSync as an outage. It only means live state differs from the repository; the service may be perfectly fine. Health is a separate column, and conflating the two turns \"configuration drift\" into \"the service is down\"."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argocd-application-controller",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argocd-application-controller"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argocd-application-controller"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argocd-application-controller"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argocd:v3.2.4",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "AppProject",
+              "metadata": {
+                "name": "default",
+                "namespace": "argocd"
+              },
+              "spec": {
+                "sourceRepos": [
+                  "*"
+                ],
+                "destinations": [
+                  {
+                    "namespace": "*",
+                    "server": "https://kubernetes.default.svc"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 5,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/application.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: portal\n  namespace: argocd\nspec:\n  project: default\n  source:\n    repoURL: https://git.corp.internal/platform/apps\n    path: apps/portal\n    targetRevision: main\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: payments\n"
+          },
+          "referenceFiles": {
+            "/root/infra/application.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: portal\n  namespace: argocd\nspec:\n  project: default\n  source:\n    repoURL: https://git.corp.internal/platform/apps\n    path: apps/portal\n    targetRevision: main\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: payments\n  syncPolicy:\n    automated:\n      prune: true\n      selfHeal: true\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/application.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "gitops-with-argocd.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst REPO = 'https://git.corp.internal/platform/apps';\n\ndescribe('GitOps', () => {\n  it('门户归 Argo CD 管，Synced + Healthy', () => {\n    const application = get('Application', 'portal', 'argocd');\n    expect(application).toBeTruthy();\n    expect(application.status.sync.status).toBe('Synced');\n    expect(application.status.health.status).toBe('Healthy');\n  });\n\n  it('集群里的副本数和仓库一致', async () => {\n    const cloned = await sh('rm -rf /tmp/check && git clone ' + REPO + ' /tmp/check');\n    expect(cloned.code).toBe(0);\n    const manifest = await sh('grep -E \"^  replicas:\" /tmp/check/apps/portal/deployment.yaml');\n    const wanted = Number(manifest.stdout.split(':')[1].trim());\n\n    const deployment = get('Deployment', 'portal', 'payments');\n    expect(deployment.spec.replicas).toBe(wanted);\n  });\n\n  it('手改会被改回去 —— 不需要人介入', async () => {\n    await sh('kubectl scale deploy/portal -n payments --replicas=11');\n    const deployment = get('Deployment', 'portal', 'payments');\n    expect(deployment.spec.replicas).not.toBe(11);\n  });\n\n  it('仓库里删掉的对象，集群里也会消失', async () => {\n    await sh('rm -rf /tmp/prune && git clone ' + REPO + ' /tmp/prune');\n    await sh('cd /tmp/prune && rm apps/portal/service.yaml && git add -A'\n      + ' && git commit -m \"drop the service\" && git push origin main');\n\n    const services = list('Service', { namespace: 'payments' })\n      .map((item) => item.metadata.name);\n    expect(services).not.toContain('portal');\n  });\n\n  it('Argo CD 认的是远端仓库，不是跳板机上那个克隆', () => {\n    const application = get('Application', 'portal', 'argocd');\n    expect(application.spec.source.repoURL).toBe(REPO);\n    // revision 是一个真的 commit sha，不是分支名\n    expect(application.status.sync.revision).toMatch(/^[0-9a-f]{40}$/);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "GitOps 真正改变的不是部署方式，是**「现在到底跑着什么」这个问题的答案从哪里来**。\n在此之前答案只能从集群里问，而集群会被任何一个有权限的人改动，改动不留痕；\n之后答案在仓库里，有历史、有审核、能回滚。\n\n代价是那条手工通道被堵死了。开了 selfHeal 之后，`kubectl edit` 改的东西\n活不过一轮同步 —— 这对救火的人是个不小的调整。真集群里的做法是给\nApplication 加 `ignoreDifferences`（哪些字段不比对，比如 HPA 管的副本数），\n而不是把 selfHeal 关掉。\n\n还有一个容易忽略的点：Argo CD 自己也应该由 Argo CD 管（app-of-apps）。\n不然升级 Argo CD 这件事本身就还是手工的，而它恰恰是最不该漂移的组件。\n",
+          "en": "What GitOps really changes is not how you deploy but **where the answer to\n\"what is running right now\" comes from**. Before, you could only ask the\ncluster, and the cluster can be changed by anyone with access, leaving no trace.\nAfter, the answer lives in a repository with history, review, and rollback.\n\nThe price is that the manual path is closed. With selfHeal on, anything\n`kubectl edit` changes does not survive a sync, which is a real adjustment for\nwhoever is firefighting. The production answer is to add\n`ignoreDifferences` to the Application for fields owned by something else\n(replica counts managed by an HPA, for instance) rather than turning selfHeal\noff.\n\nOne more thing that is easy to miss: Argo CD should manage Argo CD (app of\napps). Otherwise upgrading it stays a manual operation, and it is exactly the\ncomponent that should never drift.\n"
+        },
+        "primer": {
+          "zh": "`GitOps` 把「集群里应该跑什么」这个答案从集群搬到了仓库。一个 Git 仓库存着全部 manifest，一个控制器不停地把仓库和集群比对，不一致就补齐。改配置的方式从「敲 kubectl」变成「提交一次代码」，于是每一次变更天然有作者、有时间、有 review、能回滚。\n\n`Argo CD` 是最常见的实现。它的核心对象是 `Application`：`spec.source` 指到仓库的某个路径与某个分支，`spec.destination` 指到集群的某个命名空间。控制器把那个路径下的 YAML 渲染出来，和集群里的现状比一比，结果写进 `status`。要强调的是它读的是**远端仓库**：本地 commit 了没 push，对它来说等于什么都没发生。\n\n`status` 里有两栏，代表两件完全不同的事，混在一起看会误判。`sync.status` 是 `Synced` 还是 `OutOfSync`，说的是「现状和仓库一不一致」；`health.status` 是 `Healthy` / `Progressing` / `Degraded`，说的是「服务好不好」。一个刚被人手工扩容过的服务是 OutOfSync 但 Healthy；一个刚同步完但镜像拉不下来的服务是 Synced 但 Degraded。\n\n同步行为由 `syncPolicy` 上三个独立的开关决定，各管各的：不写 `automated` 时它只比对、只报告，什么都不动；写了 `automated` 之后仓库一变就自动 apply；再加 `selfHeal: true`，集群里的手工改动也会被拉回仓库的样子；再加 `prune: true`，仓库里删掉的对象才会在集群里被删除。想手动触发一次同步，写 `operation` 字段就行，`argocd app sync` 做的正是这件事。",
+          "en": "`GitOps` moves the answer to \"what should be running\" out of the cluster and into a repository. One Git repository holds all the manifests, a controller continuously compares repository against cluster, and reconciles any difference. Changing configuration becomes committing code, so every change comes with an author, a timestamp, a review, and a way back.\n\n`Argo CD` is the common implementation. Its central object is the `Application`: `spec.source` points at a path and revision in a repository, `spec.destination` at a namespace in a cluster. The controller renders the YAML under that path, compares it with live state, and writes the outcome into `status`. Note that it reads the **remote** repository: a local commit that was never pushed may as well not exist.\n\nTwo fields in `status` mean two entirely different things, and conflating them causes misdiagnosis. `sync.status` (`Synced` or `OutOfSync`) says whether live state matches the repository. `health.status` (`Healthy`, `Progressing`, `Degraded`) says whether the workload is well. A service someone just hand-scaled is OutOfSync but Healthy; a freshly synced service whose image will not pull is Synced but Degraded.\n\nSync behaviour comes from three independent switches under `syncPolicy`. Without `automated`, the controller only compares and reports, never acts. With `automated`, repository changes get applied. Adding `selfHeal: true` also pulls hand edits in the cluster back to what the repository says. Adding `prune: true` deletes objects that no longer exist in the repository. To trigger one sync by hand, write the `operation` field, which is exactly what `argocd app sync` does."
         }
       }
     ]

--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -157,6 +157,25 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
       ];
     },
   },
+  applications: {
+    columns: [
+      NAME_COLUMN,
+      col('Sync Status', 'Whether the live state matches the repository.'),
+      col('Health Status', 'Health of the resources this application manages.'),
+      col('Revision', 'The revision the application is synced to.', 1),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        status.sync?.status ?? 'Unknown',
+        status.health?.status ?? 'Unknown',
+        (status.sync?.revision ?? '').slice(0, 7) || '<none>',
+        age,
+      ];
+    },
+  },
   namespaces: {
     columns: [NAME_COLUMN, col('Status', 'The status of the namespace.'), AGE_COLUMN],
     cells: (object, age) => [

--- a/src/lib/opslab/argocd/controller.ts
+++ b/src/lib/opslab/argocd/controller.ts
@@ -1,0 +1,396 @@
+/**
+ * Argo CD 的 application controller
+ *
+ * 它做的事只有一件：把「仓库里那份 YAML」和「集群里的现状」比一比，
+ * 然后按 syncPolicy 决定要不要动手。
+ *
+ * 三条最容易被误解的规则，这里都照真的实现：
+ *  1. **OutOfSync 不等于坏了**。它只说明现状和仓库不一致，服务可能好好的。
+ *     健康与否是另一个维度（`status.health`）。
+ *  2. **没有 automated 就不会自己动**。它只把差异报出来，等人来 sync。
+ *  3. **selfHeal 才会把手改改回去**。只开 automated 不开 selfHeal 的话，
+ *     `kubectl edit` 改的东西会一直留着，直到仓库那边有新提交。
+ *
+ * 控制器自己是集群里的一个工作负载：Deployment 停了，同步就停了 ——
+ * 和 Envoy Gateway、cert-manager 一样。
+ */
+import type { KubeObject, ResourceDefinition } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { parseYamlAll } from '../yaml';
+import { APPLICATIONS, ARGOCD_LABEL, TRACKING_LABEL } from './resources';
+
+/** 仓库在某个版本上的样子 */
+export interface RepoSnapshot {
+  revision: string;
+  files: Record<string, string>;
+}
+
+export type RepoResolver = (url: string, revision: string) => RepoSnapshot | { error: string };
+
+export interface ArgoCdOptions {
+  /** 去哪儿取仓库内容。由世界注入 —— 集群自己不认识 Git。 */
+  source: RepoResolver;
+  /**
+   * 仓库有新提交时叫一声。
+   *
+   * 这是 webhook。没有它就只能等轮询 —— 真集群里「push 完过了两分钟才生效」
+   * 通常就是 webhook 没配。
+   */
+  subscribe?(listener: () => void): void;
+}
+
+/** Argo CD 默认的轮询间隔 */
+export const POLL_INTERVAL_MS = 180_000;
+
+interface Managed {
+  definition: ResourceDefinition;
+  namespace?: string;
+  object: KubeObject;
+}
+
+interface ResourceStatus {
+  group: string;
+  version: string;
+  kind: string;
+  namespace?: string;
+  name: string;
+  status: string;
+  health: string;
+}
+
+export class ArgoCdController extends Controller {
+  private applications: Informer;
+  private deployments: Informer;
+
+  constructor(context: ControllerContext, private readonly options: ArgoCdOptions) {
+    super(context, 'argocd-application-controller');
+    this.applications = new Informer(this.registry, APPLICATIONS);
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.watch(this.applications);
+    // 被管的工作负载变了，健康状态要跟着变
+    this.deployments.onChange(() => this.enqueueAll());
+    // webhook：仓库一有新提交就重新比对
+    options.subscribe?.(() => this.enqueueAll());
+    /**
+     * 兜底轮询。
+     *
+     * 标成 background —— 它「永远有下一次」，算成前台的话世界就再也静不下来了。
+     * 想看到轮询生效，把虚拟时钟往前推（advanceBy）就行，和真集群里等三分钟一样。
+     */
+    this.kernel.setInterval(() => this.enqueueAll(), POLL_INTERVAL_MS, {
+      background: true,
+      label: 'argocd:poll',
+    });
+  }
+
+  private enqueueAll(): void {
+    for (const application of this.applications.list()) this.enqueue(objectKey(application));
+  }
+
+  /** 控制器在不在。这是「组件是工作负载」这条约束的兑现处。 */
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[ARGOCD_LABEL.key] !== ARGOCD_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let application: KubeObject;
+    try {
+      application = this.registry.get(APPLICATIONS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (application.metadata.deletionTimestamp) return;
+
+    const spec = (application.spec ?? {}) as any;
+    const source = spec.source ?? {};
+    const snapshot = this.options.source(source.repoURL ?? '', source.targetRevision ?? 'HEAD');
+    if ('error' in snapshot) {
+      await this.writeStatus(application, {
+        sync: { status: 'Unknown' },
+        health: { status: 'Unknown' },
+        conditions: [{ type: 'ComparisonError', message: snapshot.error }],
+      });
+      return;
+    }
+
+    const desired = this.desiredObjects(snapshot, source.path ?? '', spec.destination ?? {});
+    if ('error' in desired) {
+      await this.writeStatus(application, {
+        sync: { status: 'Unknown', revision: snapshot.revision },
+        health: { status: 'Unknown' },
+        conditions: [{ type: 'ComparisonError', message: desired.error }],
+      });
+      return;
+    }
+
+    const automated = spec.syncPolicy?.automated;
+    // `operation` 是手动 sync 的入口 —— argocd CLI 写进去的就是这个字段
+    const requested = Boolean((application as any).operation?.sync);
+
+    if (automated || requested) {
+      this.apply(desired.objects, {
+        instance: application.metadata.name!,
+        // 手动 sync 一定会把现状拉回仓库；自动同步要开了 selfHeal 才会
+        selfHeal: Boolean(automated?.selfHeal) || requested,
+      });
+      if (automated?.prune || requested) this.prune(application, desired.objects);
+    }
+
+    const resources = desired.objects.map((managed) => this.statusOf(managed));
+    const outOfSync = resources.some((entry) => entry.status !== 'Synced');
+    await this.writeStatus(application, {
+      sync: { status: outOfSync ? 'OutOfSync' : 'Synced', revision: snapshot.revision },
+      health: { status: healthOf(resources) },
+      resources,
+      // 上一次同步的结果要留着 —— `argocd app history` 看的就是它，
+      // 每次比对都把它抹掉的话，「上次是什么时候同步的」就永远查不到
+      operationState: (requested || automated)
+        ? {
+            phase: 'Succeeded',
+            finishedAt: new Date(this.context.now()).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+            syncResult: { revision: snapshot.revision },
+          }
+        : (application.status as { operationState?: unknown } | undefined)?.operationState,
+    });
+
+    // 手动 sync 做完就把 operation 摘掉，和真 Argo 一样
+    if (requested) {
+      await ignoreConflict(() => {
+        const latest = this.registry.get(APPLICATIONS, namespace, name) as Record<string, unknown>;
+        if (!latest.operation) return;
+        const next = { ...latest };
+        delete next.operation;
+        this.registry.update(APPLICATIONS, namespace, name, next as KubeObject);
+      });
+    }
+  }
+
+  /** 仓库里那一路径下的 manifest 变成对象 */
+  private desiredObjects(
+    snapshot: RepoSnapshot,
+    path: string,
+    destination: { namespace?: string }
+  ): { objects: Managed[] } | { error: string } {
+    const prefix = path === '' || path === '.' ? '' : `${path.replace(/\/$/, '')}/`;
+    const matched = Object.entries(snapshot.files)
+      .filter(([file]) => file.startsWith(prefix) && /\.ya?ml$/.test(file))
+      .sort(([a], [b]) => (a < b ? -1 : 1));
+    if (matched.length === 0) {
+      return { error: `app path does not exist: ${path || '.'}` };
+    }
+
+    const objects: Managed[] = [];
+    for (const [file, content] of matched) {
+      let documents: unknown[];
+      try {
+        documents = parseYamlAll(content);
+      } catch (error) {
+        return { error: `Failed to load target state: ${file}: ${(error as Error).message}` };
+      }
+      for (const document of documents) {
+        const object = document as KubeObject;
+        if (!object?.apiVersion || !object.kind) continue;
+        const [group, version] = splitApiVersion(object.apiVersion);
+        const definition = this.context.scheme.resolveKind(group, version, object.kind);
+        if (!definition) {
+          return {
+            error: `Failed to load target state: ${object.apiVersion}/${object.kind} `
+              + 'is not registered in the cluster',
+          };
+        }
+        const namespace = definition.namespaced
+          ? object.metadata?.namespace ?? destination.namespace ?? 'default'
+          : undefined;
+        objects.push({ definition, namespace, object });
+      }
+    }
+    return { objects };
+  }
+
+  private apply(objects: Managed[], options: { instance: string; selfHeal: boolean }): void {
+    for (const managed of objects) {
+      const { definition, namespace, object } = managed;
+      const name = object.metadata?.name;
+      if (!name) continue;
+
+      let live: KubeObject | undefined;
+      try {
+        live = this.registry.get(definition, namespace, name);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+
+      if (!live) {
+        this.registry.create(definition, namespace, tracked(object, namespace, options.instance));
+        continue;
+      }
+
+      /**
+       * 每次同步都要落一次 tracking 标签，不只是建对象的时候。
+       *
+       * 这条决定了「接管」能不能发生：一个本来手工建出来的对象，被
+       * Application 纳入之后要打上标签，prune 才认得它是自己的地盘。
+       * 只在 create 时打的话，那些先有后管的对象永远删不掉。
+       */
+      const adopting = live.metadata.labels?.[TRACKING_LABEL] !== options.instance;
+      const drifted = !matchesDesired(object.spec, live.spec);
+      if (!adopting && !(options.selfHeal && drifted)) continue;
+
+      this.registry.update(definition, namespace, name, {
+        ...live,
+        metadata: {
+          ...live.metadata,
+          labels: {
+            ...live.metadata.labels,
+            ...(options.selfHeal ? object.metadata?.labels : {}),
+            [TRACKING_LABEL]: options.instance,
+          },
+        },
+        // selfHeal：把现状拉回仓库的样子。手改的东西就是在这里被改回去的。
+        // 合并而不是整体替换 —— 服务端补上的字段（ClusterIP 之类）不能被抹掉。
+        spec: options.selfHeal && drifted ? mergeDesired(live.spec, object.spec) : live.spec,
+      });
+    }
+  }
+
+  /**
+   * 仓库里删掉的对象，集群里也删掉。
+   *
+   * 只删自己建的（带 tracking 标签的），不然一个 Application 会把
+   * 别人的东西也收走 —— 真 Argo 用同样的方式圈定自己的地盘。
+   */
+  private prune(application: KubeObject, objects: Managed[]): void {
+    const wanted = new Set(objects.map((managed) =>
+      `${managed.definition.resource}/${managed.namespace ?? ''}/${managed.object.metadata?.name}`));
+    const instance = application.metadata.name;
+
+    for (const definition of this.context.scheme.list()) {
+      if (definition.resource === 'applications') continue;
+      let live: KubeObject[];
+      try {
+        live = this.registry.list(definition).items;
+      } catch {
+        continue;
+      }
+      for (const object of live) {
+        if (object.metadata.labels?.[TRACKING_LABEL] !== instance) continue;
+        const key = `${definition.resource}/${object.metadata.namespace ?? ''}/${object.metadata.name}`;
+        if (wanted.has(key)) continue;
+        try {
+          this.registry.delete(definition, object.metadata.namespace, object.metadata.name);
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+        }
+      }
+    }
+  }
+
+  private statusOf(managed: Managed): ResourceStatus {
+    const { definition, namespace, object } = managed;
+    const name = object.metadata?.name ?? '';
+    const base = {
+      group: definition.group, version: definition.version, kind: definition.kind,
+      namespace, name,
+    };
+    let live: KubeObject;
+    try {
+      live = this.registry.get(definition, namespace, name);
+    } catch {
+      return { ...base, status: 'OutOfSync', health: 'Missing' };
+    }
+    const same = matchesDesired(object.spec, live.spec);
+    return { ...base, status: same ? 'Synced' : 'OutOfSync', health: healthOfObject(definition, live) };
+  }
+
+  private async writeStatus(application: KubeObject, status: Record<string, unknown>): Promise<void> {
+    await ignoreConflict(() => {
+      updateStatusIfChanged(
+        this.registry, APPLICATIONS,
+        application.metadata.namespace, application.metadata.name!,
+        status
+      );
+    });
+  }
+}
+
+/* ------------------------------------------------------------------ */
+
+/**
+ * 仓库里写了的字段，集群里是不是就是那样。
+ *
+ * 只比对**仓库写了的**那些字段。服务端自己补上的东西（Service 的
+ * ClusterIP、各种默认值）不算漂移 —— 否则每个对象一建出来就是 OutOfSync，
+ * 这一栏就再也没有信息量了。真 Argo CD 做的是同一件事，
+ * 只是它靠 last-applied 注解来判断哪些字段归自己管。
+ *
+ * 代价：仓库里**删掉**一个字段不会被认出来。真 Argo 靠 last-applied 能认，
+ * 我们这里认不出。
+ */
+export function matchesDesired(desired: unknown, live: unknown): boolean {
+  if (desired === null || desired === undefined) return true;
+  if (Array.isArray(desired)) {
+    if (!Array.isArray(live) || live.length !== desired.length) return false;
+    return desired.every((item, index) => matchesDesired(item, live[index]));
+  }
+  if (typeof desired === 'object') {
+    if (typeof live !== 'object' || live === null || Array.isArray(live)) return false;
+    return Object.entries(desired as Record<string, unknown>).every(
+      ([key, value]) => matchesDesired(value, (live as Record<string, unknown>)[key])
+    );
+  }
+  return desired === live;
+}
+
+/** 把仓库写了的字段盖到现状上，其余保留 */
+function mergeDesired(live: unknown, desired: unknown): unknown {
+  if (desired === null || desired === undefined) return live;
+  if (Array.isArray(desired)) return desired;
+  if (typeof desired !== 'object') return desired;
+  if (typeof live !== 'object' || live === null || Array.isArray(live)) return desired;
+  const out: Record<string, unknown> = { ...(live as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(desired as Record<string, unknown>)) {
+    out[key] = mergeDesired((live as Record<string, unknown>)[key], value);
+  }
+  return out;
+}
+
+function tracked(object: KubeObject, namespace: string | undefined, instance: string): KubeObject {
+  return {
+    ...object,
+    metadata: {
+      ...object.metadata,
+      namespace: namespace ?? object.metadata?.namespace,
+      labels: { ...(object.metadata?.labels ?? {}), [TRACKING_LABEL]: instance },
+    },
+  };
+}
+
+/** 一个 Application 的健康度取最差的那一个 */
+function healthOf(resources: ResourceStatus[]): string {
+  if (resources.some((entry) => entry.health === 'Missing')) return 'Missing';
+  if (resources.some((entry) => entry.health === 'Degraded')) return 'Degraded';
+  if (resources.some((entry) => entry.health === 'Progressing')) return 'Progressing';
+  return 'Healthy';
+}
+
+function healthOfObject(definition: ResourceDefinition, live: KubeObject): string {
+  if (definition.resource !== 'deployments') return 'Healthy';
+  const spec = (live.spec ?? {}) as { replicas?: number };
+  const status = (live.status ?? {}) as { availableReplicas?: number };
+  return (status.availableReplicas ?? 0) >= (spec.replicas ?? 1) ? 'Healthy' : 'Progressing';
+}
+
+function splitApiVersion(apiVersion: string): [string, string] {
+  const index = apiVersion.indexOf('/');
+  return index < 0 ? ['', apiVersion] : [apiVersion.slice(0, index), apiVersion.slice(index + 1)];
+}

--- a/src/lib/opslab/argocd/controller.ts
+++ b/src/lib/opslab/argocd/controller.ts
@@ -81,13 +81,25 @@ export class ArgoCdController extends Controller {
      * 标成 background —— 它「永远有下一次」，算成前台的话世界就再也静不下来了。
      * 想看到轮询生效，把虚拟时钟往前推（advanceBy）就行，和真集群里等三分钟一样。
      */
-    this.kernel.setInterval(() => this.enqueueAll(), POLL_INTERVAL_MS, {
+    this.poll = this.kernel.setInterval(() => this.enqueueAll(), POLL_INTERVAL_MS, {
       background: true,
       label: 'argocd:poll',
     });
   }
 
+  private poll: number;
+  private stopped = false;
+
+  stop(): void {
+    // webhook 的订阅摘不掉（GitNetwork 只管发），所以这里立个旗子；
+    // 轮询的定时器要显式清掉，不然换一个集群起来还有上一个在敲门
+    this.stopped = true;
+    this.kernel.clearTimer(this.poll);
+    super.stop();
+  }
+
   private enqueueAll(): void {
+    if (this.stopped) return;
     for (const application of this.applications.list()) this.enqueue(objectKey(application));
   }
 
@@ -143,7 +155,9 @@ export class ArgoCdController extends Controller {
         // 手动 sync 一定会把现状拉回仓库；自动同步要开了 selfHeal 才会
         selfHeal: Boolean(automated?.selfHeal) || requested,
       });
-      if (automated?.prune || requested) this.prune(application, desired.objects);
+      if (automated?.prune || requested) {
+        this.prune(application, desired.objects, previousKinds(application));
+      }
     }
 
     const resources = desired.objects.map((managed) => this.statusOf(managed));
@@ -269,13 +283,23 @@ export class ArgoCdController extends Controller {
    * 只删自己建的（带 tracking 标签的），不然一个 Application 会把
    * 别人的东西也收走 —— 真 Argo 用同样的方式圈定自己的地盘。
    */
-  private prune(application: KubeObject, objects: Managed[]): void {
+  private prune(application: KubeObject, objects: Managed[], previous: Set<string>): void {
     const wanted = new Set(objects.map((managed) =>
       `${managed.definition.resource}/${managed.namespace ?? ''}/${managed.object.metadata?.name}`));
     const instance = application.metadata.name;
 
+    /**
+     * 只扫这个 Application 碰过的资源类型。
+     *
+     * 「上一轮 status 里出现过的」加上「这一轮仓库里有的」——
+     * 一个 kind 从仓库里整个消失时，它还在上一轮的 status 里，所以扫得到。
+     * 不这么收窄的话每次同步都要把全集群所有类型 list 一遍。
+     */
+    const kinds = new Set([...previous, ...objects.map((managed) => managed.definition.resource)]);
+
     for (const definition of this.context.scheme.list()) {
       if (definition.resource === 'applications') continue;
+      if (!kinds.has(definition.resource)) continue;
       let live: KubeObject[];
       try {
         live = this.registry.list(definition).items;
@@ -362,6 +386,22 @@ function mergeDesired(live: unknown, desired: unknown): unknown {
     out[key] = mergeDesired((live as Record<string, unknown>)[key], value);
   }
   return out;
+}
+
+/** 上一轮同步管过哪些资源类型 —— 从 status.resources 里读回来 */
+function previousKinds(application: KubeObject): Set<string> {
+  const resources = ((application.status ?? {}) as { resources?: Array<{ kind?: string }> }).resources ?? [];
+  // status 里记的是 kind，prune 要按 resource 复数名对；两边都收着，
+  // 命中判断用 resource，多一个 kind 不影响正确性
+  return new Set(resources.map((entry) => pluralOf(entry.kind ?? '')));
+}
+
+/** Kind -> resource 的粗略复数化。只用于收窄扫描范围，判错了顶多多扫一类。 */
+function pluralOf(kind: string): string {
+  const lower = kind.toLowerCase();
+  if (lower.endsWith('s')) return `${lower}es`;
+  if (lower.endsWith('y')) return `${lower.slice(0, -1)}ies`;
+  return `${lower}s`;
 }
 
 function tracked(object: KubeObject, namespace: string | undefined, instance: string): KubeObject {

--- a/src/lib/opslab/argocd/index.ts
+++ b/src/lib/opslab/argocd/index.ts
@@ -1,0 +1,3 @@
+export { APPLICATIONS, APPPROJECTS, ARGOCD_RESOURCES, ARGOCD_LABEL, TRACKING_LABEL } from './resources';
+export { ArgoCdController, POLL_INTERVAL_MS } from './controller';
+export type { ArgoCdOptions, RepoResolver, RepoSnapshot } from './controller';

--- a/src/lib/opslab/argocd/resources.ts
+++ b/src/lib/opslab/argocd/resources.ts
@@ -1,0 +1,27 @@
+/**
+ * Argo CD 的 CRD
+ *
+ * 字段照抄上游 —— `kubectl get app` 打出来的列、`-o yaml` 里的路径，
+ * 都要和真集群一致，不然学员在这里学的读法带不走。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const APPLICATIONS: ResourceDefinition = {
+  group: 'argoproj.io', version: 'v1alpha1', resource: 'applications',
+  singular: 'application', kind: 'Application', namespaced: true,
+  shortNames: ['app'], subresources: ['status'],
+};
+
+export const APPPROJECTS: ResourceDefinition = {
+  group: 'argoproj.io', version: 'v1alpha1', resource: 'appprojects',
+  singular: 'appproject', kind: 'AppProject', namespaced: true,
+  shortNames: ['appproj'], subresources: ['status'],
+};
+
+export const ARGOCD_RESOURCES: ResourceDefinition[] = [APPLICATIONS, APPPROJECTS];
+
+/** 控制器自己的标签。没有可用的 Deployment，什么都不同步。 */
+export const ARGOCD_LABEL = { key: 'app.kubernetes.io/name', value: 'argocd-application-controller' };
+
+/** Argo 给自己管的对象打的标签，prune 靠它认领地盘 */
+export const TRACKING_LABEL = 'app.kubernetes.io/instance';

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -18,6 +18,7 @@ import {
 import { Controller, ControllerContext } from './framework';
 import { createServiceIpDefaulter } from './serviceip';
 import { DaemonSetController } from './daemonset';
+import { ARGOCD_RESOURCES, ArgoCdController } from '../argocd';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -60,6 +61,15 @@ export interface ClusterOptions {
   resolveImage?: (image: string) => ImageSpec | undefined;
   /** 集群外的名字，`harbor.corp.internal` 之类 */
   externalHosts?: Record<string, string[]>;
+  /**
+   * Argo CD 去哪儿取仓库内容。
+   *
+   * 集群自己不认识 Git —— 这条由世界注入，和镜像解析、信任库一样。
+   * 不给就是这个集群没装 GitOps。
+   */
+  gitSource?: import('../argocd').RepoResolver;
+  /** 仓库有新提交时叫一声（webhook）。 */
+  gitSubscribe?: (listener: () => void) => void;
   /** Service 的 VIP 从哪个网段分。默认 10.96.0.0/12，和真集群一样。 */
   serviceCidr?: string;
   /** `kubectl exec` 落到哪。不给就是这个集群不支持 exec。 */
@@ -114,7 +124,7 @@ export class Cluster {
 
     this.store = createStore();
     this.scheme = createScheme([
-      ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES,
+      ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -259,6 +269,7 @@ export class Cluster {
     return {
       kernel: this.kernel,
       registry: this.registry,
+      scheme: this.scheme,
       now: () => this.wallClock(),
       recordEvent: (input) => this.recordEvent(input),
     };
@@ -388,6 +399,13 @@ export class Cluster {
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发
       new CertManagerController(context),
+      // GitOps：仓库里那份 YAML 才是期望状态，集群里的对象是它的投影
+      ...(this.options.gitSource
+        ? [new ArgoCdController(context, {
+            source: this.options.gitSource,
+            subscribe: this.options.gitSubscribe,
+          })]
+        : []),
       new LoadBalancerController(context, this.options.addressPools ?? DEFAULT_POOLS),
       ...this.nodeSpecs.flatMap((node) => [
         new KubeletController(context, node.name, {

--- a/src/lib/opslab/controllers/framework.ts
+++ b/src/lib/opslab/controllers/framework.ts
@@ -14,7 +14,7 @@
  *    只要重新起控制器就能收敛的原因。
  */
 import { Kernel, Priority } from '../kernel';
-import { ApiError, KubeObject, Registry, ResourceDefinition } from '../apiserver';
+import { ApiError, KubeObject, Registry, ResourceDefinition, Scheme } from '../apiserver';
 
 /** 对象在队列里的身份：`namespace/name`，集群级资源就是 `name` */
 export function objectKey(object: KubeObject): string {
@@ -264,6 +264,14 @@ export class WorkQueue {
 export interface ControllerContext {
   kernel: Kernel;
   registry: Registry;
+  /**
+   * 类型表。
+   *
+   * 多数控制器只认自己那几种资源，用不上它；但像 Argo CD 这种
+   * 「仓库里写什么就 apply 什么」的控制器，必须能在运行时把
+   * apiVersion/kind 映射到资源。
+   */
+  scheme: Scheme;
   /** 世界的墙钟（起始时刻 + 虚拟流逝），写进对象时间戳用 —— 内核的 now() 是从 0 开始的 */
   now: () => number;
   /** 记一条 Event，学员在 describe 里能看到 */

--- a/src/lib/opslab/git/command.ts
+++ b/src/lib/opslab/git/command.ts
@@ -66,7 +66,9 @@ export function createGitCommand(options: GitCommandOptions): CommandHandler {
       case 'add': {
         const repository = open();
         if (!repository) return notARepo;
-        const paths = rest.filter((entry) => !entry.startsWith('-'));
+        // `-A` / `--all` / `-u` 都是「整棵树」，包括删除
+        const all = rest.some((entry) => entry === '-A' || entry === '--all' || entry === '-u');
+        const paths = all ? ['.'] : rest.filter((entry) => !entry.startsWith('-'));
         if (paths.length === 0) return { stderr: 'Nothing specified, nothing added.\n', code: 1 };
         const { missing } = repository.add(paths);
         if (missing.length > 0) {
@@ -416,6 +418,7 @@ function push(repository: Repository | undefined, argv: string[], options: GitCo
 
   repository.objects.copyTo(bare.repository.objects, hash);
   bare.repository.refs[branch] = hash;
+  options.network.notifyPush(url);
   const range = before ? `${before.slice(0, 7)}..${hash.slice(0, 7)}` : `[new branch]      ${branch}`;
   return {
     stderr: `To ${url}\n   ${range}  ${branch} -> ${branch}\n`,

--- a/src/lib/opslab/git/remote.ts
+++ b/src/lib/opslab/git/remote.ts
@@ -20,6 +20,21 @@ export interface BareRepository {
 
 export class GitNetwork {
   private readonly repositories = new Map<string, BareRepository>();
+  private readonly listeners: Array<(url: string) => void> = [];
+
+  /**
+   * 有人推了新提交。
+   *
+   * 真集群里这是 Git 服务打过来的 webhook —— 没有它，Argo CD 要等下一轮
+   * 轮询（默认三分钟）才会发现。这个世界里两条路都有。
+   */
+  onPush(listener: (url: string) => void): void {
+    this.listeners.push(listener);
+  }
+
+  notifyPush(url: string): void {
+    for (const listener of this.listeners) listener(GitNetwork.normalize(url));
+  }
 
   /** URL 归一化：去掉结尾的斜杠与 `.git` */
   static normalize(url: string): string {

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -20,7 +20,7 @@ import { createNetTools } from '../net';
 import { parseChain } from '../crypto';
 import { createOpensslCommand } from './openssl';
 import { materializePki } from './pki';
-import { GitNetwork, createGitCommand, seedRepository } from '../git';
+import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } from '../git';
 import { createExecHandler } from './podshell';
 import { CliRuntime, installClusterCli } from '../wasm';
 import type { KubeObject } from '../apiserver';
@@ -99,6 +99,23 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     resolveImage: (image) => lookupPushedImage(image),
     externalHosts,
     addressPools: spec.addressPools,
+    /**
+     * Argo CD 从这里取仓库内容。
+     *
+     * 取的是**远端**而不是跳板机上那个克隆 —— GitOps 的期望状态住在
+     * 远端仓库里，学员在本地改了不 push，集群就不该看见。
+     */
+    gitSubscribe: (listener) => git.onPush(() => listener()),
+    gitSource: (url, revision) => {
+      const bare = git.get(url);
+      if (!bare) return { error: `repository not accessible: ${url}` };
+      const branch = !revision || revision === 'HEAD' ? bare.head : revision;
+      const head = bare.refs[branch];
+      if (!head) return { error: `Unable to resolve '${revision}' to a commit SHA` };
+      const commit = bare.objects.get(head);
+      if (!commit || commit.type !== 'commit') return { error: `object not found: ${head}` };
+      return { revision: head, files: readTree(bare.objects, parseCommit(commit.body).tree) };
+    },
     /**
      * 跳板机信任哪些根。
      *

--- a/src/lib/opslab/yaml/index.ts
+++ b/src/lib/opslab/yaml/index.ts
@@ -1,0 +1,2 @@
+export { parseYaml, parseYamlAll, parseScalar, YamlError } from './parse';
+export { stringifyYaml } from './stringify';

--- a/src/lib/opslab/yaml/parse.ts
+++ b/src/lib/opslab/yaml/parse.ts
@@ -1,0 +1,304 @@
+/**
+ * YAML 的一个子集
+ *
+ * 只覆盖 Kubernetes manifest 会用到的部分：嵌套映射、列表、标量、引号、
+ * 块标量（`|` 与 `>`）、注释、多文档（`---`）。不做锚点、别名、标签、
+ * 流式映射之外的复杂结构。
+ *
+ * 为什么要自己写：Argo CD 那类控制器跑在宿主这一侧（TypeScript），
+ * 得把仓库里的 YAML 变成对象才能 apply。kubectl 自己带 YAML 解析，
+ * 但它在 wasm 里，控制器够不着。
+ *
+ * 正确性靠交叉验证：同一份 manifest 走这里和走真 kubectl
+ * （`apply --dry-run=client -o json`），结果必须一致。见 tests/opslab/yaml.test.ts。
+ */
+
+export class YamlError extends Error {
+  constructor(message: string, readonly line: number) {
+    super(`${message} (line ${line + 1})`);
+    this.name = 'YamlError';
+  }
+}
+
+interface Line {
+  indent: number;
+  text: string;
+  index: number;
+}
+
+/** 一份文档 */
+export function parseYaml(source: string): unknown {
+  const documents = parseYamlAll(source);
+  return documents.length ? documents[0] : undefined;
+}
+
+/** `---` 分隔的多份文档。空文档会被丢掉，和 kubectl 一致。 */
+export function parseYamlAll(source: string): unknown[] {
+  const chunks: string[][] = [[]];
+  for (const raw of source.split('\n')) {
+    if (/^---\s*(#.*)?$/.test(raw)) { chunks.push([]); continue; }
+    if (/^\.\.\.\s*$/.test(raw)) { chunks.push([]); continue; }
+    chunks[chunks.length - 1].push(raw);
+  }
+  return chunks
+    .map((chunk) => parseDocument(chunk))
+    .filter((value) => value !== undefined && value !== null);
+}
+
+function parseDocument(rawLines: string[]): unknown {
+  const lines: Line[] = [];
+  let blockIndent: number | null = null;
+  rawLines.forEach((raw, index) => {
+    // 块标量内部原样保留，注释与缩进都不能动
+    if (blockIndent !== null) {
+      const indent = indentOf(raw);
+      if (raw.trim() === '' || indent >= blockIndent) { lines.push({ indent, text: raw, index }); return; }
+      blockIndent = null;
+    }
+    if (raw.trim() === '' || /^\s*#/.test(raw)) return;
+    const indent = indentOf(raw);
+    const text = stripComment(raw.slice(indent));
+    if (text === '') return;
+    lines.push({ indent, text, index });
+    if (/[|>][-+]?\s*$/.test(text)) blockIndent = indent + 1;
+  });
+  if (lines.length === 0) return undefined;
+  const [value, consumed] = parseBlock(lines, 0, lines[0].indent);
+  if (consumed < lines.length) {
+    throw new YamlError('unexpected content', lines[consumed].index);
+  }
+  return value;
+}
+
+function indentOf(raw: string): number {
+  let count = 0;
+  while (count < raw.length && raw[count] === ' ') count += 1;
+  if (raw[count] === '\t') throw new YamlError('found character that cannot start any token (tab)', 0);
+  return count;
+}
+
+/**
+ * 去掉行尾注释。
+ *
+ * `#` 只有前面是空白时才算注释起点 —— `image: nginx#1` 里那个不是。
+ * 引号里的也不算。
+ */
+function stripComment(text: string): string {
+  let quote: string | null = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else if (ch === '\\' && quote === '"') i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === '#' && (i === 0 || /\s/.test(text[i - 1]))) return text.slice(0, i).trimEnd();
+  }
+  return text.trimEnd();
+}
+
+/** 返回 [值, 消耗掉的行数] */
+function parseBlock(lines: Line[], start: number, indent: number): [unknown, number] {
+  if (start >= lines.length) return [null, start];
+  if (lines[start].text.startsWith('- ') || lines[start].text === '-') {
+    return parseSequence(lines, start, indent);
+  }
+  return parseMapping(lines, start, indent);
+}
+
+function parseSequence(lines: Line[], start: number, indent: number): [unknown[], number] {
+  const out: unknown[] = [];
+  let cursor = start;
+  while (cursor < lines.length && lines[cursor].indent === indent
+    && (lines[cursor].text === '-' || lines[cursor].text.startsWith('- '))) {
+    const line = lines[cursor];
+    const inline = line.text === '-' ? '' : line.text.slice(2).trim();
+    cursor += 1;
+
+    if (inline === '') {
+      const [value, next] = childBlock(lines, cursor, indent);
+      out.push(value);
+      cursor = next;
+      continue;
+    }
+    // `- name: app` 这种：这一项是个映射，第一个键就写在横杠后面
+    if (isMappingEntry(inline)) {
+      const childIndent = indent + 2;
+      const virtual: Line[] = [{ indent: childIndent, text: inline, index: line.index }];
+      while (cursor < lines.length && lines[cursor].indent >= childIndent) {
+        virtual.push(lines[cursor]);
+        cursor += 1;
+      }
+      const [value] = parseMapping(virtual, 0, childIndent);
+      out.push(value);
+      continue;
+    }
+    out.push(parseScalar(inline));
+  }
+  return [out, cursor];
+}
+
+function parseMapping(lines: Line[], start: number, indent: number): [Record<string, unknown>, number] {
+  const out: Record<string, unknown> = {};
+  let cursor = start;
+  while (cursor < lines.length && lines[cursor].indent === indent) {
+    const line = lines[cursor];
+    const split = splitKey(line.text);
+    if (!split) throw new YamlError(`could not find expected ':'`, line.index);
+    const [key, rest] = split;
+    cursor += 1;
+
+    if (rest === '') {
+      const [value, next] = childBlock(lines, cursor, indent);
+      out[key] = value;
+      cursor = next;
+      continue;
+    }
+    if (/^[|>][-+]?$/.test(rest)) {
+      const [value, next] = parseBlockScalar(lines, cursor, indent, rest);
+      out[key] = value;
+      cursor = next;
+      continue;
+    }
+    out[key] = parseScalar(rest);
+  }
+  return [out, cursor];
+}
+
+/** 下一层：可能是嵌套映射、列表，或者什么都没有（null） */
+function childBlock(lines: Line[], cursor: number, indent: number): [unknown, number] {
+  if (cursor >= lines.length) return [null, cursor];
+  const next = lines[cursor];
+  // YAML 允许列表和它的键同缩进
+  if (next.indent === indent && (next.text === '-' || next.text.startsWith('- '))) {
+    return parseSequence(lines, cursor, indent);
+  }
+  if (next.indent <= indent) return [null, cursor];
+  return parseBlock(lines, cursor, next.indent);
+}
+
+function parseBlockScalar(
+  lines: Line[], cursor: number, indent: number, marker: string
+): [string, number] {
+  const folded = marker.startsWith('>');
+  const chomp = marker.includes('-') ? 'strip' : marker.includes('+') ? 'keep' : 'clip';
+  const body: string[] = [];
+  let base: number | null = null;
+  let end = cursor;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (line.text.trim() === '') { body.push(''); end += 1; continue; }
+    const raw = line.text;
+    const lineIndent = raw === line.text ? line.indent : 0;
+    if (lineIndent <= indent) break;
+    if (base === null) base = lineIndent;
+    body.push(raw.slice(base).replace(/^\s+/, (spaces) => spaces));
+    end += 1;
+  }
+  while (body.length && body[body.length - 1] === '') body.pop();
+  let text = folded ? foldLines(body) : body.join('\n');
+  if (chomp !== 'strip' && text !== '') text += '\n';
+  return [text, end];
+}
+
+/** `>` 折叠：空行是段落分隔，其余的连成一行 */
+function foldLines(body: string[]): string {
+  const out: string[] = [];
+  for (const line of body) {
+    if (line === '') { out.push('\n'); continue; }
+    if (out.length && out[out.length - 1] !== '\n') out.push(' ');
+    out.push(line);
+  }
+  return out.join('').replace(/\n /g, '\n');
+}
+
+function isMappingEntry(text: string): boolean {
+  return splitKey(text) !== undefined;
+}
+
+/** `key: value` 里的冒号 —— 引号里的不算，`http://x` 里的也不算 */
+function splitKey(text: string): [string, string] | undefined {
+  let quote: string | null = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else if (ch === '\\' && quote === '"') i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === '{' || ch === '[') return undefined;
+    if (ch === ':' && (i + 1 >= text.length || /\s/.test(text[i + 1]))) {
+      return [unquote(text.slice(0, i).trim()), text.slice(i + 1).trim()];
+    }
+  }
+  return undefined;
+}
+
+export function parseScalar(text: string): unknown {
+  if (text === '') return null;
+  if (text.startsWith('"') || text.startsWith("'")) return unquote(text);
+  if (text.startsWith('{')) return parseFlowMap(text);
+  if (text.startsWith('[')) return parseFlowSeq(text);
+  if (text === 'null' || text === '~') return null;
+  if (text === 'true' || text === 'True') return true;
+  if (text === 'false' || text === 'False') return false;
+  if (/^-?\d+$/.test(text)) return Number(text);
+  if (/^-?\d*\.\d+$/.test(text)) return Number(text);
+  return text;
+}
+
+function unquote(text: string): string {
+  if (text.length >= 2 && text[0] === '"' && text[text.length - 1] === '"') {
+    return text.slice(1, -1)
+      .replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+      .replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  if (text.length >= 2 && text[0] === "'" && text[text.length - 1] === "'") {
+    return text.slice(1, -1).replace(/''/g, "'");
+  }
+  return text;
+}
+
+function splitFlow(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let current = '';
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; current += ch; continue; }
+    if (ch === '{' || ch === '[') depth += 1;
+    if (ch === '}' || ch === ']') depth -= 1;
+    if (ch === ',' && depth === 0) { parts.push(current); current = ''; continue; }
+    current += ch;
+  }
+  if (current.trim() !== '') parts.push(current);
+  return parts.map((part) => part.trim()).filter((part) => part !== '');
+}
+
+function parseFlowMap(text: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const part of splitFlow(text.slice(1, -1))) {
+    const split = splitKey(part) ?? splitFlowKey(part);
+    if (!split) continue;
+    out[split[0]] = parseScalar(split[1]);
+  }
+  return out;
+}
+
+/** 流式映射里 `a: b` 的冒号后面可以没有空格 */
+function splitFlowKey(part: string): [string, string] | undefined {
+  const index = part.indexOf(':');
+  return index < 0 ? undefined : [unquote(part.slice(0, index).trim()), part.slice(index + 1).trim()];
+}
+
+function parseFlowSeq(text: string): unknown[] {
+  return splitFlow(text.slice(1, -1)).map((part) => parseScalar(part));
+}

--- a/src/lib/opslab/yaml/stringify.ts
+++ b/src/lib/opslab/yaml/stringify.ts
@@ -1,0 +1,53 @@
+/**
+ * 反过来：对象 -> YAML
+ *
+ * Argo CD 要把「仓库里的期望」和「集群里的现状」摆在一起给人看，
+ * `argocd app diff` 打的就是这个。所以序列化的排版要稳定：同一个对象
+ * 每次输出必须逐字节一致，否则 diff 里全是噪声。
+ */
+export function stringifyYaml(value: unknown, indent = 0): string {
+  const pad = ' '.repeat(indent);
+
+  if (value === null || value === undefined) return 'null\n';
+  if (typeof value === 'boolean' || typeof value === 'number') return `${value}\n`;
+  if (typeof value === 'string') return `${scalar(value)}\n`;
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]\n';
+    return value.map((item) => {
+      const body = stringifyYaml(item, indent + 2);
+      if (isBlock(item)) return `${pad}-\n${body}`;
+      return `${pad}- ${body.trimStart()}`;
+    }).join('');
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return '{}\n';
+  return entries.map(([key, item]) => {
+    if (isBlock(item)) {
+      const body = stringifyYaml(item, Array.isArray(item) ? indent : indent + 2);
+      return `${pad}${key}:\n${body}`;
+    }
+    return `${pad}${key}: ${stringifyYaml(item, 0)}`;
+  }).join('');
+}
+
+function isBlock(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  return typeof value === 'object' && value !== null && Object.keys(value).length > 0;
+}
+
+/**
+ * 该不该加引号。
+ *
+ * 加错了不只是难看：`version: 1.10` 不加引号是数字 1.1，
+ * `enabled: "true"` 不加引号就变成布尔值。
+ */
+function scalar(text: string): string {
+  if (text === '') return "''";
+  if (text.includes('\n')) return JSON.stringify(text);
+  if (/^(true|false|null|~|True|False|yes|no|on|off)$/i.test(text)) return `'${text}'`;
+  if (/^-?\d*\.?\d+$/.test(text)) return `'${text}'`;
+  if (/^[\s]|[\s]$|[:#{}[\],&*!|>'"%@`]/.test(text)) return JSON.stringify(text);
+  return text;
+}

--- a/tests/opslab/argocd.test.ts
+++ b/tests/opslab/argocd.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Argo CD
+ *
+ * 三条最容易被误解的规则，这里逐条钉住：
+ *  1. OutOfSync 不等于坏了 —— 它和 health 是两个维度；
+ *  2. 没有 automated 就不会自己动，只报差异；
+ *  3. selfHeal 才会把手改改回去。
+ *
+ * 还有一条架构约束：控制器自己是集群里的工作负载，停了就不同步。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import { seedRepository } from '../../src/lib/opslab/git';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const REPO = 'https://git.corp.internal/platform/apps';
+const IMAGE = 'harbor.corp.internal/team/portal:1.4.0';
+
+const PORTAL_YAML = (replicas: number) => [
+  'apiVersion: apps/v1',
+  'kind: Deployment',
+  'metadata:',
+  '  name: portal',
+  '  namespace: shop',
+  'spec:',
+  `  replicas: ${replicas}`,
+  '  selector:',
+  '    matchLabels:',
+  '      app: portal',
+  '  template:',
+  '    metadata:',
+  '      labels:',
+  '        app: portal',
+  '    spec:',
+  '      containers:',
+  '      - name: web',
+  `        image: ${IMAGE}`,
+  '        ports:',
+  '        - containerPort: 8080',
+  '',
+].join('\n');
+
+const SERVICE_YAML = [
+  'apiVersion: v1',
+  'kind: Service',
+  'metadata:',
+  '  name: portal',
+  '  namespace: shop',
+  'spec:',
+  '  selector:',
+  '    app: portal',
+  '  ports:',
+  '  - port: 80',
+  '    targetPort: 8080',
+  '',
+].join('\n');
+
+const ARGOCD_DEPLOYMENT = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: {
+    name: 'argocd-application-controller', namespace: 'argocd',
+    labels: { 'app.kubernetes.io/name': 'argocd-application-controller' },
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'argocd-application-controller' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'argocd-application-controller' } },
+      spec: { containers: [{ name: 'controller', image: 'quay.io/argoproj/argocd:v3.2.4' }] },
+    },
+  },
+};
+
+function application(syncPolicy?: Record<string, unknown>) {
+  return {
+    apiVersion: 'argoproj.io/v1alpha1', kind: 'Application',
+    metadata: { name: 'portal', namespace: 'argocd' },
+    spec: {
+      project: 'default',
+      source: { repoURL: REPO, path: 'apps', targetRevision: 'main' },
+      destination: { server: 'https://kubernetes.default.svc', namespace: 'shop' },
+      ...(syncPolicy ? { syncPolicy } : {}),
+    },
+  };
+}
+
+function worldSpec(objects: unknown[], files: Record<string, string>): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'argocd', 'shop'],
+    images: {
+      [IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      'quay.io/argoproj/argocd:v3.2.4': { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    gitRepositories: [{ url: REPO, files }],
+    objects: objects as never,
+  };
+}
+
+const DEFAULT_FILES = { 'apps/portal.yaml': PORTAL_YAML(2), 'README.md': '# platform\n' };
+
+async function build(syncPolicy?: Record<string, unknown>, files: Record<string, string> = DEFAULT_FILES) {
+  return createOpsWorld({
+    world: worldSpec([ARGOCD_DEPLOYMENT, application(syncPolicy)], files),
+  });
+}
+
+/** 模拟平台组在别处推了一版，连带发出 webhook */
+function push(
+  world: Awaited<ReturnType<typeof build>>,
+  files: Record<string, string>,
+  message: string
+): void {
+  seedRepository(world.git.get(REPO)!, files, { message, timestamp: world.now() });
+  world.git.notifyPush(REPO);
+}
+
+const app = (world: Awaited<ReturnType<typeof build>>): KubeObject =>
+  world.cluster.registry.get(
+    world.cluster.scheme.mustGet({ group: 'argoproj.io', version: 'v1alpha1', resource: 'applications' }),
+    'argocd', 'portal'
+  );
+
+const deployment = (world: Awaited<ReturnType<typeof build>>): KubeObject | undefined => {
+  try {
+    return world.cluster.registry.get(
+      world.cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' }),
+      'shop', 'portal'
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+describe('比对', () => {
+  it('仓库里有、集群里没有 -> OutOfSync + Missing，而且不会自己动手', async () => {
+    const world = await build();
+    const status = app(world).status as any;
+    expect(status.sync.status).toBe('OutOfSync');
+    expect(status.health.status).toBe('Missing');
+    expect(deployment(world)).toBeUndefined();
+  });
+
+  it('status.sync.revision 就是远端那个 commit', async () => {
+    const world = await build();
+    const bare = world.git.get(REPO)!;
+    expect((app(world).status as any).sync.revision).toBe(bare.refs.main);
+  });
+
+  it('仓库连不上时说的是 ComparisonError，不是 OutOfSync', async () => {
+    const world = await createOpsWorld({
+      world: {
+        ...worldSpec([ARGOCD_DEPLOYMENT, {
+          ...application(),
+          spec: { ...application().spec, source: { repoURL: 'https://git.corp.internal/nope/nope', path: 'apps' } },
+        }], DEFAULT_FILES),
+      },
+    });
+    const status = app(world).status as any;
+    expect(status.sync.status).toBe('Unknown');
+    expect(status.conditions[0].type).toBe('ComparisonError');
+    expect(status.conditions[0].message).toContain('repository not accessible');
+  });
+
+  it('path 指错了会直接说出来 —— 不会静默同步 0 个对象', async () => {
+    const world = await createOpsWorld({
+      world: worldSpec([ARGOCD_DEPLOYMENT, {
+        ...application(),
+        spec: { ...application().spec, source: { repoURL: REPO, path: 'manifests', targetRevision: 'main' } },
+      }], DEFAULT_FILES),
+    });
+    const status = app(world).status as any;
+    expect(status.conditions[0].message).toContain('app path does not exist: manifests');
+  });
+});
+
+describe('自动同步', () => {
+  it('automated 打开之后对象被建出来，最终 Synced + Healthy', async () => {
+    const world = await build({ automated: {} });
+    const status = app(world).status as any;
+    expect(deployment(world)).toBeDefined();
+    expect(status.sync.status).toBe('Synced');
+    expect(status.health.status).toBe('Healthy');
+  });
+
+  it('同一个仓库里的多个文件都会被 apply', async () => {
+    const world = await build({ automated: {} }, {
+      'apps/portal.yaml': PORTAL_YAML(2),
+      'apps/service.yaml': SERVICE_YAML,
+    });
+    const services = world.cluster.registry.list(
+      world.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'services' }), { namespace: 'shop' }
+    );
+    expect(services.items.map((item) => item.metadata.name)).toContain('portal');
+    expect((app(world).status as any).resources).toHaveLength(2);
+  });
+
+  it('path 之外的文件不管 —— README 不是 manifest', async () => {
+    const world = await build({ automated: {} });
+    expect((app(world).status as any).resources).toHaveLength(1);
+  });
+
+  it('仓库有了新提交，集群跟着走', async () => {
+    const world = await build({ automated: { selfHeal: true } });
+    expect((deployment(world)!.spec as any).replicas).toBe(2);
+
+    push(world, { 'apps/portal.yaml': PORTAL_YAML(4) }, 'scale to 4');
+    await world.run('true');
+    expect((deployment(world)!.spec as any).replicas).toBe(4);
+  });
+});
+
+describe('手改之后会怎样', () => {
+  /**
+   * 有人手工改了副本数。
+   *
+   * 这里直接改对象而不是走 kubectl —— 这一组不需要真 CLI，
+   * `kubectl scale` 那条路在关卡的反向验证里走过了。
+   */
+  async function drift(syncPolicy?: Record<string, unknown>) {
+    const world = await build(syncPolicy ?? { automated: {} });
+    const definition = world.cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' });
+    const live = world.cluster.registry.get(definition, 'shop', 'portal');
+    world.cluster.registry.update(definition, 'shop', 'portal', {
+      ...live, spec: { ...(live.spec as any), replicas: 7 },
+    });
+    await world.cluster.settle();
+    return world;
+  }
+
+  it('只开 automated 不开 selfHeal：手改留着，只是被标成 OutOfSync', async () => {
+    const world = await drift({ automated: {} });
+    expect((deployment(world)!.spec as any).replicas).toBe(7);
+    expect((app(world).status as any).sync.status).toBe('OutOfSync');
+    // 但服务是好的 —— OutOfSync 不等于坏了
+    expect((app(world).status as any).health.status).toBe('Healthy');
+  });
+
+  it('开了 selfHeal：手改会被改回去', async () => {
+    const world = await drift({ automated: { selfHeal: true } });
+    expect((deployment(world)!.spec as any).replicas).toBe(2);
+    expect((app(world).status as any).sync.status).toBe('Synced');
+  });
+});
+
+describe('手动 sync', () => {
+  it('写 operation 就同步一次，做完把 operation 摘掉', async () => {
+    const world = await build();
+    expect(deployment(world)).toBeUndefined();
+
+    // argocd CLI 写的就是这个字段；关卡里学员敲的是 kubectl patch
+    const definition = world.cluster.scheme.mustGet({
+      group: 'argoproj.io', version: 'v1alpha1', resource: 'applications',
+    });
+    const live = world.cluster.registry.get(definition, 'argocd', 'portal');
+    world.cluster.registry.update(definition, 'argocd', 'portal', {
+      ...live, operation: { sync: {} },
+    } as never);
+    await world.cluster.settle();
+    expect(deployment(world)).toBeDefined();
+    expect((app(world).status as any).sync.status).toBe('Synced');
+    expect((app(world).status as any).operationState.phase).toBe('Succeeded');
+    expect((app(world) as any).operation).toBeUndefined();
+  });
+});
+
+describe('prune', () => {
+  it('仓库里删掉的对象，开了 prune 才会被删', async () => {
+    const world = await build({ automated: { prune: true, selfHeal: true } }, {
+      'apps/portal.yaml': PORTAL_YAML(2),
+      'apps/service.yaml': SERVICE_YAML,
+    });
+    const services = () => world.cluster.registry.list(
+      world.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'services' }), { namespace: 'shop' }
+    ).items.map((item) => item.metadata.name);
+    expect(services()).toContain('portal');
+
+    push(world, { 'apps/portal.yaml': PORTAL_YAML(2) }, 'drop the service');
+    await world.run('true');
+    expect(services()).not.toContain('portal');
+  });
+
+  it('不是 Argo 建的对象不会被 prune 掉', async () => {
+    const world = await build({ automated: { prune: true, selfHeal: true } });
+    world.cluster.registry.create(
+      world.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'configmaps' }), 'shop',
+      { apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: '手工建的', namespace: 'shop' }, data: {} } as never
+    );
+    await world.run('true');
+    const maps = world.cluster.registry.list(
+      world.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'configmaps' }), { namespace: 'shop' }
+    );
+    expect(maps.items.map((item) => item.metadata.name)).toContain('手工建的');
+  });
+});
+
+describe('控制器自己是工作负载', () => {
+  it('Deployment 缩到 0，同步就停了', async () => {
+    const world = await build({ automated: { selfHeal: true } });
+    expect(deployment(world)).toBeDefined();
+
+    const definition = world.cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' });
+    const controller = world.cluster.registry.get(definition, 'argocd', 'argocd-application-controller');
+    world.cluster.registry.update(definition, 'argocd', 'argocd-application-controller', {
+      ...controller, spec: { ...(controller.spec as any), replicas: 0 },
+    });
+    await world.cluster.settle();
+    push(world, { 'apps/portal.yaml': PORTAL_YAML(9) }, 'scale to 9');
+    await world.cluster.settle();
+    // 控制器不在，新提交不会被同步下来
+    expect((deployment(world)!.spec as any).replicas).toBe(2);
+  });
+});

--- a/tests/opslab/yaml.test.ts
+++ b/tests/opslab/yaml.test.ts
@@ -1,0 +1,261 @@
+/**
+ * YAML
+ *
+ * 说了算的是最后那一组：同一份 manifest，走我们的解析器和走真 kubectl
+ * （`apply --dry-run=client -o json`），结果必须一致。前面的单元测试
+ * 只证明「我们以为 YAML 是这样」，那一组才证明「kubectl 也这么认为」。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { parseYaml, parseYamlAll, stringifyYaml, YamlError } from '../../src/lib/opslab/yaml';
+import { createVfs } from '../../src/lib/opslab/machine';
+import { createCliRuntime, defaultKubeconfig, renderKubeconfig } from '../../src/lib/opslab/wasm';
+import { createCluster } from '../../src/lib/opslab/controllers';
+
+describe('标量', () => {
+  it('数字、布尔、null 各归各的类型', () => {
+    expect(parseYaml('a: 3\nb: true\nc: false\nd: null\ne: ~\nf: 1.5\n')).toEqual({
+      a: 3, b: true, c: false, d: null, e: null, f: 1.5,
+    });
+  });
+
+  it('引号里的东西保持字符串 —— 版本号不加引号会变成小数', () => {
+    expect(parseYaml('a: "3"\nb: \'true\'\nc: 1.10\nd: "1.10"\n')).toEqual({
+      a: '3', b: 'true', c: 1.1, d: '1.10',
+    });
+  });
+
+  it('行尾注释去掉，但值里的 # 留着', () => {
+    expect(parseYaml('a: nginx  # 用这个\nb: nginx#1\nc: "x # y"\n')).toEqual({
+      a: 'nginx', b: 'nginx#1', c: 'x # y',
+    });
+  });
+
+  it('冒号后面必须有空白才算分隔 —— URL 不会被切开', () => {
+    expect(parseYaml('url: https://git.corp.internal/platform/apps\n')).toEqual({
+      url: 'https://git.corp.internal/platform/apps',
+    });
+  });
+});
+
+describe('结构', () => {
+  it('嵌套映射与列表', () => {
+    expect(parseYaml([
+      'spec:',
+      '  replicas: 2',
+      '  template:',
+      '    spec:',
+      '      containers:',
+      '      - name: app',
+      '        image: nginx:1.27',
+      '        ports:',
+      '        - containerPort: 8080',
+      '',
+    ].join('\n'))).toEqual({
+      spec: {
+        replicas: 2,
+        template: {
+          spec: { containers: [{ name: 'app', image: 'nginx:1.27', ports: [{ containerPort: 8080 }] }] },
+        },
+      },
+    });
+  });
+
+  it('列表可以和它的键同缩进，也可以多缩进一层', () => {
+    const flat = parseYaml('items:\n- a\n- b\n');
+    const nested = parseYaml('items:\n  - a\n  - b\n');
+    expect(flat).toEqual({ items: ['a', 'b'] });
+    expect(nested).toEqual(flat);
+  });
+
+  it('流式写法：{} 与 []', () => {
+    expect(parseYaml('a: {x: 1, y: two}\nb: [1, 2, "three"]\nc: {}\n')).toEqual({
+      a: { x: 1, y: 'two' }, b: [1, 2, 'three'], c: {},
+    });
+  });
+
+  it('块标量 | 保留换行，> 折成一行', () => {
+    const parsed = parseYaml([
+      'literal: |',
+      '  line one',
+      '  line two',
+      'folded: >',
+      '  line one',
+      '  line two',
+      'stripped: |-',
+      '  no trailing newline',
+      '',
+    ].join('\n')) as Record<string, string>;
+    expect(parsed.literal).toBe('line one\nline two\n');
+    expect(parsed.folded).toBe('line one line two\n');
+    expect(parsed.stripped).toBe('no trailing newline');
+  });
+
+  it('块标量里的 # 不是注释', () => {
+    const parsed = parseYaml('script: |\n  # 这是脚本的一部分\n  echo hi\n') as Record<string, string>;
+    expect(parsed.script).toBe('# 这是脚本的一部分\necho hi\n');
+  });
+
+  it('--- 分开的多份文档，空的丢掉', () => {
+    const docs = parseYamlAll('---\nkind: A\n---\n# 只有注释\n---\nkind: B\n');
+    expect(docs).toEqual([{ kind: 'A' }, { kind: 'B' }]);
+  });
+
+  it('tab 缩进照 YAML 的规矩报错', () => {
+    expect(() => parseYaml('a:\n\tb: 1\n')).toThrow(YamlError);
+  });
+});
+
+describe('序列化', () => {
+  it('转回去再解析出来是同一个对象', () => {
+    const object = {
+      apiVersion: 'apps/v1', kind: 'Deployment',
+      metadata: { name: 'portal', labels: { app: 'portal' } },
+      spec: {
+        replicas: 2,
+        template: { spec: { containers: [{ name: 'app', image: 'nginx:1.27', ports: [{ containerPort: 8080 }] }] } },
+      },
+    };
+    expect(parseYaml(stringifyYaml(object))).toEqual(object);
+  });
+
+  it('会被读成别的类型的字符串要加引号', () => {
+    const text = stringifyYaml({ version: '1.10', enabled: 'true', empty: '' });
+    expect(text).toContain("version: '1.10'");
+    expect(text).toContain("enabled: 'true'");
+    expect(parseYaml(text)).toEqual({ version: '1.10', enabled: 'true', empty: '' });
+  });
+
+  it('同一个对象输出逐字节一致 —— 否则 diff 里全是噪声', () => {
+    const object = { a: [1, 2], b: { c: 'd' } };
+    expect(stringifyYaml(object)).toBe(stringifyYaml(object));
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 和真 kubectl 对答案                                                 */
+/* ------------------------------------------------------------------ */
+
+const WASM_PATH = path.join(__dirname, '../../public/opslab/opslab-cli.wasm');
+const WASM_EXEC = path.join(__dirname, '../../public/opslab/wasm_exec.js');
+const HAS_ARTIFACT = fs.existsSync(WASM_PATH) && fs.existsSync(WASM_EXEC);
+const describeIfBuilt = HAS_ARTIFACT ? describe : describe.skip;
+
+const MANIFESTS: Array<[string, string]> = [
+  ['最普通的 Deployment', [
+    'apiVersion: apps/v1',
+    'kind: Deployment',
+    'metadata:',
+    '  name: portal',
+    '  namespace: payments',
+    '  labels:',
+    '    app: portal',
+    'spec:',
+    '  replicas: 2',
+    '  selector:',
+    '    matchLabels:',
+    '      app: portal',
+    '  template:',
+    '    metadata:',
+    '      labels:',
+    '        app: portal',
+    '    spec:',
+    '      containers:',
+    '      - name: web',
+    '        image: harbor.corp.internal/team/portal:1.4.0',
+    '        ports:',
+    '        - containerPort: 8080',
+    '        env:',
+    '        - name: TIER',
+    '          value: "web"',
+    '        - name: REPLICAS',
+    '          value: "2"',
+    '',
+  ].join('\n')],
+  ['带注释、引号与流式写法', [
+    'apiVersion: v1   # 核心组',
+    'kind: ConfigMap',
+    'metadata:',
+    '  name: settings',
+    '  namespace: payments',
+    '  annotations: {owner: platform, tier: "1"}',
+    'data:',
+    '  endpoint: https://portal.corp.internal/api',
+    '  version: "1.10"',
+    '  retries: "3"',
+    '  banner: |',
+    '    line one',
+    '    line two',
+    '',
+  ].join('\n')],
+  ['NetworkPolicy —— 嵌套列表套映射', [
+    'apiVersion: networking.k8s.io/v1',
+    'kind: NetworkPolicy',
+    'metadata:',
+    '  name: ledger',
+    '  namespace: payments',
+    'spec:',
+    '  podSelector:',
+    '    matchLabels:',
+    '      app: ledger',
+    '  policyTypes:',
+    '  - Ingress',
+    '  - Egress',
+    '  ingress:',
+    '  - from:',
+    '    - podSelector:',
+    '        matchLabels:',
+    '          app: portal',
+    '  egress:',
+    '  - to:',
+    '    - namespaceSelector:',
+    '        matchLabels:',
+    '          kubernetes.io/metadata.name: kube-system',
+    '    ports:',
+    '    - protocol: UDP',
+    '      port: 53',
+    '',
+  ].join('\n')],
+];
+
+describeIfBuilt('和真 kubectl 对答案', () => {
+  jest.setTimeout(120_000);
+
+  let runtime: ReturnType<typeof createCliRuntime> | null = null;
+  function cli() {
+    if (!runtime) {
+      if (!(globalThis as Record<string, unknown>).Go) createRequire(__filename)(WASM_EXEC);
+      runtime = createCliRuntime({ bytes: new Uint8Array(fs.readFileSync(WASM_PATH)), cache: false });
+    }
+    return runtime;
+  }
+
+  it.each(MANIFESTS)('%s', async (_name, manifest) => {
+    // 用一个真集群做 discovery —— kubectl 得先能把 kind 映射到资源上
+    const cluster = createCluster();
+    cluster.start();
+    const vfs = createVfs(() => 0);
+    vfs.writeFile('/root/.kube/config', renderKubeconfig(defaultKubeconfig()));
+    vfs.writeFile('/root/m.yaml', manifest);
+    const result = await cli().run('kubectl', // 校验要向 apiserver 取 OpenAPI，这里没有真集群；关掉它，
+      // 我们要的只是 kubectl 自己的 YAML 解析结果
+      ['apply', '-f', 'm.yaml', '--dry-run=client', '--validate=false', '-o', 'json'], {
+      vfs, cwd: '/root',
+      fetch: (url, init) => cluster.apiServer.handle(url, init as never),
+      now: () => 0,
+    });
+    expect(result.stderr).toBe('');
+
+    const fromKubectl = JSON.parse(result.stdout);
+    // kubectl 会补上 apply 的注解与空 status，比对之前去掉
+    delete fromKubectl.metadata.annotations?.['kubectl.kubernetes.io/last-applied-configuration'];
+    if (fromKubectl.metadata.annotations && Object.keys(fromKubectl.metadata.annotations).length === 0) {
+      delete fromKubectl.metadata.annotations;
+    }
+    delete fromKubectl.metadata.creationTimestamp;
+    delete fromKubectl.status;
+
+    expect(parseYaml(manifest)).toEqual(fromKubectl);
+  });
+});


### PR DESCRIPTION
## 这一关教什么

集群里跑着 5 个副本，仓库里写的是 2 个 —— 某次大促手工 `kubectl scale` 上去的，没回写。谁也说不清还有多少这种改动。GitOps 要解决的就是「现在到底跑着什么」这个问题的答案该从哪里来。

三条最容易被误解的规则，判定逐条钉住：

1. **OutOfSync 不等于坏了**。它和 `health` 是两个维度。刚被手工扩容过的服务是 OutOfSync 但 Healthy；刚同步完但镜像拉不下来的是 Synced 但 Degraded。
2. **没有 `automated` 就不会自己动**，只报差异。
3. **`selfHeal` 才会把手改改回去，`prune` 才会删仓库里已经没有的对象**。三个开关管三件事。

## 配套做的东西

**YAML 子集解析器**（`src/lib/opslab/yaml/`）。Argo 的控制器跑在宿主侧，够不着 wasm 里 kubectl 自带的解析器。正确性不靠自证：三份非平凡 manifest（Deployment、带注释与流式写法的 ConfigMap、嵌套列表套映射的 NetworkPolicy）同时走我们的解析器和真 kubectl 的 `apply --dry-run=client -o json`，结果必须逐字段一致。

**只比对仓库写了的字段**。第一版做 `JSON.stringify` 全等，结果 Service 永远 OutOfSync —— 因为 apiserver 给它补了 `clusterIPs`。真 Argo 靠 last-applied 注解圈定自己管的字段，我们用「desired 是 live 的子集」达到同样效果。不这么做的话每个对象一建出来就是 OutOfSync，这一栏就没有信息量了。

**每次同步都落一次 tracking 标签**，不只是建对象的时候。否则先手工建、后被 Application 纳管的对象永远 prune 不掉 —— 而「接管存量」正是这一关的场景。

**webhook + 兜底轮询**。`git push` 之后立刻重新比对；轮询（180s，Argo 的默认值）标成 background，不然世界永远静不下来。

## 反向验证

除了标准的两条，两种近似解都单独跑过：

| 情形 | 结果 |
| --- | --- |
| 草稿原样应用（没有 syncPolicy） | OutOfSync，手改留着 → 判定 1、3 挂 |
| 只开 `automated`，不开 selfHeal | 初始那 5 个副本不会被纠正，手改也留着 → 判定 1、3 挂 |
| 参考解（automated + selfHeal + prune） | 全绿 |

## 顺带

`git add -A` 之前不认（`-A` 被当成普通 flag 过滤掉，然后报 "Nothing specified"）。

全量 1381 个用例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)