### PR TITLE
feat(opslab): 服务端 apply，以及让 Go 的时钟跟着虚拟时钟走

### DIFF
--- a/scripts/build-opslab-wasm.sh
+++ b/scripts/build-opslab-wasm.sh
@@ -121,4 +121,27 @@ GOOS=js GOARCH=wasm go -C "$ROOT/$WORK" build \
 cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$ROOT/$OUT_DIR/wasm_exec.js" 2>/dev/null \
   || cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" "$ROOT/$OUT_DIR/wasm_exec.js"
 
+# Go 的 time.Now() 在 js/wasm 里读的是宿主的 Date。虚拟世界里这会让
+# `helm list` 的 UPDATED 列、各种时间戳每次都不一样，回放就对不上了。
+# 把两个时钟入口接到宿主提供的虚拟时钟上（不提供时仍然用真时间）。
+python3 - "$ROOT/$OUT_DIR/wasm_exec.js" <<'PYEOF'
+import sys
+path = sys.argv[1]
+source = open(path).read()
+old_wall = '''					const msec = (new Date).getTime();'''
+new_wall = '''					// opslab: 虚拟时钟优先，回放才逐字节一致
+					const msec = (globalThis.__opslabNow ? globalThis.__opslabNow() : (new Date).getTime());'''
+old_nano = '''						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);'''
+new_nano = '''						// opslab: 单调时钟同样跟着虚拟时钟走。
+						// 加 1 是必须的：Go 的运行时把 nanotime 返回 0 当成致命错误，
+						// 而虚拟时钟从 0 开始是很正常的事。
+						setInt64(sp + 8, (globalThis.__opslabNow
+							? globalThis.__opslabNow() + 1
+							: (timeOrigin + performance.now())) * 1000000);'''
+if old_wall not in source or old_nano not in source:
+    raise SystemExit('wasm_exec.js 的时钟入口变了，补丁要重写')
+source = source.replace(old_wall, new_wall).replace(old_nano, new_nano)
+open(path, 'w').write(source)
+PYEOF
+
 ls -lh "$ROOT/$OUT_DIR/$OUT_NAME" | awk '{print "'"$OUT_NAME"':", $5}'

--- a/src/lib/opslab/apiserver/http.ts
+++ b/src/lib/opslab/apiserver/http.ts
@@ -11,7 +11,7 @@
  */
 import { Registry } from './registry';
 import { Scheme, ResourceDefinition } from './scheme';
-import { ApiError, badRequest, notFound, toStatus } from './errors';
+import { ApiError, badRequest, invalid, notFound, toStatus } from './errors';
 import { renderTable, wantsTable } from './tables';
 import type { KubeObject, PropagationPolicy, WatchEventOut } from './types';
 
@@ -34,6 +34,16 @@ import { openApiDocument, openApiRoot } from './openapi';
 import type { PatchType } from './patch';
 import { createExecSession, parseExecRequest, type ExecHandler } from './exec';
 import type { StreamSession, UpgradeRequest } from '../net';
+import { parseYaml } from '../yaml';
+
+/** apply 的载荷：先按 JSON 试，不行再按 YAML */
+function parseYamlBody(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return parseYaml(raw);
+  }
+}
 
 interface ParsedPath {
   group: string;
@@ -409,9 +419,28 @@ export class ApiServer {
     const raw = await this.readBodyRaw(init);
     let patch: unknown;
     try {
-      patch = raw ? JSON.parse(raw) : {};
+      // apply 的载荷是 YAML（JSON 也是合法 YAML，客户端多半就发 JSON）
+      patch = raw
+        ? (patchType === 'application/apply-patch+yaml' ? parseYamlBody(raw) : JSON.parse(raw))
+        : {};
     } catch {
       return statusResponse(badRequest('the object provided is unrecognized (must be of type Patch)'));
+    }
+
+    if (patchType === 'application/apply-patch+yaml') {
+      const fieldManager = params.get('fieldManager');
+      if (!fieldManager) {
+        return statusResponse(invalid(definition.kind, parsed.name, [{
+          reason: 'FieldValueRequired',
+          message: 'Required value: is required for apply patch',
+          field: 'metadata.fieldManager',
+        }], definition.group));
+      }
+      const applied = this.registry.apply(
+        definition, parsed.namespace, parsed.name, patch as never,
+        { fieldManager, dryRun: params.getAll('dryRun').includes('All') }
+      );
+      return json(applied);
     }
 
     const patched = this.registry.patch(definition, parsed.namespace, parsed.name, patch, patchType, {

--- a/src/lib/opslab/apiserver/patch.ts
+++ b/src/lib/opslab/apiserver/patch.ts
@@ -190,10 +190,8 @@ export function applyPatch(target: Json, patch: Json, type: PatchType): Json {
     case 'application/merge-patch+json': return applyMergePatch(target, patch);
     case 'application/strategic-merge-patch+json': return applyStrategicMergePatch(target, patch);
     case 'application/apply-patch+yaml':
-      throw badRequest(
-        'the server responded with the status code 415 but did not return more information: ' +
-        'server-side apply is not supported by opslab; drop --server-side'
-      );
+      // 走的是 Registry.apply（要 fieldManager 与 managedFields），不在这里
+      throw badRequest('apply patches must go through server-side apply');
     default:
       throw badRequest(`Unsupported Media Type: ${String(type)}`);
   }

--- a/src/lib/opslab/apiserver/registry.ts
+++ b/src/lib/opslab/apiserver/registry.ts
@@ -9,6 +9,9 @@
  * 会接官方 OpenAPI + ajv。这里管的是**对象生命周期**，两者边界分清。
  */
 import { applyPatch, PatchType } from './patch';
+import {
+  fieldSetOf, mergeApplied, ownedBy, pruneUnowned, recordOwnership, strippedForApply,
+} from './ssa';
 import { Store, WatchEvent } from '../store';
 import {
   alreadyExists,
@@ -323,6 +326,51 @@ export class Registry {
 
     const kv = this.store.put(key, candidate);
     return this.decorate(kv.value as KubeObject, kv.modRevision);
+  }
+
+  /**
+   * 服务端 apply。
+   *
+   * 和 update 的区别是「谁写的」被记了下来（managedFields），于是下一次
+   * apply 少写了某个字段，服务端能自己把它删掉 —— 客户端不用算差异。
+   * helm 4 与 `kubectl apply --server-side` 走的都是这条路。
+   */
+  apply(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    name: string,
+    desired: KubeObject,
+    options: { fieldManager: string; dryRun?: boolean }
+  ): KubeObject {
+    this.assertScope(definition, namespace);
+    const key = storageKey(definition, namespace, name);
+    const existing = this.store.get(key);
+    const stripped = strippedForApply(desired);
+    const fields = fieldSetOf(stripped);
+    const apiVersion = Scheme.toApiVersion(definition.group, definition.version);
+
+    if (!existing) {
+      const created = clone(stripped);
+      created.metadata = created.metadata ?? ({} as ObjectMeta);
+      created.metadata.name = name;
+      (created.metadata as unknown as Record<string, unknown>).managedFields =
+        recordOwnership(created, options.fieldManager, apiVersion, formatTimestamp(this.now()), fields);
+      return this.create(definition, namespace, created, { dryRun: options.dryRun });
+    }
+
+    const live = existing.value as KubeObject;
+    const owned = ownedBy(live, options.fieldManager);
+    // 先把自己上一次写过、这次不写的字段摘掉，再合并这一次的
+    const pruned = pruneUnowned(live, owned, fields) as KubeObject;
+    const merged = mergeApplied(pruned, stripped) as KubeObject;
+    merged.metadata = { ...live.metadata, ...merged.metadata };
+    (merged.metadata as unknown as Record<string, unknown>).managedFields =
+      recordOwnership(live, options.fieldManager, apiVersion, formatTimestamp(this.now()), fields);
+    // status 归 status 子资源管，apply 主资源动不了它
+    merged.status = live.status;
+    delete (merged.metadata as unknown as Record<string, unknown>).resourceVersion;
+
+    return this.update(definition, namespace, name, merged, { dryRun: options.dryRun });
   }
 
   /**

--- a/src/lib/opslab/apiserver/ssa.ts
+++ b/src/lib/opslab/apiserver/ssa.ts
@@ -1,0 +1,117 @@
+/**
+ * 服务端 apply
+ *
+ * `PATCH ... Content-Type: application/apply-patch+yaml` —— 客户端把「我要的
+ * 样子」整份发过来，服务端合并，并记下**哪些字段是谁写的**（managedFields）。
+ *
+ * 关键在最后那一句。有了归属，下一次 apply 少写了某个字段，服务端就知道
+ * 「这个字段本来是我加的、现在我不要了」，于是删掉它 —— 客户端不必自己算差异。
+ * 这正是 `helm upgrade` 能把上一版多出来的字段清掉的原因，也是
+ * `kubectl apply --server-side` 相对 last-applied 注解的进步。
+ *
+ * 不做的部分：**冲突检测**。真 apiserver 会在两个 manager 抢同一个字段时报
+ * 409 并要求 `--force-conflicts`。这里所有 apply 都当作带了 force。
+ */
+import type { KubeObject } from './types';
+
+export interface FieldSet {
+  [key: string]: FieldSet;
+}
+
+const PREFIX = 'f:';
+
+/**
+ * 一个对象声明了哪些字段。
+ *
+ * 真 k8s 的 FieldsV1 会给「有 merge key 的列表」拆成 `k:{"name":"web"}` 这种
+ * 逐项归属。这里整个列表算一个字段 —— 于是「两个 manager 各往
+ * containers 里加一个」这种情况我们分不开，但「apply 少写了一项就删掉」
+ * 这个主要行为是对的。
+ */
+export function fieldSetOf(value: unknown): FieldSet {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return {};
+  const out: FieldSet = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    out[`${PREFIX}${key}`] = fieldSetOf(child);
+  }
+  return out;
+}
+
+/** 把 desired 合进 live。列表整体替换，映射逐键递归 —— 和 SSA 一致。 */
+export function mergeApplied(live: unknown, desired: unknown): unknown {
+  if (desired === null) return null;
+  if (typeof desired !== 'object' || Array.isArray(desired)) return desired;
+  if (typeof live !== 'object' || live === null || Array.isArray(live)) {
+    return JSON.parse(JSON.stringify(desired));
+  }
+  const out: Record<string, unknown> = { ...(live as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(desired as Record<string, unknown>)) {
+    out[key] = mergeApplied((live as Record<string, unknown>)[key], value);
+  }
+  return out;
+}
+
+/**
+ * 上一次这个 manager 写过、这次不写了的字段，删掉。
+ *
+ * 没有这一步，`helm upgrade` 去掉一个 env 之后那个 env 会一直留在集群里，
+ * 而 chart 里已经找不到它了 —— 最难查的一类「幽灵配置」。
+ */
+export function pruneUnowned(target: unknown, before: FieldSet, after: FieldSet): unknown {
+  if (typeof target !== 'object' || target === null || Array.isArray(target)) return target;
+  const out: Record<string, unknown> = { ...(target as Record<string, unknown>) };
+  for (const key of Object.keys(before)) {
+    const name = key.slice(PREFIX.length);
+    if (!(key in after)) {
+      delete out[name];
+      continue;
+    }
+    const child = pruneUnowned(out[name], before[key], after[key]);
+    if (child !== undefined) out[name] = child;
+  }
+  return out;
+}
+
+export interface ManagedFieldsEntry {
+  manager: string;
+  operation: 'Apply' | 'Update';
+  apiVersion: string;
+  time: string;
+  fieldsType: 'FieldsV1';
+  fieldsV1: FieldSet;
+}
+
+/** 取出某个 manager 上一次 apply 的字段集 */
+export function ownedBy(object: KubeObject, manager: string): FieldSet {
+  const entries = (object.metadata as unknown as { managedFields?: ManagedFieldsEntry[] }).managedFields ?? [];
+  return entries.find((entry) => entry.manager === manager && entry.operation === 'Apply')?.fieldsV1 ?? {};
+}
+
+/** 记下这一次的归属，替换掉这个 manager 之前那条 */
+export function recordOwnership(
+  object: KubeObject,
+  manager: string,
+  apiVersion: string,
+  time: string,
+  fields: FieldSet
+): ManagedFieldsEntry[] {
+  const entries = ((object.metadata as unknown as { managedFields?: ManagedFieldsEntry[] }).managedFields ?? [])
+    .filter((entry) => !(entry.manager === manager && entry.operation === 'Apply'));
+  entries.push({ manager, operation: 'Apply', apiVersion, time, fieldsType: 'FieldsV1', fieldsV1: fields });
+  return entries.sort((a, b) => (a.manager < b.manager ? -1 : a.manager > b.manager ? 1 : 0));
+}
+
+/**
+ * apply 的时候哪些字段不算「客户端声明的」。
+ *
+ * 服务端自己写的东西不该被 prune 掉，也不该算进归属里。
+ */
+export function strippedForApply(object: KubeObject): KubeObject {
+  const clone = JSON.parse(JSON.stringify(object)) as KubeObject;
+  const metadata = clone.metadata as unknown as Record<string, unknown>;
+  for (const key of ['uid', 'resourceVersion', 'generation', 'creationTimestamp', 'managedFields', 'selfLink']) {
+    delete metadata[key];
+  }
+  delete (clone as Record<string, unknown>).status;
+  return clone;
+}

--- a/src/lib/opslab/wasm/runtime.ts
+++ b/src/lib/opslab/wasm/runtime.ts
@@ -168,13 +168,14 @@ export class CliRuntime {
       HOME: '/root',
       KUBECONFIG: '/root/.kube/config',
       PATH: '/usr/local/bin:/usr/bin:/bin',
+      TZ: 'UTC',
       ...(options.env ?? {}),
     };
 
     const host = globalThis as Record<string, unknown>;
     const saved = {
       fs: host.fs, fetch: host.fetch, process: host.process, path: host.path,
-      dial: host.__opslabDial,
+      dial: host.__opslabDial, now: host.__opslabNow,
     };
     const openConnections: WebSocketConnection[] = [];
     // Go 退出之后再 resume 就是 "Go program has already exited"。
@@ -189,6 +190,27 @@ export class CliRuntime {
       env, on: () => {},
     };
     host.fetch = (url: unknown, init: unknown) => options.fetch(String(url), init);
+    /**
+     * Go 的 time.Now()。
+     *
+     * 不接的话 `helm list` 的 UPDATED 列、各种时间戳读的都是宿主的真时间，
+     * 同一串命令重放两遍输出就不一样了。wasm_exec.js 那两个时钟入口
+     * 由构建脚本打了补丁，会先看这个函数。
+     */
+    if (options.now) host.__opslabNow = options.now;
+    else delete host.__opslabNow;
+
+    /**
+     * 时区固定成 UTC。
+     *
+     * Go 在 js/wasm 上不看 `TZ`，它是拿 `new Date().getTimezoneOffset()` 问
+     * 宿主的。不管的话 `helm list` 的 UPDATED 列会带上这台机器的时区，
+     * 同一个世界换台机器重放，输出就不一样了。
+     * 只在这一次运行期间生效，跑完还回去。
+     */
+    const savedOffset = Date.prototype.getTimezoneOffset;
+    // eslint-disable-next-line no-extend-native
+    Date.prototype.getTimezoneOffset = () => 0;
     host.__opslabDial = (address: unknown): DialHandle | null => {
       const server = options.dial?.(String(address));
       if (!server) return null;
@@ -239,6 +261,9 @@ export class CliRuntime {
       host.process = saved.process;
       host.path = saved.path;
       host.__opslabDial = saved.dial;
+      host.__opslabNow = saved.now;
+      // eslint-disable-next-line no-extend-native
+      Date.prototype.getTimezoneOffset = savedOffset;
       // Go 正常退出时自己会 Close；异常退出时别把连接留着，
       // 不然下一条命令跑起来还有上一条的会话在往一个已经没人听的口子写
       finished = true;

--- a/tests/opslab/apiserver.test.ts
+++ b/tests/opslab/apiserver.test.ts
@@ -485,3 +485,90 @@ describe('确定性', () => {
     for (let i = 0; i < 99; i += 1) expect(run()).toBe(first);
   });
 });
+
+/**
+ * 服务端 apply
+ *
+ * 和普通 update 的区别只有一句话：**哪些字段是谁写的**被记了下来。
+ * 有了归属，下一次 apply 少写了某个字段，服务端就知道该删掉它。
+ * 没有这一步，`helm upgrade` 去掉一个 env 之后那个 env 会一直留在集群里，
+ * 而 chart 里已经找不到它了。
+ */
+describe('服务端 apply', () => {
+  const CONFIGMAPS: ResourceDefinition = {
+    group: '', version: 'v1', resource: 'configmaps', singular: 'configmap',
+    kind: 'ConfigMap', namespaced: true, shortNames: ['cm'],
+  };
+
+  function bench() {
+    const store = createStore();
+    const scheme = createScheme([CONFIGMAPS]);
+    let uid = 0;
+    const registry = new Registry({
+      store, scheme,
+      now: () => Date.parse('2026-03-02T09:00:00Z'),
+      uid: () => `uid-${++uid}`,
+    });
+    return { registry };
+  }
+
+  const desired = (data: Record<string, string>) => ({
+    apiVersion: 'v1', kind: 'ConfigMap',
+    metadata: { name: 'settings', namespace: 'default' },
+    data,
+  });
+
+  it('对象不存在就建出来', () => {
+    const { registry } = bench();
+    const applied = registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '1' }) as never, {
+      fieldManager: 'helm',
+    });
+    expect((applied as any).data).toEqual({ a: '1' });
+  });
+
+  it('记下谁写了哪些字段', () => {
+    const { registry } = bench();
+    const applied = registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '1' }) as never, {
+      fieldManager: 'helm',
+    });
+    const managed = (applied.metadata as any).managedFields;
+    expect(managed).toHaveLength(1);
+    expect(managed[0]).toMatchObject({ manager: 'helm', operation: 'Apply', fieldsType: 'FieldsV1' });
+    expect(managed[0].fieldsV1['f:data']).toEqual({ 'f:a': {} });
+  });
+
+  it('这一次不写的字段会被删掉 —— 这是 SSA 的全部意义', () => {
+    const { registry } = bench();
+    registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '1', b: '2' }) as never, {
+      fieldManager: 'helm',
+    });
+    const second = registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '9' }) as never, {
+      fieldManager: 'helm',
+    });
+    expect((second as any).data).toEqual({ a: '9' });
+  });
+
+  it('别人写的字段不会被顺手删掉', () => {
+    const { registry } = bench();
+    registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '1' }) as never, { fieldManager: 'helm' });
+    registry.apply(CONFIGMAPS, 'default', 'settings', desired({ b: '2' }) as never, { fieldManager: 'kubectl' });
+    // helm 再 apply 一次，只声明 a —— b 是 kubectl 的，留着
+    const third = registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '1' }) as never, {
+      fieldManager: 'helm',
+    });
+    expect((third as any).data).toEqual({ a: '1', b: '2' });
+    expect((third.metadata as any).managedFields.map((entry: any) => entry.manager)).toEqual(['helm', 'kubectl']);
+  });
+
+  it('服务端自己写的东西不算客户端声明的', () => {
+    const { registry } = bench();
+    const created = registry.apply(CONFIGMAPS, 'default', 'settings', desired({ a: '1' }) as never, {
+      fieldManager: 'helm',
+    });
+    // uid / creationTimestamp 是服务端补的，不该出现在归属里
+    const fields = (created.metadata as any).managedFields[0].fieldsV1;
+    expect(fields['f:metadata']?.['f:uid']).toBeUndefined();
+    expect(fields['f:metadata']?.['f:creationTimestamp']).toBeUndefined();
+    expect(created.metadata.uid).toBeTruthy();
+  });
+});

--- a/tests/opslab/helm.test.ts
+++ b/tests/opslab/helm.test.ts
@@ -1,0 +1,146 @@
+/**
+ * 真 helm 打到我们的 apiserver 上
+ *
+ * helm 4 用的是**服务端 apply**：整份对象 PATCH 过去，服务端合并并记下
+ * 归属。所以这一组同时在验两件事 —— helm 能不能干活，以及我们的 SSA
+ * 对不对。
+ *
+ * 产物约 136MB，不进仓库 —— 没有时整组跳过，
+ * 先跑 `bash scripts/build-opslab-wasm.sh`。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { createVfs } from '../../src/lib/opslab/machine';
+import { CliRuntime, createCliRuntime, defaultKubeconfig, renderKubeconfig } from '../../src/lib/opslab/wasm';
+import { Cluster, createCluster } from '../../src/lib/opslab/controllers';
+
+const WASM_PATH = path.join(__dirname, '../../public/opslab/opslab-cli.wasm');
+const WASM_EXEC = path.join(__dirname, '../../public/opslab/wasm_exec.js');
+const HAS_ARTIFACT = fs.existsSync(WASM_PATH) && fs.existsSync(WASM_EXEC);
+const describeIfBuilt = HAS_ARTIFACT ? describe : describe.skip;
+
+const NOW = Date.parse('2026-03-02T09:00:00Z');
+
+let shared: CliRuntime | null = null;
+function cli(): CliRuntime {
+  if (!shared) {
+    if (!(globalThis as Record<string, unknown>).Go) createRequire(__filename)(WASM_EXEC);
+    shared = createCliRuntime({ bytes: new Uint8Array(fs.readFileSync(WASM_PATH)), cache: false });
+  }
+  return shared;
+}
+
+function bench() {
+  const cluster = createCluster();
+  cluster.start();
+  const vfs = createVfs(() => NOW);
+  vfs.mkdirp('/root');
+  vfs.writeFile('/root/.kube/config', renderKubeconfig(defaultKubeconfig()));
+  const helm = (argv: string[]) => cli().run('helm', argv, {
+    vfs, cwd: '/root',
+    env: { KUBECONFIG: '/root/.kube/config', HELM_NAMESPACE: 'default' },
+    fetch: (url, init) => cluster.apiServer.handle(url, init as never),
+    now: () => NOW,
+  });
+  return { cluster, vfs, helm };
+}
+
+const deploymentsOf = (cluster: Cluster) =>
+  cluster.registry.list(cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' }), {});
+
+describeIfBuilt('真 helm', () => {
+  jest.setTimeout(180_000);
+
+  it('helm create 铺出一个完整的 chart', async () => {
+    const { vfs, helm } = bench();
+    const result = await helm(['create', 'portal']);
+    expect(result.code).toBe(0);
+    const files = vfs.walkAll('/root/portal').map((entry) => entry.slice('/root/portal/'.length));
+    expect(files).toContain('Chart.yaml');
+    expect(files).toContain('values.yaml');
+    expect(files).toContain('templates/deployment.yaml');
+    expect(files).toContain('templates/_helpers.tpl');
+  });
+
+  it('helm template 渲染出来的是真 YAML，--set 改得动', async () => {
+    const { helm } = bench();
+    await helm(['create', 'portal']);
+    const rendered = await helm(['template', 'portal', './portal', '--set', 'replicaCount=4']);
+    expect(rendered.code).toBe(0);
+    expect(rendered.stdout).toContain('kind: Deployment');
+    expect(rendered.stdout).toContain('replicas: 4');
+  });
+
+  it('helm lint 认得出坏掉的 chart', async () => {
+    const { vfs, helm } = bench();
+    await helm(['create', 'portal']);
+    const ok = await helm(['lint', './portal']);
+    expect(ok.code).toBe(0);
+    expect(ok.stdout).toContain('0 chart(s) failed');
+
+    vfs.writeFile('/root/portal/Chart.yaml', 'apiVersion: v2\n');   // 少了 name 与 version
+    const broken = await helm(['lint', './portal']);
+    expect(broken.code).not.toBe(0);
+    expect(broken.stdout + broken.stderr).toContain('1 chart(s) failed');
+  });
+
+  it('helm install 真的把对象建进了集群', async () => {
+    const { cluster, helm } = bench();
+    await helm(['create', 'portal']);
+    const installed = await helm(['install', 'portal', './portal']);
+    expect(installed.stderr).toBe('');
+    expect(installed.stdout).toContain('STATUS: deployed');
+
+    await cluster.settle();
+    expect(deploymentsOf(cluster).items.map((item) => item.metadata.name)).toEqual(['portal']);
+  });
+
+  it('helm list 的时间戳跟着虚拟时钟走 —— 换台机器重放也一样', async () => {
+    const { helm } = bench();
+    await helm(['create', 'portal']);
+    await helm(['install', 'portal', './portal']);
+    const list = await helm(['list']);
+    expect(list.stdout).toContain('2026-03-02 09:00:00 +0000 UTC');
+    expect(list.stdout).toContain('deployed');
+  });
+
+  it('helm upgrade 改得动已经在跑的东西', async () => {
+    const { cluster, helm } = bench();
+    await helm(['create', 'portal']);
+    await helm(['install', 'portal', './portal']);
+    await cluster.settle();
+
+    const upgraded = await helm(['upgrade', 'portal', './portal', '--set', 'replicaCount=3']);
+    expect(upgraded.stdout).toContain('REVISION: 2');
+    await cluster.settle();
+
+    const deployment = deploymentsOf(cluster).items[0];
+    expect((deployment.spec as { replicas: number }).replicas).toBe(3);
+    // 服务端 apply 记下了是谁写的
+    const managed = (deployment.metadata as unknown as { managedFields?: Array<{ manager: string }> }).managedFields;
+    expect(managed?.map((entry) => entry.manager)).toContain('helm');
+  });
+
+  it('helm uninstall 把建出来的东西收回去', async () => {
+    const { cluster, helm } = bench();
+    await helm(['create', 'portal']);
+    await helm(['install', 'portal', './portal']);
+    await cluster.settle();
+    expect(deploymentsOf(cluster).items).toHaveLength(1);
+
+    await helm(['uninstall', 'portal']);
+    await cluster.settle();
+    expect(deploymentsOf(cluster).items).toHaveLength(0);
+  });
+
+  it('同一串命令重放两遍，输出逐字节一致', async () => {
+    const once = async () => {
+      const { helm } = bench();
+      await helm(['create', 'portal']);
+      await helm(['install', 'portal', './portal']);
+      return (await helm(['list'])).stdout;
+    };
+    expect(await once()).toBe(await once());
+  });
+});

--- a/tests/opslab/patch.test.ts
+++ b/tests/opslab/patch.test.ts
@@ -150,8 +150,9 @@ describe('按 content-type 分发', () => {
     });
   });
 
-  it('服务端 apply 明确不支持，而不是装作支持了', () => {
+  it('服务端 apply 不走这里 —— 它要 fieldManager 与 managedFields', () => {
+    // 走的是 Registry.apply，见 tests/opslab/apiserver.test.ts 里那一组
     expect(() => applyPatch({}, {}, 'application/apply-patch+yaml'))
-      .toThrow(/server-side apply is not supported/);
+      .toThrow(/apply patches must go through server-side apply/);
   });
 });

--- a/tests/opslab/yaml.test.ts
+++ b/tests/opslab/yaml.test.ts
@@ -141,6 +141,7 @@ const WASM_PATH = path.join(__dirname, '../../public/opslab/opslab-cli.wasm');
 const WASM_EXEC = path.join(__dirname, '../../public/opslab/wasm_exec.js');
 const HAS_ARTIFACT = fs.existsSync(WASM_PATH) && fs.existsSync(WASM_EXEC);
 const describeIfBuilt = HAS_ARTIFACT ? describe : describe.skip;
+const NOW = Date.parse('2026-03-02T09:00:00Z');
 
 const MANIFESTS: Array<[string, string]> = [
   ['最普通的 Deployment', [
@@ -235,7 +236,7 @@ describeIfBuilt('和真 kubectl 对答案', () => {
     // 用一个真集群做 discovery —— kubectl 得先能把 kind 映射到资源上
     const cluster = createCluster();
     cluster.start();
-    const vfs = createVfs(() => 0);
+    const vfs = createVfs(() => NOW);
     vfs.writeFile('/root/.kube/config', renderKubeconfig(defaultKubeconfig()));
     vfs.writeFile('/root/m.yaml', manifest);
     const result = await cli().run('kubectl', // 校验要向 apiserver 取 OpenAPI，这里没有真集群；关掉它，
@@ -243,7 +244,7 @@ describeIfBuilt('和真 kubectl 对答案', () => {
       ['apply', '-f', 'm.yaml', '--dry-run=client', '--validate=false', '-o', 'json'], {
       vfs, cwd: '/root',
       fetch: (url, init) => cluster.apiServer.handle(url, init as never),
-      now: () => 0,
+      now: () => NOW,
     });
     expect(result.stderr).toBe('');
 


### PR DESCRIPTION
真 helm 4 打不进来，两个原因，都不小。

## 一、helm 4 用服务端 apply

`Content-Type: application/apply-patch+yaml`，而我们只做了三种 patch，直接 415。现在补上了（`src/lib/opslab/apiserver/ssa.ts`）。

SSA 和普通 update 的区别只有一句话：**哪些字段是谁写的**被记进 `managedFields`。有了归属，下一次 apply 少写了某个字段，服务端就知道「这本来是我加的、现在我不要了」，于是删掉它 —— 客户端不必自己算差异。

没有这一步的后果很具体：`helm upgrade` 去掉一个 env 之后，那个 env 会一直留在集群里，而 chart 里已经找不到它了。这是最难查的一类幽灵配置。

判定里钉住了四条：建、记归属、这次不写的删掉、**别人写的不删**。

不做的部分写在代码注释里：**冲突检测**。真 apiserver 会在两个 manager 抢同一字段时报 409 并要求 `--force-conflicts`，这里所有 apply 都当作带了 force。列表的逐项归属（`k:{"name":"web"}`）也没做，整个列表算一个字段。

## 二、Go 的 `time.Now()` 读的是宿主的真时间

`helm list` 的 UPDATED 列每次都不一样，回放就对不上了。构建脚本现在给 `wasm_exec.js` 的两个时钟入口打补丁，接到宿主提供的虚拟时钟上。

两个坑：

- **nanotime 返回 0 会被 Go 运行时当成致命错误**（`fatal error: nanotime returning zero`），而虚拟时钟从 0 开始是很正常的事 —— 加 1。
- **时区 Go 在 js/wasm 上不看 `TZ`**，它是拿 `new Date().getTimezoneOffset()` 问宿主的。所以运行期间把这个方法按住返回 0，跑完还回去。

## 结果

真 helm 全套可用，8 个用例：create / template（`--set` 改得动）/ lint（认得出坏 chart）/ install（对象真的进集群）/ list（时间戳跟虚拟时钟走）/ upgrade（managedFields 记着 `helm`）/ uninstall / 重放逐字节一致。

WASM 产物 142,253,608 字节，和上一版**完全一致** —— 这次只动了 `wasm_exec.js`。

全量 1394 个用例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)