### PR TITLE
feat(opslab): 包路径面板 + 第 14 关「顺着包走一遍」

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -30,6 +30,7 @@ const REPORTS_IMAGE_RC = 'harbor.corp.internal/team/reports:2.2.0-rc1';
 // 第三方的对账 exporter。上游那个地址内网拉不到，只有 harbor 上的镜像能用。
 const EXPORTER_UPSTREAM = 'quay.io/acme/settlement-exporter:1.4.2';
 const EXPORTER_MIRROR = 'harbor.corp.internal/mirror/settlement-exporter:1.4.2';
+const SESSIONS_IMAGE = 'harbor.corp.internal/team/sessions:1.8.0';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -173,6 +174,11 @@ const WORLD = {
     [EXPORTER_MIRROR]: {
       pullMs: 300, startupMs: 400, readyAfterMs: 200,
       listens: [9100], routes: { '/metrics': 200 }, memoryUsage: '120Mi',
+    },
+    // 会话存储
+    [SESSIONS_IMAGE]: {
+      pullMs: 300, startupMs: 500, readyAfterMs: 200,
+      listens: [8080], routes: { '/': 200, '/healthz': 200 }, memoryUsage: '160Mi',
     },
     // 报表服务的预发版本
     [REPORTS_IMAGE_RC]: {
@@ -3912,6 +3918,326 @@ const stage13 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 14 关                                                            */
+/* ------------------------------------------------------------------ */
+
+/** 会话存储。Service 的 selector 打错了，于是没有后端。 */
+const SESSIONS_WORKLOAD = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'sessions', namespace: 'payments' },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'sessions' } },
+      template: {
+        metadata: { labels: { app: 'sessions' } },
+        spec: { containers: [{ name: 'app', image: SESSIONS_IMAGE, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'sessions', namespace: 'payments' },
+    // 上一次重构把 Deployment 的标签从 session-store 改成了 sessions，
+    // Service 这边忘了跟着改
+    spec: { selector: { app: 'session-store' }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+];
+
+/** 路由的 hostname 写反了：portal.internal.corp */
+const BROKEN_ROUTE = {
+  apiVersion: 'gateway.networking.k8s.io/v1', kind: 'HTTPRoute',
+  metadata: { name: 'portal', namespace: 'payments' },
+  spec: {
+    parentRefs: [{ name: 'corp-gw' }],
+    hostnames: ['portal.internal.corp'],
+    rules: [{
+      matches: [{ path: { type: 'PathPrefix', value: '/' } }],
+      backendRefs: [{ name: 'portal', port: 80 }],
+    }],
+  },
+};
+
+/** 只放行 reports —— 但门户的标签是 portal */
+const LEDGER_POLICY = {
+  apiVersion: 'networking.k8s.io/v1', kind: 'NetworkPolicy',
+  metadata: { name: 'ledger', namespace: 'payments' },
+  spec: {
+    podSelector: { matchLabels: { app: 'ledger' } },
+    policyTypes: ['Ingress'],
+    ingress: [{ from: [{ podSelector: { matchLabels: { app: 'reports' } } }] }],
+  },
+};
+
+const TRIAGE_REFERENCE = code`
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    parentRefs:
+    - name: corp-gw
+    hostnames:
+    - portal.corp.internal
+    rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+      - name: portal
+        port: 80
+  ---
+  apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: ledger
+    namespace: payments
+  spec:
+    podSelector:
+      matchLabels:
+        app: ledger
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: portal
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: sessions
+    namespace: payments
+  spec:
+    selector:
+      app: sessions
+    ports:
+    - port: 80
+      targetPort: 8080
+`;
+
+const stage14 = {
+  id: 'follow-the-packet',
+  title: t('顺着包走一遍', 'Follow the Packet'),
+  goal: t(
+    code`
+      周一早上三件事一起报过来，\`kubectl get\` 看下去却哪儿都正常：
+      Gateway 是 Programmed，Pod 全 Running，Service 都在。
+
+      - 从跳板机访问 \`https://portal.corp.internal/\` 返回 **404**；
+      - 门户访问 \`http://ledger\` **卡住不动，最后超时**；
+      - 门户访问 \`http://sessions\` **立刻被拒**。
+
+      三种现象指向三个不同的层。右边的「包路径」面板会把每一次连接
+      逐跳列出来 —— 哪一跳被丢掉、哪一跳被拒绝，上面写着。
+
+      ## 通关标准
+
+      1. 从跳板机不加 \`-k\` 访问门户返回 200；
+      2. 门户访问得到 \`http://ledger\`；
+      3. 门户访问得到 \`http://sessions\`；
+      4. **修的方式要对**：Gateway 的 listener 不许放宽成通配、
+         ledger 的入向策略不许删掉、sessions 这个 Service 不许换名字。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      curl -sv --resolve portal.corp.internal:443:<Gateway 地址> https://portal.corp.internal/
+      kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w '%{http_code}' http://ledger
+      kubectl exec -n payments deploy/portal -- curl -s -m 5 http://sessions
+      kubectl get httproute portal -n payments -o yaml
+      kubectl get endpoints -n payments
+      kubectl get netpol -n payments -o yaml
+      \`\`\`
+    `,
+    code`
+      Three reports land on Monday morning, and \`kubectl get\` shows nothing wrong:
+      the Gateway is Programmed, every pod is Running, the Services are all there.
+
+      - \`https://portal.corp.internal/\` from the jump host returns **404**;
+      - the portal reaching \`http://ledger\` **hangs and eventually times out**;
+      - the portal reaching \`http://sessions\` is **refused immediately**.
+
+      Three symptoms, three different layers. The packet path panel on the right lists
+      every hop of every connection, and says which hop dropped or rejected it.
+
+      ## Done when
+
+      1. the portal returns 200 from the jump host, without \`-k\`;
+      2. the portal can reach \`http://ledger\`;
+      3. the portal can reach \`http://sessions\`;
+      4. **and the fixes are the right ones**: the Gateway listener is not widened to a
+         wildcard, ledger's ingress policy is not deleted, and the sessions Service
+         keeps its name.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      curl -sv --resolve portal.corp.internal:443:<gateway address> https://portal.corp.internal/
+      kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w '%{http_code}' http://ledger
+      kubectl exec -n payments deploy/portal -- curl -s -m 5 http://sessions
+      kubectl get httproute portal -n payments -o yaml
+      kubectl get endpoints -n payments
+      kubectl get netpol -n payments -o yaml
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('三种现象分别定位到正确的那一层', 'Each symptom traced to the right layer'),
+    t('三条路都通了', 'All three paths work'),
+    t('修的是根因，不是把防护拆掉', 'Root causes fixed, not protections removed'),
+  ],
+  hints: [
+    t(
+      '**404 说明 Gateway 是活的**。连不上才是 Gateway 的问题；404 是「进来了但没有路由认领这个请求」，去看 HTTPRoute 的 hostnames 与 rules。',
+      '**A 404 means the Gateway is alive.** A dead Gateway refuses the connection. A 404 means the request got in and no route claimed it, so look at the HTTPRoute hostnames and rules.'
+    ),
+    t(
+      '**超时和拒绝是两件事**。拒绝说明包到了对端而没人听（或者 Service 没有后端，kube-proxy 直接回 RST）；超时说明包被丢了 —— NetworkPolicy 丢包，不回任何东西。',
+      '**Timeout and refusal are different.** Refusal means the packet arrived and nobody was listening (or the Service has no endpoints and kube-proxy resets). A timeout means the packet was dropped, and dropping is what NetworkPolicy does.'
+    ),
+    t(
+      '\`kubectl get endpoints\` 是 Service 这一层最直接的体检：Endpoints 为空说明 selector 一个 Pod 都没选中，而 \`kubectl get svc\` 看上去完全正常。',
+      '`kubectl get endpoints` is the direct check at the Service layer: an empty Endpoints means the selector matched no pods, while `kubectl get svc` looks perfectly healthy.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '把 Gateway listener 的 hostname 删掉，让它接受所有域名。404 确实没了，但这台 Gateway 从此会把任何域名的请求都往门户转 —— 判定检查 listener 还在不在。',
+      'Removing the hostname from the Gateway listener so it accepts everything. The 404 goes away, and now that Gateway forwards requests for any hostname to the portal. The grader checks the listener is still scoped.'
+    ),
+    t(
+      '把 ledger 的 NetworkPolicy 删了。超时确实没了 —— 因为 ledger 重新对整个集群开放了，而它正是上一关刚关起来的东西。',
+      'Deleting ledger’s NetworkPolicy. The timeout goes away because ledger is open to the whole cluster again, which is exactly what the previous stage closed.'
+    ),
+    t(
+      '看到 Endpoints 为空就重建 Service。名字一换，所有引用它的地方（HTTPRoute、其他服务的配置）都得跟着改，而问题只是 selector 里的一个词。',
+      'Recreating the Service because its Endpoints are empty. Renaming it means every reference (HTTPRoutes, other services’ config) has to change too, when the actual problem is one word in the selector.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM,
+      ...PORTAL_WORKLOAD, ...LEDGER_WORKLOAD, ...SESSIONS_WORKLOAD,
+      BROKEN_ROUTE, LEDGER_POLICY,
+    ],
+    files: {},
+    referenceFiles: { '/root/infra/triage.yaml': TRIAGE_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/triage.yaml',
+    ],
+  },
+  specs: [
+    spec('follow-the-packet.spec.ts', code`
+      import { get, list, sh } from '@ops/lab';
+
+      const EXEC = 'kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w %{http_code} ';
+
+      describe('顺着包走一遍', () => {
+        it('从跳板机访问门户返回 200', async () => {
+          const gateway = list('Gateway', { namespace: 'payments' })[0];
+          const address = gateway.status.addresses[0].value;
+          const result = await sh(
+            'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address
+            + ' https://portal.corp.internal/'
+          );
+          expect(result.stdout).toBe('200');
+        });
+
+        it('门户访问得到 ledger', async () => {
+          const result = await sh(EXEC + 'http://ledger');
+          expect(result.stdout).toBe('200');
+        });
+
+        it('门户访问得到 sessions', async () => {
+          const result = await sh(EXEC + 'http://sessions');
+          expect(result.stdout).toBe('200');
+        });
+
+        it('Gateway 的 listener 没有被放宽成通配', () => {
+          const gateway = list('Gateway', { namespace: 'payments' })[0];
+          for (const listener of gateway.spec.listeners) {
+            expect(listener.hostname).toBeTruthy();
+            expect(listener.hostname).not.toContain('*');
+          }
+        });
+
+        it('ledger 还被入向策略保护着', () => {
+          const policies = list('NetworkPolicy', { namespace: 'payments' })
+            .filter((policy) => (policy.spec.podSelector.matchLabels || {}).app === 'ledger'
+              && (policy.spec.policyTypes || []).includes('Ingress'));
+          expect(policies.length).toBeGreaterThan(0);
+          // 而且不是靠 from 留空重新对全集群开放
+          for (const policy of policies) {
+            for (const rule of policy.spec.ingress || []) {
+              expect((rule.from || []).length).toBeGreaterThan(0);
+            }
+          }
+        });
+
+        it('sessions 这个 Service 还在，而且是靠 selector 修好的', () => {
+          const service = get('Service', 'sessions', 'payments');
+          expect(service).toBeTruthy();
+          const endpoints = get('Endpoints', 'sessions', 'payments');
+          const addresses = (endpoints.subsets || []).flatMap((subset) => subset.addresses || []);
+          expect(addresses.length).toBe(2);
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'resilience'],
+  extension: t(
+    code`
+      这一关真正要练的是**从现象反推层次**，而不是三个具体的 bug。把它记成一张表：
+
+      - \`Connection refused\`：包到了对端，那里没人听。Service 没有 Endpoints
+        （kube-proxy 直接 RST）、进程没起来、端口写错，都长这样。
+      - \`timeout\`：包被丢了，没有任何回应。防火墙、NetworkPolicy、
+        路由不通、安全组，都长这样。**看到超时先想「谁在丢包」**。
+      - \`connection reset\`：连上了又被断开。TLS 握手失败、协议对不上
+        （拿 HTTP 打 HTTPS 端口）常见。
+      - \`404 / 502 / 503\`：**连接是成功的**。这是应用层或者代理层的回答，
+        说明前面每一层都通了，问题在最后那一段。
+      - DNS 失败：连尝试都没发生。名字错了、search domain 不对、
+        CoreDNS 挂了。
+
+      这张表的价值在于它**排除**掉的东西：看到 404 就不用再查网络策略，
+      看到 timeout 就不用再查 HTTPRoute。真集群里排查最费时间的从来不是修，
+      是在错误的层里找。
+    `,
+    code`
+      What this stage actually trains is **reasoning from symptom to layer**, not three
+      specific bugs. Keep the table:
+
+      - \`Connection refused\`: the packet arrived and nobody was listening. A Service
+        with no Endpoints (kube-proxy resets), a process that never started, a wrong
+        port all look like this.
+      - \`timeout\`: the packet was dropped with no reply at all. Firewalls, network
+        policies, missing routes, security groups. **A timeout means asking who is
+        dropping packets.**
+      - \`connection reset\`: connected, then torn down. Typically a failed TLS
+        handshake or a protocol mismatch such as plain HTTP against an HTTPS port.
+      - \`404 / 502 / 503\`: **the connection succeeded**. This is an answer from the
+        application or the proxy, which means every layer below it worked and the
+        problem is in the last hop.
+      - DNS failure: no connection was even attempted. Wrong name, wrong search
+        domain, or CoreDNS is down.
+
+      The value of the table is what it **rules out**: a 404 means you can stop looking
+      at network policies, and a timeout means you can stop reading HTTPRoutes. The
+      expensive part of real debugging is never the fix, it is searching in the wrong
+      layer.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -3956,6 +4282,6 @@ module.exports = {
   files: [],
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
-    stage7, stage8, stage9, stage10, stage11, stage12, stage13,
+    stage7, stage8, stage9, stage10, stage11, stage12, stage13, stage14,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5700,6 +5700,19 @@
             },
             "memoryUsage": "120Mi"
           },
+          "harbor.corp.internal/team/sessions:1.8.0": {
+            "pullMs": 300,
+            "startupMs": 500,
+            "readyAfterMs": 200,
+            "listens": [
+              8080
+            ],
+            "routes": {
+              "/": 200,
+              "/healthz": 200
+            },
+            "memoryUsage": "160Mi"
+          },
           "harbor.corp.internal/team/reports:2.2.0-rc1": {
             "pullMs": 500,
             "startupMs": 800,
@@ -8864,6 +8877,562 @@
         "primer": {
           "zh": "`kustomize` 和 Helm 常被拿来比，但它们解决的不是同一个问题。Helm 是模板：被打包的一方先把参数挖好（`{{ .Values.x }}`），你只能改对方想到的那些点。kustomize 不是模板，它是对 YAML 做结构化修改：不需要对方配合，任何一份 manifest 都能被改。所以「自己的服务」适合写 chart，「别人给的东西」适合套 overlay。它内置在 `kubectl` 里：`kubectl kustomize <dir>` 只渲染，`kubectl apply -k <dir>` 渲染并提交。\n\n结构是 `base` 加 `overlays`。`base` 是一份能直接 apply 的完整 manifest；每个 overlay 是一个目录，里面的 `kustomization.yaml` 用 `resources: [../../base]` 指回 base，然后只写差异。关键在于 base 保持原样：上游升级时整个目录换掉，你的修改都在 overlay 里，一条都不会丢。\n\n有一批常见改动不用写 patch，`kustomization.yaml` 里一行就够：`namespace` 改命名空间，`namePrefix` / `nameSuffix` 加前后缀，`labels` 打统一标签，`images` 改镜像仓库或 tag，`replicas` 改副本数，`configMapGenerator` 从文件生成 ConfigMap 并自动带上内容哈希后缀（内容一变名字就变，Pod 因此会滚动重启）。只有这些表达不了的，才需要 `patches`。\n\n`patches` 有两种写法，行为差别很大。`strategic merge patch` 是写一份不完整的 YAML，读起来自然，但**列表的合并取决于 merge key**：容器列表的 merge key 是 `name`，patch 里漏写它，kustomize 不会报错，而是把整个 `containers` 替换成你写的那一项，镜像、端口、资源全都没了。`JSON patch`（`op` / `path` / `value`）啰嗦但精确，`/spec/template/spec/containers/0/env/-` 明确表示追加到第 0 个容器的 env 末尾，不存在猜的余地。",
           "en": "`kustomize` gets compared to Helm constantly, but they solve different problems. Helm is templating: the packager has to anticipate every parameter (`{{ .Values.x }}`), so you can only change what they thought of. Kustomize is not templating; it edits YAML structurally, needing no cooperation from the author, so any manifest can be changed. Charts suit your own services, overlays suit what other people hand you. It ships inside `kubectl`: `kubectl kustomize <dir>` renders, `kubectl apply -k <dir>` renders and submits.\n\nThe structure is a `base` plus `overlays`. The base is a complete, directly appliable manifest. Each overlay is a directory whose `kustomization.yaml` points back with `resources: [../../base]` and then states only the difference. The point is that the base stays pristine: when upstream ships a new version the whole directory is replaced, and because every change of yours lives in the overlay, nothing is lost.\n\nA whole class of changes needs no patch at all, just a line in `kustomization.yaml`: `namespace` moves everything, `namePrefix` / `nameSuffix` rename, `labels` stamps labels, `images` rewrites registry or tag, `replicas` sets counts, and `configMapGenerator` builds a ConfigMap from files with a content hash appended to its name, so changing the content changes the name and rolls the pods. Reach for `patches` only for what these cannot express.\n\n`patches` come in two forms that behave very differently. A `strategic merge patch` is partial YAML, natural to read, but **list merging depends on the merge key**. For containers that key is `name`; omit it and kustomize does not complain, it replaces the entire `containers` list with the single entry you wrote, losing the image, ports, and resources. A `JSON patch` (`op` / `path` / `value`) is verbose but exact: `/spec/template/spec/containers/0/env/-` says append to the env of container zero, with nothing left to infer."
+        }
+      },
+      {
+        "id": "follow-the-packet",
+        "title": {
+          "zh": "顺着包走一遍",
+          "en": "Follow the Packet"
+        },
+        "goal": {
+          "zh": "周一早上三件事一起报过来，`kubectl get` 看下去却哪儿都正常：\nGateway 是 Programmed，Pod 全 Running，Service 都在。\n\n- 从跳板机访问 `https://portal.corp.internal/` 返回 **404**；\n- 门户访问 `http://ledger` **卡住不动，最后超时**；\n- 门户访问 `http://sessions` **立刻被拒**。\n\n三种现象指向三个不同的层。右边的「包路径」面板会把每一次连接\n逐跳列出来 —— 哪一跳被丢掉、哪一跳被拒绝，上面写着。\n\n## 通关标准\n\n1. 从跳板机不加 `-k` 访问门户返回 200；\n2. 门户访问得到 `http://ledger`；\n3. 门户访问得到 `http://sessions`；\n4. **修的方式要对**：Gateway 的 listener 不许放宽成通配、\n   ledger 的入向策略不许删掉、sessions 这个 Service 不许换名字。\n\n## 会用到的命令\n\n```bash\ncurl -sv --resolve portal.corp.internal:443:<Gateway 地址> https://portal.corp.internal/\nkubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w '%{http_code}' http://ledger\nkubectl exec -n payments deploy/portal -- curl -s -m 5 http://sessions\nkubectl get httproute portal -n payments -o yaml\nkubectl get endpoints -n payments\nkubectl get netpol -n payments -o yaml\n```\n",
+          "en": "Three reports land on Monday morning, and `kubectl get` shows nothing wrong:\nthe Gateway is Programmed, every pod is Running, the Services are all there.\n\n- `https://portal.corp.internal/` from the jump host returns **404**;\n- the portal reaching `http://ledger` **hangs and eventually times out**;\n- the portal reaching `http://sessions` is **refused immediately**.\n\nThree symptoms, three different layers. The packet path panel on the right lists\nevery hop of every connection, and says which hop dropped or rejected it.\n\n## Done when\n\n1. the portal returns 200 from the jump host, without `-k`;\n2. the portal can reach `http://ledger`;\n3. the portal can reach `http://sessions`;\n4. **and the fixes are the right ones**: the Gateway listener is not widened to a\n   wildcard, ledger's ingress policy is not deleted, and the sessions Service\n   keeps its name.\n\n## Commands you will need\n\n```bash\ncurl -sv --resolve portal.corp.internal:443:<gateway address> https://portal.corp.internal/\nkubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w '%{http_code}' http://ledger\nkubectl exec -n payments deploy/portal -- curl -s -m 5 http://sessions\nkubectl get httproute portal -n payments -o yaml\nkubectl get endpoints -n payments\nkubectl get netpol -n payments -o yaml\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "三种现象分别定位到正确的那一层",
+            "en": "Each symptom traced to the right layer"
+          },
+          {
+            "zh": "三条路都通了",
+            "en": "All three paths work"
+          },
+          {
+            "zh": "修的是根因，不是把防护拆掉",
+            "en": "Root causes fixed, not protections removed"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "**404 说明 Gateway 是活的**。连不上才是 Gateway 的问题；404 是「进来了但没有路由认领这个请求」，去看 HTTPRoute 的 hostnames 与 rules。",
+            "en": "**A 404 means the Gateway is alive.** A dead Gateway refuses the connection. A 404 means the request got in and no route claimed it, so look at the HTTPRoute hostnames and rules."
+          },
+          {
+            "zh": "**超时和拒绝是两件事**。拒绝说明包到了对端而没人听（或者 Service 没有后端，kube-proxy 直接回 RST）；超时说明包被丢了 —— NetworkPolicy 丢包，不回任何东西。",
+            "en": "**Timeout and refusal are different.** Refusal means the packet arrived and nobody was listening (or the Service has no endpoints and kube-proxy resets). A timeout means the packet was dropped, and dropping is what NetworkPolicy does."
+          },
+          {
+            "zh": "`kubectl get endpoints` 是 Service 这一层最直接的体检：Endpoints 为空说明 selector 一个 Pod 都没选中，而 `kubectl get svc` 看上去完全正常。",
+            "en": "`kubectl get endpoints` is the direct check at the Service layer: an empty Endpoints means the selector matched no pods, while `kubectl get svc` looks perfectly healthy."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "把 Gateway listener 的 hostname 删掉，让它接受所有域名。404 确实没了，但这台 Gateway 从此会把任何域名的请求都往门户转 —— 判定检查 listener 还在不在。",
+            "en": "Removing the hostname from the Gateway listener so it accepts everything. The 404 goes away, and now that Gateway forwards requests for any hostname to the portal. The grader checks the listener is still scoped."
+          },
+          {
+            "zh": "把 ledger 的 NetworkPolicy 删了。超时确实没了 —— 因为 ledger 重新对整个集群开放了，而它正是上一关刚关起来的东西。",
+            "en": "Deleting ledger’s NetworkPolicy. The timeout goes away because ledger is open to the whole cluster again, which is exactly what the previous stage closed."
+          },
+          {
+            "zh": "看到 Endpoints 为空就重建 Service。名字一换，所有引用它的地方（HTTPRoute、其他服务的配置）都得跟着改，而问题只是 selector 里的一个词。",
+            "en": "Recreating the Service because its Endpoints are empty. Renaming it means every reference (HTTPRoutes, other services’ config) has to change too, when the actual problem is one word in the selector."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "ledger"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ledger"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/ledger:3.2.1",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "ledger"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "sessions",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "sessions"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "sessions"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/sessions:1.8.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "sessions",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "session-store"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.internal.corp"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "networking.k8s.io/v1",
+              "kind": "NetworkPolicy",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "podSelector": {
+                  "matchLabels": {
+                    "app": "ledger"
+                  }
+                },
+                "policyTypes": [
+                  "Ingress"
+                ],
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "podSelector": {
+                          "matchLabels": {
+                            "app": "reports"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {},
+          "referenceFiles": {
+            "/root/infra/triage.yaml": "apiVersion: gateway.networking.k8s.io/v1\nkind: HTTPRoute\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  parentRefs:\n  - name: corp-gw\n  hostnames:\n  - portal.corp.internal\n  rules:\n  - matches:\n    - path:\n        type: PathPrefix\n        value: /\n    backendRefs:\n    - name: portal\n      port: 80\n---\napiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: ledger\n  namespace: payments\nspec:\n  podSelector:\n    matchLabels:\n      app: ledger\n  policyTypes:\n  - Ingress\n  ingress:\n  - from:\n    - podSelector:\n        matchLabels:\n          app: portal\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: sessions\n  namespace: payments\nspec:\n  selector:\n    app: sessions\n  ports:\n  - port: 80\n    targetPort: 8080\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/triage.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "follow-the-packet.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst EXEC = 'kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w %{http_code} ';\n\ndescribe('顺着包走一遍', () => {\n  it('从跳板机访问门户返回 200', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address\n      + ' https://portal.corp.internal/'\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('门户访问得到 ledger', async () => {\n    const result = await sh(EXEC + 'http://ledger');\n    expect(result.stdout).toBe('200');\n  });\n\n  it('门户访问得到 sessions', async () => {\n    const result = await sh(EXEC + 'http://sessions');\n    expect(result.stdout).toBe('200');\n  });\n\n  it('Gateway 的 listener 没有被放宽成通配', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    for (const listener of gateway.spec.listeners) {\n      expect(listener.hostname).toBeTruthy();\n      expect(listener.hostname).not.toContain('*');\n    }\n  });\n\n  it('ledger 还被入向策略保护着', () => {\n    const policies = list('NetworkPolicy', { namespace: 'payments' })\n      .filter((policy) => (policy.spec.podSelector.matchLabels || {}).app === 'ledger'\n        && (policy.spec.policyTypes || []).includes('Ingress'));\n    expect(policies.length).toBeGreaterThan(0);\n    // 而且不是靠 from 留空重新对全集群开放\n    for (const policy of policies) {\n      for (const rule of policy.spec.ingress || []) {\n        expect((rule.from || []).length).toBeGreaterThan(0);\n      }\n    }\n  });\n\n  it('sessions 这个 Service 还在，而且是靠 selector 修好的', () => {\n    const service = get('Service', 'sessions', 'payments');\n    expect(service).toBeTruthy();\n    const endpoints = get('Endpoints', 'sessions', 'payments');\n    const addresses = (endpoints.subsets || []).flatMap((subset) => subset.addresses || []);\n    expect(addresses.length).toBe(2);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "这一关真正要练的是**从现象反推层次**，而不是三个具体的 bug。把它记成一张表：\n\n- `Connection refused`：包到了对端，那里没人听。Service 没有 Endpoints\n  （kube-proxy 直接 RST）、进程没起来、端口写错，都长这样。\n- `timeout`：包被丢了，没有任何回应。防火墙、NetworkPolicy、\n  路由不通、安全组，都长这样。**看到超时先想「谁在丢包」**。\n- `connection reset`：连上了又被断开。TLS 握手失败、协议对不上\n  （拿 HTTP 打 HTTPS 端口）常见。\n- `404 / 502 / 503`：**连接是成功的**。这是应用层或者代理层的回答，\n  说明前面每一层都通了，问题在最后那一段。\n- DNS 失败：连尝试都没发生。名字错了、search domain 不对、\n  CoreDNS 挂了。\n\n这张表的价值在于它**排除**掉的东西：看到 404 就不用再查网络策略，\n看到 timeout 就不用再查 HTTPRoute。真集群里排查最费时间的从来不是修，\n是在错误的层里找。\n",
+          "en": "What this stage actually trains is **reasoning from symptom to layer**, not three\nspecific bugs. Keep the table:\n\n- `Connection refused`: the packet arrived and nobody was listening. A Service\n  with no Endpoints (kube-proxy resets), a process that never started, a wrong\n  port all look like this.\n- `timeout`: the packet was dropped with no reply at all. Firewalls, network\n  policies, missing routes, security groups. **A timeout means asking who is\n  dropping packets.**\n- `connection reset`: connected, then torn down. Typically a failed TLS\n  handshake or a protocol mismatch such as plain HTTP against an HTTPS port.\n- `404 / 502 / 503`: **the connection succeeded**. This is an answer from the\n  application or the proxy, which means every layer below it worked and the\n  problem is in the last hop.\n- DNS failure: no connection was even attempted. Wrong name, wrong search\n  domain, or CoreDNS is down.\n\nThe value of the table is what it **rules out**: a 404 means you can stop looking\nat network policies, and a timeout means you can stop reading HTTPRoutes. The\nexpensive part of real debugging is never the fix, it is searching in the wrong\nlayer.\n"
+        },
+        "primer": {
+          "zh": "排查网络问题最费时间的从来不是修，是在错误的层里找。而现象本身已经把层次说清楚了，只要认得出来。一条 TCP 连接从发起到拿到响应，要顺次经过：名字解析、路由可达、目标端口有没有人听、中间有没有人丢包、TLS 握手、最后才是应用的回答。每一层失败的样子都不一样。\n\n`Connection refused` 说明包**到了**对端，而那里没有进程在听。Kubernetes 里最常见的成因是 Service 的 selector 没选中任何 Pod：Endpoints 为空，kube-proxy 直接回 RST。注意 `kubectl get svc` 这时看上去完全正常，有 ClusterIP、有端口；要看的是 `kubectl get endpoints`。\n\n`timeout` 说明包被**丢**了，对端不回任何东西。防火墙、安全组、路由不通、NetworkPolicy 都长这样。这也是为什么策略拒绝表现为卡住而不是立刻失败：丢包的一方按定义不会告诉你它丢了。看到超时，该问的是「谁在丢包」，而不是「服务是不是挂了」。\n\n`404`、`502`、`503` 这类 HTTP 状态码意味着**连接是成功的**。这是应用或者代理给的回答，说明下面每一层都通了。Gateway 回 404 是「我活着，但没有路由认领这个域名或路径」，去看 HTTPRoute 的 `hostnames` 与 `rules`；连不上才是 Gateway 本身的问题。再往前一层，如果连 DNS 都没解析出来，那连接压根没发起过，`dig` 和 `/etc/resolv.conf` 才是现场。",
+          "en": "The expensive part of debugging a network problem is never the fix, it is searching in the wrong layer. The symptom already tells you the layer, if you can read it. A TCP connection passes through name resolution, route reachability, something listening on the target port, nobody dropping the packet, a TLS handshake, and only then the application answer. Each layer fails differently.\n\n`Connection refused` means the packet **arrived** and no process was listening. In Kubernetes the usual cause is a Service selector matching no pods: Endpoints is empty and kube-proxy resets the connection. Note that `kubectl get svc` looks perfectly healthy at that moment, with a ClusterIP and ports; the thing to read is `kubectl get endpoints`.\n\n`timeout` means the packet was **dropped** with no reply. Firewalls, security groups, missing routes, and NetworkPolicy all look like this. It is also why a policy denial hangs instead of failing fast: whoever drops the packet, by definition, does not tell you. A timeout should prompt \"who is dropping packets\", not \"is the service down\".\n\nHTTP status codes such as `404`, `502`, and `503` mean the **connection succeeded**. They are an answer from the application or the proxy, which means every layer below worked. A Gateway returning 404 is saying \"I am alive and no route claimed this hostname or path\", so read the HTTPRoute `hostnames` and `rules`; a Gateway that is actually broken refuses the connection instead. One layer earlier, if DNS never resolved, no connection was attempted at all and the scene of the crime is `dig` and `/etc/resolv.conf`."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1237,6 +1237,21 @@ const primers = {
       )
     ),
 
+    'follow-the-packet': t(
+      p(
+        '排查网络问题最费时间的从来不是修，是在错误的层里找。而现象本身已经把层次说清楚了，只要认得出来。一条 TCP 连接从发起到拿到响应，要顺次经过：名字解析、路由可达、目标端口有没有人听、中间有没有人丢包、TLS 握手、最后才是应用的回答。每一层失败的样子都不一样。',
+        '`Connection refused` 说明包**到了**对端，而那里没有进程在听。Kubernetes 里最常见的成因是 Service 的 selector 没选中任何 Pod：Endpoints 为空，kube-proxy 直接回 RST。注意 `kubectl get svc` 这时看上去完全正常，有 ClusterIP、有端口；要看的是 `kubectl get endpoints`。',
+        '`timeout` 说明包被**丢**了，对端不回任何东西。防火墙、安全组、路由不通、NetworkPolicy 都长这样。这也是为什么策略拒绝表现为卡住而不是立刻失败：丢包的一方按定义不会告诉你它丢了。看到超时，该问的是「谁在丢包」，而不是「服务是不是挂了」。',
+        '`404`、`502`、`503` 这类 HTTP 状态码意味着**连接是成功的**。这是应用或者代理给的回答，说明下面每一层都通了。Gateway 回 404 是「我活着，但没有路由认领这个域名或路径」，去看 HTTPRoute 的 `hostnames` 与 `rules`；连不上才是 Gateway 本身的问题。再往前一层，如果连 DNS 都没解析出来，那连接压根没发起过，`dig` 和 `/etc/resolv.conf` 才是现场。'
+      ),
+      p(
+        'The expensive part of debugging a network problem is never the fix, it is searching in the wrong layer. The symptom already tells you the layer, if you can read it. A TCP connection passes through name resolution, route reachability, something listening on the target port, nobody dropping the packet, a TLS handshake, and only then the application answer. Each layer fails differently.',
+        '`Connection refused` means the packet **arrived** and no process was listening. In Kubernetes the usual cause is a Service selector matching no pods: Endpoints is empty and kube-proxy resets the connection. Note that `kubectl get svc` looks perfectly healthy at that moment, with a ClusterIP and ports; the thing to read is `kubectl get endpoints`.',
+        '`timeout` means the packet was **dropped** with no reply. Firewalls, security groups, missing routes, and NetworkPolicy all look like this. It is also why a policy denial hangs instead of failing fast: whoever drops the packet, by definition, does not tell you. A timeout should prompt "who is dropping packets", not "is the service down".',
+        'HTTP status codes such as `404`, `502`, and `503` mean the **connection succeeded**. They are an answer from the application or the proxy, which means every layer below worked. A Gateway returning 404 is saying "I am alive and no route claimed this hostname or path", so read the HTTPRoute `hostnames` and `rules`; a Gateway that is actually broken refuses the connection instead. One layer earlier, if DNS never resolved, no connection was attempted at all and the scene of the crime is `dig` and `/etc/resolv.conf`.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5700,6 +5700,19 @@
             },
             "memoryUsage": "120Mi"
           },
+          "harbor.corp.internal/team/sessions:1.8.0": {
+            "pullMs": 300,
+            "startupMs": 500,
+            "readyAfterMs": 200,
+            "listens": [
+              8080
+            ],
+            "routes": {
+              "/": 200,
+              "/healthz": 200
+            },
+            "memoryUsage": "160Mi"
+          },
           "harbor.corp.internal/team/reports:2.2.0-rc1": {
             "pullMs": 500,
             "startupMs": 800,
@@ -8864,6 +8877,562 @@
         "primer": {
           "zh": "`kustomize` 和 Helm 常被拿来比，但它们解决的不是同一个问题。Helm 是模板：被打包的一方先把参数挖好（`{{ .Values.x }}`），你只能改对方想到的那些点。kustomize 不是模板，它是对 YAML 做结构化修改：不需要对方配合，任何一份 manifest 都能被改。所以「自己的服务」适合写 chart，「别人给的东西」适合套 overlay。它内置在 `kubectl` 里：`kubectl kustomize <dir>` 只渲染，`kubectl apply -k <dir>` 渲染并提交。\n\n结构是 `base` 加 `overlays`。`base` 是一份能直接 apply 的完整 manifest；每个 overlay 是一个目录，里面的 `kustomization.yaml` 用 `resources: [../../base]` 指回 base，然后只写差异。关键在于 base 保持原样：上游升级时整个目录换掉，你的修改都在 overlay 里，一条都不会丢。\n\n有一批常见改动不用写 patch，`kustomization.yaml` 里一行就够：`namespace` 改命名空间，`namePrefix` / `nameSuffix` 加前后缀，`labels` 打统一标签，`images` 改镜像仓库或 tag，`replicas` 改副本数，`configMapGenerator` 从文件生成 ConfigMap 并自动带上内容哈希后缀（内容一变名字就变，Pod 因此会滚动重启）。只有这些表达不了的，才需要 `patches`。\n\n`patches` 有两种写法，行为差别很大。`strategic merge patch` 是写一份不完整的 YAML，读起来自然，但**列表的合并取决于 merge key**：容器列表的 merge key 是 `name`，patch 里漏写它，kustomize 不会报错，而是把整个 `containers` 替换成你写的那一项，镜像、端口、资源全都没了。`JSON patch`（`op` / `path` / `value`）啰嗦但精确，`/spec/template/spec/containers/0/env/-` 明确表示追加到第 0 个容器的 env 末尾，不存在猜的余地。",
           "en": "`kustomize` gets compared to Helm constantly, but they solve different problems. Helm is templating: the packager has to anticipate every parameter (`{{ .Values.x }}`), so you can only change what they thought of. Kustomize is not templating; it edits YAML structurally, needing no cooperation from the author, so any manifest can be changed. Charts suit your own services, overlays suit what other people hand you. It ships inside `kubectl`: `kubectl kustomize <dir>` renders, `kubectl apply -k <dir>` renders and submits.\n\nThe structure is a `base` plus `overlays`. The base is a complete, directly appliable manifest. Each overlay is a directory whose `kustomization.yaml` points back with `resources: [../../base]` and then states only the difference. The point is that the base stays pristine: when upstream ships a new version the whole directory is replaced, and because every change of yours lives in the overlay, nothing is lost.\n\nA whole class of changes needs no patch at all, just a line in `kustomization.yaml`: `namespace` moves everything, `namePrefix` / `nameSuffix` rename, `labels` stamps labels, `images` rewrites registry or tag, `replicas` sets counts, and `configMapGenerator` builds a ConfigMap from files with a content hash appended to its name, so changing the content changes the name and rolls the pods. Reach for `patches` only for what these cannot express.\n\n`patches` come in two forms that behave very differently. A `strategic merge patch` is partial YAML, natural to read, but **list merging depends on the merge key**. For containers that key is `name`; omit it and kustomize does not complain, it replaces the entire `containers` list with the single entry you wrote, losing the image, ports, and resources. A `JSON patch` (`op` / `path` / `value`) is verbose but exact: `/spec/template/spec/containers/0/env/-` says append to the env of container zero, with nothing left to infer."
+        }
+      },
+      {
+        "id": "follow-the-packet",
+        "title": {
+          "zh": "顺着包走一遍",
+          "en": "Follow the Packet"
+        },
+        "goal": {
+          "zh": "周一早上三件事一起报过来，`kubectl get` 看下去却哪儿都正常：\nGateway 是 Programmed，Pod 全 Running，Service 都在。\n\n- 从跳板机访问 `https://portal.corp.internal/` 返回 **404**；\n- 门户访问 `http://ledger` **卡住不动，最后超时**；\n- 门户访问 `http://sessions` **立刻被拒**。\n\n三种现象指向三个不同的层。右边的「包路径」面板会把每一次连接\n逐跳列出来 —— 哪一跳被丢掉、哪一跳被拒绝，上面写着。\n\n## 通关标准\n\n1. 从跳板机不加 `-k` 访问门户返回 200；\n2. 门户访问得到 `http://ledger`；\n3. 门户访问得到 `http://sessions`；\n4. **修的方式要对**：Gateway 的 listener 不许放宽成通配、\n   ledger 的入向策略不许删掉、sessions 这个 Service 不许换名字。\n\n## 会用到的命令\n\n```bash\ncurl -sv --resolve portal.corp.internal:443:<Gateway 地址> https://portal.corp.internal/\nkubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w '%{http_code}' http://ledger\nkubectl exec -n payments deploy/portal -- curl -s -m 5 http://sessions\nkubectl get httproute portal -n payments -o yaml\nkubectl get endpoints -n payments\nkubectl get netpol -n payments -o yaml\n```\n",
+          "en": "Three reports land on Monday morning, and `kubectl get` shows nothing wrong:\nthe Gateway is Programmed, every pod is Running, the Services are all there.\n\n- `https://portal.corp.internal/` from the jump host returns **404**;\n- the portal reaching `http://ledger` **hangs and eventually times out**;\n- the portal reaching `http://sessions` is **refused immediately**.\n\nThree symptoms, three different layers. The packet path panel on the right lists\nevery hop of every connection, and says which hop dropped or rejected it.\n\n## Done when\n\n1. the portal returns 200 from the jump host, without `-k`;\n2. the portal can reach `http://ledger`;\n3. the portal can reach `http://sessions`;\n4. **and the fixes are the right ones**: the Gateway listener is not widened to a\n   wildcard, ledger's ingress policy is not deleted, and the sessions Service\n   keeps its name.\n\n## Commands you will need\n\n```bash\ncurl -sv --resolve portal.corp.internal:443:<gateway address> https://portal.corp.internal/\nkubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w '%{http_code}' http://ledger\nkubectl exec -n payments deploy/portal -- curl -s -m 5 http://sessions\nkubectl get httproute portal -n payments -o yaml\nkubectl get endpoints -n payments\nkubectl get netpol -n payments -o yaml\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "三种现象分别定位到正确的那一层",
+            "en": "Each symptom traced to the right layer"
+          },
+          {
+            "zh": "三条路都通了",
+            "en": "All three paths work"
+          },
+          {
+            "zh": "修的是根因，不是把防护拆掉",
+            "en": "Root causes fixed, not protections removed"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "**404 说明 Gateway 是活的**。连不上才是 Gateway 的问题；404 是「进来了但没有路由认领这个请求」，去看 HTTPRoute 的 hostnames 与 rules。",
+            "en": "**A 404 means the Gateway is alive.** A dead Gateway refuses the connection. A 404 means the request got in and no route claimed it, so look at the HTTPRoute hostnames and rules."
+          },
+          {
+            "zh": "**超时和拒绝是两件事**。拒绝说明包到了对端而没人听（或者 Service 没有后端，kube-proxy 直接回 RST）；超时说明包被丢了 —— NetworkPolicy 丢包，不回任何东西。",
+            "en": "**Timeout and refusal are different.** Refusal means the packet arrived and nobody was listening (or the Service has no endpoints and kube-proxy resets). A timeout means the packet was dropped, and dropping is what NetworkPolicy does."
+          },
+          {
+            "zh": "`kubectl get endpoints` 是 Service 这一层最直接的体检：Endpoints 为空说明 selector 一个 Pod 都没选中，而 `kubectl get svc` 看上去完全正常。",
+            "en": "`kubectl get endpoints` is the direct check at the Service layer: an empty Endpoints means the selector matched no pods, while `kubectl get svc` looks perfectly healthy."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "把 Gateway listener 的 hostname 删掉，让它接受所有域名。404 确实没了，但这台 Gateway 从此会把任何域名的请求都往门户转 —— 判定检查 listener 还在不在。",
+            "en": "Removing the hostname from the Gateway listener so it accepts everything. The 404 goes away, and now that Gateway forwards requests for any hostname to the portal. The grader checks the listener is still scoped."
+          },
+          {
+            "zh": "把 ledger 的 NetworkPolicy 删了。超时确实没了 —— 因为 ledger 重新对整个集群开放了，而它正是上一关刚关起来的东西。",
+            "en": "Deleting ledger’s NetworkPolicy. The timeout goes away because ledger is open to the whole cluster again, which is exactly what the previous stage closed."
+          },
+          {
+            "zh": "看到 Endpoints 为空就重建 Service。名字一换，所有引用它的地方（HTTPRoute、其他服务的配置）都得跟着改，而问题只是 selector 里的一个词。",
+            "en": "Recreating the Service because its Endpoints are empty. Renaming it means every reference (HTTPRoutes, other services’ config) has to change too, when the actual problem is one word in the selector."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "ledger"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ledger"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/ledger:3.2.1",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "ledger"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "sessions",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "sessions"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "sessions"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/sessions:1.8.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "sessions",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "session-store"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.internal.corp"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "networking.k8s.io/v1",
+              "kind": "NetworkPolicy",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "podSelector": {
+                  "matchLabels": {
+                    "app": "ledger"
+                  }
+                },
+                "policyTypes": [
+                  "Ingress"
+                ],
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "podSelector": {
+                          "matchLabels": {
+                            "app": "reports"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {},
+          "referenceFiles": {
+            "/root/infra/triage.yaml": "apiVersion: gateway.networking.k8s.io/v1\nkind: HTTPRoute\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  parentRefs:\n  - name: corp-gw\n  hostnames:\n  - portal.corp.internal\n  rules:\n  - matches:\n    - path:\n        type: PathPrefix\n        value: /\n    backendRefs:\n    - name: portal\n      port: 80\n---\napiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: ledger\n  namespace: payments\nspec:\n  podSelector:\n    matchLabels:\n      app: ledger\n  policyTypes:\n  - Ingress\n  ingress:\n  - from:\n    - podSelector:\n        matchLabels:\n          app: portal\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: sessions\n  namespace: payments\nspec:\n  selector:\n    app: sessions\n  ports:\n  - port: 80\n    targetPort: 8080\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/triage.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "follow-the-packet.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst EXEC = 'kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w %{http_code} ';\n\ndescribe('顺着包走一遍', () => {\n  it('从跳板机访问门户返回 200', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    const address = gateway.status.addresses[0].value;\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address\n      + ' https://portal.corp.internal/'\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('门户访问得到 ledger', async () => {\n    const result = await sh(EXEC + 'http://ledger');\n    expect(result.stdout).toBe('200');\n  });\n\n  it('门户访问得到 sessions', async () => {\n    const result = await sh(EXEC + 'http://sessions');\n    expect(result.stdout).toBe('200');\n  });\n\n  it('Gateway 的 listener 没有被放宽成通配', () => {\n    const gateway = list('Gateway', { namespace: 'payments' })[0];\n    for (const listener of gateway.spec.listeners) {\n      expect(listener.hostname).toBeTruthy();\n      expect(listener.hostname).not.toContain('*');\n    }\n  });\n\n  it('ledger 还被入向策略保护着', () => {\n    const policies = list('NetworkPolicy', { namespace: 'payments' })\n      .filter((policy) => (policy.spec.podSelector.matchLabels || {}).app === 'ledger'\n        && (policy.spec.policyTypes || []).includes('Ingress'));\n    expect(policies.length).toBeGreaterThan(0);\n    // 而且不是靠 from 留空重新对全集群开放\n    for (const policy of policies) {\n      for (const rule of policy.spec.ingress || []) {\n        expect((rule.from || []).length).toBeGreaterThan(0);\n      }\n    }\n  });\n\n  it('sessions 这个 Service 还在，而且是靠 selector 修好的', () => {\n    const service = get('Service', 'sessions', 'payments');\n    expect(service).toBeTruthy();\n    const endpoints = get('Endpoints', 'sessions', 'payments');\n    const addresses = (endpoints.subsets || []).flatMap((subset) => subset.addresses || []);\n    expect(addresses.length).toBe(2);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "这一关真正要练的是**从现象反推层次**，而不是三个具体的 bug。把它记成一张表：\n\n- `Connection refused`：包到了对端，那里没人听。Service 没有 Endpoints\n  （kube-proxy 直接 RST）、进程没起来、端口写错，都长这样。\n- `timeout`：包被丢了，没有任何回应。防火墙、NetworkPolicy、\n  路由不通、安全组，都长这样。**看到超时先想「谁在丢包」**。\n- `connection reset`：连上了又被断开。TLS 握手失败、协议对不上\n  （拿 HTTP 打 HTTPS 端口）常见。\n- `404 / 502 / 503`：**连接是成功的**。这是应用层或者代理层的回答，\n  说明前面每一层都通了，问题在最后那一段。\n- DNS 失败：连尝试都没发生。名字错了、search domain 不对、\n  CoreDNS 挂了。\n\n这张表的价值在于它**排除**掉的东西：看到 404 就不用再查网络策略，\n看到 timeout 就不用再查 HTTPRoute。真集群里排查最费时间的从来不是修，\n是在错误的层里找。\n",
+          "en": "What this stage actually trains is **reasoning from symptom to layer**, not three\nspecific bugs. Keep the table:\n\n- `Connection refused`: the packet arrived and nobody was listening. A Service\n  with no Endpoints (kube-proxy resets), a process that never started, a wrong\n  port all look like this.\n- `timeout`: the packet was dropped with no reply at all. Firewalls, network\n  policies, missing routes, security groups. **A timeout means asking who is\n  dropping packets.**\n- `connection reset`: connected, then torn down. Typically a failed TLS\n  handshake or a protocol mismatch such as plain HTTP against an HTTPS port.\n- `404 / 502 / 503`: **the connection succeeded**. This is an answer from the\n  application or the proxy, which means every layer below it worked and the\n  problem is in the last hop.\n- DNS failure: no connection was even attempted. Wrong name, wrong search\n  domain, or CoreDNS is down.\n\nThe value of the table is what it **rules out**: a 404 means you can stop looking\nat network policies, and a timeout means you can stop reading HTTPRoutes. The\nexpensive part of real debugging is never the fix, it is searching in the wrong\nlayer.\n"
+        },
+        "primer": {
+          "zh": "排查网络问题最费时间的从来不是修，是在错误的层里找。而现象本身已经把层次说清楚了，只要认得出来。一条 TCP 连接从发起到拿到响应，要顺次经过：名字解析、路由可达、目标端口有没有人听、中间有没有人丢包、TLS 握手、最后才是应用的回答。每一层失败的样子都不一样。\n\n`Connection refused` 说明包**到了**对端，而那里没有进程在听。Kubernetes 里最常见的成因是 Service 的 selector 没选中任何 Pod：Endpoints 为空，kube-proxy 直接回 RST。注意 `kubectl get svc` 这时看上去完全正常，有 ClusterIP、有端口；要看的是 `kubectl get endpoints`。\n\n`timeout` 说明包被**丢**了，对端不回任何东西。防火墙、安全组、路由不通、NetworkPolicy 都长这样。这也是为什么策略拒绝表现为卡住而不是立刻失败：丢包的一方按定义不会告诉你它丢了。看到超时，该问的是「谁在丢包」，而不是「服务是不是挂了」。\n\n`404`、`502`、`503` 这类 HTTP 状态码意味着**连接是成功的**。这是应用或者代理给的回答，说明下面每一层都通了。Gateway 回 404 是「我活着，但没有路由认领这个域名或路径」，去看 HTTPRoute 的 `hostnames` 与 `rules`；连不上才是 Gateway 本身的问题。再往前一层，如果连 DNS 都没解析出来，那连接压根没发起过，`dig` 和 `/etc/resolv.conf` 才是现场。",
+          "en": "The expensive part of debugging a network problem is never the fix, it is searching in the wrong layer. The symptom already tells you the layer, if you can read it. A TCP connection passes through name resolution, route reachability, something listening on the target port, nobody dropping the packet, a TLS handshake, and only then the application answer. Each layer fails differently.\n\n`Connection refused` means the packet **arrived** and no process was listening. In Kubernetes the usual cause is a Service selector matching no pods: Endpoints is empty and kube-proxy resets the connection. Note that `kubectl get svc` looks perfectly healthy at that moment, with a ClusterIP and ports; the thing to read is `kubectl get endpoints`.\n\n`timeout` means the packet was **dropped** with no reply. Firewalls, security groups, missing routes, and NetworkPolicy all look like this. It is also why a policy denial hangs instead of failing fast: whoever drops the packet, by definition, does not tell you. A timeout should prompt \"who is dropping packets\", not \"is the service down\".\n\nHTTP status codes such as `404`, `502`, and `503` mean the **connection succeeded**. They are an answer from the application or the proxy, which means every layer below worked. A Gateway returning 404 is saying \"I am alive and no route claimed this hostname or path\", so read the HTTPRoute `hostnames` and `rules`; a Gateway that is actually broken refuses the connection instead. One layer earlier, if DNS never resolved, no connection was attempted at all and the scene of the crime is `dig` and `/etc/resolv.conf`."
         }
       }
     ]

--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mantine/core';
 import {
   IconAlertTriangle, IconDeviceDesktop, IconFileCode, IconPlayerPlay,
-  IconRefresh, IconSitemap, IconTimeline,
+  IconRefresh, IconRoute, IconSitemap, IconTimeline,
 } from '@tabler/icons-react';
 import { useMantineColorScheme } from '@mantine/core';
 import Editor from '@monaco-editor/react';
@@ -33,6 +33,7 @@ import type { StageRunReport } from '../../lib/engineering/types';
 
 const OpsTerminal = dynamic(() => import('./OpsTerminal'), { ssr: false });
 const TopologyView = dynamic(() => import('./TopologyView'), { ssr: false });
+const PacketPathPanel = dynamic(() => import('./PacketPathPanel'), { ssr: false });
 
 export interface OpsWorkspaceProps {
   session: ProjectSession;
@@ -79,6 +80,13 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
   const [report, setReport] = useState<StageRunReport | null>(null);
   const [running, setRunning] = useState(false);
   const [rightTab, setRightTab] = useState<string>('topology');
+  /**
+   * 包路径选中的那一跳对应的拓扑节点。
+   *
+   * 存在这里而不是各自面板里：两个面板在同一个位置轮换，切回拓扑时
+   * 那一跳还该是圈着的 —— 不然「先看路径、再切回图上找它」这个动作就断了。
+   */
+  const [highlight, setHighlight] = useState<string | undefined>();
   const insertRef = useRef<((command: string) => void) | null>(null);
 
   // 换关卡 / 重置时把结果清掉，和代码形态一样
@@ -331,6 +339,7 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                     data={[
                       { value: 'topology', label: <Group gap={4} wrap="nowrap"><IconSitemap size={12} />拓扑</Group> },
                       { value: 'changes', label: <Group gap={4} wrap="nowrap"><IconTimeline size={12} />事件与变更</Group> },
+                      { value: 'packets', label: <Group gap={4} wrap="nowrap"><IconRoute size={12} />包路径</Group> },
                     ]}
                   />
                   <Group gap="xs">
@@ -354,9 +363,15 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 </Group>
                 <div style={{ flex: 1, minHeight: 0 }}>
                   <ErrorBoundary fallback={renderPanelError}>
-                    {rightTab === 'topology'
-                      ? <TopologyView graph={ops.topology} onInspect={handleInspect} />
-                      : <ChangeStream changes={ops.changes} events={ops.events} />}
+                    {rightTab === 'topology' && (
+                      <TopologyView graph={ops.topology} onInspect={handleInspect} highlight={highlight} />
+                    )}
+                    {rightTab === 'changes' && (
+                      <ChangeStream changes={ops.changes} events={ops.events} />
+                    )}
+                    {rightTab === 'packets' && (
+                      <PacketPathPanel paths={ops.packetPaths} onHighlight={setHighlight} />
+                    )}
                   </ErrorBoundary>
                 </div>
               </div>

--- a/src/components/opslab/PacketPathPanel.tsx
+++ b/src/components/opslab/PacketPathPanel.tsx
@@ -1,0 +1,140 @@
+/**
+ * 包路径
+ *
+ * 排查网络问题时最缺的一句话是「这个包走到哪一步被拦下的」。这里把最近几次
+ * 连接逐跳列出来，选中某一跳就在拓扑图上把对应的节点圈出来。
+ *
+ * 刻意不做成动画自动播放：学员要停在某一跳上读那行 detail，而不是看它闪过去。
+ * 「上一跳 / 下一跳」是手动的，键盘也能走。
+ */
+import { useEffect, useState } from 'react';
+import { ActionIcon, Badge, Group, ScrollArea, Select, Stack, Text, Tooltip } from '@mantine/core';
+import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
+import type { PacketPath, PacketStep } from '../../lib/opslab/lab';
+
+const VERDICT: Record<PacketStep['verdict'], { color: string; label: string }> = {
+  forward: { color: 'blue', label: '转发' },
+  deliver: { color: 'teal', label: '送达' },
+  drop: { color: 'red', label: '丢弃' },
+  reject: { color: 'orange', label: '拒绝' },
+};
+
+const OUTCOME: Record<PacketPath['outcome'], { color: string; label: string }> = {
+  ok: { color: 'teal', label: '通' },
+  refused: { color: 'orange', label: '连接被拒' },
+  timeout: { color: 'red', label: '超时' },
+  reset: { color: 'orange', label: '连接重置' },
+  'no-route': { color: 'red', label: '没有路由' },
+  'dns-failure': { color: 'red', label: '解析失败' },
+};
+
+export interface PacketPathPanelProps {
+  paths: PacketPath[];
+  /** 选中的那一跳对应的拓扑节点 —— 交给拓扑图去高亮 */
+  onHighlight?: (nodeId: string | undefined) => void;
+}
+
+export default function PacketPathPanel({ paths, onHighlight }: PacketPathPanelProps) {
+  const [pathId, setPathId] = useState<number | undefined>(paths[0]?.id);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  // 有新的连接进来就跳到它，并从第一跳开始
+  useEffect(() => {
+    if (paths.length === 0) return;
+    if (!paths.some((path) => path.id === pathId)) {
+      setPathId(paths[0].id);
+      setStepIndex(0);
+    }
+  }, [paths, pathId]);
+
+  const path = paths.find((item) => item.id === pathId) ?? paths[0];
+  const step = path?.steps[stepIndex];
+
+  useEffect(() => {
+    onHighlight?.(step?.nodeId);
+  }, [step?.nodeId, onHighlight]);
+
+  if (!path) {
+    return (
+      <Stack align="center" justify="center" h="100%" gap={4}>
+        <Text size="sm" c="dimmed">还没有发过请求</Text>
+        <Text size="xs" c="dimmed">在终端里 curl 一下，这里会记下包走过的每一跳</Text>
+      </Stack>
+    );
+  }
+
+  const outcome = OUTCOME[path.outcome];
+  const move = (delta: number) => {
+    setStepIndex((value) => Math.min(Math.max(value + delta, 0), path.steps.length - 1));
+  };
+
+  return (
+    <Stack gap={0} h="100%">
+      <Group gap="xs" px="sm" py={6} style={{ borderBottom: '1px solid var(--app-border)' }}>
+        <Select
+          size="xs"
+          flex={1}
+          value={String(path.id)}
+          onChange={(value) => { if (value) { setPathId(Number(value)); setStepIndex(0); } }}
+          data={paths.map((item) => ({
+            value: String(item.id),
+            label: `#${item.id} ${item.from} → ${item.to}`,
+          }))}
+          comboboxProps={{ withinPortal: true }}
+        />
+        <Tooltip label="上一跳"><ActionIcon size="sm" variant="default" onClick={() => move(-1)} disabled={stepIndex === 0}>
+          <IconArrowLeft size={13} />
+        </ActionIcon></Tooltip>
+        <Tooltip label="下一跳"><ActionIcon
+          size="sm" variant="default" onClick={() => move(1)}
+          disabled={stepIndex >= path.steps.length - 1}
+        >
+          <IconArrowRight size={13} />
+        </ActionIcon></Tooltip>
+      </Group>
+
+      <Group gap={8} px="sm" py={6} style={{ borderBottom: '1px solid var(--app-border)' }}>
+        <Badge size="sm" color={outcome.color} variant="light">{outcome.label}</Badge>
+        {path.status !== undefined && <Badge size="sm" variant="default">HTTP {path.status}</Badge>}
+        <Text size="xs" c="dimmed">{path.totalMs} ms</Text>
+        {path.blockedBy && (
+          <Text size="xs" c="dimmed" truncate>被 {path.blockedBy} 挡下</Text>
+        )}
+      </Group>
+
+      <ScrollArea style={{ flex: 1, minHeight: 0 }}>
+        <Stack gap={0} p="xs">
+          {path.steps.map((item, index) => {
+            const verdict = VERDICT[item.verdict];
+            const active = index === stepIndex;
+            return (
+              <button
+                key={item.index}
+                type="button"
+                onClick={() => setStepIndex(index)}
+                style={{
+                  textAlign: 'left',
+                  border: 'none',
+                  cursor: 'pointer',
+                  padding: '6px 8px',
+                  borderRadius: 6,
+                  background: active ? 'var(--mantine-color-default-hover)' : 'transparent',
+                  borderLeft: `3px solid var(--mantine-color-${verdict.color}-6)`,
+                  marginBottom: 2,
+                }}
+              >
+                <Group gap={6} wrap="nowrap">
+                  <Text size="10px" c="dimmed" w={18}>{item.index}</Text>
+                  <Text size="xs" fw={600} truncate style={{ flex: 1 }}>{item.at}</Text>
+                  <Badge size="xs" color={verdict.color} variant="light">{verdict.label}</Badge>
+                  <Text size="10px" c="dimmed">{item.elapsedMs}ms</Text>
+                </Group>
+                <Text size="11px" c="dimmed" pl={24} style={{ whiteSpace: 'normal' }}>{item.detail}</Text>
+              </button>
+            );
+          })}
+        </Stack>
+      </ScrollArea>
+    </Stack>
+  );
+}

--- a/src/components/opslab/TopologyView.tsx
+++ b/src/components/opslab/TopologyView.tsx
@@ -36,6 +36,8 @@ type ResourceData = {
   detail: string;
   status: TopologyStatus;
   changed?: boolean;
+  /** 包路径当前停在这一跳上 */
+  onPath?: boolean;
 };
 
 /**
@@ -55,10 +57,16 @@ function ResourceNode({ data }: NodeProps) {
         width: 168,
         padding: '8px 10px',
         borderRadius: 8,
-        border: `1px solid ${item.changed ? 'var(--mantine-color-orange-5)' : 'var(--app-border)'}`,
+        border: `1px solid ${
+          item.onPath ? 'var(--mantine-color-blue-6)'
+            : item.changed ? 'var(--mantine-color-orange-5)'
+              : 'var(--app-border)'
+        }`,
         borderLeft: `4px solid ${STATUS_COLOR[item.status]}`,
         background: 'var(--mantine-color-body)',
-        boxShadow: item.changed ? '0 0 0 3px rgba(255,146,43,0.18)' : 'none',
+        boxShadow: item.onPath
+          ? '0 0 0 3px rgba(34,139,230,0.28)'
+          : item.changed ? '0 0 0 3px rgba(255,146,43,0.18)' : 'none',
       }}
     >
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} isConnectable={false} />
@@ -76,19 +84,25 @@ export interface TopologyViewProps {
   graph: TopologyGraph;
   /** 点节点：把只读命令插进终端 */
   onInspect?: (command: string) => void;
+  /** 包路径停在哪个节点上，圈出来 */
+  highlight?: string;
 }
 
-export default function TopologyView({ graph, onInspect }: TopologyViewProps) {
+export default function TopologyView({ graph, onInspect, highlight }: TopologyViewProps) {
   const initialNodes = useMemo<Node[]>(
     () => graph.nodes.map((node) => ({
       id: node.id,
       type: 'resource',
       position: { x: node.x, y: node.y },
-      data: { kind: node.kind, name: node.name, detail: node.detail, status: node.status, changed: node.changed },
+      data: {
+        kind: node.kind, name: node.name, detail: node.detail,
+        status: node.status, changed: node.changed,
+        onPath: node.id === highlight,
+      },
       draggable: false,
       selectable: true,
     })),
-    [graph]
+    [graph, highlight]
   );
 
   const initialEdges = useMemo<Edge[]>(

--- a/src/hooks/useOpsWorkspace.ts
+++ b/src/hooks/useOpsWorkspace.ts
@@ -11,8 +11,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KubeObject } from '../lib/opslab/apiserver';
 import type { CommandRecord } from '../lib/opslab/machine';
 import {
-  buildTopology, createOpsWorld, currentNamespaceOf, diffVersions, snapshotVersions,
-  type ChangeEntry, type OpsWorld, type TopologyGraph,
+  buildPacketPaths, buildTopology, createOpsWorld, currentNamespaceOf, diffVersions, snapshotVersions,
+  type ChangeEntry, type OpsWorld, type PacketPath, type TopologyGraph,
 } from '../lib/opslab/lab';
 import { sharedCliRuntime } from '../lib/opslab/wasm';
 import type { OpsStageSpec, OpsWorldSpec } from '../lib/engineering/types';
@@ -42,6 +42,8 @@ export interface OpsWorkspaceState {
   /** 装上的真 CLI */
   applets: string[];
   topology: TopologyGraph;
+  /** 最近几次连接走过的路，最新的在前 */
+  packetPaths: PacketPath[];
   /** 最近一次命令引起的变更 */
   changes: ChangeEntry[];
   events: KubeObject[];
@@ -152,6 +154,16 @@ export function useOpsWorkspace(options: UseOpsWorkspaceOptions): OpsWorkspaceSt
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [world, revision, namespace, showReplicaSets]);
 
+  /**
+   * 包路径依赖拓扑图：能对上节点的跳才带 nodeId。
+   * 所以它排在 topology 后面算，而不是并列。
+   */
+  const packetPaths = useMemo(() => {
+    if (!world) return [];
+    return buildPacketPaths(world.cluster, topology);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [world, revision, topology]);
+
   const events = useMemo(() => {
     if (!world) return [];
     const definition = world.cluster.scheme.get({ group: '', version: 'v1', resource: 'events' });
@@ -173,6 +185,7 @@ export function useOpsWorkspace(options: UseOpsWorkspaceOptions): OpsWorkspaceSt
     error,
     applets,
     topology,
+    packetPaths,
     changes,
     events,
     history,

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -189,6 +189,13 @@ export interface OpsNodeSpec {
 }
 
 /** 镜像目录里的一条：不在目录里的镜像拉不到，会进 ImagePullBackOff */
+/**
+ * 一个镜像在这个世界里怎么表现。
+ *
+ * 时间之外的字段是**运行时行为**：端口上有没有人听、HTTP 路径返回什么、
+ * 吃多少内存。关卡的镜像表就是靠它们把「这个服务是什么样」写清楚的，
+ * 而不是靠宿主认识某个具体的镜像名。
+ */
 export interface OpsImageSpec {
   /** 拉取耗时（虚拟毫秒） */
   pullMs?: number;
@@ -198,6 +205,23 @@ export interface OpsImageSpec {
   readyAfterMs?: number;
   /** 缺了这些环境变量就崩 */
   needsEnv?: string[];
+  /** 真正在听的端口 */
+  listens?: number[];
+  /** HTTP 路径 -> 状态码。没列出的路径按 404 算。 */
+  routes?: Record<string, number>;
+  /** 声明的内存占用，如 `220Mi`。超过 limit 就 OOMKilled。 */
+  memoryUsage?: string;
+  /** 收到 SIGTERM 会不会先摘流量再优雅退出 */
+  handlesSigterm?: boolean;
+  /** 以哪个 uid 跑（Dockerfile 里的 USER）。0 表示 root。 */
+  runAsUser?: number;
+  /**
+   * 这个镜像是不是一个会执行 NetworkPolicy 的 CNI。
+   *
+   * 只要世界里有任何一个镜像写了这一条，「CNI 执不执行策略」就成为这个世界的
+   * 一个维度：没有执行者时策略对象还在，但一个包都不拦。
+   */
+  enforcesNetworkPolicy?: boolean;
 }
 
 /** 内网 Git 服务上的一个仓库 */

--- a/src/lib/opslab/lab/index.ts
+++ b/src/lib/opslab/lab/index.ts
@@ -12,3 +12,5 @@ export {
 
 export { toolchainFor, baseImageOf, type ToolchainName } from './toolchains';
 export { createExecHandler, normalizeCommand } from './podshell';
+export { buildPacketPath, buildPacketPaths } from './view';
+export type { PacketPath, PacketStep } from './view';

--- a/src/lib/opslab/lab/view.ts
+++ b/src/lib/opslab/lab/view.ts
@@ -10,6 +10,7 @@
  */
 import type { Cluster } from '../controllers';
 import type { KubeObject } from '../apiserver';
+import type { ConnectResult, ConnectTrace, Hop, Source, Target } from '../net';
 
 export type TopologyStatus = 'ok' | 'pending' | 'warn' | 'error';
 
@@ -369,4 +370,118 @@ export function currentNamespaceOf(kubeconfig: string, fallback = 'default'): st
 
 function escapeForRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/* ------------------------------------------------------------------ */
+/* 数据面：一个包走过的路                                              */
+/* ------------------------------------------------------------------ */
+
+export interface PacketStep {
+  /** 第几跳，从 1 开始 */
+  index: number;
+  /** 这一跳发生在哪 —— 原样来自 Hop.at，如 `svc/payments/portal` */
+  at: string;
+  detail: string;
+  verdict: Hop['verdict'];
+  /** 到这一跳为止累计花了多少虚拟毫秒 */
+  elapsedMs: number;
+  /**
+   * 对应拓扑图上的哪个节点。
+   *
+   * 对不上的跳（DNS、分区边界、NetworkPolicy）没有节点 —— 它们不是集群里的
+   * 对象。这些恰恰是最常出问题的地方，所以路径面板要能单独把它们显示出来，
+   * 而不是只在图上高亮。
+   */
+  nodeId?: string;
+}
+
+export interface PacketPath {
+  id: number;
+  /** 谁发起的，如 `jump-01` 或 `pod/payments/portal-xxx` */
+  from: string;
+  /** 打给谁，如 `https://portal.corp.internal/` */
+  to: string;
+  /** ok / refused / timeout / reset / no-route / dns-failure */
+  outcome: ConnectResult['kind'];
+  /** HTTP 状态码，只有 kind === 'ok' 时有 */
+  status?: number;
+  /** 被谁挡下的 */
+  blockedBy?: string;
+  totalMs: number;
+  steps: PacketStep[];
+}
+
+/**
+ * 把一次连接翻译成拓扑图上的一条路径。
+ *
+ * 只做映射，不做判断 —— 「哪一跳出的问题」在 hop 的 verdict 里已经写好了。
+ */
+export function buildPacketPath(trace: ConnectTrace, graph?: TopologyGraph): PacketPath {
+  const known = new Set((graph?.nodes ?? []).map((node) => node.id));
+  let elapsed = 0;
+  const steps = trace.result.hops.map((hop, index) => {
+    elapsed += hop.elapsedMs;
+    const nodeId = nodeIdForHop(hop.at);
+    return {
+      index: index + 1,
+      at: hop.at,
+      detail: hop.detail,
+      verdict: hop.verdict,
+      elapsedMs: elapsed,
+      nodeId: nodeId && (known.size === 0 || known.has(nodeId)) ? nodeId : undefined,
+    };
+  });
+
+  return {
+    id: trace.id,
+    from: sourceLabel(trace.source),
+    to: targetLabel(trace.target),
+    outcome: trace.result.kind,
+    status: trace.result.status,
+    blockedBy: trace.result.blockedBy,
+    totalMs: trace.result.elapsedMs,
+    steps,
+  };
+}
+
+/** 最近几次连接，最新的在前 */
+export function buildPacketPaths(cluster: Cluster, graph?: TopologyGraph): PacketPath[] {
+  return [...cluster.network.traces]
+    .reverse()
+    .map((trace) => buildPacketPath(trace, graph));
+}
+
+/**
+ * hop 的 `at` 长什么样 -> 拓扑节点 id。
+ *
+ * 网络层写的是 `svc/ns/name` 这种小写复数形式，拓扑节点的 id 是
+ * `Kind/ns/name`。两边各有各的道理（一个抄的是 kubectl，一个抄的是 GVK），
+ * 所以在这里翻译，而不是逼一边改。
+ */
+function nodeIdForHop(at: string): string | undefined {
+  const [prefix, ...rest] = at.split('/');
+  if (rest.length !== 2) return undefined;
+  const kind = HOP_KINDS[prefix];
+  return kind ? `${kind}/${rest[0]}/${rest[1]}` : undefined;
+}
+
+const HOP_KINDS: Record<string, string> = {
+  svc: 'Service',
+  service: 'Service',
+  pod: 'Pod',
+  gateway: 'Gateway',
+  httproute: 'HTTPRoute',
+};
+
+function sourceLabel(source: Source): string {
+  if (source.zone === 'cluster' && source.podName) {
+    return `pod/${source.namespace ?? 'default'}/${source.podName}`;
+  }
+  return source.label ?? source.zone;
+}
+
+function targetLabel(target: Target): string {
+  const scheme = target.tls ? 'https' : 'http';
+  const port = target.port === (target.tls ? 443 : 80) ? '' : `:${target.port}`;
+  return `${scheme}://${target.host}${port}${target.path ?? ''}`;
 }

--- a/src/lib/opslab/net/index.ts
+++ b/src/lib/opslab/net/index.ts
@@ -16,3 +16,4 @@ export {
   readFrame, writeFrame, OPCODE,
   type UpgradeRequest, type StreamSession, type StreamServer, type Frame,
 } from './websocket';
+export type { ConnectTrace } from './network';

--- a/src/lib/opslab/net/network.ts
+++ b/src/lib/opslab/net/network.ts
@@ -81,8 +81,37 @@ export interface NetworkDeps {
 const LATENCY = { dns: 2, hop: 1, app: 8 };
 export const CONNECT_TIMEOUT_MS = 30_000;
 
+/** 一次连接留下的记录。面板拿它回放包走过的路。 */
+export interface ConnectTrace {
+  id: number;
+  /** 虚拟墙钟 */
+  at: number;
+  source: Source;
+  target: Target;
+  result: ConnectResult;
+}
+
+/** 留最近这么多条。再多面板也看不过来，而且会拖住快照。 */
+const TRACE_LIMIT = 24;
+
 export class Network {
   constructor(private readonly deps: NetworkDeps) {}
+
+  /**
+   * 最近几次连接。
+   *
+   * 排查网络问题时最缺的东西是「这个包到底走到哪一步被拦下的」。
+   * 每次 connect 都记一条，面板可以逐跳回放 —— 不用学员自己脑补。
+   */
+  readonly traces: ConnectTrace[] = [];
+  private traceSeq = 0;
+
+  private record(source: Source, target: Target, result: ConnectResult): ConnectResult {
+    this.traceSeq += 1;
+    this.traces.push({ id: this.traceSeq, at: this.deps.now(), source, target, result });
+    if (this.traces.length > TRACE_LIMIT) this.traces.shift();
+    return result;
+  }
 
   /** Pod 的 resolv.conf，`kubectl exec ... cat /etc/resolv.conf` 就该打这个 */
   resolvConfOf(namespace: string): string {
@@ -103,8 +132,14 @@ export class Network {
    * 连一次。
    *
    * 返回的 hops 是完整的包路径，拓扑的数据面层与 Hubble 的流日志都读它。
+   * 每次连接都会留一条 trace，面板据此逐跳回放。
    */
   connect(source: Source, target: Target): ConnectResult {
+    return this.record(source, target, this.route(source, target));
+  }
+
+  /** connect 的本体。分出来只是为了让每条返回路径都被记上。 */
+  private route(source: Source, target: Target): ConnectResult {
     const hops: Hop[] = [];
     let elapsed = 0;
 

--- a/tests/opslab/packetpath.test.ts
+++ b/tests/opslab/packetpath.test.ts
@@ -1,0 +1,159 @@
+/**
+ * 包路径
+ *
+ * 排查网络问题时最缺的东西是「这个包到底走到哪一步被拦下的」。
+ * 网络层每次连接都留一条 trace，这里把它翻译成拓扑图上的一条路径。
+ */
+import { buildPacketPath, buildPacketPaths, buildTopology, createOpsWorld } from '../../src/lib/opslab/lab';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+const IMAGE = 'harbor.corp.internal/team/portal:1.4.0';
+const CILIUM = 'quay.io/cilium/cilium:v1.19.2';
+
+function workload(name: string, namespace: string) {
+  return {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name, namespace },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: name } },
+      template: {
+        metadata: { labels: { app: name } },
+        spec: { containers: [{ name: 'app', image: IMAGE, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  };
+}
+
+const WORLD: OpsWorldSpec = {
+  namespaces: ['default', 'kube-system', 'shop'],
+  images: {
+    [IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    [CILIUM]: { pullMs: 10, startupMs: 10, readyAfterMs: 10, enforcesNetworkPolicy: true },
+  },
+  objects: [
+    {
+      apiVersion: 'apps/v1', kind: 'DaemonSet',
+      metadata: { name: 'cilium', namespace: 'kube-system' },
+      spec: {
+        selector: { matchLabels: { app: 'cilium' } },
+        template: {
+          metadata: { labels: { app: 'cilium' } },
+          spec: { containers: [{ name: 'agent', image: CILIUM }] },
+        },
+      },
+    },
+    workload('portal', 'shop'),
+    workload('ledger', 'shop'),
+    {
+      apiVersion: 'v1', kind: 'Service',
+      metadata: { name: 'ledger', namespace: 'shop' },
+      spec: { selector: { app: 'ledger' }, ports: [{ port: 80, targetPort: 8080 }] },
+    },
+  ] as never,
+};
+
+async function world(extra: unknown[] = []) {
+  return createOpsWorld({ world: { ...WORLD, objects: [...(WORLD.objects ?? []), ...extra] as never } });
+}
+
+function podName(w: Awaited<ReturnType<typeof world>>, app: string): string {
+  return w.cluster.registry.list(
+    w.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }), { namespace: 'shop' }
+  ).items.find((pod) => pod.metadata.labels?.app === app)!.metadata.name!;
+}
+
+describe('包路径', () => {
+  it('每次连接都留一条 trace', async () => {
+    const w = await world();
+    expect(w.cluster.network.traces).toHaveLength(0);
+    await w.run('curl -s -m 5 http://ledger.shop.svc.cluster.local');
+    expect(w.cluster.network.traces).toHaveLength(1);
+  });
+
+  it('通的那条路：DNS -> Service -> Pod，每一跳都记下来', async () => {
+    const w = await world();
+    await w.run(`kubectl exec -n shop pod/${podName(w, 'portal')} -- true`);
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    w.cluster.network.connect(from, { host: 'ledger', port: 80, path: '/' });
+
+    const path = buildPacketPaths(w.cluster)[0];
+    expect(path.outcome).toBe('ok');
+    expect(path.status).toBe(200);
+    expect(path.steps.map((step) => step.at.split('/')[0])).toEqual(['dns', 'svc', 'pod']);
+    // 累计耗时是单调不减的
+    const times = path.steps.map((step) => step.elapsedMs);
+    expect([...times].sort((a, b) => a - b)).toEqual(times);
+  });
+
+  it('被策略拦下时，路径上明确有一跳是 drop', async () => {
+    const w = await world([{
+      apiVersion: 'networking.k8s.io/v1', kind: 'NetworkPolicy',
+      metadata: { name: 'deny-ledger', namespace: 'shop' },
+      spec: { podSelector: { matchLabels: { app: 'ledger' } }, policyTypes: ['Ingress'] },
+    }]);
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    w.cluster.network.connect(from, { host: 'ledger', port: 80, path: '/' });
+
+    const path = buildPacketPaths(w.cluster)[0];
+    expect(path.outcome).toBe('timeout');
+    const dropped = path.steps.filter((step) => step.verdict === 'drop');
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].at).toContain('policy/');
+    expect(dropped[0].detail).toContain('超时');
+  });
+
+  it('能对上拓扑节点的跳带上 nodeId，对不上的（DNS、策略）不带', async () => {
+    const w = await world();
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    w.cluster.network.connect(from, { host: 'ledger', port: 80, path: '/' });
+
+    const graph = buildTopology(w.cluster, { namespace: 'shop' });
+    const path = buildPacketPath(w.cluster.network.traces[0], graph);
+    const byPrefix = Object.fromEntries(path.steps.map((step) => [step.at.split('/')[0], step.nodeId]));
+    expect(byPrefix.dns).toBeUndefined();
+    expect(byPrefix.svc).toBe('Service/shop/ledger');
+    expect(byPrefix.pod).toBe(`Pod/shop/${podName(w, 'ledger')}`);
+  });
+
+  it('图上没有的节点不硬塞 nodeId', async () => {
+    const w = await world();
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    w.cluster.network.connect(from, { host: 'ledger', port: 80, path: '/' });
+    // 换一个命名空间的图，shop 里的对象都不在上面
+    const graph = buildTopology(w.cluster, { namespace: 'default' });
+    const path = buildPacketPath(w.cluster.network.traces[0], graph);
+    expect(path.steps.every((step) => step.nodeId === undefined)).toBe(true);
+  });
+
+  it('DNS 查不到时路径就停在 dns 那一跳', async () => {
+    const w = await world();
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    w.cluster.network.connect(from, { host: 'nope', port: 80, path: '/' });
+    const path = buildPacketPaths(w.cluster)[0];
+    expect(path.outcome).toBe('dns-failure');
+    expect(path.steps).toHaveLength(1);
+    expect(path.steps[0].verdict).toBe('drop');
+  });
+
+  it('最近的排在最前，而且只留最近若干条', async () => {
+    const w = await world();
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    for (let i = 0; i < 30; i += 1) {
+      w.cluster.network.connect(from, { host: 'ledger', port: 80, path: `/p${i}` });
+    }
+    const paths = buildPacketPaths(w.cluster);
+    expect(paths.length).toBeLessThanOrEqual(24);
+    expect(paths[0].to).toContain('/p29');
+    expect(paths[0].id).toBeGreaterThan(paths[1].id);
+  });
+
+  it('源和目标写成人能读的样子', async () => {
+    const w = await world();
+    const from = { zone: 'cluster' as const, namespace: 'shop', podName: podName(w, 'portal'), label: 'portal' };
+    w.cluster.network.connect(from, { host: 'ledger', port: 8443, path: '/health', tls: true });
+    const path = buildPacketPaths(w.cluster)[0];
+    expect(path.from).toBe(`pod/shop/${podName(w, 'portal')}`);
+    expect(path.to).toBe('https://ledger:8443/health');
+  });
+});


### PR DESCRIPTION
## 包路径

排查网络问题时最缺的一句话是「这个包到底走到哪一步被拦下的」。网络层每次 `connect` 都留一条 trace（最近 24 条），面板逐跳列出来：哪一跳被丢掉、哪一跳被拒绝、各花了多少虚拟毫秒。选中某一跳，拓扑图上对应的节点被圈出来。

刻意**不做自动播放的动画**：学员要停在某一跳上读那行 detail，而不是看它闪过去。上一跳 / 下一跳是手动的。

映射也不硬凑：DNS、分区边界、NetworkPolicy 这些跳在拓扑图上没有对应节点 —— 而它们恰恰是最常出问题的地方，所以路径面板要能单独显示它们，不能只靠图上高亮。

## 第 14 关

把连接语义那张表变成一道题。三种现象同时报过来，而 `kubectl get` 看下去哪儿都正常（Gateway Programmed、Pod 全 Running、Service 都在）：

| 请求 | 现象 | 包路径上是哪一跳 |
| --- | --- | --- |
| `https://portal.corp.internal/` | 404 | `gateway/payments/corp-gw : reject` |
| portal → `http://ledger` | timeout | `policy/ingress:payments/ledger : drop` |
| portal → `http://sessions` | refused | `svc/payments/sessions : reject`（没有 Endpoints） |

判定不只看「通没通」，还看**修的方式对不对**：Gateway 的 listener 不许放宽成通配、ledger 的入向策略不许删、sessions 这个 Service 不许换名字。这三种做法都能让现象消失，也都会让前面几关的成果作废。

## 顺带

`OpsImageSpec` 补齐了：`listens` / `routes` / `memoryUsage` / `runAsUser` / `enforcesNetworkPolicy` 这些字段关卡一直在用，但类型里没有 —— 关卡定义是 JS，不过类型检查，所以一直没暴露。

## 验证

浏览器里走了一遍（先截图强制出一帧）：空态文案、发一次 curl 之后路径出现、跳的选中、拓扑高亮，控制台无报错，`PacketPathPanel_tsx.js` 正常加载。

全量 1411 个用例通过（新增 8 个包路径用例 + 3 个关卡反向验证）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)