### PR TITLE
feat(opslab): 第 15 关 —— 服务网格，谁在用什么身份访问谁

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -31,6 +31,8 @@ const REPORTS_IMAGE_RC = 'harbor.corp.internal/team/reports:2.2.0-rc1';
 const EXPORTER_UPSTREAM = 'quay.io/acme/settlement-exporter:1.4.2';
 const EXPORTER_MIRROR = 'harbor.corp.internal/mirror/settlement-exporter:1.4.2';
 const SESSIONS_IMAGE = 'harbor.corp.internal/team/sessions:1.8.0';
+const ISTIOD_IMAGE = 'docker.io/istio/pilot:1.28.1';
+const ZTUNNEL_IMAGE = 'docker.io/istio/ztunnel:1.28.1';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -136,7 +138,7 @@ const WORLD = {
   ],
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
-    'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd',
+    'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -175,6 +177,9 @@ const WORLD = {
       pullMs: 300, startupMs: 400, readyAfterMs: 200,
       listens: [9100], routes: { '/metrics': 200 }, memoryUsage: '120Mi',
     },
+    // 服务网格的控制面与数据面
+    [ISTIOD_IMAGE]: { pullMs: 600, startupMs: 900, readyAfterMs: 400, listens: [15012] },
+    [ZTUNNEL_IMAGE]: { pullMs: 400, startupMs: 500, readyAfterMs: 200, listens: [15008] },
     // 会话存储
     [SESSIONS_IMAGE]: {
       pullMs: 300, startupMs: 500, readyAfterMs: 200,
@@ -4238,6 +4243,424 @@ const stage14 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 15 关                                                            */
+/* ------------------------------------------------------------------ */
+
+/** 网格的控制面与数据面，平台组已经装好 */
+const MESH_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'istiod', namespace: 'istio-system', labels: { app: 'istiod' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'istiod' } },
+      template: {
+        metadata: { labels: { app: 'istiod' } },
+        spec: { containers: [{ name: 'discovery', image: ISTIOD_IMAGE, ports: [{ containerPort: 15012 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'DaemonSet',
+    metadata: { name: 'ztunnel', namespace: 'istio-system', labels: { app: 'ztunnel' } },
+    spec: {
+      selector: { matchLabels: { app: 'ztunnel' } },
+      template: {
+        metadata: { labels: { app: 'ztunnel' } },
+        spec: { containers: [{ name: 'ztunnel', image: ZTUNNEL_IMAGE, ports: [{ containerPort: 15008 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'gateway.networking.k8s.io/v1', kind: 'GatewayClass',
+    metadata: { name: 'istio-waypoint' },
+    spec: { controllerName: 'istio.io/mesh-controller' },
+  },
+];
+
+/** 支付核心，跑在自己的 ServiceAccount 上 */
+const MESH_LEDGER = [
+  {
+    apiVersion: 'v1', kind: 'ServiceAccount',
+    metadata: { name: 'ledger', namespace: 'payments' },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'ledger', namespace: 'payments' },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'ledger' } },
+      template: {
+        metadata: { labels: { app: 'ledger' } },
+        spec: {
+          serviceAccountName: 'ledger',
+          containers: [{ name: 'app', image: LEDGER_IMAGE, ports: [{ containerPort: 8080 }] }],
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'ledger', namespace: 'payments' },
+    spec: { selector: { app: 'ledger' }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+];
+
+/** 门户也换成自己的身份 */
+const MESH_PORTAL = [
+  { apiVersion: 'v1', kind: 'ServiceAccount', metadata: { name: 'portal', namespace: 'payments' } },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'portal', namespace: 'payments' },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'portal' } },
+      template: {
+        metadata: { labels: { app: 'portal' } },
+        spec: {
+          serviceAccountName: 'portal',
+          containers: [{ name: 'web', image: PORTAL_IMAGE, ports: [{ containerPort: 8080 }] }],
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'portal', namespace: 'payments' },
+    spec: { clusterIP: '10.96.1.10', selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+];
+
+/** analytics 里的报表机 —— 它不该访问得到 ledger */
+const MESH_REPORTS = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name: 'reports', namespace: 'analytics' },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { app: 'reports' } },
+    template: {
+      metadata: { labels: { app: 'reports' } },
+      spec: {
+        containers: [{
+          name: 'app', image: REPORTS_IMAGE, ports: [{ containerPort: 9090 }],
+          resources: { requests: { memory: '256Mi' }, limits: { memory: '1Gi' } },
+        }],
+      },
+    },
+  },
+};
+
+const MESH_STARTER = code`
+  # 前任写到一半的东西。装上去之前先想清楚它会不会生效。
+  apiVersion: security.istio.io/v1
+  kind: AuthorizationPolicy
+  metadata:
+    name: ledger
+    namespace: payments
+  spec:
+    selector:
+      matchLabels:
+        app: ledger
+    action: ALLOW
+    rules:
+    - from:
+      - source:
+          principals:
+          - cluster.local/ns/payments/sa/portal
+      to:
+      - operation:
+          methods:
+          - GET
+          paths:
+          - /balance*
+`;
+
+const MESH_REFERENCE = code`
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: payments
+    labels:
+      istio.io/dataplane-mode: ambient
+  ---
+  # 入口的数据面也得有身份，否则 STRICT 之后它自己就被挡在外面了
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: envoy-gateway-system
+    labels:
+      istio.io/dataplane-mode: ambient
+  ---
+  apiVersion: security.istio.io/v1
+  kind: PeerAuthentication
+  metadata:
+    name: default
+    namespace: payments
+  spec:
+    mtls:
+      mode: STRICT
+  ---
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: waypoint
+    namespace: payments
+  spec:
+    gatewayClassName: istio-waypoint
+    listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+  ---
+  apiVersion: security.istio.io/v1
+  kind: AuthorizationPolicy
+  metadata:
+    name: ledger
+    namespace: payments
+  spec:
+    selector:
+      matchLabels:
+        app: ledger
+    action: ALLOW
+    rules:
+    - from:
+      - source:
+          principals:
+          - spiffe://cluster.local/ns/payments/sa/portal
+      to:
+      - operation:
+          methods:
+          - GET
+          paths:
+          - /*
+`;
+
+const stage15 = {
+  id: 'service-mesh-ambient',
+  title: t('服务网格：谁在用什么身份访问谁', 'Service Mesh: Who Is Calling Whom, As Whom'),
+  goal: t(
+    code`
+      安全评审又提了一条，这次是关于**身份**的：\`ledger\` 只允许门户访问，
+      而且要能证明「访问它的确实是门户」，不是谁都能伪造的 IP 或标签。
+      NetworkPolicy 按 IP 与标签判，标签是能改的；网格按**证书身份**判。
+
+      平台组已经把 Istio ambient 装好了（istiod + ztunnel），命名空间还没接进去。
+      \`/root/infra/mesh.yaml\` 里是前任写到一半的一条授权策略。
+
+      ## 通关标准
+
+      1. \`payments\` 接进网格，里面的工作负载走 mTLS；
+      2. 明文直连被拒 —— \`analytics\` 的报表机连不上 \`ledger\`；
+      3. 门户访问得到 \`ledger\`，而且判定看的是 SPIFFE 身份不是 IP；
+      4. \`istioctl analyze\` 干净（没有「策略写了但不生效」这类告警）；
+      5. 网格外的入口照常：从跳板机访问门户仍然 200。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl label namespace payments istio.io/dataplane-mode=ambient
+      istioctl ztunnel-config workload
+      istioctl x describe pod <pod> -n payments
+      istioctl analyze -n payments
+      kubectl apply -f /root/infra/mesh.yaml
+      kubectl exec -n analytics deploy/reports -- curl -s -m 5 http://ledger.payments.svc.cluster.local
+      \`\`\`
+    `,
+    code`
+      Another security review, this time about **identity**: only the portal may reach
+      \`ledger\`, and it must be provable that the caller really is the portal, not
+      something that borrowed an IP or a label. NetworkPolicy judges by IP and labels,
+      and labels can be edited. A mesh judges by **certificate identity**.
+
+      The platform team already installed Istio ambient (istiod plus ztunnel); no
+      namespace is enrolled yet. \`/root/infra/mesh.yaml\` holds a half-written
+      authorization policy your predecessor left behind.
+
+      ## Done when
+
+      1. \`payments\` is enrolled and its workloads talk over mTLS;
+      2. plaintext is refused: the reports pod in \`analytics\` cannot reach \`ledger\`;
+      3. the portal can reach \`ledger\`, and the decision is based on SPIFFE identity
+         rather than an IP;
+      4. \`istioctl analyze\` is clean, with no "written but not enforced" warnings;
+      5. the outside entrance still works: the portal answers 200 from the jump host.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl label namespace payments istio.io/dataplane-mode=ambient
+      istioctl ztunnel-config workload
+      istioctl x describe pod <pod> -n payments
+      istioctl analyze -n payments
+      kubectl apply -f /root/infra/mesh.yaml
+      kubectl exec -n analytics deploy/reports -- curl -s -m 5 http://ledger.payments.svc.cluster.local
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('命名空间接进网格，mTLS 生效', 'Namespace enrolled, mTLS in effect'),
+    t('按身份授权，明文被拒', 'Authorization by identity, plaintext refused'),
+    t('L7 规则真的被求值', 'The L7 rules are actually evaluated'),
+  ],
+  hints: [
+    t(
+      'ambient 靠命名空间上的一个标签接管：\`istio.io/dataplane-mode=ambient\`。接没接进去用 \`istioctl ztunnel-config workload\` 看 PROTOCOL 那一列，HBONE 才算数。',
+      'Ambient enrolls by a namespace label: `istio.io/dataplane-mode=ambient`. Check with `istioctl ztunnel-config workload` and read the PROTOCOL column: HBONE means enrolled.'
+    ),
+    t(
+      'ztunnel 只做 L4 —— 身份、端口。要按 HTTP 方法或路径授权，得给命名空间挂一个 waypoint（一个 \`gatewayClassName: istio-waypoint\` 的 Gateway）。没有它，那些规则不会被求值，\`istioctl analyze\` 会直说。',
+      'ztunnel only does L4: identity and ports. Authorizing by HTTP method or path needs a waypoint for the namespace (a Gateway with `gatewayClassName: istio-waypoint`). Without one those rules are never evaluated, and `istioctl analyze` says so.'
+    ),
+    t(
+      'principal 的写法是完整的 SPIFFE ID：\`spiffe://cluster.local/ns/<ns>/sa/<sa>\`。写成 \`cluster.local/ns/...\`（少了 scheme）不会报错，只会永远匹配不上。',
+      'A principal is a full SPIFFE ID: `spiffe://cluster.local/ns/<ns>/sa/<sa>`. Writing `cluster.local/ns/...` without the scheme raises no error and simply never matches.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '以为加了一条 ALLOW 就只是「多放行一个来源」。恰恰相反：一旦有 ALLOW 策略选中某个工作负载，**没被任何一条 rule 命中的访问全部被拒**。上线前先确认自己知道有哪些调用方。',
+      'Assuming an ALLOW policy merely permits one more caller. The opposite is true: once any ALLOW policy selects a workload, **everything not matched by some rule is denied**. Know your callers before shipping one.'
+    ),
+    t(
+      '把 NetworkPolicy 删掉，觉得「有网格了就不需要它」。两者判的不是一回事：网格判身份，NetworkPolicy 判网络可达性，而且网格只覆盖接进来的命名空间。它们是叠加的，不是替代的。',
+      'Deleting NetworkPolicies because "the mesh handles it now". They answer different questions: the mesh judges identity, NetworkPolicy judges reachability, and the mesh only covers enrolled namespaces. They stack, they do not replace each other.'
+    ),
+    t(
+      '被网格拒绝表现为**连接被重置**，不是超时。ztunnel 会明确回一个 RST。看到超时该去查 NetworkPolicy，看到 reset 才该来查网格 —— 两者指向不同的层。',
+      'A mesh denial shows up as a **connection reset**, not a timeout: ztunnel answers with an RST. A timeout points at NetworkPolicy; a reset points at the mesh. Different layers.'
+    ),
+    t(
+      '只把业务的命名空间接进网格，忘了入口。开了 STRICT 之后，Gateway 的数据面是从网格外发起明文连接的，于是它自己第一个被挡在外面 —— 门户对外直接不可用。入口所在的命名空间也要有身份。',
+      'Enrolling only the application namespace and forgetting the entrance. Once STRICT is on, the Gateway data plane is calling in as plaintext from outside the mesh, so it is the first thing refused and the portal goes dark from outside. The entrance namespace needs an identity too.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM, ...MESH_PLATFORM,
+      ...MESH_PORTAL, PORTAL_ROUTE, ...MESH_LEDGER, MESH_REPORTS,
+    ],
+    files: { '/root/infra/mesh.yaml': MESH_STARTER },
+    referenceFiles: { '/root/infra/mesh.yaml': MESH_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/mesh.yaml',
+    ],
+  },
+  specs: [
+    spec('service-mesh-ambient.spec.ts', code`
+      import { get, list, sh } from '@ops/lab';
+
+      const LEDGER = 'http://ledger.payments.svc.cluster.local';
+
+      describe('服务网格', () => {
+        it('payments 接进了网格', async () => {
+          const result = await sh('istioctl ztunnel-config workload');
+          expect(result.code).toBe(0);
+          // 按 NAMESPACE 那一列判断 —— envoy-payments-corp-gw-... 在别的命名空间里
+          const rows = result.stdout.split('\\n').filter((line) => line.startsWith('payments '));
+          expect(rows.length).toBeGreaterThan(0);
+          for (const row of rows) expect(row).toContain('HBONE');
+        });
+
+        it('门户访问得到 ledger', async () => {
+          const result = await sh(
+            'kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w %{http_code} ' + LEDGER
+          );
+          expect(result.stdout).toBe('200');
+        });
+
+        it('网格外的明文直连被拒 —— 而且是 reset 不是超时', async () => {
+          const result = await sh('kubectl exec -n analytics deploy/reports -- curl -s -m 5 ' + LEDGER);
+          expect(result.stdout).toBe('');
+          // 56 = 收到 RST；28 才是超时，那说明拦它的是 NetworkPolicy 不是网格
+          expect(result.stderr).toContain('curl: (56)');
+        });
+
+        it('判的是 SPIFFE 身份，不是 IP 或标签', () => {
+          const policies = list('AuthorizationPolicy', { namespace: 'payments' });
+          expect(policies.length).toBeGreaterThan(0);
+          const principals = policies.flatMap((policy) => (policy.spec.rules || [])
+            .flatMap((rule) => (rule.from || [])
+              .flatMap((entry) => (entry.source || {}).principals || [])));
+          expect(principals.length).toBeGreaterThan(0);
+          for (const principal of principals) {
+            expect(principal.startsWith('spiffe://')).toBe(true);
+          }
+        });
+
+        it('mTLS 是 STRICT', () => {
+          const policies = list('PeerAuthentication', { namespace: 'payments' });
+          expect(policies.some((policy) => policy.spec.mtls.mode === 'STRICT')).toBe(true);
+        });
+
+        it('istioctl analyze 是干净的 —— 没有「写了但不生效」', async () => {
+          const result = await sh('istioctl analyze -n payments');
+          expect(result.stdout).toContain('No validation issues found');
+          expect(result.code).toBe(0);
+        });
+
+        it('网格外的入口照常', async () => {
+          const gateway = list('Gateway', { namespace: 'payments' })
+            .find((item) => item.spec.gatewayClassName !== 'istio-waypoint');
+          const address = gateway.status.addresses[0].value;
+          const result = await sh(
+            'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address
+            + ' https://portal.corp.internal/'
+          );
+          expect(result.stdout).toBe('200');
+        });
+
+        it('没有靠删掉报表机来蒙过去', () => {
+          const reports = get('Deployment', 'reports', 'analytics');
+          expect(reports.status.readyReplicas).toBeGreaterThan(0);
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'resilience'],
+  extension: t(
+    code`
+      网格解决的是 NetworkPolicy 解决不了的那一类问题：**证明调用方是谁**。
+      NetworkPolicy 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签是
+      apiserver 里的一个字段，有权限的人随时能改；网格判的是「对面出示的证书
+      属于哪个 ServiceAccount」，那是一次真的 mTLS 双向验证。所以两者不是替代
+      关系：一个管网络可达性，一个管身份，叠着用。
+
+      ambient 相对 sidecar 的变化值得记住：数据面从「每个 Pod 一个 Envoy」变成
+      「每个节点一个 ztunnel + 按需的 waypoint」。代价是**分层**：ztunnel 只看
+      得到 L4，所以按方法、按路径的授权、重试、熔断这些都需要 waypoint。
+      这条分层是 ambient 里最常见的困惑来源 —— 策略写得没错，只是没有人求值。
+
+      还有一个容易忽略的点：SPIFFE 身份来自 **ServiceAccount**，不是 Pod 名也
+      不是标签。所有工作负载都用 \`default\` 这个 SA 的集群，网格给不出任何有用的
+      区分 —— 上网格之前，先把 ServiceAccount 分开。
+    `,
+    code`
+      A mesh solves the problem NetworkPolicy cannot: **proving who the caller is**.
+      NetworkPolicy says "this IP belongs to a pod carrying that label", and a label is
+      a field in the apiserver that anyone with access can change. A mesh says "the
+      certificate the peer presented belongs to that ServiceAccount", established by a
+      real mutual TLS handshake. They are not alternatives: one governs reachability,
+      the other identity, and they stack.
+
+      The ambient change worth remembering: the data plane moves from "an Envoy beside
+      every pod" to "one ztunnel per node plus waypoints where needed". The price is
+      **layering**: ztunnel only sees L4, so per-method and per-path authorization,
+      retries, and circuit breaking all require a waypoint. That layering is the most
+      common source of confusion in ambient, because the policy is not wrong, it simply
+      has nobody evaluating it.
+
+      One more thing that is easy to miss: SPIFFE identity comes from the
+      **ServiceAccount**, not the pod name or its labels. A cluster where everything
+      runs as \`default\` gets no useful distinction out of a mesh. Split the
+      ServiceAccounts before you enroll.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -4282,6 +4705,6 @@ module.exports = {
   files: [],
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
-    stage7, stage8, stage9, stage10, stage11, stage12, stage13, stage14,
+    stage7, stage8, stage9, stage10, stage11, stage12, stage13, stage14, stage15,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5617,7 +5617,8 @@
           "envoy-gateway-system",
           "ingress-nginx",
           "cert-manager",
-          "argocd"
+          "argocd",
+          "istio-system"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5699,6 +5700,22 @@
               "/metrics": 200
             },
             "memoryUsage": "120Mi"
+          },
+          "docker.io/istio/pilot:1.28.1": {
+            "pullMs": 600,
+            "startupMs": 900,
+            "readyAfterMs": 400,
+            "listens": [
+              15012
+            ]
+          },
+          "docker.io/istio/ztunnel:1.28.1": {
+            "pullMs": 400,
+            "startupMs": 500,
+            "readyAfterMs": 200,
+            "listens": [
+              15008
+            ]
           },
           "harbor.corp.internal/team/sessions:1.8.0": {
             "pullMs": 300,
@@ -9433,6 +9450,631 @@
         "primer": {
           "zh": "排查网络问题最费时间的从来不是修，是在错误的层里找。而现象本身已经把层次说清楚了，只要认得出来。一条 TCP 连接从发起到拿到响应，要顺次经过：名字解析、路由可达、目标端口有没有人听、中间有没有人丢包、TLS 握手、最后才是应用的回答。每一层失败的样子都不一样。\n\n`Connection refused` 说明包**到了**对端，而那里没有进程在听。Kubernetes 里最常见的成因是 Service 的 selector 没选中任何 Pod：Endpoints 为空，kube-proxy 直接回 RST。注意 `kubectl get svc` 这时看上去完全正常，有 ClusterIP、有端口；要看的是 `kubectl get endpoints`。\n\n`timeout` 说明包被**丢**了，对端不回任何东西。防火墙、安全组、路由不通、NetworkPolicy 都长这样。这也是为什么策略拒绝表现为卡住而不是立刻失败：丢包的一方按定义不会告诉你它丢了。看到超时，该问的是「谁在丢包」，而不是「服务是不是挂了」。\n\n`404`、`502`、`503` 这类 HTTP 状态码意味着**连接是成功的**。这是应用或者代理给的回答，说明下面每一层都通了。Gateway 回 404 是「我活着，但没有路由认领这个域名或路径」，去看 HTTPRoute 的 `hostnames` 与 `rules`；连不上才是 Gateway 本身的问题。再往前一层，如果连 DNS 都没解析出来，那连接压根没发起过，`dig` 和 `/etc/resolv.conf` 才是现场。",
           "en": "The expensive part of debugging a network problem is never the fix, it is searching in the wrong layer. The symptom already tells you the layer, if you can read it. A TCP connection passes through name resolution, route reachability, something listening on the target port, nobody dropping the packet, a TLS handshake, and only then the application answer. Each layer fails differently.\n\n`Connection refused` means the packet **arrived** and no process was listening. In Kubernetes the usual cause is a Service selector matching no pods: Endpoints is empty and kube-proxy resets the connection. Note that `kubectl get svc` looks perfectly healthy at that moment, with a ClusterIP and ports; the thing to read is `kubectl get endpoints`.\n\n`timeout` means the packet was **dropped** with no reply. Firewalls, security groups, missing routes, and NetworkPolicy all look like this. It is also why a policy denial hangs instead of failing fast: whoever drops the packet, by definition, does not tell you. A timeout should prompt \"who is dropping packets\", not \"is the service down\".\n\nHTTP status codes such as `404`, `502`, and `503` mean the **connection succeeded**. They are an answer from the application or the proxy, which means every layer below worked. A Gateway returning 404 is saying \"I am alive and no route claimed this hostname or path\", so read the HTTPRoute `hostnames` and `rules`; a Gateway that is actually broken refuses the connection instead. One layer earlier, if DNS never resolved, no connection was attempted at all and the scene of the crime is `dig` and `/etc/resolv.conf`."
+        }
+      },
+      {
+        "id": "service-mesh-ambient",
+        "title": {
+          "zh": "服务网格：谁在用什么身份访问谁",
+          "en": "Service Mesh: Who Is Calling Whom, As Whom"
+        },
+        "goal": {
+          "zh": "安全评审又提了一条，这次是关于**身份**的：`ledger` 只允许门户访问，\n而且要能证明「访问它的确实是门户」，不是谁都能伪造的 IP 或标签。\nNetworkPolicy 按 IP 与标签判，标签是能改的；网格按**证书身份**判。\n\n平台组已经把 Istio ambient 装好了（istiod + ztunnel），命名空间还没接进去。\n`/root/infra/mesh.yaml` 里是前任写到一半的一条授权策略。\n\n## 通关标准\n\n1. `payments` 接进网格，里面的工作负载走 mTLS；\n2. 明文直连被拒 —— `analytics` 的报表机连不上 `ledger`；\n3. 门户访问得到 `ledger`，而且判定看的是 SPIFFE 身份不是 IP；\n4. `istioctl analyze` 干净（没有「策略写了但不生效」这类告警）；\n5. 网格外的入口照常：从跳板机访问门户仍然 200。\n\n## 会用到的命令\n\n```bash\nkubectl label namespace payments istio.io/dataplane-mode=ambient\nistioctl ztunnel-config workload\nistioctl x describe pod <pod> -n payments\nistioctl analyze -n payments\nkubectl apply -f /root/infra/mesh.yaml\nkubectl exec -n analytics deploy/reports -- curl -s -m 5 http://ledger.payments.svc.cluster.local\n```\n",
+          "en": "Another security review, this time about **identity**: only the portal may reach\n`ledger`, and it must be provable that the caller really is the portal, not\nsomething that borrowed an IP or a label. NetworkPolicy judges by IP and labels,\nand labels can be edited. A mesh judges by **certificate identity**.\n\nThe platform team already installed Istio ambient (istiod plus ztunnel); no\nnamespace is enrolled yet. `/root/infra/mesh.yaml` holds a half-written\nauthorization policy your predecessor left behind.\n\n## Done when\n\n1. `payments` is enrolled and its workloads talk over mTLS;\n2. plaintext is refused: the reports pod in `analytics` cannot reach `ledger`;\n3. the portal can reach `ledger`, and the decision is based on SPIFFE identity\n   rather than an IP;\n4. `istioctl analyze` is clean, with no \"written but not enforced\" warnings;\n5. the outside entrance still works: the portal answers 200 from the jump host.\n\n## Commands you will need\n\n```bash\nkubectl label namespace payments istio.io/dataplane-mode=ambient\nistioctl ztunnel-config workload\nistioctl x describe pod <pod> -n payments\nistioctl analyze -n payments\nkubectl apply -f /root/infra/mesh.yaml\nkubectl exec -n analytics deploy/reports -- curl -s -m 5 http://ledger.payments.svc.cluster.local\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "命名空间接进网格，mTLS 生效",
+            "en": "Namespace enrolled, mTLS in effect"
+          },
+          {
+            "zh": "按身份授权，明文被拒",
+            "en": "Authorization by identity, plaintext refused"
+          },
+          {
+            "zh": "L7 规则真的被求值",
+            "en": "The L7 rules are actually evaluated"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "ambient 靠命名空间上的一个标签接管：`istio.io/dataplane-mode=ambient`。接没接进去用 `istioctl ztunnel-config workload` 看 PROTOCOL 那一列，HBONE 才算数。",
+            "en": "Ambient enrolls by a namespace label: `istio.io/dataplane-mode=ambient`. Check with `istioctl ztunnel-config workload` and read the PROTOCOL column: HBONE means enrolled."
+          },
+          {
+            "zh": "ztunnel 只做 L4 —— 身份、端口。要按 HTTP 方法或路径授权，得给命名空间挂一个 waypoint（一个 `gatewayClassName: istio-waypoint` 的 Gateway）。没有它，那些规则不会被求值，`istioctl analyze` 会直说。",
+            "en": "ztunnel only does L4: identity and ports. Authorizing by HTTP method or path needs a waypoint for the namespace (a Gateway with `gatewayClassName: istio-waypoint`). Without one those rules are never evaluated, and `istioctl analyze` says so."
+          },
+          {
+            "zh": "principal 的写法是完整的 SPIFFE ID：`spiffe://cluster.local/ns/<ns>/sa/<sa>`。写成 `cluster.local/ns/...`（少了 scheme）不会报错，只会永远匹配不上。",
+            "en": "A principal is a full SPIFFE ID: `spiffe://cluster.local/ns/<ns>/sa/<sa>`. Writing `cluster.local/ns/...` without the scheme raises no error and simply never matches."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "以为加了一条 ALLOW 就只是「多放行一个来源」。恰恰相反：一旦有 ALLOW 策略选中某个工作负载，**没被任何一条 rule 命中的访问全部被拒**。上线前先确认自己知道有哪些调用方。",
+            "en": "Assuming an ALLOW policy merely permits one more caller. The opposite is true: once any ALLOW policy selects a workload, **everything not matched by some rule is denied**. Know your callers before shipping one."
+          },
+          {
+            "zh": "把 NetworkPolicy 删掉，觉得「有网格了就不需要它」。两者判的不是一回事：网格判身份，NetworkPolicy 判网络可达性，而且网格只覆盖接进来的命名空间。它们是叠加的，不是替代的。",
+            "en": "Deleting NetworkPolicies because \"the mesh handles it now\". They answer different questions: the mesh judges identity, NetworkPolicy judges reachability, and the mesh only covers enrolled namespaces. They stack, they do not replace each other."
+          },
+          {
+            "zh": "被网格拒绝表现为**连接被重置**，不是超时。ztunnel 会明确回一个 RST。看到超时该去查 NetworkPolicy，看到 reset 才该来查网格 —— 两者指向不同的层。",
+            "en": "A mesh denial shows up as a **connection reset**, not a timeout: ztunnel answers with an RST. A timeout points at NetworkPolicy; a reset points at the mesh. Different layers."
+          },
+          {
+            "zh": "只把业务的命名空间接进网格，忘了入口。开了 STRICT 之后，Gateway 的数据面是从网格外发起明文连接的，于是它自己第一个被挡在外面 —— 门户对外直接不可用。入口所在的命名空间也要有身份。",
+            "en": "Enrolling only the application namespace and forgetting the entrance. Once STRICT is on, the Gateway data plane is calling in as plaintext from outside the mesh, so it is the first thing refused and the portal goes dark from outside. The entrance namespace needs an identity too."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "istiod",
+                "namespace": "istio-system",
+                "labels": {
+                  "app": "istiod"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "istiod"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "istiod"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "discovery",
+                        "image": "docker.io/istio/pilot:1.28.1",
+                        "ports": [
+                          {
+                            "containerPort": 15012
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "ztunnel",
+                "namespace": "istio-system",
+                "labels": {
+                  "app": "ztunnel"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "ztunnel"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ztunnel"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "ztunnel",
+                        "image": "docker.io/istio/ztunnel:1.28.1",
+                        "ports": [
+                          {
+                            "containerPort": 15008
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "istio-waypoint"
+              },
+              "spec": {
+                "controllerName": "istio.io/mesh-controller"
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "serviceAccountName": "portal",
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "ledger"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ledger"
+                    }
+                  },
+                  "spec": {
+                    "serviceAccountName": "ledger",
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/ledger:3.2.1",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "ledger"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "reports",
+                "namespace": "analytics"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "reports"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "reports"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/reports:2.1.0",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ],
+                        "resources": {
+                          "requests": {
+                            "memory": "256Mi"
+                          },
+                          "limits": {
+                            "memory": "1Gi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/mesh.yaml": "# 前任写到一半的东西。装上去之前先想清楚它会不会生效。\napiVersion: security.istio.io/v1\nkind: AuthorizationPolicy\nmetadata:\n  name: ledger\n  namespace: payments\nspec:\n  selector:\n    matchLabels:\n      app: ledger\n  action: ALLOW\n  rules:\n  - from:\n    - source:\n        principals:\n        - cluster.local/ns/payments/sa/portal\n    to:\n    - operation:\n        methods:\n        - GET\n        paths:\n        - /balance*\n"
+          },
+          "referenceFiles": {
+            "/root/infra/mesh.yaml": "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: payments\n  labels:\n    istio.io/dataplane-mode: ambient\n---\n# 入口的数据面也得有身份，否则 STRICT 之后它自己就被挡在外面了\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: envoy-gateway-system\n  labels:\n    istio.io/dataplane-mode: ambient\n---\napiVersion: security.istio.io/v1\nkind: PeerAuthentication\nmetadata:\n  name: default\n  namespace: payments\nspec:\n  mtls:\n    mode: STRICT\n---\napiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: waypoint\n  namespace: payments\nspec:\n  gatewayClassName: istio-waypoint\n  listeners:\n  - name: mesh\n    port: 15008\n    protocol: HBONE\n---\napiVersion: security.istio.io/v1\nkind: AuthorizationPolicy\nmetadata:\n  name: ledger\n  namespace: payments\nspec:\n  selector:\n    matchLabels:\n      app: ledger\n  action: ALLOW\n  rules:\n  - from:\n    - source:\n        principals:\n        - spiffe://cluster.local/ns/payments/sa/portal\n    to:\n    - operation:\n        methods:\n        - GET\n        paths:\n        - /*\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/mesh.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "service-mesh-ambient.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst LEDGER = 'http://ledger.payments.svc.cluster.local';\n\ndescribe('服务网格', () => {\n  it('payments 接进了网格', async () => {\n    const result = await sh('istioctl ztunnel-config workload');\n    expect(result.code).toBe(0);\n    // 按 NAMESPACE 那一列判断 —— envoy-payments-corp-gw-... 在别的命名空间里\n    const rows = result.stdout.split('\\n').filter((line) => line.startsWith('payments '));\n    expect(rows.length).toBeGreaterThan(0);\n    for (const row of rows) expect(row).toContain('HBONE');\n  });\n\n  it('门户访问得到 ledger', async () => {\n    const result = await sh(\n      'kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w %{http_code} ' + LEDGER\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('网格外的明文直连被拒 —— 而且是 reset 不是超时', async () => {\n    const result = await sh('kubectl exec -n analytics deploy/reports -- curl -s -m 5 ' + LEDGER);\n    expect(result.stdout).toBe('');\n    // 56 = 收到 RST；28 才是超时，那说明拦它的是 NetworkPolicy 不是网格\n    expect(result.stderr).toContain('curl: (56)');\n  });\n\n  it('判的是 SPIFFE 身份，不是 IP 或标签', () => {\n    const policies = list('AuthorizationPolicy', { namespace: 'payments' });\n    expect(policies.length).toBeGreaterThan(0);\n    const principals = policies.flatMap((policy) => (policy.spec.rules || [])\n      .flatMap((rule) => (rule.from || [])\n        .flatMap((entry) => (entry.source || {}).principals || [])));\n    expect(principals.length).toBeGreaterThan(0);\n    for (const principal of principals) {\n      expect(principal.startsWith('spiffe://')).toBe(true);\n    }\n  });\n\n  it('mTLS 是 STRICT', () => {\n    const policies = list('PeerAuthentication', { namespace: 'payments' });\n    expect(policies.some((policy) => policy.spec.mtls.mode === 'STRICT')).toBe(true);\n  });\n\n  it('istioctl analyze 是干净的 —— 没有「写了但不生效」', async () => {\n    const result = await sh('istioctl analyze -n payments');\n    expect(result.stdout).toContain('No validation issues found');\n    expect(result.code).toBe(0);\n  });\n\n  it('网格外的入口照常', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })\n      .find((item) => item.spec.gatewayClassName !== 'istio-waypoint');\n    const address = gateway.status.addresses[0].value;\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address\n      + ' https://portal.corp.internal/'\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('没有靠删掉报表机来蒙过去', () => {\n    const reports = get('Deployment', 'reports', 'analytics');\n    expect(reports.status.readyReplicas).toBeGreaterThan(0);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "网格解决的是 NetworkPolicy 解决不了的那一类问题：**证明调用方是谁**。\nNetworkPolicy 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签是\napiserver 里的一个字段，有权限的人随时能改；网格判的是「对面出示的证书\n属于哪个 ServiceAccount」，那是一次真的 mTLS 双向验证。所以两者不是替代\n关系：一个管网络可达性，一个管身份，叠着用。\n\nambient 相对 sidecar 的变化值得记住：数据面从「每个 Pod 一个 Envoy」变成\n「每个节点一个 ztunnel + 按需的 waypoint」。代价是**分层**：ztunnel 只看\n得到 L4，所以按方法、按路径的授权、重试、熔断这些都需要 waypoint。\n这条分层是 ambient 里最常见的困惑来源 —— 策略写得没错，只是没有人求值。\n\n还有一个容易忽略的点：SPIFFE 身份来自 **ServiceAccount**，不是 Pod 名也\n不是标签。所有工作负载都用 `default` 这个 SA 的集群，网格给不出任何有用的\n区分 —— 上网格之前，先把 ServiceAccount 分开。\n",
+          "en": "A mesh solves the problem NetworkPolicy cannot: **proving who the caller is**.\nNetworkPolicy says \"this IP belongs to a pod carrying that label\", and a label is\na field in the apiserver that anyone with access can change. A mesh says \"the\ncertificate the peer presented belongs to that ServiceAccount\", established by a\nreal mutual TLS handshake. They are not alternatives: one governs reachability,\nthe other identity, and they stack.\n\nThe ambient change worth remembering: the data plane moves from \"an Envoy beside\nevery pod\" to \"one ztunnel per node plus waypoints where needed\". The price is\n**layering**: ztunnel only sees L4, so per-method and per-path authorization,\nretries, and circuit breaking all require a waypoint. That layering is the most\ncommon source of confusion in ambient, because the policy is not wrong, it simply\nhas nobody evaluating it.\n\nOne more thing that is easy to miss: SPIFFE identity comes from the\n**ServiceAccount**, not the pod name or its labels. A cluster where everything\nruns as `default` gets no useful distinction out of a mesh. Split the\nServiceAccounts before you enroll.\n"
+        },
+        "primer": {
+          "zh": "`NetworkPolicy` 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签只是 apiserver 里的一个字段，有权限的人随时能改。服务网格判的是另一件事：**对面出示的证书属于谁**。每个工作负载拿到一张由集群 CA 签发的证书，身份写在 SAN 里，格式是 `SPIFFE`：`spiffe://cluster.local/ns/<命名空间>/sa/<ServiceAccount>`。注意身份来自 ServiceAccount，不是 Pod 名也不是标签；所有服务都用 `default` 这个 SA 的集群，上了网格也分不出谁是谁。\n\n`Istio ambient` 是 2026 年的主流形态，和早年的 sidecar 模式差别很大：不再给每个 Pod 塞一个 Envoy，而是每个节点跑一个 `ztunnel`（DaemonSet）负责 L4：建立 mTLS、校验对端身份、按身份与端口授权。接入方式是给命名空间打一个标签 `istio.io/dataplane-mode=ambient`，Pod 不用改、不用重启。`istioctl ztunnel-config workload` 里 PROTOCOL 那一列是 HBONE 就说明接进来了。\n\n要按 HTTP 方法或路径授权、要重试与熔断，就得再加一层 `waypoint`，也就是一个 `gatewayClassName: istio-waypoint` 的 Gateway，按命名空间或按服务挂。这条分层是 ambient 最常见的困惑来源：带 `methods` 或 `paths` 的 `AuthorizationPolicy` 在没有 waypoint 的时候**根本不会被求值**，而 apiserver 照样收下它。`istioctl analyze` 会把这类问题直接报出来。\n\n`AuthorizationPolicy` 的判定顺序值得单独记：任何一条 DENY 命中就拒绝；没有任何 ALLOW 策略选中这个工作负载则放行；一旦有 ALLOW 策略选中它，只有命中某条 rule 才放行，**其余一律拒绝**。所以给一个服务加第一条 ALLOW 策略，等于同时把「默认拒绝」也打开了，很多人以为自己只是多放行了一个来源。还有一点：被网格拒绝表现为连接被重置（ztunnel 回 RST），而不是超时；超时是丢包，指向 NetworkPolicy 那一层。",
+          "en": "`NetworkPolicy` decides based on \"this IP belongs to a pod carrying that label\", and a label is just a field in the apiserver that anyone with access can change. A service mesh answers a different question: **whose certificate did the peer present**. Each workload gets a certificate from the cluster CA with its identity in the SAN, in `SPIFFE` form: `spiffe://cluster.local/ns/<namespace>/sa/<serviceaccount>`. Identity comes from the ServiceAccount, not the pod name or its labels, so a cluster where everything runs as `default` gains nothing by enrolling.\n\n`Istio ambient` is the mainstream shape in 2026 and differs sharply from the older sidecar model: instead of an Envoy beside every pod, one `ztunnel` per node (a DaemonSet) handles L4, establishing mTLS, verifying peer identity, and authorizing by identity and port. Enrolling is a namespace label, `istio.io/dataplane-mode=ambient`, with no pod changes and no restarts. In `istioctl ztunnel-config workload`, a PROTOCOL of HBONE means enrolled.\n\nAuthorizing by HTTP method or path, or doing retries and circuit breaking, needs one more layer: a `waypoint`, a Gateway with `gatewayClassName: istio-waypoint`, attached per namespace or per service. This layering is the most common confusion in ambient, because an `AuthorizationPolicy` with `methods` or `paths` is **never evaluated** without a waypoint, while the apiserver accepts it happily. `istioctl analyze` reports exactly this class of problem.\n\nThe evaluation order of `AuthorizationPolicy` is worth memorising: any matching DENY refuses; with no ALLOW policy selecting the workload, traffic is permitted; once some ALLOW policy selects it, only traffic matching a rule is permitted and **everything else is refused**. So adding the first ALLOW policy to a service also turns on default-deny, which surprises people who thought they were merely permitting one more caller. One more distinction: a mesh denial arrives as a connection reset, because ztunnel answers with an RST, whereas a timeout means dropped packets and points at the NetworkPolicy layer."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1252,6 +1252,21 @@ const primers = {
       )
     ),
 
+    'service-mesh-ambient': t(
+      p(
+        '`NetworkPolicy` 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签只是 apiserver 里的一个字段，有权限的人随时能改。服务网格判的是另一件事：**对面出示的证书属于谁**。每个工作负载拿到一张由集群 CA 签发的证书，身份写在 SAN 里，格式是 `SPIFFE`：`spiffe://cluster.local/ns/<命名空间>/sa/<ServiceAccount>`。注意身份来自 ServiceAccount，不是 Pod 名也不是标签；所有服务都用 `default` 这个 SA 的集群，上了网格也分不出谁是谁。',
+        '`Istio ambient` 是 2026 年的主流形态，和早年的 sidecar 模式差别很大：不再给每个 Pod 塞一个 Envoy，而是每个节点跑一个 `ztunnel`（DaemonSet）负责 L4：建立 mTLS、校验对端身份、按身份与端口授权。接入方式是给命名空间打一个标签 `istio.io/dataplane-mode=ambient`，Pod 不用改、不用重启。`istioctl ztunnel-config workload` 里 PROTOCOL 那一列是 HBONE 就说明接进来了。',
+        '要按 HTTP 方法或路径授权、要重试与熔断，就得再加一层 `waypoint`，也就是一个 `gatewayClassName: istio-waypoint` 的 Gateway，按命名空间或按服务挂。这条分层是 ambient 最常见的困惑来源：带 `methods` 或 `paths` 的 `AuthorizationPolicy` 在没有 waypoint 的时候**根本不会被求值**，而 apiserver 照样收下它。`istioctl analyze` 会把这类问题直接报出来。',
+        '`AuthorizationPolicy` 的判定顺序值得单独记：任何一条 DENY 命中就拒绝；没有任何 ALLOW 策略选中这个工作负载则放行；一旦有 ALLOW 策略选中它，只有命中某条 rule 才放行，**其余一律拒绝**。所以给一个服务加第一条 ALLOW 策略，等于同时把「默认拒绝」也打开了，很多人以为自己只是多放行了一个来源。还有一点：被网格拒绝表现为连接被重置（ztunnel 回 RST），而不是超时；超时是丢包，指向 NetworkPolicy 那一层。'
+      ),
+      p(
+        '`NetworkPolicy` decides based on "this IP belongs to a pod carrying that label", and a label is just a field in the apiserver that anyone with access can change. A service mesh answers a different question: **whose certificate did the peer present**. Each workload gets a certificate from the cluster CA with its identity in the SAN, in `SPIFFE` form: `spiffe://cluster.local/ns/<namespace>/sa/<serviceaccount>`. Identity comes from the ServiceAccount, not the pod name or its labels, so a cluster where everything runs as `default` gains nothing by enrolling.',
+        '`Istio ambient` is the mainstream shape in 2026 and differs sharply from the older sidecar model: instead of an Envoy beside every pod, one `ztunnel` per node (a DaemonSet) handles L4, establishing mTLS, verifying peer identity, and authorizing by identity and port. Enrolling is a namespace label, `istio.io/dataplane-mode=ambient`, with no pod changes and no restarts. In `istioctl ztunnel-config workload`, a PROTOCOL of HBONE means enrolled.',
+        'Authorizing by HTTP method or path, or doing retries and circuit breaking, needs one more layer: a `waypoint`, a Gateway with `gatewayClassName: istio-waypoint`, attached per namespace or per service. This layering is the most common confusion in ambient, because an `AuthorizationPolicy` with `methods` or `paths` is **never evaluated** without a waypoint, while the apiserver accepts it happily. `istioctl analyze` reports exactly this class of problem.',
+        'The evaluation order of `AuthorizationPolicy` is worth memorising: any matching DENY refuses; with no ALLOW policy selecting the workload, traffic is permitted; once some ALLOW policy selects it, only traffic matching a rule is permitted and **everything else is refused**. So adding the first ALLOW policy to a service also turns on default-deny, which surprises people who thought they were merely permitting one more caller. One more distinction: a mesh denial arrives as a connection reset, because ztunnel answers with an RST, whereas a timeout means dropped packets and points at the NetworkPolicy layer.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5617,7 +5617,8 @@
           "envoy-gateway-system",
           "ingress-nginx",
           "cert-manager",
-          "argocd"
+          "argocd",
+          "istio-system"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5699,6 +5700,22 @@
               "/metrics": 200
             },
             "memoryUsage": "120Mi"
+          },
+          "docker.io/istio/pilot:1.28.1": {
+            "pullMs": 600,
+            "startupMs": 900,
+            "readyAfterMs": 400,
+            "listens": [
+              15012
+            ]
+          },
+          "docker.io/istio/ztunnel:1.28.1": {
+            "pullMs": 400,
+            "startupMs": 500,
+            "readyAfterMs": 200,
+            "listens": [
+              15008
+            ]
           },
           "harbor.corp.internal/team/sessions:1.8.0": {
             "pullMs": 300,
@@ -9433,6 +9450,631 @@
         "primer": {
           "zh": "排查网络问题最费时间的从来不是修，是在错误的层里找。而现象本身已经把层次说清楚了，只要认得出来。一条 TCP 连接从发起到拿到响应，要顺次经过：名字解析、路由可达、目标端口有没有人听、中间有没有人丢包、TLS 握手、最后才是应用的回答。每一层失败的样子都不一样。\n\n`Connection refused` 说明包**到了**对端，而那里没有进程在听。Kubernetes 里最常见的成因是 Service 的 selector 没选中任何 Pod：Endpoints 为空，kube-proxy 直接回 RST。注意 `kubectl get svc` 这时看上去完全正常，有 ClusterIP、有端口；要看的是 `kubectl get endpoints`。\n\n`timeout` 说明包被**丢**了，对端不回任何东西。防火墙、安全组、路由不通、NetworkPolicy 都长这样。这也是为什么策略拒绝表现为卡住而不是立刻失败：丢包的一方按定义不会告诉你它丢了。看到超时，该问的是「谁在丢包」，而不是「服务是不是挂了」。\n\n`404`、`502`、`503` 这类 HTTP 状态码意味着**连接是成功的**。这是应用或者代理给的回答，说明下面每一层都通了。Gateway 回 404 是「我活着，但没有路由认领这个域名或路径」，去看 HTTPRoute 的 `hostnames` 与 `rules`；连不上才是 Gateway 本身的问题。再往前一层，如果连 DNS 都没解析出来，那连接压根没发起过，`dig` 和 `/etc/resolv.conf` 才是现场。",
           "en": "The expensive part of debugging a network problem is never the fix, it is searching in the wrong layer. The symptom already tells you the layer, if you can read it. A TCP connection passes through name resolution, route reachability, something listening on the target port, nobody dropping the packet, a TLS handshake, and only then the application answer. Each layer fails differently.\n\n`Connection refused` means the packet **arrived** and no process was listening. In Kubernetes the usual cause is a Service selector matching no pods: Endpoints is empty and kube-proxy resets the connection. Note that `kubectl get svc` looks perfectly healthy at that moment, with a ClusterIP and ports; the thing to read is `kubectl get endpoints`.\n\n`timeout` means the packet was **dropped** with no reply. Firewalls, security groups, missing routes, and NetworkPolicy all look like this. It is also why a policy denial hangs instead of failing fast: whoever drops the packet, by definition, does not tell you. A timeout should prompt \"who is dropping packets\", not \"is the service down\".\n\nHTTP status codes such as `404`, `502`, and `503` mean the **connection succeeded**. They are an answer from the application or the proxy, which means every layer below worked. A Gateway returning 404 is saying \"I am alive and no route claimed this hostname or path\", so read the HTTPRoute `hostnames` and `rules`; a Gateway that is actually broken refuses the connection instead. One layer earlier, if DNS never resolved, no connection was attempted at all and the scene of the crime is `dig` and `/etc/resolv.conf`."
+        }
+      },
+      {
+        "id": "service-mesh-ambient",
+        "title": {
+          "zh": "服务网格：谁在用什么身份访问谁",
+          "en": "Service Mesh: Who Is Calling Whom, As Whom"
+        },
+        "goal": {
+          "zh": "安全评审又提了一条，这次是关于**身份**的：`ledger` 只允许门户访问，\n而且要能证明「访问它的确实是门户」，不是谁都能伪造的 IP 或标签。\nNetworkPolicy 按 IP 与标签判，标签是能改的；网格按**证书身份**判。\n\n平台组已经把 Istio ambient 装好了（istiod + ztunnel），命名空间还没接进去。\n`/root/infra/mesh.yaml` 里是前任写到一半的一条授权策略。\n\n## 通关标准\n\n1. `payments` 接进网格，里面的工作负载走 mTLS；\n2. 明文直连被拒 —— `analytics` 的报表机连不上 `ledger`；\n3. 门户访问得到 `ledger`，而且判定看的是 SPIFFE 身份不是 IP；\n4. `istioctl analyze` 干净（没有「策略写了但不生效」这类告警）；\n5. 网格外的入口照常：从跳板机访问门户仍然 200。\n\n## 会用到的命令\n\n```bash\nkubectl label namespace payments istio.io/dataplane-mode=ambient\nistioctl ztunnel-config workload\nistioctl x describe pod <pod> -n payments\nistioctl analyze -n payments\nkubectl apply -f /root/infra/mesh.yaml\nkubectl exec -n analytics deploy/reports -- curl -s -m 5 http://ledger.payments.svc.cluster.local\n```\n",
+          "en": "Another security review, this time about **identity**: only the portal may reach\n`ledger`, and it must be provable that the caller really is the portal, not\nsomething that borrowed an IP or a label. NetworkPolicy judges by IP and labels,\nand labels can be edited. A mesh judges by **certificate identity**.\n\nThe platform team already installed Istio ambient (istiod plus ztunnel); no\nnamespace is enrolled yet. `/root/infra/mesh.yaml` holds a half-written\nauthorization policy your predecessor left behind.\n\n## Done when\n\n1. `payments` is enrolled and its workloads talk over mTLS;\n2. plaintext is refused: the reports pod in `analytics` cannot reach `ledger`;\n3. the portal can reach `ledger`, and the decision is based on SPIFFE identity\n   rather than an IP;\n4. `istioctl analyze` is clean, with no \"written but not enforced\" warnings;\n5. the outside entrance still works: the portal answers 200 from the jump host.\n\n## Commands you will need\n\n```bash\nkubectl label namespace payments istio.io/dataplane-mode=ambient\nistioctl ztunnel-config workload\nistioctl x describe pod <pod> -n payments\nistioctl analyze -n payments\nkubectl apply -f /root/infra/mesh.yaml\nkubectl exec -n analytics deploy/reports -- curl -s -m 5 http://ledger.payments.svc.cluster.local\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "命名空间接进网格，mTLS 生效",
+            "en": "Namespace enrolled, mTLS in effect"
+          },
+          {
+            "zh": "按身份授权，明文被拒",
+            "en": "Authorization by identity, plaintext refused"
+          },
+          {
+            "zh": "L7 规则真的被求值",
+            "en": "The L7 rules are actually evaluated"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "ambient 靠命名空间上的一个标签接管：`istio.io/dataplane-mode=ambient`。接没接进去用 `istioctl ztunnel-config workload` 看 PROTOCOL 那一列，HBONE 才算数。",
+            "en": "Ambient enrolls by a namespace label: `istio.io/dataplane-mode=ambient`. Check with `istioctl ztunnel-config workload` and read the PROTOCOL column: HBONE means enrolled."
+          },
+          {
+            "zh": "ztunnel 只做 L4 —— 身份、端口。要按 HTTP 方法或路径授权，得给命名空间挂一个 waypoint（一个 `gatewayClassName: istio-waypoint` 的 Gateway）。没有它，那些规则不会被求值，`istioctl analyze` 会直说。",
+            "en": "ztunnel only does L4: identity and ports. Authorizing by HTTP method or path needs a waypoint for the namespace (a Gateway with `gatewayClassName: istio-waypoint`). Without one those rules are never evaluated, and `istioctl analyze` says so."
+          },
+          {
+            "zh": "principal 的写法是完整的 SPIFFE ID：`spiffe://cluster.local/ns/<ns>/sa/<sa>`。写成 `cluster.local/ns/...`（少了 scheme）不会报错，只会永远匹配不上。",
+            "en": "A principal is a full SPIFFE ID: `spiffe://cluster.local/ns/<ns>/sa/<sa>`. Writing `cluster.local/ns/...` without the scheme raises no error and simply never matches."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "以为加了一条 ALLOW 就只是「多放行一个来源」。恰恰相反：一旦有 ALLOW 策略选中某个工作负载，**没被任何一条 rule 命中的访问全部被拒**。上线前先确认自己知道有哪些调用方。",
+            "en": "Assuming an ALLOW policy merely permits one more caller. The opposite is true: once any ALLOW policy selects a workload, **everything not matched by some rule is denied**. Know your callers before shipping one."
+          },
+          {
+            "zh": "把 NetworkPolicy 删掉，觉得「有网格了就不需要它」。两者判的不是一回事：网格判身份，NetworkPolicy 判网络可达性，而且网格只覆盖接进来的命名空间。它们是叠加的，不是替代的。",
+            "en": "Deleting NetworkPolicies because \"the mesh handles it now\". They answer different questions: the mesh judges identity, NetworkPolicy judges reachability, and the mesh only covers enrolled namespaces. They stack, they do not replace each other."
+          },
+          {
+            "zh": "被网格拒绝表现为**连接被重置**，不是超时。ztunnel 会明确回一个 RST。看到超时该去查 NetworkPolicy，看到 reset 才该来查网格 —— 两者指向不同的层。",
+            "en": "A mesh denial shows up as a **connection reset**, not a timeout: ztunnel answers with an RST. A timeout points at NetworkPolicy; a reset points at the mesh. Different layers."
+          },
+          {
+            "zh": "只把业务的命名空间接进网格，忘了入口。开了 STRICT 之后，Gateway 的数据面是从网格外发起明文连接的，于是它自己第一个被挡在外面 —— 门户对外直接不可用。入口所在的命名空间也要有身份。",
+            "en": "Enrolling only the application namespace and forgetting the entrance. Once STRICT is on, the Gateway data plane is calling in as plaintext from outside the mesh, so it is the first thing refused and the portal goes dark from outside. The entrance namespace needs an identity too."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "istiod",
+                "namespace": "istio-system",
+                "labels": {
+                  "app": "istiod"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "istiod"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "istiod"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "discovery",
+                        "image": "docker.io/istio/pilot:1.28.1",
+                        "ports": [
+                          {
+                            "containerPort": 15012
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "ztunnel",
+                "namespace": "istio-system",
+                "labels": {
+                  "app": "ztunnel"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "ztunnel"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ztunnel"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "ztunnel",
+                        "image": "docker.io/istio/ztunnel:1.28.1",
+                        "ports": [
+                          {
+                            "containerPort": 15008
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "istio-waypoint"
+              },
+              "spec": {
+                "controllerName": "istio.io/mesh-controller"
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "serviceAccountName": "portal",
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "ledger"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ledger"
+                    }
+                  },
+                  "spec": {
+                    "serviceAccountName": "ledger",
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/ledger:3.2.1",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "ledger",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "ledger"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "reports",
+                "namespace": "analytics"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "reports"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "reports"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/reports:2.1.0",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ],
+                        "resources": {
+                          "requests": {
+                            "memory": "256Mi"
+                          },
+                          "limits": {
+                            "memory": "1Gi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/mesh.yaml": "# 前任写到一半的东西。装上去之前先想清楚它会不会生效。\napiVersion: security.istio.io/v1\nkind: AuthorizationPolicy\nmetadata:\n  name: ledger\n  namespace: payments\nspec:\n  selector:\n    matchLabels:\n      app: ledger\n  action: ALLOW\n  rules:\n  - from:\n    - source:\n        principals:\n        - cluster.local/ns/payments/sa/portal\n    to:\n    - operation:\n        methods:\n        - GET\n        paths:\n        - /balance*\n"
+          },
+          "referenceFiles": {
+            "/root/infra/mesh.yaml": "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: payments\n  labels:\n    istio.io/dataplane-mode: ambient\n---\n# 入口的数据面也得有身份，否则 STRICT 之后它自己就被挡在外面了\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: envoy-gateway-system\n  labels:\n    istio.io/dataplane-mode: ambient\n---\napiVersion: security.istio.io/v1\nkind: PeerAuthentication\nmetadata:\n  name: default\n  namespace: payments\nspec:\n  mtls:\n    mode: STRICT\n---\napiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: waypoint\n  namespace: payments\nspec:\n  gatewayClassName: istio-waypoint\n  listeners:\n  - name: mesh\n    port: 15008\n    protocol: HBONE\n---\napiVersion: security.istio.io/v1\nkind: AuthorizationPolicy\nmetadata:\n  name: ledger\n  namespace: payments\nspec:\n  selector:\n    matchLabels:\n      app: ledger\n  action: ALLOW\n  rules:\n  - from:\n    - source:\n        principals:\n        - spiffe://cluster.local/ns/payments/sa/portal\n    to:\n    - operation:\n        methods:\n        - GET\n        paths:\n        - /*\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/mesh.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "service-mesh-ambient.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst LEDGER = 'http://ledger.payments.svc.cluster.local';\n\ndescribe('服务网格', () => {\n  it('payments 接进了网格', async () => {\n    const result = await sh('istioctl ztunnel-config workload');\n    expect(result.code).toBe(0);\n    // 按 NAMESPACE 那一列判断 —— envoy-payments-corp-gw-... 在别的命名空间里\n    const rows = result.stdout.split('\\n').filter((line) => line.startsWith('payments '));\n    expect(rows.length).toBeGreaterThan(0);\n    for (const row of rows) expect(row).toContain('HBONE');\n  });\n\n  it('门户访问得到 ledger', async () => {\n    const result = await sh(\n      'kubectl exec -n payments deploy/portal -- curl -s -m 5 -o /dev/null -w %{http_code} ' + LEDGER\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('网格外的明文直连被拒 —— 而且是 reset 不是超时', async () => {\n    const result = await sh('kubectl exec -n analytics deploy/reports -- curl -s -m 5 ' + LEDGER);\n    expect(result.stdout).toBe('');\n    // 56 = 收到 RST；28 才是超时，那说明拦它的是 NetworkPolicy 不是网格\n    expect(result.stderr).toContain('curl: (56)');\n  });\n\n  it('判的是 SPIFFE 身份，不是 IP 或标签', () => {\n    const policies = list('AuthorizationPolicy', { namespace: 'payments' });\n    expect(policies.length).toBeGreaterThan(0);\n    const principals = policies.flatMap((policy) => (policy.spec.rules || [])\n      .flatMap((rule) => (rule.from || [])\n        .flatMap((entry) => (entry.source || {}).principals || [])));\n    expect(principals.length).toBeGreaterThan(0);\n    for (const principal of principals) {\n      expect(principal.startsWith('spiffe://')).toBe(true);\n    }\n  });\n\n  it('mTLS 是 STRICT', () => {\n    const policies = list('PeerAuthentication', { namespace: 'payments' });\n    expect(policies.some((policy) => policy.spec.mtls.mode === 'STRICT')).toBe(true);\n  });\n\n  it('istioctl analyze 是干净的 —— 没有「写了但不生效」', async () => {\n    const result = await sh('istioctl analyze -n payments');\n    expect(result.stdout).toContain('No validation issues found');\n    expect(result.code).toBe(0);\n  });\n\n  it('网格外的入口照常', async () => {\n    const gateway = list('Gateway', { namespace: 'payments' })\n      .find((item) => item.spec.gatewayClassName !== 'istio-waypoint');\n    const address = gateway.status.addresses[0].value;\n    const result = await sh(\n      'curl -s -o /dev/null -w %{http_code} --resolve portal.corp.internal:443:' + address\n      + ' https://portal.corp.internal/'\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('没有靠删掉报表机来蒙过去', () => {\n    const reports = get('Deployment', 'reports', 'analytics');\n    expect(reports.status.readyReplicas).toBeGreaterThan(0);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "resilience"
+        ],
+        "extension": {
+          "zh": "网格解决的是 NetworkPolicy 解决不了的那一类问题：**证明调用方是谁**。\nNetworkPolicy 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签是\napiserver 里的一个字段，有权限的人随时能改；网格判的是「对面出示的证书\n属于哪个 ServiceAccount」，那是一次真的 mTLS 双向验证。所以两者不是替代\n关系：一个管网络可达性，一个管身份，叠着用。\n\nambient 相对 sidecar 的变化值得记住：数据面从「每个 Pod 一个 Envoy」变成\n「每个节点一个 ztunnel + 按需的 waypoint」。代价是**分层**：ztunnel 只看\n得到 L4，所以按方法、按路径的授权、重试、熔断这些都需要 waypoint。\n这条分层是 ambient 里最常见的困惑来源 —— 策略写得没错，只是没有人求值。\n\n还有一个容易忽略的点：SPIFFE 身份来自 **ServiceAccount**，不是 Pod 名也\n不是标签。所有工作负载都用 `default` 这个 SA 的集群，网格给不出任何有用的\n区分 —— 上网格之前，先把 ServiceAccount 分开。\n",
+          "en": "A mesh solves the problem NetworkPolicy cannot: **proving who the caller is**.\nNetworkPolicy says \"this IP belongs to a pod carrying that label\", and a label is\na field in the apiserver that anyone with access can change. A mesh says \"the\ncertificate the peer presented belongs to that ServiceAccount\", established by a\nreal mutual TLS handshake. They are not alternatives: one governs reachability,\nthe other identity, and they stack.\n\nThe ambient change worth remembering: the data plane moves from \"an Envoy beside\nevery pod\" to \"one ztunnel per node plus waypoints where needed\". The price is\n**layering**: ztunnel only sees L4, so per-method and per-path authorization,\nretries, and circuit breaking all require a waypoint. That layering is the most\ncommon source of confusion in ambient, because the policy is not wrong, it simply\nhas nobody evaluating it.\n\nOne more thing that is easy to miss: SPIFFE identity comes from the\n**ServiceAccount**, not the pod name or its labels. A cluster where everything\nruns as `default` gets no useful distinction out of a mesh. Split the\nServiceAccounts before you enroll.\n"
+        },
+        "primer": {
+          "zh": "`NetworkPolicy` 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签只是 apiserver 里的一个字段，有权限的人随时能改。服务网格判的是另一件事：**对面出示的证书属于谁**。每个工作负载拿到一张由集群 CA 签发的证书，身份写在 SAN 里，格式是 `SPIFFE`：`spiffe://cluster.local/ns/<命名空间>/sa/<ServiceAccount>`。注意身份来自 ServiceAccount，不是 Pod 名也不是标签；所有服务都用 `default` 这个 SA 的集群，上了网格也分不出谁是谁。\n\n`Istio ambient` 是 2026 年的主流形态，和早年的 sidecar 模式差别很大：不再给每个 Pod 塞一个 Envoy，而是每个节点跑一个 `ztunnel`（DaemonSet）负责 L4：建立 mTLS、校验对端身份、按身份与端口授权。接入方式是给命名空间打一个标签 `istio.io/dataplane-mode=ambient`，Pod 不用改、不用重启。`istioctl ztunnel-config workload` 里 PROTOCOL 那一列是 HBONE 就说明接进来了。\n\n要按 HTTP 方法或路径授权、要重试与熔断，就得再加一层 `waypoint`，也就是一个 `gatewayClassName: istio-waypoint` 的 Gateway，按命名空间或按服务挂。这条分层是 ambient 最常见的困惑来源：带 `methods` 或 `paths` 的 `AuthorizationPolicy` 在没有 waypoint 的时候**根本不会被求值**，而 apiserver 照样收下它。`istioctl analyze` 会把这类问题直接报出来。\n\n`AuthorizationPolicy` 的判定顺序值得单独记：任何一条 DENY 命中就拒绝；没有任何 ALLOW 策略选中这个工作负载则放行；一旦有 ALLOW 策略选中它，只有命中某条 rule 才放行，**其余一律拒绝**。所以给一个服务加第一条 ALLOW 策略，等于同时把「默认拒绝」也打开了，很多人以为自己只是多放行了一个来源。还有一点：被网格拒绝表现为连接被重置（ztunnel 回 RST），而不是超时；超时是丢包，指向 NetworkPolicy 那一层。",
+          "en": "`NetworkPolicy` decides based on \"this IP belongs to a pod carrying that label\", and a label is just a field in the apiserver that anyone with access can change. A service mesh answers a different question: **whose certificate did the peer present**. Each workload gets a certificate from the cluster CA with its identity in the SAN, in `SPIFFE` form: `spiffe://cluster.local/ns/<namespace>/sa/<serviceaccount>`. Identity comes from the ServiceAccount, not the pod name or its labels, so a cluster where everything runs as `default` gains nothing by enrolling.\n\n`Istio ambient` is the mainstream shape in 2026 and differs sharply from the older sidecar model: instead of an Envoy beside every pod, one `ztunnel` per node (a DaemonSet) handles L4, establishing mTLS, verifying peer identity, and authorizing by identity and port. Enrolling is a namespace label, `istio.io/dataplane-mode=ambient`, with no pod changes and no restarts. In `istioctl ztunnel-config workload`, a PROTOCOL of HBONE means enrolled.\n\nAuthorizing by HTTP method or path, or doing retries and circuit breaking, needs one more layer: a `waypoint`, a Gateway with `gatewayClassName: istio-waypoint`, attached per namespace or per service. This layering is the most common confusion in ambient, because an `AuthorizationPolicy` with `methods` or `paths` is **never evaluated** without a waypoint, while the apiserver accepts it happily. `istioctl analyze` reports exactly this class of problem.\n\nThe evaluation order of `AuthorizationPolicy` is worth memorising: any matching DENY refuses; with no ALLOW policy selecting the workload, traffic is permitted; once some ALLOW policy selects it, only traffic matching a rule is permitted and **everything else is refused**. So adding the first ALLOW policy to a service also turns on default-deny, which surprises people who thought they were merely permitting one more caller. One more distinction: a mesh denial arrives as a connection reset, because ztunnel answers with an RST, whereas a timeout means dropped packets and points at the NetworkPolicy layer."
         }
       }
     ]

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -19,6 +19,10 @@ import { Controller, ControllerContext } from './framework';
 import { createServiceIpDefaulter } from './serviceip';
 import { DaemonSetController } from './daemonset';
 import { ARGOCD_RESOURCES, ArgoCdController } from '../argocd';
+import {
+  ISTIOD_LABEL, MESH_RESOURCES, WAYPOINT_CLASS, ZTUNNEL_LABEL, isAmbient, traverseMesh,
+  type MeshPeer, type MeshView,
+} from '../mesh';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -30,7 +34,7 @@ import {
   SchedulerController,
 } from './workloads';
 import type { ImageBehavior, RegistryAuth } from './runtime';
-import { Network, createNetwork, type Zone } from '../net';
+import { Network, createNetwork, type Source, type Zone } from '../net';
 import {
   AddressPool, GATEWAY_RESOURCES, GatewayController, LoadBalancerController, resolveGateway,
 } from '../gateway';
@@ -125,6 +129,7 @@ export class Cluster {
     this.store = createStore();
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
+      ...MESH_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -151,6 +156,7 @@ export class Cluster {
       trustBundle: (source) => options.trustBundle?.(source) ?? [],
       imageOf: (image) => this.imageBehaviorOf(image),
       policyEnforced: () => this.policyEnforced(),
+      mesh: (input) => this.meshDecision(input),
       now,
     });
 
@@ -253,6 +259,107 @@ export class Cluster {
       return containers.some((container: any) =>
         this.imageBehaviorOf(container.image)?.enforcesNetworkPolicy);
     });
+  }
+
+  /**
+   * 一条连接过网格时发生了什么。
+   *
+   * 网络层不认识 Istio 的 CRD —— 它只拿到一句话和一个「拦没拦」。
+   * 和 Envoy Gateway、cert-manager 一样，网格的控制面与数据面都是集群里的
+   * 工作负载：istiod 或 ztunnel 不可用，这里直接返回 off。
+   */
+  private meshDecision(input: {
+    source: Source; destination: KubeObject; port: number; method?: string; path?: string;
+  }): { kind: string; detail: string; blocked?: boolean } | undefined {
+    const view = this.meshView();
+    if (!view) return undefined;
+    const outcome = traverseMesh(view, this.meshPeerOf(input.source), this.meshPeerOfPod(input.destination), {
+      port: input.port, method: input.method, path: input.path,
+    });
+    return {
+      kind: outcome.kind,
+      detail: outcome.detail,
+      blocked: outcome.kind === 'denied' || outcome.kind === 'plaintext-rejected',
+    };
+  }
+
+  /** 给 istioctl 用的只读视图。命令不改任何东西。 */
+  istioView() {
+    const mesh = this.meshView();
+    if (!mesh) return undefined;
+    const pods = this.scheme.get({ group: '', version: 'v1', resource: 'pods' })!;
+    const namespaces = this.scheme.get({ group: '', version: 'v1', resource: 'namespaces' })!;
+    const services = this.scheme.get({ group: '', version: 'v1', resource: 'services' })!;
+    return {
+      mesh,
+      pods: (namespace?: string) => this.registry.list(pods, { namespace }).items,
+      namespaces: () => this.registry.list(namespaces).items,
+      services: (namespace?: string) => this.registry.list(services, { namespace }).items,
+      peerOf: (pod: KubeObject) => this.meshPeerOfPod(pod),
+    };
+  }
+
+  private meshView(): MeshView | undefined {
+    const peerAuth = this.scheme.get({
+      group: 'security.istio.io', version: 'v1', resource: 'peerauthentications',
+    });
+    const authz = this.scheme.get({
+      group: 'security.istio.io', version: 'v1', resource: 'authorizationpolicies',
+    });
+    if (!peerAuth || !authz) return undefined;
+    return {
+      installed: () => this.meshInstalled(),
+      hasWaypoint: (namespace) => this.hasWaypoint(namespace),
+      peerAuthentications: () => this.registry.list(peerAuth).items,
+      authorizationPolicies: () => this.registry.list(authz).items,
+    };
+  }
+
+  /** istiod 与 ztunnel 都得在跑 —— 少一个网格就不成立 */
+  private meshInstalled(): boolean {
+    const deployments = this.scheme.get({ group: 'apps', version: 'v1', resource: 'deployments' });
+    const daemonSets = this.scheme.get({ group: 'apps', version: 'v1', resource: 'daemonsets' });
+    if (!deployments || !daemonSets) return false;
+    const istiod = this.registry.list(deployments).items.some((item) =>
+      item.metadata.labels?.[ISTIOD_LABEL.key] === ISTIOD_LABEL.value
+      && (((item.status ?? {}) as any).availableReplicas ?? 0) > 0);
+    const ztunnel = this.registry.list(daemonSets).items.some((item) =>
+      item.metadata.labels?.[ZTUNNEL_LABEL.key] === ZTUNNEL_LABEL.value
+      && (((item.status ?? {}) as any).numberReady ?? 0) > 0);
+    return istiod && ztunnel;
+  }
+
+  /** 这个命名空间挂了 waypoint 没有。挂上才有 L7。 */
+  private hasWaypoint(namespace: string): boolean {
+    const gateways = this.scheme.get({
+      group: 'gateway.networking.k8s.io', version: 'v1', resource: 'gateways',
+    });
+    if (!gateways) return false;
+    return this.registry.list(gateways, { namespace }).items.some((gateway) =>
+      ((gateway.spec ?? {}) as any).gatewayClassName === WAYPOINT_CLASS);
+  }
+
+  private meshPeerOf(source: Source): MeshPeer | undefined {
+    if (source.zone !== 'cluster' || !source.podName || !source.namespace) return undefined;
+    const pods = this.scheme.get({ group: '', version: 'v1', resource: 'pods' });
+    if (!pods) return undefined;
+    const pod = this.registry.list(pods, { namespace: source.namespace }).items
+      .find((item) => item.metadata.name === source.podName);
+    return pod ? this.meshPeerOfPod(pod) : undefined;
+  }
+
+  private meshPeerOfPod(pod: KubeObject): MeshPeer {
+    const namespace = pod.metadata.namespace ?? 'default';
+    const namespaces = this.scheme.get({ group: '', version: 'v1', resource: 'namespaces' });
+    const object = namespaces
+      ? this.registry.list(namespaces).items.find((item) => item.metadata.name === namespace)
+      : undefined;
+    return {
+      namespace,
+      labels: pod.metadata.labels ?? {},
+      serviceAccount: ((pod.spec ?? {}) as any).serviceAccountName ?? 'default',
+      enrolled: isAmbient(object),
+    };
   }
 
   imageBehaviorOf(image: string | undefined): ImageBehavior | undefined {

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -21,6 +21,9 @@ import { parseChain } from '../crypto';
 import { createOpensslCommand } from './openssl';
 import { materializePki } from './pki';
 import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } from '../git';
+import { createIstioctlCommand } from '../mesh';
+import { currentNamespaceOf } from './view';
+import { DEFAULT_KUBECONFIG_PATH } from '../wasm';
 import { createExecHandler } from './podshell';
 import { CliRuntime, installClusterCli } from '../wasm';
 import type { KubeObject } from '../apiserver';
@@ -186,6 +189,13 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   }
 
   machine.install('openssl', createOpensslCommand());
+
+  machine.install('istioctl', createIstioctlCommand({
+    view: () => cluster.istioView(),
+    namespace: () => (machine.vfs.exists(DEFAULT_KUBECONFIG_PATH)
+      ? currentNamespaceOf(machine.vfs.readFile(DEFAULT_KUBECONFIG_PATH))
+      : 'default'),
+  }));
 
   machine.install('git', createGitCommand({
     network: git,

--- a/src/lib/opslab/mesh/index.ts
+++ b/src/lib/opslab/mesh/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Istio ambient
+ *
+ * 做的是可观察面与判定面：谁用什么身份访问谁、被哪条策略放行或拒绝。
+ * 不做 HBONE 的字节流 —— 那一层对「排查网格」这件事没有教学价值，
+ * 而它带来的实现量足以淹没其余部分。
+ */
+export {
+  AUTHORIZATIONPOLICIES, PEERAUTHENTICATIONS, MESH_RESOURCES,
+  AMBIENT_LABEL, ZTUNNEL_LABEL, ISTIOD_LABEL, WAYPOINT_CLASS, TRUST_DOMAIN, spiffeId,
+} from './resources';
+export { evaluateAuthz, policiesFor, globMatch } from './policy';
+export type { AuthzDecision, MeshRequest, MeshTarget } from './policy';
+export { traverseMesh, strictnessFor, isAmbient } from './mesh';
+export type { MeshOutcome, MeshPeer, MeshView } from './mesh';
+export { createIstioctlCommand } from './istioctl';
+export type { IstioctlOptions } from './istioctl';

--- a/src/lib/opslab/mesh/istioctl.ts
+++ b/src/lib/opslab/mesh/istioctl.ts
@@ -1,0 +1,270 @@
+/**
+ * `istioctl`
+ *
+ * 真 istioctl 是 Go 写的，把它编进多合一二进制要多背一份 Istio 的 API 与
+ * proto，产物会涨一大截 —— 而它在这里的价值全在**输出**上：
+ * `ztunnel-config workload` 那张表、`x describe pod` 那几行判定、
+ * `analyze` 报出来的问题。所以这里按行为等价重写，输出照抄上游的格式。
+ *
+ * 不做的：`istioctl install`（用 kubectl apply 装）、`proxy-config`
+ * （那是 sidecar 模式的东西，ambient 里没有 sidecar）。
+ */
+import type { KubeObject } from '../apiserver';
+import type { CommandHandler, CommandResult } from '../machine/shell/shell';
+import { policiesFor } from './policy';
+import { isAmbient, strictnessFor, type MeshPeer, type MeshView } from './mesh';
+import { AMBIENT_LABEL, spiffeId } from './resources';
+
+export interface IstioctlOptions {
+  /** 集群视图。命令只读，不改任何东西。 */
+  view(): {
+    mesh: MeshView;
+    pods(namespace?: string): KubeObject[];
+    namespaces(): KubeObject[];
+    services(namespace?: string): KubeObject[];
+    peerOf(pod: KubeObject): MeshPeer;
+  } | undefined;
+  /** 默认命名空间 */
+  namespace(): string;
+}
+
+export function createIstioctlCommand(options: IstioctlOptions): CommandHandler {
+  return ({ argv }) => {
+    const view = options.view();
+    if (!view) return { stderr: 'istioctl: 这个集群没有注册 Istio 的类型\n', code: 1 };
+
+    const [command, ...rest] = argv;
+    switch (command) {
+      case undefined:
+      case 'help':
+      case '--help':
+        return { stdout: USAGE };
+      case 'version':
+        return { stdout: 'client version: 1.28.1\ncontrol plane version: 1.28.1\nztunnel version: 1.28.1\n' };
+      case 'x':
+      case 'experimental':
+        return experimental(rest, view, options);
+      case 'ztunnel-config':
+        return ztunnelConfig(rest, view);
+      case 'analyze':
+        return analyze(rest, view, options);
+      case 'proxy-status':
+      case 'ps':
+        return proxyStatus(view);
+      default:
+        return { stderr: `unknown command ${JSON.stringify(command)}\n${USAGE}`, code: 1 };
+    }
+  };
+}
+
+const USAGE = `Istio configuration command line utility.
+
+Usage:
+  istioctl [command]
+
+Available Commands:
+  analyze          Analyze Istio policy and print validation messages
+  proxy-status     Retrieves the synchronization status of the mesh
+  version          Prints out build version information
+  x                Experimental commands
+  ztunnel-config   Update or retrieve current ztunnel configuration
+`;
+
+function experimental(argv: string[], view: NonNullable<ReturnType<IstioctlOptions['view']>>, options: IstioctlOptions): CommandResult {
+  const [command, ...rest] = argv;
+  if (command === 'ztunnel-config') return ztunnelConfig(rest, view);
+  if (command === 'describe') return describe(rest, view, options);
+  return { stderr: `unknown experimental command ${JSON.stringify(command ?? '')}\n`, code: 1 };
+}
+
+/**
+ * `istioctl ztunnel-config workload`
+ *
+ * 这张表回答的是「哪些工作负载真的进网格了」。`PROTOCOL` 那一列是重点：
+ * HBONE 表示 ztunnel 接管了它，TCP 表示没有 —— 命名空间标签打了没打，
+ * 一眼就看出来。
+ */
+function ztunnelConfig(argv: string[], view: NonNullable<ReturnType<IstioctlOptions['view']>>): CommandResult {
+  const what = argv.find((entry) => !entry.startsWith('-')) ?? 'workload';
+  if (!what.startsWith('workload')) {
+    return { stderr: `istioctl: 这里只做 workload 视图\n`, code: 1 };
+  }
+  const rows = view.pods()
+    .filter((pod) => ((pod.status ?? {}) as any).phase === 'Running')
+    .map((pod) => {
+      const peer = view.peerOf(pod);
+      return {
+        namespace: pod.metadata.namespace ?? 'default',
+        name: pod.metadata.name ?? '',
+        ip: ((pod.status ?? {}) as any).podIP ?? '',
+        node: ((pod.spec ?? {}) as any).nodeName ?? '',
+        waypoint: view.mesh.hasWaypoint(pod.metadata.namespace ?? 'default') ? 'waypoint' : 'None',
+        protocol: peer.enrolled ? 'HBONE' : 'TCP',
+      };
+    })
+    .sort((a, b) => (`${a.namespace}/${a.name}` < `${b.namespace}/${b.name}` ? -1 : 1));
+
+  const header = ['NAMESPACE', 'POD NAME', 'ADDRESS', 'NODE', 'WAYPOINT', 'PROTOCOL'];
+  const table = rows.map((row) => [row.namespace, row.name, row.ip, row.node, row.waypoint, row.protocol]);
+  return { stdout: renderTable(header, table) };
+}
+
+/**
+ * `istioctl x describe pod <name>`
+ *
+ * 上游这条命令的价值在于它把散落在几个对象里的判定合到一起说：
+ * 进没进网格、mTLS 是什么模式、哪些 AuthorizationPolicy 选中了它。
+ */
+function describe(argv: string[], view: NonNullable<ReturnType<IstioctlOptions['view']>>, options: IstioctlOptions): CommandResult {
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  if (positional[0] !== 'pod' || !positional[1]) {
+    return { stderr: 'usage: istioctl x describe pod <pod-name> [-n <namespace>]\n', code: 1 };
+  }
+  const namespace = namespaceOf(argv) ?? options.namespace();
+  const pod = view.pods(namespace).find((item) => item.metadata.name === positional[1]);
+  if (!pod) {
+    return { stderr: `pod ${positional[1]} not found in namespace ${namespace}\n`, code: 1 };
+  }
+
+  const peer = view.peerOf(pod);
+  const lines = [`Pod: ${pod.metadata.name}`];
+  lines.push(`   Pod Revision: default`);
+  if (!view.mesh.installed()) {
+    lines.push('WARNING: 网格没有在跑（istiod / ztunnel 不可用），下面的判定不会生效');
+  }
+  lines.push(peer.enrolled
+    ? `   Pod Ports: ambient (ztunnel)`
+    : `   Pod Ports: 不在网格里（命名空间缺少 ${AMBIENT_LABEL.key}=${AMBIENT_LABEL.value}）`);
+  lines.push(`   Identity: ${spiffeId(peer.namespace, peer.serviceAccount)}`);
+
+  const mode = strictnessFor(view.mesh.peerAuthentications(), peer);
+  lines.push('');
+  lines.push(`Effective PeerAuthentication:`);
+  lines.push(`   Workload mTLS mode: ${mode.mtls}${mode.policy ? ` (${mode.policy})` : ' (default)'}`);
+
+  const selected = policiesFor(view.mesh.authorizationPolicies(), {
+    namespace: peer.namespace, labels: peer.labels,
+  });
+  lines.push('');
+  if (selected.length === 0) {
+    lines.push('Exposed on Ingress Gateway: none');
+    lines.push('AuthorizationPolicy: 没有策略选中这个工作负载（默认允许）');
+  } else {
+    lines.push('AuthorizationPolicy:');
+    for (const policy of selected) {
+      const action = ((policy.spec ?? {}) as any).action ?? 'ALLOW';
+      lines.push(`   ${policy.metadata.namespace}/${policy.metadata.name}: ${action}`);
+    }
+    if (!view.mesh.hasWaypoint(peer.namespace) && usesLayer7(selected)) {
+      lines.push(
+        `WARNING: 有规则用到了 methods/paths，但 ${peer.namespace} 没有 waypoint，`
+        + 'ztunnel 求值不了这些条件，它们会被忽略'
+      );
+    }
+  }
+  return { stdout: `${lines.join('\n')}\n` };
+}
+
+/**
+ * `istioctl analyze`
+ *
+ * 只报真会咬人的那几类。报太多没人看，报错了比不报还糟。
+ */
+function analyze(argv: string[], view: NonNullable<ReturnType<IstioctlOptions['view']>>, options: IstioctlOptions): CommandResult {
+  const all = argv.includes('-A') || argv.includes('--all-namespaces');
+  const namespace = namespaceOf(argv) ?? options.namespace();
+  const scope = all ? undefined : namespace;
+  const messages: string[] = [];
+
+  if (!view.mesh.installed()) {
+    messages.push(
+      'Error [IST0001] (Mesh) 网格的控制面或数据面不可用：istiod 与 ztunnel 都需要在跑，'
+      + '否则 PeerAuthentication 与 AuthorizationPolicy 全部不生效'
+    );
+  }
+
+  // L7 规则没有 waypoint
+  for (const policy of view.mesh.authorizationPolicies()) {
+    const policyNamespace = policy.metadata.namespace ?? 'default';
+    if (scope && policyNamespace !== scope) continue;
+    if (!usesLayer7([policy])) continue;
+    if (view.mesh.hasWaypoint(policyNamespace)) continue;
+    messages.push(
+      `Warning [IST0162] (AuthorizationPolicy ${policyNamespace}/${policy.metadata.name}) `
+      + `规则里用到了 methods/paths，但 ${policyNamespace} 没有挂 waypoint。`
+      + `ztunnel 只做 L4，这些条件不会被求值。`
+    );
+  }
+
+  // STRICT 但命名空间没进网格
+  for (const policy of view.mesh.peerAuthentications()) {
+    const policyNamespace = policy.metadata.namespace ?? 'default';
+    if (scope && policyNamespace !== scope) continue;
+    if (((policy.spec ?? {}) as any).mtls?.mode !== 'STRICT') continue;
+    const object = view.namespaces().find((item) => item.metadata.name === policyNamespace);
+    if (isAmbient(object) || policyNamespace === 'istio-system') continue;
+    messages.push(
+      `Warning [IST0163] (PeerAuthentication ${policyNamespace}/${policy.metadata.name}) `
+      + `要求 STRICT，但 ${policyNamespace} 没有打上 ${AMBIENT_LABEL.key}=${AMBIENT_LABEL.value}，`
+      + `里面的工作负载不在网格里，这条策略不会生效。`
+    );
+  }
+
+  // 一有 ALLOW 策略，其余全拒 —— 值得提醒一次
+  for (const policy of view.mesh.authorizationPolicies()) {
+    const policyNamespace = policy.metadata.namespace ?? 'default';
+    if (scope && policyNamespace !== scope) continue;
+    const spec = (policy.spec ?? {}) as any;
+    if ((spec.action ?? 'ALLOW') !== 'ALLOW') continue;
+    if ((spec.rules ?? []).length > 0) continue;
+    messages.push(
+      `Warning [IST0164] (AuthorizationPolicy ${policyNamespace}/${policy.metadata.name}) `
+      + `ALLOW 但一条 rule 都没有，等于拒绝所有访问。`
+    );
+  }
+
+  if (messages.length === 0) {
+    return { stdout: `✔ No validation issues found when analyzing ${all ? 'all namespaces' : `namespace: ${namespace}`}.\n` };
+  }
+  return { stdout: `${messages.join('\n')}\n`, code: 1 };
+}
+
+/** `istioctl proxy-status`：ambient 下看的是 ztunnel 有没有跟上配置 */
+function proxyStatus(view: NonNullable<ReturnType<IstioctlOptions['view']>>): CommandResult {
+  if (!view.mesh.installed()) {
+    return { stderr: 'Error: 无法连接到控制面：istiod 不可用\n', code: 1 };
+  }
+  const rows = view.pods()
+    .filter((pod) => ((pod.status ?? {}) as any).phase === 'Running' && view.peerOf(pod).enrolled)
+    .map((pod) => [
+      `${pod.metadata.name}.${pod.metadata.namespace}`,
+      'ztunnel',
+      'SYNCED', 'SYNCED', 'SYNCED', 'SYNCED',
+      'istiod-5d9f8c7b6-abcde', '1.28.1',
+    ])
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1));
+  const header = ['NAME', 'CLUSTER', 'CDS', 'LDS', 'EDS', 'RDS', 'ISTIOD', 'VERSION'];
+  return { stdout: renderTable(header, rows) };
+}
+
+/* ------------------------------------------------------------------ */
+
+function usesLayer7(policies: KubeObject[]): boolean {
+  return policies.some((policy) =>
+    (((policy.spec ?? {}) as any).rules ?? []).some((rule: any) =>
+      (rule.to ?? []).some((entry: any) => entry.operation?.methods || entry.operation?.paths)));
+}
+
+function namespaceOf(argv: string[]): string | undefined {
+  const index = argv.findIndex((entry) => entry === '-n' || entry === '--namespace');
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+/** 和 kubectl 一样：每列按最宽的内容对齐，列间三个空格 */
+function renderTable(header: string[], rows: string[][]): string {
+  const widths = header.map((title, index) =>
+    Math.max(title.length, ...rows.map((row) => (row[index] ?? '').length)));
+  const line = (cells: string[]) =>
+    cells.map((cell, index) => (index === cells.length - 1 ? cell : cell.padEnd(widths[index]))).join('   ');
+  return [line(header), ...rows.map(line)].join('\n') + '\n';
+}

--- a/src/lib/opslab/mesh/mesh.ts
+++ b/src/lib/opslab/mesh/mesh.ts
@@ -1,0 +1,157 @@
+/**
+ * 网格在数据面上做什么
+ *
+ * ambient 的分工：ztunnel（每节点一个）负责 L4 —— 把明文升级成 mTLS、
+ * 校验对端身份、按身份与端口做授权；waypoint（按命名空间或服务挂）负责 L7。
+ *
+ * 三条会让人卡住的规则，这里都照真的实现：
+ *
+ *  1. **没有 ztunnel，什么都不发生**。istiod 和 ztunnel 是集群里的工作负载，
+ *     卸载掉网格就消失，而 CRD 还在、`kubectl get` 还看得见。
+ *  2. **PeerAuthentication STRICT 会拒明文**。网格外的调用方连不上网格里的
+ *     服务，表现是连接被重置 —— 不是超时，因为 ztunnel 确实回了东西。
+ *  3. **L7 授权没有 waypoint 就不生效**。带 methods / paths 的规则
+ *     ztunnel 求值不了，于是那一条等于不存在。
+ */
+import type { KubeObject } from '../apiserver';
+import { evaluateAuthz, type AuthzDecision, type MeshRequest } from './policy';
+import { AMBIENT_LABEL, spiffeId } from './resources';
+
+export interface MeshPeer {
+  namespace: string;
+  labels: Record<string, string>;
+  serviceAccount: string;
+  /** 在不在网格里 */
+  enrolled: boolean;
+}
+
+export interface MeshView {
+  /** 网格的控制面与数据面都在跑吗 */
+  installed(): boolean;
+  /** 这个命名空间有没有挂 waypoint */
+  hasWaypoint(namespace: string): boolean;
+  peerAuthentications(): KubeObject[];
+  authorizationPolicies(): KubeObject[];
+}
+
+export type MeshOutcome =
+  | { kind: 'off'; detail: string }
+  | { kind: 'passthrough'; detail: string }
+  | { kind: 'mtls'; detail: string; principal: string; decision: AuthzDecision }
+  | { kind: 'plaintext-rejected'; detail: string; policy: string }
+  | { kind: 'denied'; detail: string; policy?: string; decision: AuthzDecision };
+
+/**
+ * 一次连接经过网格时发生了什么。
+ *
+ * 返回的 detail 会原样进包路径 —— 学员看到的就是这句话，所以它得把
+ * 「谁用什么身份访问谁、被哪条策略怎么判的」说完整。
+ */
+export function traverseMesh(
+  view: MeshView,
+  source: MeshPeer | undefined,
+  destination: MeshPeer,
+  request: { port: number; method?: string; path?: string }
+): MeshOutcome {
+  if (!view.installed()) {
+    return { kind: 'off', detail: '网格没有在跑（istiod / ztunnel 不可用），流量按明文直连' };
+  }
+  if (!destination.enrolled) {
+    return { kind: 'passthrough', detail: '目标不在网格里，ztunnel 不接管这条连接' };
+  }
+
+  const mode = strictnessFor(view.peerAuthentications(), destination);
+  const meshed = Boolean(source?.enrolled);
+
+  if (!meshed) {
+    if (mode.mtls === 'STRICT') {
+      return {
+        kind: 'plaintext-rejected',
+        policy: mode.policy ?? 'mesh default',
+        detail: `明文连接被拒（PeerAuthentication ${mode.policy ?? 'mesh default'} = STRICT）`,
+      };
+    }
+    return { kind: 'passthrough', detail: `调用方不在网格里，PERMISSIVE 下按明文放行` };
+  }
+
+  const principal = spiffeId(source!.namespace, source!.serviceAccount);
+  const target = { namespace: destination.namespace, labels: destination.labels };
+  const hasWaypoint = view.hasWaypoint(destination.namespace);
+  const meshRequest: MeshRequest = {
+    principal,
+    sourceNamespace: source!.namespace,
+    port: request.port,
+    method: request.method,
+    path: request.path,
+  };
+  const decision = evaluateAuthz(view.authorizationPolicies(), target, meshRequest, hasWaypoint);
+
+  if (!decision.allowed) {
+    return {
+      kind: 'denied',
+      policy: decision.policy,
+      decision,
+      detail: denialDetail(decision, principal),
+    };
+  }
+
+  const peer = spiffeId(destination.namespace, destination.serviceAccount);
+  const suffix = decision.policy
+    ? `，${decision.policy} 放行`
+    : '，没有 AuthorizationPolicy 选中它（默认允许）';
+  const warning = decision.needsWaypoint
+    ? '；注意：带 methods/paths 的规则没有 waypoint 求值不了，已被忽略'
+    : '';
+  return {
+    kind: 'mtls',
+    principal,
+    decision,
+    detail: `mTLS ${principal} -> ${peer}${suffix}${warning}`,
+  };
+}
+
+function denialDetail(decision: AuthzDecision, principal: string): string {
+  if (decision.reason === 'deny-matched') {
+    return `${principal} 被 ${decision.policy} 明确拒绝（DENY）`;
+  }
+  const hint = decision.needsWaypoint
+    ? '；这个命名空间没有 waypoint，带 methods/paths 的规则不会被求值'
+    : '';
+  return `${principal} 不匹配 ${decision.policy} 的任何一条 rule`
+    + `，而一旦有 ALLOW 策略选中目标，其余一律拒绝${hint}`;
+}
+
+/**
+ * 目标工作负载的 mTLS 模式。
+ *
+ * 优先级和真 Istio 一致：带 selector 的命名空间级策略 > 不带 selector 的
+ * 命名空间级策略 > 网格默认（在 istio-system 里那条）。没有任何策略时，
+ * ambient 的默认是 PERMISSIVE。
+ */
+export function strictnessFor(
+  policies: KubeObject[],
+  destination: MeshPeer
+): { mtls: 'STRICT' | 'PERMISSIVE' | 'DISABLE'; policy?: string } {
+  const candidates = policies.filter((policy) => {
+    if (policy.metadata.namespace === 'istio-system') return true;
+    if (policy.metadata.namespace !== destination.namespace) return false;
+    const selector = ((policy.spec ?? {}) as any).selector?.matchLabels as Record<string, string> | undefined;
+    if (!selector) return true;
+    return Object.entries(selector).every(([key, value]) => destination.labels[key] === value);
+  });
+
+  const rank = (policy: KubeObject): number => {
+    const selector = ((policy.spec ?? {}) as any).selector?.matchLabels;
+    if (policy.metadata.namespace === 'istio-system') return 0;
+    return selector ? 2 : 1;
+  };
+  const winner = [...candidates].sort((a, b) => rank(b) - rank(a))[0];
+  if (!winner) return { mtls: 'PERMISSIVE' };
+  const mode = ((winner.spec ?? {}) as any).mtls?.mode ?? 'PERMISSIVE';
+  return { mtls: mode, policy: `${winner.metadata.namespace}/${winner.metadata.name}` };
+}
+
+/** 命名空间在不在 ambient 里 */
+export function isAmbient(namespace: KubeObject | undefined): boolean {
+  return namespace?.metadata.labels?.[AMBIENT_LABEL.key] === AMBIENT_LABEL.value;
+}

--- a/src/lib/opslab/mesh/policy.ts
+++ b/src/lib/opslab/mesh/policy.ts
@@ -1,0 +1,186 @@
+/**
+ * AuthorizationPolicy 的判定
+ *
+ * 规则本身不复杂，复杂的是**优先级**，而顺序错了会让人以为策略没生效：
+ *
+ *  1. 有 CUSTOM 动作的先走（我们不做外部授权，跳过）；
+ *  2. 任何一条 DENY 命中 -> 拒绝；
+ *  3. 没有任何 ALLOW 策略选中这个工作负载 -> 放行（默认允许）；
+ *  4. 有 ALLOW 策略选中它：命中任意一条 -> 放行，否则 -> 拒绝。
+ *
+ * 第 3 条和第 4 条的差别是最要命的：给一个服务加**第一条** ALLOW 策略，
+ * 等于同时把「其余全部拒绝」也打开了。很多人以为自己只是加了一条放行。
+ */
+import type { KubeObject } from '../apiserver';
+
+export interface MeshRequest {
+  /** 调用方的 SPIFFE 身份。不在网格里就是 undefined。 */
+  principal?: string;
+  sourceNamespace?: string;
+  /** 目标端口 */
+  port: number;
+  method?: string;
+  path?: string;
+}
+
+export interface MeshTarget {
+  namespace: string;
+  labels: Record<string, string>;
+}
+
+export interface AuthzDecision {
+  allowed: boolean;
+  /** 命中的策略，写进包路径里 */
+  policy?: string;
+  /** 判定为什么是这个结果 */
+  reason: 'no-policy' | 'allow-matched' | 'allow-not-matched' | 'deny-matched';
+  /** 这条判定需要 L7 信息（方法/路径），而没有 waypoint 就拿不到 */
+  needsWaypoint?: boolean;
+}
+
+/** 选中这个工作负载的策略 */
+export function policiesFor(policies: KubeObject[], target: MeshTarget): KubeObject[] {
+  return policies.filter((policy) => {
+    if (policy.metadata.namespace !== target.namespace) return false;
+    const selector = ((policy.spec ?? {}) as any).selector?.matchLabels as Record<string, string> | undefined;
+    if (!selector) return true;   // 不写 selector = 整个命名空间
+    return Object.entries(selector).every(([key, value]) => target.labels[key] === value);
+  });
+}
+
+/**
+ * 判一次。
+ *
+ * `hasWaypoint` 决定 L7 条件算不算数：没有 waypoint 时 ztunnel 只看得到
+ * L4（身份、端口），带 `methods` / `paths` 的规则**根本不会被求值** ——
+ * 这正是 ambient 里最常见的「策略写了但没用」。
+ */
+export function evaluateAuthz(
+  policies: KubeObject[],
+  target: MeshTarget,
+  request: MeshRequest,
+  hasWaypoint: boolean
+): AuthzDecision {
+  const selected = policiesFor(policies, target);
+  const denies = selected.filter((policy) => actionOf(policy) === 'DENY');
+  const allows = selected.filter((policy) => actionOf(policy) === 'ALLOW');
+
+  let needsWaypoint = false;
+  for (const policy of denies) {
+    const hit = matchesAny(policy, request, hasWaypoint);
+    if (hit.l7Ignored) needsWaypoint = true;
+    if (hit.matched) {
+      return { allowed: false, policy: refOf(policy), reason: 'deny-matched', needsWaypoint };
+    }
+  }
+
+  if (allows.length === 0) {
+    return { allowed: true, reason: 'no-policy', needsWaypoint };
+  }
+  for (const policy of allows) {
+    const hit = matchesAny(policy, request, hasWaypoint);
+    if (hit.l7Ignored) needsWaypoint = true;
+    if (hit.matched) {
+      return { allowed: true, policy: refOf(policy), reason: 'allow-matched', needsWaypoint };
+    }
+  }
+  return {
+    allowed: false,
+    policy: refOf(allows[0]),
+    reason: 'allow-not-matched',
+    needsWaypoint,
+  };
+}
+
+function actionOf(policy: KubeObject): string {
+  return ((policy.spec ?? {}) as any).action ?? 'ALLOW';
+}
+
+function refOf(policy: KubeObject): string {
+  return `${policy.metadata.namespace}/${policy.metadata.name}`;
+}
+
+/** 策略里的 rules 是「或」：任意一条命中就算命中 */
+function matchesAny(
+  policy: KubeObject,
+  request: MeshRequest,
+  hasWaypoint: boolean
+): { matched: boolean; l7Ignored: boolean } {
+  const rules: any[] = ((policy.spec ?? {}) as any).rules ?? [];
+  // 一条 rules 都没有：ALLOW 表示什么都不放行，DENY 表示全部拒绝
+  if (rules.length === 0) {
+    return { matched: actionOf(policy) === 'DENY', l7Ignored: false };
+  }
+  let l7Ignored = false;
+  for (const rule of rules) {
+    const outcome = matchesRule(rule, request, hasWaypoint);
+    if (outcome.l7Ignored) l7Ignored = true;
+    if (outcome.matched) return { matched: true, l7Ignored };
+  }
+  return { matched: false, l7Ignored };
+}
+
+/** rule 里的 from / to / when 之间是「与」，每一项内部是「或」 */
+function matchesRule(
+  rule: any,
+  request: MeshRequest,
+  hasWaypoint: boolean
+): { matched: boolean; l7Ignored: boolean } {
+  let l7Ignored = false;
+
+  const from: any[] = rule.from ?? [];
+  if (from.length > 0) {
+    const ok = from.some((entry) => matchesSource(entry.source ?? {}, request));
+    if (!ok) return { matched: false, l7Ignored };
+  }
+
+  const to: any[] = rule.to ?? [];
+  if (to.length > 0) {
+    let matchedTo = false;
+    for (const entry of to) {
+      const operation = entry.operation ?? {};
+      const usesL7 = Boolean(operation.methods || operation.paths);
+      if (usesL7 && !hasWaypoint) {
+        // ztunnel 看不到 HTTP。这一条不是「不匹配」，是「压根没被求值」。
+        l7Ignored = true;
+        continue;
+      }
+      if (matchesOperation(operation, request)) { matchedTo = true; break; }
+    }
+    if (!matchedTo) return { matched: false, l7Ignored };
+  }
+
+  return { matched: true, l7Ignored };
+}
+
+function matchesSource(source: any, request: MeshRequest): boolean {
+  const principals: string[] = source.principals ?? [];
+  const namespaces: string[] = source.namespaces ?? [];
+  if (principals.length > 0) {
+    if (!request.principal) return false;
+    if (!principals.some((entry) => globMatch(entry, request.principal!))) return false;
+  }
+  if (namespaces.length > 0) {
+    if (!request.sourceNamespace) return false;
+    if (!namespaces.some((entry) => globMatch(entry, request.sourceNamespace!))) return false;
+  }
+  return true;
+}
+
+function matchesOperation(operation: any, request: MeshRequest): boolean {
+  const ports: string[] = operation.ports ?? [];
+  if (ports.length > 0 && !ports.includes(String(request.port))) return false;
+  const methods: string[] = operation.methods ?? [];
+  if (methods.length > 0 && !methods.some((entry) => globMatch(entry, request.method ?? 'GET'))) return false;
+  const paths: string[] = operation.paths ?? [];
+  if (paths.length > 0 && !paths.some((entry) => globMatch(entry, request.path ?? '/'))) return false;
+  return true;
+}
+
+/** Istio 的通配只支持前缀 `*x` 与后缀 `x*`，不是完整的 glob */
+export function globMatch(pattern: string, value: string): boolean {
+  if (pattern === '*') return true;
+  if (pattern.startsWith('*')) return value.endsWith(pattern.slice(1));
+  if (pattern.endsWith('*')) return value.startsWith(pattern.slice(0, -1));
+  return pattern === value;
+}

--- a/src/lib/opslab/mesh/resources.ts
+++ b/src/lib/opslab/mesh/resources.ts
@@ -1,0 +1,43 @@
+/**
+ * Istio ambient 的对象
+ *
+ * ambient 模式下没有 sidecar：每个节点一个 ztunnel（DaemonSet）做 L4 —— mTLS
+ * 与身份；需要 L7（按方法、按路径授权，重试，熔断）时再给命名空间或服务
+ * 挂一个 waypoint 代理。
+ *
+ * 这个分层是 ambient 最容易踩的地方：**L7 的授权策略在没有 waypoint 的时候
+ * 不生效**，而 apiserver 照样收下，`kubectl get` 照样看得见。和「没有 CNI 时
+ * NetworkPolicy 是废纸」是同一类问题。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const PEERAUTHENTICATIONS: ResourceDefinition = {
+  group: 'security.istio.io', version: 'v1', resource: 'peerauthentications',
+  singular: 'peerauthentication', kind: 'PeerAuthentication', namespaced: true,
+  shortNames: ['pa'], subresources: ['status'],
+};
+
+export const AUTHORIZATIONPOLICIES: ResourceDefinition = {
+  group: 'security.istio.io', version: 'v1', resource: 'authorizationpolicies',
+  singular: 'authorizationpolicy', kind: 'AuthorizationPolicy', namespaced: true,
+  shortNames: ['ap'], subresources: ['status'],
+};
+
+export const MESH_RESOURCES: ResourceDefinition[] = [PEERAUTHENTICATIONS, AUTHORIZATIONPOLICIES];
+
+/** 命名空间打上这个标签，里面的 Pod 就进网格 */
+export const AMBIENT_LABEL = { key: 'istio.io/dataplane-mode', value: 'ambient' };
+
+/** ztunnel 与 istiod 各自的标识。没有它们，网格里什么都不发生。 */
+export const ZTUNNEL_LABEL = { key: 'app', value: 'ztunnel' };
+export const ISTIOD_LABEL = { key: 'app', value: 'istiod' };
+
+/** waypoint 的 GatewayClass。挂上它，这个命名空间才有 L7。 */
+export const WAYPOINT_CLASS = 'istio-waypoint';
+
+/** SPIFFE：`spiffe://<trust domain>/ns/<ns>/sa/<serviceaccount>` */
+export const TRUST_DOMAIN = 'cluster.local';
+
+export function spiffeId(namespace: string, serviceAccount = 'default'): string {
+  return `spiffe://${TRUST_DOMAIN}/ns/${namespace}/sa/${serviceAccount}`;
+}

--- a/src/lib/opslab/net/network.ts
+++ b/src/lib/opslab/net/network.ts
@@ -42,6 +42,18 @@ export interface NetworkDeps {
    */
   policyEnforced?(): boolean;
   /**
+   * 这条连接过不过服务网格，过了之后发生了什么。
+   *
+   * 由集群注入 —— 网络层不认识 Istio 的 CRD，它只负责把结果画进包路径。
+   */
+  mesh?(input: {
+    source: Source;
+    destination: KubeObject;
+    port: number;
+    method?: string;
+    path?: string;
+  }): { kind: string; detail: string; blocked?: boolean } | undefined;
+  /**
    * 这个地址归不归某个 Gateway 管、这个请求该转到哪。
    *
    * 由集群注入，网络层自己不认识 Gateway 的 CRD —— 数据面只管「转给谁」。
@@ -299,6 +311,28 @@ export class Network {
         verdict: 'forward',
         elapsedMs: 0,
       });
+    }
+
+    // 5.5 服务网格。ztunnel 在 CNI 之后、应用之前拦一道。
+    const mesh = this.deps.mesh?.({
+      source: policySource,
+      destination: chosen.pod,
+      port: chosen.port,
+      method: target.method,
+      path: target.path,
+    });
+    if (mesh && mesh.kind !== 'off' && mesh.kind !== 'passthrough') {
+      elapsed += LATENCY.hop;
+      hops.push({
+        at: 'mesh/ztunnel',
+        detail: mesh.detail,
+        verdict: mesh.blocked ? 'reject' : 'forward',
+        elapsedMs: LATENCY.hop,
+      });
+      if (mesh.blocked) {
+        // ztunnel 会回 RST —— 是连接被重置，不是超时。这个区别指向不同的层。
+        return { kind: 'reset', hops, elapsedMs: elapsed, blockedBy: mesh.kind };
+      }
     }
 
     // 6. TLS 握手。证书验不过就在这里断，还没到应用。

--- a/src/lib/opslab/net/tools.ts
+++ b/src/lib/opslab/net/tools.ts
@@ -180,9 +180,23 @@ function curl(argv: string[], options: NetToolsOptions): CommandResult {
           code: 60,
         };
       }
+      /**
+       * 连接层被断开是 56，不是 35。
+       *
+       * 35 是 TLS 握手阶段出的问题（比如拿明文打 HTTPS 端口）。而 ztunnel
+       * 拒绝一条明文连接、或者授权不通过，都是**建连之后收到 RST** ——
+       * curl 报的是 `(56) Recv failure: Connection reset by peer`。
+       * 这两个码指向不同的层，混在一起就白瞎了这条线索。
+       */
+      if (target.tls) {
+        return {
+          stderr: `curl: (35) OpenSSL/3.4.0: error:0A00010B:SSL routines::${result.blockedBy ?? 'wrong version number'}\n`,
+          code: 35,
+        };
+      }
       return {
-        stderr: `curl: (35) OpenSSL/3.4.0: error:0A00010B:SSL routines::${result.blockedBy ?? 'wrong version number'}\n`,
-        code: 35,
+        stderr: `curl: (56) Recv failure: Connection reset by peer\n`,
+        code: 56,
       };
     }
     default:

--- a/tests/opslab/mesh.test.ts
+++ b/tests/opslab/mesh.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Istio ambient
+ *
+ * 三条会让人卡住的规则，逐条钉住：
+ *  1. 没有 istiod / ztunnel，网格里什么都不发生 —— CRD 还在，判定不生效；
+ *  2. PeerAuthentication STRICT 拒明文，表现是连接被重置而不是超时；
+ *  3. 带 methods/paths 的授权规则没有 waypoint 就不会被求值。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import { evaluateAuthz, globMatch, spiffeId, strictnessFor } from '../../src/lib/opslab/mesh';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const APP = 'harbor.corp.internal/team/portal:1.4.0';
+const ISTIOD = 'docker.io/istio/pilot:1.28.1';
+const ZTUNNEL = 'docker.io/istio/ztunnel:1.28.1';
+
+function deployment(name: string, namespace: string, serviceAccount?: string) {
+  return {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name, namespace },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: name } },
+      template: {
+        metadata: { labels: { app: name } },
+        spec: {
+          ...(serviceAccount ? { serviceAccountName: serviceAccount } : {}),
+          containers: [{ name: 'app', image: APP, ports: [{ containerPort: 8080 }] }],
+        },
+      },
+    },
+  };
+}
+
+const MESH_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'istiod', namespace: 'istio-system', labels: { app: 'istiod' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'istiod' } },
+      template: {
+        metadata: { labels: { app: 'istiod' } },
+        spec: { containers: [{ name: 'discovery', image: ISTIOD }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'DaemonSet',
+    metadata: { name: 'ztunnel', namespace: 'istio-system', labels: { app: 'ztunnel' } },
+    spec: {
+      selector: { matchLabels: { app: 'ztunnel' } },
+      template: {
+        metadata: { labels: { app: 'ztunnel' } },
+        spec: { containers: [{ name: 'ztunnel', image: ZTUNNEL }] },
+      },
+    },
+  },
+];
+
+const WAYPOINT = {
+  apiVersion: 'gateway.networking.k8s.io/v1', kind: 'Gateway',
+  metadata: { name: 'waypoint', namespace: 'shop' },
+  spec: {
+    gatewayClassName: 'istio-waypoint',
+    listeners: [{ name: 'mesh', port: 15008, protocol: 'HBONE' }],
+  },
+};
+
+function spec(options: {
+  ambient?: boolean; platform?: boolean; extra?: unknown[];
+} = {}): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'istio-system', 'outside'],
+    images: {
+      [APP]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [ISTIOD]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [ZTUNNEL]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: [
+      {
+        apiVersion: 'v1', kind: 'Namespace',
+        metadata: {
+          name: 'shop',
+          ...(options.ambient === false ? {} : { labels: { 'istio.io/dataplane-mode': 'ambient' } }),
+        },
+        status: { phase: 'Active' },
+      },
+      ...(options.platform === false ? [] : MESH_PLATFORM),
+      deployment('portal', 'shop', 'portal'),
+      deployment('ledger', 'shop', 'ledger'),
+      deployment('scanner', 'outside'),
+      {
+        apiVersion: 'v1', kind: 'Service',
+        metadata: { name: 'ledger', namespace: 'shop' },
+        spec: { selector: { app: 'ledger' }, ports: [{ port: 80, targetPort: 8080 }] },
+      },
+      ...(options.extra ?? []),
+    ] as never,
+  };
+}
+
+async function build(options: Parameters<typeof spec>[0] = {}) {
+  return createOpsWorld({ world: spec(options) });
+}
+
+function podOf(w: Awaited<ReturnType<typeof build>>, app: string, namespace: string): string {
+  return w.cluster.registry.list(
+    w.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'pods' }), { namespace }
+  ).items.find((pod) => pod.metadata.labels?.app === app)!.metadata.name!;
+}
+
+function call(
+  w: Awaited<ReturnType<typeof build>>,
+  from: { app: string; namespace: string },
+  target: { host: string; path?: string; method?: string }
+) {
+  return w.cluster.network.connect(
+    { zone: 'cluster', namespace: from.namespace, podName: podOf(w, from.app, from.namespace), label: from.app },
+    { host: target.host, port: 80, path: target.path ?? '/', method: target.method }
+  );
+}
+
+describe('身份', () => {
+  it('SPIFFE 就是命名空间加 ServiceAccount', () => {
+    expect(spiffeId('shop', 'portal')).toBe('spiffe://cluster.local/ns/shop/sa/portal');
+    expect(spiffeId('shop')).toBe('spiffe://cluster.local/ns/shop/sa/default');
+  });
+
+  it('网格里的调用带上调用方的身份', async () => {
+    const w = await build();
+    const result = call(w, { app: 'portal', namespace: 'shop' }, { host: 'ledger.shop.svc.cluster.local' });
+    expect(result.kind).toBe('ok');
+    const hop = result.hops.find((entry) => entry.at === 'mesh/ztunnel');
+    expect(hop?.detail).toContain('spiffe://cluster.local/ns/shop/sa/portal');
+    expect(hop?.detail).toContain('spiffe://cluster.local/ns/shop/sa/ledger');
+  });
+});
+
+describe('网格是集群里的工作负载', () => {
+  it('没装 istiod / ztunnel 时，策略一条都不生效', async () => {
+    const w = await build({
+      platform: false,
+      extra: [{
+        apiVersion: 'security.istio.io/v1', kind: 'PeerAuthentication',
+        metadata: { name: 'strict', namespace: 'shop' },
+        spec: { mtls: { mode: 'STRICT' } },
+      }],
+    });
+    // 网格外的调用方照样连得上 —— 因为根本没人在执行
+    const result = call(w, { app: 'scanner', namespace: 'outside' }, { host: 'ledger.shop.svc.cluster.local' });
+    expect(result.kind).toBe('ok');
+    expect(result.hops.some((hop) => hop.at === 'mesh/ztunnel')).toBe(false);
+  });
+});
+
+describe('PeerAuthentication', () => {
+  const STRICT = {
+    apiVersion: 'security.istio.io/v1', kind: 'PeerAuthentication',
+    metadata: { name: 'strict', namespace: 'shop' },
+    spec: { mtls: { mode: 'STRICT' } },
+  };
+
+  it('STRICT 之下，网格外的明文连接被重置 —— 不是超时', async () => {
+    const w = await build({ extra: [STRICT] });
+    const result = call(w, { app: 'scanner', namespace: 'outside' }, { host: 'ledger.shop.svc.cluster.local' });
+    expect(result.kind).toBe('reset');
+    expect(result.blockedBy).toBe('plaintext-rejected');
+    expect(result.hops.find((hop) => hop.at === 'mesh/ztunnel')?.detail).toContain('STRICT');
+  });
+
+  it('网格里的调用不受影响', async () => {
+    const w = await build({ extra: [STRICT] });
+    expect(call(w, { app: 'portal', namespace: 'shop' }, { host: 'ledger.shop.svc.cluster.local' }).kind).toBe('ok');
+  });
+
+  it('PERMISSIVE 下明文照样通', async () => {
+    const w = await build({
+      extra: [{ ...STRICT, spec: { mtls: { mode: 'PERMISSIVE' } } }],
+    });
+    expect(call(w, { app: 'scanner', namespace: 'outside' }, { host: 'ledger.shop.svc.cluster.local' }).kind).toBe('ok');
+  });
+
+  it('带 selector 的策略压过不带 selector 的', () => {
+    const wide = {
+      apiVersion: 'security.istio.io/v1', kind: 'PeerAuthentication',
+      metadata: { name: 'wide', namespace: 'shop' }, spec: { mtls: { mode: 'STRICT' } },
+    } as KubeObject;
+    const narrow = {
+      apiVersion: 'security.istio.io/v1', kind: 'PeerAuthentication',
+      metadata: { name: 'narrow', namespace: 'shop' },
+      spec: { selector: { matchLabels: { app: 'ledger' } }, mtls: { mode: 'PERMISSIVE' } },
+    } as KubeObject;
+    const peer = { namespace: 'shop', labels: { app: 'ledger' }, serviceAccount: 'ledger', enrolled: true };
+    expect(strictnessFor([wide, narrow], peer)).toEqual({ mtls: 'PERMISSIVE', policy: 'shop/narrow' });
+  });
+});
+
+describe('AuthorizationPolicy', () => {
+  const ALLOW_PORTAL = {
+    apiVersion: 'security.istio.io/v1', kind: 'AuthorizationPolicy',
+    metadata: { name: 'ledger', namespace: 'shop' },
+    spec: {
+      selector: { matchLabels: { app: 'ledger' } },
+      action: 'ALLOW',
+      rules: [{ from: [{ source: { principals: ['spiffe://cluster.local/ns/shop/sa/portal'] } }] }],
+    },
+  };
+
+  it('第一条 ALLOW 策略同时把「其余全拒」打开了', async () => {
+    const w = await build({ extra: [ALLOW_PORTAL, deployment('reports', 'shop', 'reports')] });
+    expect(call(w, { app: 'portal', namespace: 'shop' }, { host: 'ledger.shop.svc.cluster.local' }).kind).toBe('ok');
+
+    const denied = call(w, { app: 'reports', namespace: 'shop' }, { host: 'ledger.shop.svc.cluster.local' });
+    expect(denied.kind).toBe('reset');
+    expect(denied.blockedBy).toBe('denied');
+    expect(denied.hops.find((hop) => hop.at === 'mesh/ztunnel')?.detail)
+      .toContain('一旦有 ALLOW 策略选中目标，其余一律拒绝');
+  });
+
+  it('DENY 压过 ALLOW', () => {
+    const allow = {
+      metadata: { namespace: 'shop', name: 'allow' },
+      spec: { action: 'ALLOW', rules: [{}] },
+    } as unknown as KubeObject;
+    const deny = {
+      metadata: { namespace: 'shop', name: 'deny' },
+      spec: { action: 'DENY', rules: [{ to: [{ operation: { ports: ['80'] } }] }] },
+    } as unknown as KubeObject;
+    const decision = evaluateAuthz([allow, deny], { namespace: 'shop', labels: {} }, { port: 80 }, false);
+    expect(decision).toMatchObject({ allowed: false, reason: 'deny-matched', policy: 'shop/deny' });
+  });
+
+  it('没有策略选中就默认允许', () => {
+    const other = {
+      metadata: { namespace: 'shop', name: 'other' },
+      spec: { selector: { matchLabels: { app: 'somethingelse' } }, action: 'ALLOW', rules: [] },
+    } as unknown as KubeObject;
+    expect(evaluateAuthz([other], { namespace: 'shop', labels: { app: 'ledger' } }, { port: 80 }, false))
+      .toMatchObject({ allowed: true, reason: 'no-policy' });
+  });
+
+  it('Istio 的通配只认前缀和后缀', () => {
+    expect(globMatch('*', 'anything')).toBe(true);
+    expect(globMatch('spiffe://cluster.local/ns/shop/*', 'spiffe://cluster.local/ns/shop/sa/portal')).toBe(true);
+    expect(globMatch('*.corp', 'a.corp')).toBe(true);
+    expect(globMatch('a*c', 'abc')).toBe(false);
+  });
+});
+
+describe('L7 要有 waypoint', () => {
+  const BY_METHOD = {
+    apiVersion: 'security.istio.io/v1', kind: 'AuthorizationPolicy',
+    metadata: { name: 'ledger-l7', namespace: 'shop' },
+    spec: {
+      selector: { matchLabels: { app: 'ledger' } },
+      action: 'ALLOW',
+      rules: [{
+        from: [{ source: { principals: ['spiffe://cluster.local/ns/shop/sa/portal'] } }],
+        to: [{ operation: { methods: ['GET'], paths: ['/balance*'] } }],
+      }],
+    },
+  };
+
+  it('没有 waypoint 时带 methods/paths 的规则求值不了，于是整条策略谁都不放行', async () => {
+    const w = await build({ extra: [BY_METHOD] });
+    const result = call(w, { app: 'portal', namespace: 'shop' }, {
+      host: 'ledger.shop.svc.cluster.local', path: '/balance', method: 'GET',
+    });
+    expect(result.kind).toBe('reset');
+    expect(result.hops.find((hop) => hop.at === 'mesh/ztunnel')?.detail).toContain('没有 waypoint');
+  });
+
+  it('挂上 waypoint 之后同一条策略开始按方法与路径判', async () => {
+    const w = await build({ extra: [BY_METHOD, WAYPOINT] });
+    const allowed = call(w, { app: 'portal', namespace: 'shop' }, {
+      host: 'ledger.shop.svc.cluster.local', path: '/balance', method: 'GET',
+    });
+    expect(allowed.kind).toBe('ok');
+
+    const wrongPath = call(w, { app: 'portal', namespace: 'shop' }, {
+      host: 'ledger.shop.svc.cluster.local', path: '/admin', method: 'GET',
+    });
+    expect(wrongPath.kind).toBe('reset');
+  });
+});
+
+describe('istioctl', () => {
+  it('ztunnel-config workload 用 PROTOCOL 那一列说明谁进了网格', async () => {
+    const w = await build();
+    const result = await w.run('istioctl ztunnel-config workload');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('NAMESPACE');
+    expect(result.stdout).toContain('PROTOCOL');
+    const lines = result.stdout.split('\n');
+    expect(lines.find((line) => line.includes('shop') && line.includes('portal'))).toContain('HBONE');
+    expect(lines.find((line) => line.includes('outside'))).toContain('TCP');
+  });
+
+  it('x describe pod 把身份、mTLS 模式、命中的策略摆在一起', async () => {
+    const w = await build({
+      extra: [{
+        apiVersion: 'security.istio.io/v1', kind: 'PeerAuthentication',
+        metadata: { name: 'strict', namespace: 'shop' }, spec: { mtls: { mode: 'STRICT' } },
+      }],
+    });
+    const result = await w.run(`istioctl x describe pod ${podOf(w, 'ledger', 'shop')} -n shop`);
+    expect(result.stdout).toContain('spiffe://cluster.local/ns/shop/sa/ledger');
+    expect(result.stdout).toContain('Workload mTLS mode: STRICT');
+    expect(result.stdout).toContain('没有策略选中这个工作负载');
+  });
+
+  it('analyze 报出「L7 规则没有 waypoint」', async () => {
+    const w = await build({
+      extra: [{
+        apiVersion: 'security.istio.io/v1', kind: 'AuthorizationPolicy',
+        metadata: { name: 'l7', namespace: 'shop' },
+        spec: { action: 'ALLOW', rules: [{ to: [{ operation: { paths: ['/x'] } }] }] },
+      }],
+    });
+    const result = await w.run('istioctl analyze -n shop');
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('IST0162');
+    expect(result.stdout).toContain('没有挂 waypoint');
+  });
+
+  it('analyze 报出「STRICT 但命名空间没进网格」', async () => {
+    const w = await build({
+      ambient: false,
+      extra: [{
+        apiVersion: 'security.istio.io/v1', kind: 'PeerAuthentication',
+        metadata: { name: 'strict', namespace: 'shop' }, spec: { mtls: { mode: 'STRICT' } },
+      }],
+    });
+    const result = await w.run('istioctl analyze -n shop');
+    expect(result.stdout).toContain('IST0163');
+    expect(result.stdout).toContain('istio.io/dataplane-mode=ambient');
+  });
+
+  it('干净的时候明确说没问题', async () => {
+    const w = await build();
+    const result = await w.run('istioctl analyze -n shop');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('No validation issues found');
+  });
+
+  it('控制面不在时 proxy-status 直接说连不上', async () => {
+    const w = await build({ platform: false });
+    const result = await w.run('istioctl proxy-status');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('istiod 不可用');
+  });
+});


### PR DESCRIPTION
## 这一关和第 10 关的区别

NetworkPolicy 判的是「这个 IP 属于一个带某某标签的 Pod」。标签是 apiserver 里的一个字段，有权限的人随时能改。网格判的是另一件事：**对面出示的证书属于谁** —— 一次真的 mTLS 双向验证，身份来自 ServiceAccount。

两者不是替代关系：一个管网络可达性，一个管身份，叠着用。

## 做进来的

**Istio ambient 的判定面**（`src/lib/opslab/mesh/`）。PeerAuthentication（STRICT 拒明文）、AuthorizationPolicy（DENY > 无策略放行 > 有 ALLOW 则其余默认拒绝）、SPIFFE 身份。按设计文档的路线，不做 HBONE 的字节流：那一层对「排查网格」没有教学价值，实现量却足以淹没其余部分。

**L7 要有 waypoint**。带 `methods` / `paths` 的规则 ztunnel 求值不了，于是那一条等于不存在，而 apiserver 照样收下它。和第 10 关「没有 CNI 时 NetworkPolicy 是废纸」是同一类问题 —— 这次 `istioctl analyze` 会直接报出来（IST0162）。

**istioctl**，行为等价重写。真 istioctl 编进多合一二进制要多背一份 Istio 的 API 与 proto，产物会涨一大截，而它在这里的价值全在输出上：`ztunnel-config workload` 的 PROTOCOL 列（HBONE / TCP 一眼看出谁进了网格）、`x describe pod` 把身份/mTLS 模式/命中的策略摆在一起、`analyze` 的三类告警、`proxy-status`。

## 被自己的判定抓到两件事

**curl 把连接层的 RST 也报成 35**。35 是 TLS 握手阶段的问题（拿明文打 HTTPS 端口那种）；ztunnel 拒绝一条明文连接是**建连之后收到 RST**，curl 报的是 `(56) Recv failure: Connection reset by peer`。两个码指向不同的层，混在一起就白瞎了这条线索。

**参考解一开始是错的**：只把 `payments` 接进网格，STRICT 一开，Gateway 的数据面（在 `envoy-gateway-system`，不在网格里）自己第一个被挡在外面，门户对外直接不可用。这正是真集群里上 STRICT 最常见的事故，写进 pitfalls 了，参考解也补上了入口命名空间的接入。

## 验证

19 个网格用例 + 3 个关卡反向验证。全量 1433 个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)