### PR TITLE
feat(opslab): 第 16 关 —— 把 cluster-admin 收回来

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -230,6 +230,20 @@ const WORLD = {
       anonymousPull: false,
     },
   ],
+  /**
+   * 集群认哪些身份。
+   *
+   * key 是 kubeconfig 里的 token。一旦声明了这张表，集群就开始按 RBAC 鉴权。
+   * 前面十几关的 kubeconfig 用的是 admin 那把，所以行为不变。
+   */
+  users: {
+    'admin-token': { username: 'kubernetes-admin', groups: ['system:masters'] },
+    'opslab-token': { username: 'kubernetes-admin', groups: ['system:masters'] },
+    // OIDC 发下来的：用户名带 issuer 前缀，组来自 id_token 里的 groups claim
+    'oidc-liu': { username: 'oidc:liu@corp.internal', groups: ['oidc:developers'] },
+    'oidc-chen': { username: 'oidc:chen@corp.internal', groups: ['oidc:sre'] },
+    'ci-token': { username: 'system:serviceaccount:argocd:deployer', groups: ['system:serviceaccounts'] },
+  },
   // 内网的 Git 服务。平台仓库是「本来就在」的东西，第 11 关往后都从它来。
   gitRepositories: [
     {
@@ -4661,6 +4675,379 @@ const stage15 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 16 关                                                            */
+/* ------------------------------------------------------------------ */
+
+/** 前任图省事，把 CI 的 ServiceAccount 直接绑了 cluster-admin */
+const CI_ADMIN_BINDING = {
+  apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRoleBinding',
+  metadata: { name: 'ci-admin' },
+  subjects: [{ kind: 'ServiceAccount', name: 'deployer', namespace: 'argocd' }],
+  roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'cluster-admin' },
+};
+
+/** 集群自带的那几个角色，真集群里也是预置的 */
+const BUILTIN_ROLES = [
+  {
+    apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole',
+    metadata: { name: 'cluster-admin' },
+    rules: [{ apiGroups: ['*'], resources: ['*'], verbs: ['*'] }],
+  },
+  {
+    apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole',
+    metadata: { name: 'view' },
+    rules: [
+      {
+        apiGroups: ['', 'apps', 'networking.k8s.io', 'gateway.networking.k8s.io'],
+        resources: ['pods', 'services', 'endpoints', 'configmaps', 'deployments', 'replicasets',
+          'daemonsets', 'networkpolicies', 'gateways', 'httproutes'],
+        verbs: ['get', 'list', 'watch'],
+      },
+    ],
+  },
+  { apiVersion: 'v1', kind: 'ServiceAccount', metadata: { name: 'deployer', namespace: 'argocd' } },
+];
+
+const RBAC_STARTER = code`
+  # 这里什么都还没有。想清楚每个人到底需要什么，再写。
+  #
+  #   liu  —— 开发，组 oidc:developers
+  #   chen —— SRE，组 oidc:sre
+  #   argocd/deployer —— CI 用的 ServiceAccount
+`;
+
+const RBAC_REFERENCE = code`
+  # 开发：payments 里只读 + 看日志 + 进容器排查
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: developer
+    namespace: payments
+  rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: developers
+    namespace: payments
+  subjects:
+  - kind: Group
+    name: oidc:developers
+    apiGroup: rbac.authorization.k8s.io
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: developer
+  ---
+  # SRE：全集群只读
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: sre-view
+  subjects:
+  - kind: Group
+    name: oidc:sre
+    apiGroup: rbac.authorization.k8s.io
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  ---
+  # SRE：payments 里还能动工作负载
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: workload-operator
+    namespace: payments
+  rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/scale", "statefulsets"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "delete"]
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: sre-operator
+    namespace: payments
+  subjects:
+  - kind: Group
+    name: oidc:sre
+    apiGroup: rbac.authorization.k8s.io
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: workload-operator
+  ---
+  # CI：只在 payments 里发布工作负载，碰不到 RBAC 与 Secret
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: deployer
+    namespace: payments
+  rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: ci-deployer
+    namespace: payments
+  subjects:
+  - kind: ServiceAccount
+    name: deployer
+    namespace: argocd
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: deployer
+`;
+
+const stage16 = {
+  id: 'identity-and-rbac',
+  title: t('把 cluster-admin 收回来', 'Take cluster-admin Back'),
+  goal: t(
+    code`
+      公司接了 OIDC，两个人已经能登录集群了：\`liu\`（开发，组
+      \`oidc:developers\`）和 \`chen\`（SRE，组 \`oidc:sre\`）。但集群这边一个
+      角色都没配 —— 他们登录之后什么都干不了。
+
+      与此同时，前任把 CI 用的 ServiceAccount \`argocd/deployer\` 直接绑了
+      \`cluster-admin\`。也就是说，一条流水线拿到的权限比任何一个人都大。
+
+      按最小权限把这三个主体配好。
+
+      ## 通关标准
+
+      1. \`liu\`：在 \`payments\` 里读得到工作负载、看得了日志、进得去容器排查；
+         **改不动任何东西**，也读不到 Secret；
+      2. \`chen\`：全集群只读，另外在 \`payments\` 里能改 Deployment 与删 Pod；
+         但删不掉命名空间；
+      3. \`argocd/deployer\`：只在 \`payments\` 里发布工作负载；碰不到 RBAC，
+         也读不到 Secret；
+      4. \`cluster-admin\` 不再绑给这三个主体里的任何一个。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl auth can-i --list --as=oidc:liu@corp.internal --as-group=oidc:developers -n payments
+      kubectl auth can-i create pods --subresource=exec -n payments --as=oidc:liu@corp.internal --as-group=oidc:developers
+      kubectl get clusterrolebindings
+      kubectl apply -f /root/infra/rbac.yaml
+      \`\`\`
+    `,
+    code`
+      The company wired up OIDC and two people can now log in: \`liu\` (a developer in
+      group \`oidc:developers\`) and \`chen\` (an SRE in \`oidc:sre\`). No roles exist on
+      the cluster side, so once logged in they can do nothing at all.
+
+      Meanwhile your predecessor bound the CI ServiceAccount \`argocd/deployer\`
+      straight to \`cluster-admin\`. A pipeline therefore holds more power than any
+      human does.
+
+      Give all three least privilege.
+
+      ## Done when
+
+      1. \`liu\` can read workloads in \`payments\`, read logs, and exec into containers
+         to debug, but **cannot change anything** and cannot read Secrets;
+      2. \`chen\` has cluster-wide read plus the ability to modify Deployments and
+         delete Pods in \`payments\`, but cannot delete namespaces;
+      3. \`argocd/deployer\` can ship workloads in \`payments\` only, cannot touch RBAC,
+         and cannot read Secrets;
+      4. \`cluster-admin\` is no longer bound to any of the three.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl auth can-i --list --as=oidc:liu@corp.internal --as-group=oidc:developers -n payments
+      kubectl auth can-i create pods --subresource=exec -n payments --as=oidc:liu@corp.internal --as-group=oidc:developers
+      kubectl get clusterrolebindings
+      kubectl apply -f /root/infra/rbac.yaml
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('三个主体各自拿到该有的权限', 'Each of the three gets what it needs'),
+    t('都拿不到不该有的', 'And none of them gets what it should not'),
+    t('cluster-admin 收回来了', 'cluster-admin taken back'),
+  ],
+  hints: [
+    t(
+      '\`kubectl auth can-i ... --as=<user> --as-group=<group>\` 是检查别人权限的标准做法 —— 不需要拿到对方的凭据。\`--list\` 会把这个身份在这个命名空间里能做的事全列出来。',
+      '`kubectl auth can-i ... --as=<user> --as-group=<group>` is how you check someone else’s permissions without holding their credentials. `--list` prints everything that identity can do in that namespace.'
+    ),
+    t(
+      '\`RoleBinding\` 可以引用 \`ClusterRole\`。权限的范围由 **Binding** 决定 —— 这就是「一套只读角色，绑到每个需要的命名空间」的标准写法，不用给每个命名空间各写一份 Role。',
+      'A `RoleBinding` may reference a `ClusterRole`. Scope comes from the **binding**, which is the standard way to reuse one read-only role across namespaces without writing a Role in each.'
+    ),
+    t(
+      '看日志和进容器是两个**子资源**：\`pods/log\` 的 \`get\`、\`pods/exec\` 的 \`create\`。只写 \`pods\` 是不够的，而且 exec 的动词是 create 不是 get。问的时候要用 \`--subresource=log\`：写成 \`can-i get pods/log\` 的话，kubectl 会把 log 当成 Pod 的**名字**。',
+      'Logs and exec are **subresources**: `get` on `pods/log`, `create` on `pods/exec`. Listing `pods` alone is not enough, and the verb for exec is create, not get. Ask with `--subresource=log`: written as `can-i get pods/log`, kubectl reads log as the pod **name** instead.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '给开发绑 \`edit\` 或 \`admin\` 这种内置角色图省事。它们包含对 Secret 的读权限 —— 而「只读」的要求里，最要紧的恰恰是读不到 Secret。判定专门查了这一条。',
+      'Reaching for built-in roles like `edit` or `admin`. They include read access to Secrets, and not reading Secrets is the most important half of "read only". The grader checks exactly that.'
+    ),
+    t(
+      '把 \`ci-admin\` 那条 ClusterRoleBinding 留着，另外再加一条小权限。多加的那条不会削减已有的 —— RBAC 是取并集的，只要还有一条给了 cluster-admin，前面写的全部白搭。',
+      'Leaving the `ci-admin` ClusterRoleBinding in place and adding a smaller role next to it. Adding never subtracts: RBAC unions its rules, so one remaining cluster-admin binding voids everything else you wrote.'
+    ),
+    t(
+      '用 \`resourceNames\` 去限制 list。它只对指名道姓的请求生效，list 与 watch 没有名字，带 \`resourceNames\` 的规则对它们一律不匹配 —— 于是「我明明允许了这个 Secret」但列不出来。',
+      'Using `resourceNames` to scope a list. It only applies to requests that name an object; list and watch carry no name, so such rules never match them, which is why "I clearly allowed that Secret" still cannot be listed.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM,
+      ...PORTAL_WORKLOAD, PORTAL_ROUTE,
+      ...BUILTIN_ROLES, CI_ADMIN_BINDING,
+    ],
+    files: { '/root/infra/rbac.yaml': RBAC_STARTER },
+    referenceFiles: { '/root/infra/rbac.yaml': RBAC_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/rbac.yaml',
+      'kubectl delete clusterrolebinding ci-admin',
+    ],
+  },
+  specs: [
+    spec('identity-and-rbac.spec.ts', code`
+      import { list, sh } from '@ops/lab';
+
+      const LIU = '--as=oidc:liu@corp.internal --as-group=oidc:developers';
+      const CHEN = '--as=oidc:chen@corp.internal --as-group=oidc:sre';
+      const CI = '--as=system:serviceaccount:argocd:deployer';
+
+      const canI = async (what, who) => {
+        const result = await sh('kubectl auth can-i ' + what + ' ' + who);
+        return result.stdout.trim();
+      };
+
+      describe('身份与 RBAC', () => {
+        it('开发在 payments 里读得到工作负载', async () => {
+          expect(await canI('list pods -n payments', LIU)).toBe('yes');
+          expect(await canI('list deployments -n payments', LIU)).toBe('yes');
+        });
+
+        it('开发看得了日志、进得去容器', async () => {
+          // 子资源要用 --subresource 问；写成 pods/log 的话 kubectl 会把 log
+          // 当成 Pod 的**名字**，问的就完全是另一件事了
+          expect(await canI('get pods --subresource=log -n payments', LIU)).toBe('yes');
+          expect(await canI('create pods --subresource=exec -n payments', LIU)).toBe('yes');
+        });
+
+        it('开发改不动东西，也读不到 Secret', async () => {
+          expect(await canI('delete pods -n payments', LIU)).toBe('no');
+          expect(await canI('patch deployments -n payments', LIU)).toBe('no');
+          expect(await canI('create deployments -n payments', LIU)).toBe('no');
+          expect(await canI('get secrets -n payments', LIU)).toBe('no');
+        });
+
+        it('开发的权限没有溢出到别的命名空间', async () => {
+          expect(await canI('list pods -n argocd', LIU)).toBe('no');
+        });
+
+        it('SRE 全集群只读', async () => {
+          expect(await canI('list pods --all-namespaces', CHEN)).toBe('yes');
+          expect(await canI('list deployments -n argocd', CHEN)).toBe('yes');
+        });
+
+        it('SRE 在 payments 里动得了工作负载，但删不掉命名空间', async () => {
+          expect(await canI('patch deployments -n payments', CHEN)).toBe('yes');
+          expect(await canI('delete pods -n payments', CHEN)).toBe('yes');
+          expect(await canI('delete namespaces', CHEN)).toBe('no');
+        });
+
+        it('CI 只能在 payments 里发布，碰不到 RBAC 与 Secret', async () => {
+          expect(await canI('create deployments -n payments', CI)).toBe('yes');
+          expect(await canI('create deployments -n argocd', CI)).toBe('no');
+          expect(await canI('create rolebindings -n payments', CI)).toBe('no');
+          expect(await canI('get secrets -n payments', CI)).toBe('no');
+        });
+
+        it('cluster-admin 不再绑给这三个主体', () => {
+          const bindings = list('ClusterRoleBinding')
+            .filter((binding) => binding.roleRef.name === 'cluster-admin');
+          const risky = bindings.flatMap((binding) => binding.subjects || [])
+            .filter((subject) => subject.kind !== 'Group' || !subject.name.startsWith('system:'));
+          expect(risky).toEqual([]);
+        });
+
+        it('管理员自己还进得去 —— 别把自己锁在外面', async () => {
+          const result = await sh('kubectl get pods -n payments');
+          expect(result.code).toBe(0);
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'maintainability'],
+  extension: t(
+    code`
+      RBAC 和前面几关的策略有一个根本区别：**它只有允许，没有拒绝**。
+      写不出「除了 Secret 之外都可以」这种规则 —— 想表达它，只能把 Secret 之外
+      的都列出来。所以「加一条规则」永远只会让权限变大，收权限的唯一办法是
+      **改或删已有的绑定**。前任那条 \`ci-admin\` 就是这个道理：在旁边再写一个
+      小角色，一点用都没有。
+
+      另一个值得记住的是**认证与鉴权是两件事**。OIDC 只负责回答「你是谁」——
+      它给出一个用户名和一组 group，之后集群里发生什么，全看 RBAC。
+      所以「接了 OIDC 之后大家还是什么都干不了」是完全正常的中间状态，
+      不是接错了。反过来，OIDC 那边改了 group claim 的映射，集群这边的
+      绑定会突然对不上 —— 这类故障查起来很费劲，因为两边都「没改过」。
+
+      最后一条实践：\`kubectl auth can-i --list --as=<user>\` 应该成为交付前的
+      固定动作。人对自己写的 RBAC 的判断准确率相当低，而这条命令是直接问
+      服务端要答案，不是猜。
+    `,
+    code`
+      RBAC differs from the policies in earlier stages in one fundamental way: **it
+      only allows, it never denies**. There is no way to write "anything except
+      Secrets"; you must enumerate everything else. So adding a rule can only widen
+      access, and the only way to reduce it is to **change or delete an existing
+      binding**. That is why the leftover \`ci-admin\` matters: writing a smaller role
+      beside it accomplishes nothing.
+
+      The other thing worth internalising is that **authentication and authorization
+      are separate**. OIDC only answers "who are you", producing a username and a set
+      of groups; what happens next is entirely RBAC. "Everyone can log in and still do
+      nothing" is therefore a perfectly normal intermediate state, not a broken
+      integration. Conversely, when the identity provider changes how it maps group
+      claims, cluster bindings silently stop matching, and that is painful to diagnose
+      because neither side "changed anything".
+
+      One practice worth adopting: run \`kubectl auth can-i --list --as=<user>\` before
+      calling an RBAC change done. People are remarkably bad at predicting what their
+      own rules permit, and this asks the server instead of guessing.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -4705,6 +5092,7 @@ module.exports = {
   files: [],
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
-    stage7, stage8, stage9, stage10, stage11, stage12, stage13, stage14, stage15,
+    stage7, stage8, stage9, stage10, stage11, stage12,
+    stage13, stage14, stage15, stage16,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5821,6 +5821,38 @@
             "anonymousPull": false
           }
         ],
+        "users": {
+          "admin-token": {
+            "username": "kubernetes-admin",
+            "groups": [
+              "system:masters"
+            ]
+          },
+          "opslab-token": {
+            "username": "kubernetes-admin",
+            "groups": [
+              "system:masters"
+            ]
+          },
+          "oidc-liu": {
+            "username": "oidc:liu@corp.internal",
+            "groups": [
+              "oidc:developers"
+            ]
+          },
+          "oidc-chen": {
+            "username": "oidc:chen@corp.internal",
+            "groups": [
+              "oidc:sre"
+            ]
+          },
+          "ci-token": {
+            "username": "system:serviceaccount:argocd:deployer",
+            "groups": [
+              "system:serviceaccounts"
+            ]
+          }
+        },
         "gitRepositories": [
           {
             "url": "https://git.corp.internal/platform/apps",
@@ -10075,6 +10107,505 @@
         "primer": {
           "zh": "`NetworkPolicy` 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签只是 apiserver 里的一个字段，有权限的人随时能改。服务网格判的是另一件事：**对面出示的证书属于谁**。每个工作负载拿到一张由集群 CA 签发的证书，身份写在 SAN 里，格式是 `SPIFFE`：`spiffe://cluster.local/ns/<命名空间>/sa/<ServiceAccount>`。注意身份来自 ServiceAccount，不是 Pod 名也不是标签；所有服务都用 `default` 这个 SA 的集群，上了网格也分不出谁是谁。\n\n`Istio ambient` 是 2026 年的主流形态，和早年的 sidecar 模式差别很大：不再给每个 Pod 塞一个 Envoy，而是每个节点跑一个 `ztunnel`（DaemonSet）负责 L4：建立 mTLS、校验对端身份、按身份与端口授权。接入方式是给命名空间打一个标签 `istio.io/dataplane-mode=ambient`，Pod 不用改、不用重启。`istioctl ztunnel-config workload` 里 PROTOCOL 那一列是 HBONE 就说明接进来了。\n\n要按 HTTP 方法或路径授权、要重试与熔断，就得再加一层 `waypoint`，也就是一个 `gatewayClassName: istio-waypoint` 的 Gateway，按命名空间或按服务挂。这条分层是 ambient 最常见的困惑来源：带 `methods` 或 `paths` 的 `AuthorizationPolicy` 在没有 waypoint 的时候**根本不会被求值**，而 apiserver 照样收下它。`istioctl analyze` 会把这类问题直接报出来。\n\n`AuthorizationPolicy` 的判定顺序值得单独记：任何一条 DENY 命中就拒绝；没有任何 ALLOW 策略选中这个工作负载则放行；一旦有 ALLOW 策略选中它，只有命中某条 rule 才放行，**其余一律拒绝**。所以给一个服务加第一条 ALLOW 策略，等于同时把「默认拒绝」也打开了，很多人以为自己只是多放行了一个来源。还有一点：被网格拒绝表现为连接被重置（ztunnel 回 RST），而不是超时；超时是丢包，指向 NetworkPolicy 那一层。",
           "en": "`NetworkPolicy` decides based on \"this IP belongs to a pod carrying that label\", and a label is just a field in the apiserver that anyone with access can change. A service mesh answers a different question: **whose certificate did the peer present**. Each workload gets a certificate from the cluster CA with its identity in the SAN, in `SPIFFE` form: `spiffe://cluster.local/ns/<namespace>/sa/<serviceaccount>`. Identity comes from the ServiceAccount, not the pod name or its labels, so a cluster where everything runs as `default` gains nothing by enrolling.\n\n`Istio ambient` is the mainstream shape in 2026 and differs sharply from the older sidecar model: instead of an Envoy beside every pod, one `ztunnel` per node (a DaemonSet) handles L4, establishing mTLS, verifying peer identity, and authorizing by identity and port. Enrolling is a namespace label, `istio.io/dataplane-mode=ambient`, with no pod changes and no restarts. In `istioctl ztunnel-config workload`, a PROTOCOL of HBONE means enrolled.\n\nAuthorizing by HTTP method or path, or doing retries and circuit breaking, needs one more layer: a `waypoint`, a Gateway with `gatewayClassName: istio-waypoint`, attached per namespace or per service. This layering is the most common confusion in ambient, because an `AuthorizationPolicy` with `methods` or `paths` is **never evaluated** without a waypoint, while the apiserver accepts it happily. `istioctl analyze` reports exactly this class of problem.\n\nThe evaluation order of `AuthorizationPolicy` is worth memorising: any matching DENY refuses; with no ALLOW policy selecting the workload, traffic is permitted; once some ALLOW policy selects it, only traffic matching a rule is permitted and **everything else is refused**. So adding the first ALLOW policy to a service also turns on default-deny, which surprises people who thought they were merely permitting one more caller. One more distinction: a mesh denial arrives as a connection reset, because ztunnel answers with an RST, whereas a timeout means dropped packets and points at the NetworkPolicy layer."
+        }
+      },
+      {
+        "id": "identity-and-rbac",
+        "title": {
+          "zh": "把 cluster-admin 收回来",
+          "en": "Take cluster-admin Back"
+        },
+        "goal": {
+          "zh": "公司接了 OIDC，两个人已经能登录集群了：`liu`（开发，组\n`oidc:developers`）和 `chen`（SRE，组 `oidc:sre`）。但集群这边一个\n角色都没配 —— 他们登录之后什么都干不了。\n\n与此同时，前任把 CI 用的 ServiceAccount `argocd/deployer` 直接绑了\n`cluster-admin`。也就是说，一条流水线拿到的权限比任何一个人都大。\n\n按最小权限把这三个主体配好。\n\n## 通关标准\n\n1. `liu`：在 `payments` 里读得到工作负载、看得了日志、进得去容器排查；\n   **改不动任何东西**，也读不到 Secret；\n2. `chen`：全集群只读，另外在 `payments` 里能改 Deployment 与删 Pod；\n   但删不掉命名空间；\n3. `argocd/deployer`：只在 `payments` 里发布工作负载；碰不到 RBAC，\n   也读不到 Secret；\n4. `cluster-admin` 不再绑给这三个主体里的任何一个。\n\n## 会用到的命令\n\n```bash\nkubectl auth can-i --list --as=oidc:liu@corp.internal --as-group=oidc:developers -n payments\nkubectl auth can-i create pods --subresource=exec -n payments --as=oidc:liu@corp.internal --as-group=oidc:developers\nkubectl get clusterrolebindings\nkubectl apply -f /root/infra/rbac.yaml\n```\n",
+          "en": "The company wired up OIDC and two people can now log in: `liu` (a developer in\ngroup `oidc:developers`) and `chen` (an SRE in `oidc:sre`). No roles exist on\nthe cluster side, so once logged in they can do nothing at all.\n\nMeanwhile your predecessor bound the CI ServiceAccount `argocd/deployer`\nstraight to `cluster-admin`. A pipeline therefore holds more power than any\nhuman does.\n\nGive all three least privilege.\n\n## Done when\n\n1. `liu` can read workloads in `payments`, read logs, and exec into containers\n   to debug, but **cannot change anything** and cannot read Secrets;\n2. `chen` has cluster-wide read plus the ability to modify Deployments and\n   delete Pods in `payments`, but cannot delete namespaces;\n3. `argocd/deployer` can ship workloads in `payments` only, cannot touch RBAC,\n   and cannot read Secrets;\n4. `cluster-admin` is no longer bound to any of the three.\n\n## Commands you will need\n\n```bash\nkubectl auth can-i --list --as=oidc:liu@corp.internal --as-group=oidc:developers -n payments\nkubectl auth can-i create pods --subresource=exec -n payments --as=oidc:liu@corp.internal --as-group=oidc:developers\nkubectl get clusterrolebindings\nkubectl apply -f /root/infra/rbac.yaml\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "三个主体各自拿到该有的权限",
+            "en": "Each of the three gets what it needs"
+          },
+          {
+            "zh": "都拿不到不该有的",
+            "en": "And none of them gets what it should not"
+          },
+          {
+            "zh": "cluster-admin 收回来了",
+            "en": "cluster-admin taken back"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`kubectl auth can-i ... --as=<user> --as-group=<group>` 是检查别人权限的标准做法 —— 不需要拿到对方的凭据。`--list` 会把这个身份在这个命名空间里能做的事全列出来。",
+            "en": "`kubectl auth can-i ... --as=<user> --as-group=<group>` is how you check someone else’s permissions without holding their credentials. `--list` prints everything that identity can do in that namespace."
+          },
+          {
+            "zh": "`RoleBinding` 可以引用 `ClusterRole`。权限的范围由 **Binding** 决定 —— 这就是「一套只读角色，绑到每个需要的命名空间」的标准写法，不用给每个命名空间各写一份 Role。",
+            "en": "A `RoleBinding` may reference a `ClusterRole`. Scope comes from the **binding**, which is the standard way to reuse one read-only role across namespaces without writing a Role in each."
+          },
+          {
+            "zh": "看日志和进容器是两个**子资源**：`pods/log` 的 `get`、`pods/exec` 的 `create`。只写 `pods` 是不够的，而且 exec 的动词是 create 不是 get。问的时候要用 `--subresource=log`：写成 `can-i get pods/log` 的话，kubectl 会把 log 当成 Pod 的**名字**。",
+            "en": "Logs and exec are **subresources**: `get` on `pods/log`, `create` on `pods/exec`. Listing `pods` alone is not enough, and the verb for exec is create, not get. Ask with `--subresource=log`: written as `can-i get pods/log`, kubectl reads log as the pod **name** instead."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "给开发绑 `edit` 或 `admin` 这种内置角色图省事。它们包含对 Secret 的读权限 —— 而「只读」的要求里，最要紧的恰恰是读不到 Secret。判定专门查了这一条。",
+            "en": "Reaching for built-in roles like `edit` or `admin`. They include read access to Secrets, and not reading Secrets is the most important half of \"read only\". The grader checks exactly that."
+          },
+          {
+            "zh": "把 `ci-admin` 那条 ClusterRoleBinding 留着，另外再加一条小权限。多加的那条不会削减已有的 —— RBAC 是取并集的，只要还有一条给了 cluster-admin，前面写的全部白搭。",
+            "en": "Leaving the `ci-admin` ClusterRoleBinding in place and adding a smaller role next to it. Adding never subtracts: RBAC unions its rules, so one remaining cluster-admin binding voids everything else you wrote."
+          },
+          {
+            "zh": "用 `resourceNames` 去限制 list。它只对指名道姓的请求生效，list 与 watch 没有名字，带 `resourceNames` 的规则对它们一律不匹配 —— 于是「我明明允许了这个 Secret」但列不出来。",
+            "en": "Using `resourceNames` to scope a list. It only applies to requests that name an object; list and watch carry no name, so such rules never match them, which is why \"I clearly allowed that Secret\" still cannot be listed."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRole",
+              "metadata": {
+                "name": "cluster-admin"
+              },
+              "rules": [
+                {
+                  "apiGroups": [
+                    "*"
+                  ],
+                  "resources": [
+                    "*"
+                  ],
+                  "verbs": [
+                    "*"
+                  ]
+                }
+              ]
+            },
+            {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRole",
+              "metadata": {
+                "name": "view"
+              },
+              "rules": [
+                {
+                  "apiGroups": [
+                    "",
+                    "apps",
+                    "networking.k8s.io",
+                    "gateway.networking.k8s.io"
+                  ],
+                  "resources": [
+                    "pods",
+                    "services",
+                    "endpoints",
+                    "configmaps",
+                    "deployments",
+                    "replicasets",
+                    "daemonsets",
+                    "networkpolicies",
+                    "gateways",
+                    "httproutes"
+                  ],
+                  "verbs": [
+                    "get",
+                    "list",
+                    "watch"
+                  ]
+                }
+              ]
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "deployer",
+                "namespace": "argocd"
+              }
+            },
+            {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRoleBinding",
+              "metadata": {
+                "name": "ci-admin"
+              },
+              "subjects": [
+                {
+                  "kind": "ServiceAccount",
+                  "name": "deployer",
+                  "namespace": "argocd"
+                }
+              ],
+              "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/rbac.yaml": "# 这里什么都还没有。想清楚每个人到底需要什么，再写。\n#\n#   liu  —— 开发，组 oidc:developers\n#   chen —— SRE，组 oidc:sre\n#   argocd/deployer —— CI 用的 ServiceAccount\n"
+          },
+          "referenceFiles": {
+            "/root/infra/rbac.yaml": "# 开发：payments 里只读 + 看日志 + 进容器排查\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: developer\n  namespace: payments\nrules:\n- apiGroups: [\"\"]\n  resources: [\"pods\", \"services\", \"configmaps\", \"endpoints\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n- apiGroups: [\"apps\"]\n  resources: [\"deployments\", \"replicasets\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n- apiGroups: [\"\"]\n  resources: [\"pods/log\"]\n  verbs: [\"get\"]\n- apiGroups: [\"\"]\n  resources: [\"pods/exec\"]\n  verbs: [\"create\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: developers\n  namespace: payments\nsubjects:\n- kind: Group\n  name: oidc:developers\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: developer\n---\n# SRE：全集群只读\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: sre-view\nsubjects:\n- kind: Group\n  name: oidc:sre\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: view\n---\n# SRE：payments 里还能动工作负载\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: workload-operator\n  namespace: payments\nrules:\n- apiGroups: [\"apps\"]\n  resources: [\"deployments\", \"deployments/scale\", \"statefulsets\"]\n  verbs: [\"get\", \"list\", \"watch\", \"update\", \"patch\"]\n- apiGroups: [\"\"]\n  resources: [\"pods\"]\n  verbs: [\"get\", \"list\", \"watch\", \"delete\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: sre-operator\n  namespace: payments\nsubjects:\n- kind: Group\n  name: oidc:sre\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: workload-operator\n---\n# CI：只在 payments 里发布工作负载，碰不到 RBAC 与 Secret\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: deployer\n  namespace: payments\nrules:\n- apiGroups: [\"apps\"]\n  resources: [\"deployments\", \"replicasets\", \"daemonsets\", \"statefulsets\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\"]\n- apiGroups: [\"\"]\n  resources: [\"services\", \"configmaps\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: ci-deployer\n  namespace: payments\nsubjects:\n- kind: ServiceAccount\n  name: deployer\n  namespace: argocd\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: deployer\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/rbac.yaml",
+            "kubectl delete clusterrolebinding ci-admin"
+          ]
+        },
+        "specs": [
+          {
+            "path": "identity-and-rbac.spec.ts",
+            "content": "import { list, sh } from '@ops/lab';\n\nconst LIU = '--as=oidc:liu@corp.internal --as-group=oidc:developers';\nconst CHEN = '--as=oidc:chen@corp.internal --as-group=oidc:sre';\nconst CI = '--as=system:serviceaccount:argocd:deployer';\n\nconst canI = async (what, who) => {\n  const result = await sh('kubectl auth can-i ' + what + ' ' + who);\n  return result.stdout.trim();\n};\n\ndescribe('身份与 RBAC', () => {\n  it('开发在 payments 里读得到工作负载', async () => {\n    expect(await canI('list pods -n payments', LIU)).toBe('yes');\n    expect(await canI('list deployments -n payments', LIU)).toBe('yes');\n  });\n\n  it('开发看得了日志、进得去容器', async () => {\n    // 子资源要用 --subresource 问；写成 pods/log 的话 kubectl 会把 log\n    // 当成 Pod 的**名字**，问的就完全是另一件事了\n    expect(await canI('get pods --subresource=log -n payments', LIU)).toBe('yes');\n    expect(await canI('create pods --subresource=exec -n payments', LIU)).toBe('yes');\n  });\n\n  it('开发改不动东西，也读不到 Secret', async () => {\n    expect(await canI('delete pods -n payments', LIU)).toBe('no');\n    expect(await canI('patch deployments -n payments', LIU)).toBe('no');\n    expect(await canI('create deployments -n payments', LIU)).toBe('no');\n    expect(await canI('get secrets -n payments', LIU)).toBe('no');\n  });\n\n  it('开发的权限没有溢出到别的命名空间', async () => {\n    expect(await canI('list pods -n argocd', LIU)).toBe('no');\n  });\n\n  it('SRE 全集群只读', async () => {\n    expect(await canI('list pods --all-namespaces', CHEN)).toBe('yes');\n    expect(await canI('list deployments -n argocd', CHEN)).toBe('yes');\n  });\n\n  it('SRE 在 payments 里动得了工作负载，但删不掉命名空间', async () => {\n    expect(await canI('patch deployments -n payments', CHEN)).toBe('yes');\n    expect(await canI('delete pods -n payments', CHEN)).toBe('yes');\n    expect(await canI('delete namespaces', CHEN)).toBe('no');\n  });\n\n  it('CI 只能在 payments 里发布，碰不到 RBAC 与 Secret', async () => {\n    expect(await canI('create deployments -n payments', CI)).toBe('yes');\n    expect(await canI('create deployments -n argocd', CI)).toBe('no');\n    expect(await canI('create rolebindings -n payments', CI)).toBe('no');\n    expect(await canI('get secrets -n payments', CI)).toBe('no');\n  });\n\n  it('cluster-admin 不再绑给这三个主体', () => {\n    const bindings = list('ClusterRoleBinding')\n      .filter((binding) => binding.roleRef.name === 'cluster-admin');\n    const risky = bindings.flatMap((binding) => binding.subjects || [])\n      .filter((subject) => subject.kind !== 'Group' || !subject.name.startsWith('system:'));\n    expect(risky).toEqual([]);\n  });\n\n  it('管理员自己还进得去 —— 别把自己锁在外面', async () => {\n    const result = await sh('kubectl get pods -n payments');\n    expect(result.code).toBe(0);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "RBAC 和前面几关的策略有一个根本区别：**它只有允许，没有拒绝**。\n写不出「除了 Secret 之外都可以」这种规则 —— 想表达它，只能把 Secret 之外\n的都列出来。所以「加一条规则」永远只会让权限变大，收权限的唯一办法是\n**改或删已有的绑定**。前任那条 `ci-admin` 就是这个道理：在旁边再写一个\n小角色，一点用都没有。\n\n另一个值得记住的是**认证与鉴权是两件事**。OIDC 只负责回答「你是谁」——\n它给出一个用户名和一组 group，之后集群里发生什么，全看 RBAC。\n所以「接了 OIDC 之后大家还是什么都干不了」是完全正常的中间状态，\n不是接错了。反过来，OIDC 那边改了 group claim 的映射，集群这边的\n绑定会突然对不上 —— 这类故障查起来很费劲，因为两边都「没改过」。\n\n最后一条实践：`kubectl auth can-i --list --as=<user>` 应该成为交付前的\n固定动作。人对自己写的 RBAC 的判断准确率相当低，而这条命令是直接问\n服务端要答案，不是猜。\n",
+          "en": "RBAC differs from the policies in earlier stages in one fundamental way: **it\nonly allows, it never denies**. There is no way to write \"anything except\nSecrets\"; you must enumerate everything else. So adding a rule can only widen\naccess, and the only way to reduce it is to **change or delete an existing\nbinding**. That is why the leftover `ci-admin` matters: writing a smaller role\nbeside it accomplishes nothing.\n\nThe other thing worth internalising is that **authentication and authorization\nare separate**. OIDC only answers \"who are you\", producing a username and a set\nof groups; what happens next is entirely RBAC. \"Everyone can log in and still do\nnothing\" is therefore a perfectly normal intermediate state, not a broken\nintegration. Conversely, when the identity provider changes how it maps group\nclaims, cluster bindings silently stop matching, and that is painful to diagnose\nbecause neither side \"changed anything\".\n\nOne practice worth adopting: run `kubectl auth can-i --list --as=<user>` before\ncalling an RBAC change done. People are remarkably bad at predicting what their\nown rules permit, and this asks the server instead of guessing.\n"
+        },
+        "primer": {
+          "zh": "一个请求打到 apiserver，要过两道关，它们回答的是完全不同的问题。`认证`回答「你是谁」：客户端证书、ServiceAccount 的 token、或者 OIDC 发下来的 id_token，形式不同，产物都是同一个东西：一个用户名加一组 `group`。`鉴权`回答「你能不能做这件事」，这才是 RBAC 的活。所以「接了 OIDC 之后大家还是什么都干不了」是正常的中间状态，不是接错了。\n\nRBAC 有四个对象，两两成对：`Role` 与 `ClusterRole` 描述「能对什么资源做什么动作」，`RoleBinding` 与 `ClusterRoleBinding` 描述「谁拿到这套权限」。最容易记混的组合是 `RoleBinding` 引用 `ClusterRole`：这时权限的**范围由 Binding 决定**，拿到的只是那一个命名空间里的权限。这是「一套只读角色复用到每个命名空间」的标准写法，不必给每个命名空间各抄一份 Role。\n\n规则里有几处不是望文生义的。动词上，`get` 和 `list` 是两件事，只写 `get` 的规则挡不住也放不开 `list`；`watch` 又是第三件。资源上，看日志和进容器是**子资源**，要写成 `pods/log`（动词 `get`）和 `pods/exec`（动词 `create`，不是 get）。`resourceNames` 能把权限限定到具体对象，但它只对指名道姓的请求生效；`list` 与 `watch` 没有名字，带 `resourceNames` 的规则对它们一律不匹配。\n\n最关键的一条：RBAC **只有允许，没有拒绝**。写不出「除了 Secret 之外都可以」，只能把 Secret 之外的都列出来。这意味着加规则永远只会让权限变大，收权限的唯一办法是改掉或删掉已有的绑定；在一条 cluster-admin 绑定旁边再写一个小角色，一点用都没有。检查的办法是 `kubectl auth can-i <动词> <资源> --as=<用户> --as-group=<组>`，加 `--list` 会把这个身份能做的事全列出来。人对自己写的 RBAC 判断准确率相当低，这条命令是直接问服务端要答案。",
+          "en": "A request reaching the apiserver passes two gates that answer completely different questions. `Authentication` answers \"who are you\": a client certificate, a ServiceAccount token, or an OIDC id_token, all producing the same thing, a username plus a set of `groups`. `Authorization` answers \"may you do this\", and that is RBAC job. So \"we wired up OIDC and everyone still cannot do anything\" is a normal intermediate state, not a broken integration.\n\nRBAC has four objects in two pairs. `Role` and `ClusterRole` describe what verbs apply to what resources; `RoleBinding` and `ClusterRoleBinding` describe who gets them. The combination people misremember is a `RoleBinding` referencing a `ClusterRole`: **scope comes from the binding**, so the subject gains those permissions in that one namespace. This is the standard way to reuse one read-only role across namespaces instead of copying a Role into each.\n\nSeveral details in a rule are not what they look like. On verbs, `get` and `list` are separate, so a rule granting only `get` neither blocks nor permits `list`, and `watch` is a third. On resources, reading logs and execing are **subresources**, written `pods/log` (verb `get`) and `pods/exec` (verb `create`, not get). `resourceNames` narrows a rule to specific objects, but only for requests that name one: `list` and `watch` carry no name, so such rules never match them.\n\nThe most important property: RBAC **only allows, it never denies**. There is no way to say \"anything except Secrets\"; you enumerate everything else. Adding rules can therefore only widen access, and the only way to reduce it is to change or delete an existing binding, which is why writing a smaller role next to a cluster-admin binding accomplishes nothing. To check, use `kubectl auth can-i <verb> <resource> --as=<user> --as-group=<group>`, and add `--list` to print everything that identity can do. People predict their own RBAC badly; this command asks the server instead."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1267,6 +1267,21 @@ const primers = {
       )
     ),
 
+    'identity-and-rbac': t(
+      p(
+        '一个请求打到 apiserver，要过两道关，它们回答的是完全不同的问题。`认证`回答「你是谁」：客户端证书、ServiceAccount 的 token、或者 OIDC 发下来的 id_token，形式不同，产物都是同一个东西：一个用户名加一组 `group`。`鉴权`回答「你能不能做这件事」，这才是 RBAC 的活。所以「接了 OIDC 之后大家还是什么都干不了」是正常的中间状态，不是接错了。',
+        'RBAC 有四个对象，两两成对：`Role` 与 `ClusterRole` 描述「能对什么资源做什么动作」，`RoleBinding` 与 `ClusterRoleBinding` 描述「谁拿到这套权限」。最容易记混的组合是 `RoleBinding` 引用 `ClusterRole`：这时权限的**范围由 Binding 决定**，拿到的只是那一个命名空间里的权限。这是「一套只读角色复用到每个命名空间」的标准写法，不必给每个命名空间各抄一份 Role。',
+        '规则里有几处不是望文生义的。动词上，`get` 和 `list` 是两件事，只写 `get` 的规则挡不住也放不开 `list`；`watch` 又是第三件。资源上，看日志和进容器是**子资源**，要写成 `pods/log`（动词 `get`）和 `pods/exec`（动词 `create`，不是 get）。`resourceNames` 能把权限限定到具体对象，但它只对指名道姓的请求生效；`list` 与 `watch` 没有名字，带 `resourceNames` 的规则对它们一律不匹配。',
+        '最关键的一条：RBAC **只有允许，没有拒绝**。写不出「除了 Secret 之外都可以」，只能把 Secret 之外的都列出来。这意味着加规则永远只会让权限变大，收权限的唯一办法是改掉或删掉已有的绑定；在一条 cluster-admin 绑定旁边再写一个小角色，一点用都没有。检查的办法是 `kubectl auth can-i <动词> <资源> --as=<用户> --as-group=<组>`，加 `--list` 会把这个身份能做的事全列出来。人对自己写的 RBAC 判断准确率相当低，这条命令是直接问服务端要答案。'
+      ),
+      p(
+        'A request reaching the apiserver passes two gates that answer completely different questions. `Authentication` answers "who are you": a client certificate, a ServiceAccount token, or an OIDC id_token, all producing the same thing, a username plus a set of `groups`. `Authorization` answers "may you do this", and that is RBAC job. So "we wired up OIDC and everyone still cannot do anything" is a normal intermediate state, not a broken integration.',
+        'RBAC has four objects in two pairs. `Role` and `ClusterRole` describe what verbs apply to what resources; `RoleBinding` and `ClusterRoleBinding` describe who gets them. The combination people misremember is a `RoleBinding` referencing a `ClusterRole`: **scope comes from the binding**, so the subject gains those permissions in that one namespace. This is the standard way to reuse one read-only role across namespaces instead of copying a Role into each.',
+        'Several details in a rule are not what they look like. On verbs, `get` and `list` are separate, so a rule granting only `get` neither blocks nor permits `list`, and `watch` is a third. On resources, reading logs and execing are **subresources**, written `pods/log` (verb `get`) and `pods/exec` (verb `create`, not get). `resourceNames` narrows a rule to specific objects, but only for requests that name one: `list` and `watch` carry no name, so such rules never match them.',
+        'The most important property: RBAC **only allows, it never denies**. There is no way to say "anything except Secrets"; you enumerate everything else. Adding rules can therefore only widen access, and the only way to reduce it is to change or delete an existing binding, which is why writing a smaller role next to a cluster-admin binding accomplishes nothing. To check, use `kubectl auth can-i <verb> <resource> --as=<user> --as-group=<group>`, and add `--list` to print everything that identity can do. People predict their own RBAC badly; this command asks the server instead.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5821,6 +5821,38 @@
             "anonymousPull": false
           }
         ],
+        "users": {
+          "admin-token": {
+            "username": "kubernetes-admin",
+            "groups": [
+              "system:masters"
+            ]
+          },
+          "opslab-token": {
+            "username": "kubernetes-admin",
+            "groups": [
+              "system:masters"
+            ]
+          },
+          "oidc-liu": {
+            "username": "oidc:liu@corp.internal",
+            "groups": [
+              "oidc:developers"
+            ]
+          },
+          "oidc-chen": {
+            "username": "oidc:chen@corp.internal",
+            "groups": [
+              "oidc:sre"
+            ]
+          },
+          "ci-token": {
+            "username": "system:serviceaccount:argocd:deployer",
+            "groups": [
+              "system:serviceaccounts"
+            ]
+          }
+        },
         "gitRepositories": [
           {
             "url": "https://git.corp.internal/platform/apps",
@@ -10075,6 +10107,505 @@
         "primer": {
           "zh": "`NetworkPolicy` 判的是「这个 IP 属于一个带某某标签的 Pod」，而标签只是 apiserver 里的一个字段，有权限的人随时能改。服务网格判的是另一件事：**对面出示的证书属于谁**。每个工作负载拿到一张由集群 CA 签发的证书，身份写在 SAN 里，格式是 `SPIFFE`：`spiffe://cluster.local/ns/<命名空间>/sa/<ServiceAccount>`。注意身份来自 ServiceAccount，不是 Pod 名也不是标签；所有服务都用 `default` 这个 SA 的集群，上了网格也分不出谁是谁。\n\n`Istio ambient` 是 2026 年的主流形态，和早年的 sidecar 模式差别很大：不再给每个 Pod 塞一个 Envoy，而是每个节点跑一个 `ztunnel`（DaemonSet）负责 L4：建立 mTLS、校验对端身份、按身份与端口授权。接入方式是给命名空间打一个标签 `istio.io/dataplane-mode=ambient`，Pod 不用改、不用重启。`istioctl ztunnel-config workload` 里 PROTOCOL 那一列是 HBONE 就说明接进来了。\n\n要按 HTTP 方法或路径授权、要重试与熔断，就得再加一层 `waypoint`，也就是一个 `gatewayClassName: istio-waypoint` 的 Gateway，按命名空间或按服务挂。这条分层是 ambient 最常见的困惑来源：带 `methods` 或 `paths` 的 `AuthorizationPolicy` 在没有 waypoint 的时候**根本不会被求值**，而 apiserver 照样收下它。`istioctl analyze` 会把这类问题直接报出来。\n\n`AuthorizationPolicy` 的判定顺序值得单独记：任何一条 DENY 命中就拒绝；没有任何 ALLOW 策略选中这个工作负载则放行；一旦有 ALLOW 策略选中它，只有命中某条 rule 才放行，**其余一律拒绝**。所以给一个服务加第一条 ALLOW 策略，等于同时把「默认拒绝」也打开了，很多人以为自己只是多放行了一个来源。还有一点：被网格拒绝表现为连接被重置（ztunnel 回 RST），而不是超时；超时是丢包，指向 NetworkPolicy 那一层。",
           "en": "`NetworkPolicy` decides based on \"this IP belongs to a pod carrying that label\", and a label is just a field in the apiserver that anyone with access can change. A service mesh answers a different question: **whose certificate did the peer present**. Each workload gets a certificate from the cluster CA with its identity in the SAN, in `SPIFFE` form: `spiffe://cluster.local/ns/<namespace>/sa/<serviceaccount>`. Identity comes from the ServiceAccount, not the pod name or its labels, so a cluster where everything runs as `default` gains nothing by enrolling.\n\n`Istio ambient` is the mainstream shape in 2026 and differs sharply from the older sidecar model: instead of an Envoy beside every pod, one `ztunnel` per node (a DaemonSet) handles L4, establishing mTLS, verifying peer identity, and authorizing by identity and port. Enrolling is a namespace label, `istio.io/dataplane-mode=ambient`, with no pod changes and no restarts. In `istioctl ztunnel-config workload`, a PROTOCOL of HBONE means enrolled.\n\nAuthorizing by HTTP method or path, or doing retries and circuit breaking, needs one more layer: a `waypoint`, a Gateway with `gatewayClassName: istio-waypoint`, attached per namespace or per service. This layering is the most common confusion in ambient, because an `AuthorizationPolicy` with `methods` or `paths` is **never evaluated** without a waypoint, while the apiserver accepts it happily. `istioctl analyze` reports exactly this class of problem.\n\nThe evaluation order of `AuthorizationPolicy` is worth memorising: any matching DENY refuses; with no ALLOW policy selecting the workload, traffic is permitted; once some ALLOW policy selects it, only traffic matching a rule is permitted and **everything else is refused**. So adding the first ALLOW policy to a service also turns on default-deny, which surprises people who thought they were merely permitting one more caller. One more distinction: a mesh denial arrives as a connection reset, because ztunnel answers with an RST, whereas a timeout means dropped packets and points at the NetworkPolicy layer."
+        }
+      },
+      {
+        "id": "identity-and-rbac",
+        "title": {
+          "zh": "把 cluster-admin 收回来",
+          "en": "Take cluster-admin Back"
+        },
+        "goal": {
+          "zh": "公司接了 OIDC，两个人已经能登录集群了：`liu`（开发，组\n`oidc:developers`）和 `chen`（SRE，组 `oidc:sre`）。但集群这边一个\n角色都没配 —— 他们登录之后什么都干不了。\n\n与此同时，前任把 CI 用的 ServiceAccount `argocd/deployer` 直接绑了\n`cluster-admin`。也就是说，一条流水线拿到的权限比任何一个人都大。\n\n按最小权限把这三个主体配好。\n\n## 通关标准\n\n1. `liu`：在 `payments` 里读得到工作负载、看得了日志、进得去容器排查；\n   **改不动任何东西**，也读不到 Secret；\n2. `chen`：全集群只读，另外在 `payments` 里能改 Deployment 与删 Pod；\n   但删不掉命名空间；\n3. `argocd/deployer`：只在 `payments` 里发布工作负载；碰不到 RBAC，\n   也读不到 Secret；\n4. `cluster-admin` 不再绑给这三个主体里的任何一个。\n\n## 会用到的命令\n\n```bash\nkubectl auth can-i --list --as=oidc:liu@corp.internal --as-group=oidc:developers -n payments\nkubectl auth can-i create pods --subresource=exec -n payments --as=oidc:liu@corp.internal --as-group=oidc:developers\nkubectl get clusterrolebindings\nkubectl apply -f /root/infra/rbac.yaml\n```\n",
+          "en": "The company wired up OIDC and two people can now log in: `liu` (a developer in\ngroup `oidc:developers`) and `chen` (an SRE in `oidc:sre`). No roles exist on\nthe cluster side, so once logged in they can do nothing at all.\n\nMeanwhile your predecessor bound the CI ServiceAccount `argocd/deployer`\nstraight to `cluster-admin`. A pipeline therefore holds more power than any\nhuman does.\n\nGive all three least privilege.\n\n## Done when\n\n1. `liu` can read workloads in `payments`, read logs, and exec into containers\n   to debug, but **cannot change anything** and cannot read Secrets;\n2. `chen` has cluster-wide read plus the ability to modify Deployments and\n   delete Pods in `payments`, but cannot delete namespaces;\n3. `argocd/deployer` can ship workloads in `payments` only, cannot touch RBAC,\n   and cannot read Secrets;\n4. `cluster-admin` is no longer bound to any of the three.\n\n## Commands you will need\n\n```bash\nkubectl auth can-i --list --as=oidc:liu@corp.internal --as-group=oidc:developers -n payments\nkubectl auth can-i create pods --subresource=exec -n payments --as=oidc:liu@corp.internal --as-group=oidc:developers\nkubectl get clusterrolebindings\nkubectl apply -f /root/infra/rbac.yaml\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "三个主体各自拿到该有的权限",
+            "en": "Each of the three gets what it needs"
+          },
+          {
+            "zh": "都拿不到不该有的",
+            "en": "And none of them gets what it should not"
+          },
+          {
+            "zh": "cluster-admin 收回来了",
+            "en": "cluster-admin taken back"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`kubectl auth can-i ... --as=<user> --as-group=<group>` 是检查别人权限的标准做法 —— 不需要拿到对方的凭据。`--list` 会把这个身份在这个命名空间里能做的事全列出来。",
+            "en": "`kubectl auth can-i ... --as=<user> --as-group=<group>` is how you check someone else’s permissions without holding their credentials. `--list` prints everything that identity can do in that namespace."
+          },
+          {
+            "zh": "`RoleBinding` 可以引用 `ClusterRole`。权限的范围由 **Binding** 决定 —— 这就是「一套只读角色，绑到每个需要的命名空间」的标准写法，不用给每个命名空间各写一份 Role。",
+            "en": "A `RoleBinding` may reference a `ClusterRole`. Scope comes from the **binding**, which is the standard way to reuse one read-only role across namespaces without writing a Role in each."
+          },
+          {
+            "zh": "看日志和进容器是两个**子资源**：`pods/log` 的 `get`、`pods/exec` 的 `create`。只写 `pods` 是不够的，而且 exec 的动词是 create 不是 get。问的时候要用 `--subresource=log`：写成 `can-i get pods/log` 的话，kubectl 会把 log 当成 Pod 的**名字**。",
+            "en": "Logs and exec are **subresources**: `get` on `pods/log`, `create` on `pods/exec`. Listing `pods` alone is not enough, and the verb for exec is create, not get. Ask with `--subresource=log`: written as `can-i get pods/log`, kubectl reads log as the pod **name** instead."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "给开发绑 `edit` 或 `admin` 这种内置角色图省事。它们包含对 Secret 的读权限 —— 而「只读」的要求里，最要紧的恰恰是读不到 Secret。判定专门查了这一条。",
+            "en": "Reaching for built-in roles like `edit` or `admin`. They include read access to Secrets, and not reading Secrets is the most important half of \"read only\". The grader checks exactly that."
+          },
+          {
+            "zh": "把 `ci-admin` 那条 ClusterRoleBinding 留着，另外再加一条小权限。多加的那条不会削减已有的 —— RBAC 是取并集的，只要还有一条给了 cluster-admin，前面写的全部白搭。",
+            "en": "Leaving the `ci-admin` ClusterRoleBinding in place and adding a smaller role next to it. Adding never subtracts: RBAC unions its rules, so one remaining cluster-admin binding voids everything else you wrote."
+          },
+          {
+            "zh": "用 `resourceNames` 去限制 list。它只对指名道姓的请求生效，list 与 watch 没有名字，带 `resourceNames` 的规则对它们一律不匹配 —— 于是「我明明允许了这个 Secret」但列不出来。",
+            "en": "Using `resourceNames` to scope a list. It only applies to requests that name an object; list and watch carry no name, so such rules never match them, which is why \"I clearly allowed that Secret\" still cannot be listed."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRole",
+              "metadata": {
+                "name": "cluster-admin"
+              },
+              "rules": [
+                {
+                  "apiGroups": [
+                    "*"
+                  ],
+                  "resources": [
+                    "*"
+                  ],
+                  "verbs": [
+                    "*"
+                  ]
+                }
+              ]
+            },
+            {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRole",
+              "metadata": {
+                "name": "view"
+              },
+              "rules": [
+                {
+                  "apiGroups": [
+                    "",
+                    "apps",
+                    "networking.k8s.io",
+                    "gateway.networking.k8s.io"
+                  ],
+                  "resources": [
+                    "pods",
+                    "services",
+                    "endpoints",
+                    "configmaps",
+                    "deployments",
+                    "replicasets",
+                    "daemonsets",
+                    "networkpolicies",
+                    "gateways",
+                    "httproutes"
+                  ],
+                  "verbs": [
+                    "get",
+                    "list",
+                    "watch"
+                  ]
+                }
+              ]
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "deployer",
+                "namespace": "argocd"
+              }
+            },
+            {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRoleBinding",
+              "metadata": {
+                "name": "ci-admin"
+              },
+              "subjects": [
+                {
+                  "kind": "ServiceAccount",
+                  "name": "deployer",
+                  "namespace": "argocd"
+                }
+              ],
+              "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/rbac.yaml": "# 这里什么都还没有。想清楚每个人到底需要什么，再写。\n#\n#   liu  —— 开发，组 oidc:developers\n#   chen —— SRE，组 oidc:sre\n#   argocd/deployer —— CI 用的 ServiceAccount\n"
+          },
+          "referenceFiles": {
+            "/root/infra/rbac.yaml": "# 开发：payments 里只读 + 看日志 + 进容器排查\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: developer\n  namespace: payments\nrules:\n- apiGroups: [\"\"]\n  resources: [\"pods\", \"services\", \"configmaps\", \"endpoints\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n- apiGroups: [\"apps\"]\n  resources: [\"deployments\", \"replicasets\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n- apiGroups: [\"\"]\n  resources: [\"pods/log\"]\n  verbs: [\"get\"]\n- apiGroups: [\"\"]\n  resources: [\"pods/exec\"]\n  verbs: [\"create\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: developers\n  namespace: payments\nsubjects:\n- kind: Group\n  name: oidc:developers\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: developer\n---\n# SRE：全集群只读\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: sre-view\nsubjects:\n- kind: Group\n  name: oidc:sre\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: view\n---\n# SRE：payments 里还能动工作负载\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: workload-operator\n  namespace: payments\nrules:\n- apiGroups: [\"apps\"]\n  resources: [\"deployments\", \"deployments/scale\", \"statefulsets\"]\n  verbs: [\"get\", \"list\", \"watch\", \"update\", \"patch\"]\n- apiGroups: [\"\"]\n  resources: [\"pods\"]\n  verbs: [\"get\", \"list\", \"watch\", \"delete\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: sre-operator\n  namespace: payments\nsubjects:\n- kind: Group\n  name: oidc:sre\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: workload-operator\n---\n# CI：只在 payments 里发布工作负载，碰不到 RBAC 与 Secret\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: deployer\n  namespace: payments\nrules:\n- apiGroups: [\"apps\"]\n  resources: [\"deployments\", \"replicasets\", \"daemonsets\", \"statefulsets\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\"]\n- apiGroups: [\"\"]\n  resources: [\"services\", \"configmaps\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: ci-deployer\n  namespace: payments\nsubjects:\n- kind: ServiceAccount\n  name: deployer\n  namespace: argocd\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: deployer\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/rbac.yaml",
+            "kubectl delete clusterrolebinding ci-admin"
+          ]
+        },
+        "specs": [
+          {
+            "path": "identity-and-rbac.spec.ts",
+            "content": "import { list, sh } from '@ops/lab';\n\nconst LIU = '--as=oidc:liu@corp.internal --as-group=oidc:developers';\nconst CHEN = '--as=oidc:chen@corp.internal --as-group=oidc:sre';\nconst CI = '--as=system:serviceaccount:argocd:deployer';\n\nconst canI = async (what, who) => {\n  const result = await sh('kubectl auth can-i ' + what + ' ' + who);\n  return result.stdout.trim();\n};\n\ndescribe('身份与 RBAC', () => {\n  it('开发在 payments 里读得到工作负载', async () => {\n    expect(await canI('list pods -n payments', LIU)).toBe('yes');\n    expect(await canI('list deployments -n payments', LIU)).toBe('yes');\n  });\n\n  it('开发看得了日志、进得去容器', async () => {\n    // 子资源要用 --subresource 问；写成 pods/log 的话 kubectl 会把 log\n    // 当成 Pod 的**名字**，问的就完全是另一件事了\n    expect(await canI('get pods --subresource=log -n payments', LIU)).toBe('yes');\n    expect(await canI('create pods --subresource=exec -n payments', LIU)).toBe('yes');\n  });\n\n  it('开发改不动东西，也读不到 Secret', async () => {\n    expect(await canI('delete pods -n payments', LIU)).toBe('no');\n    expect(await canI('patch deployments -n payments', LIU)).toBe('no');\n    expect(await canI('create deployments -n payments', LIU)).toBe('no');\n    expect(await canI('get secrets -n payments', LIU)).toBe('no');\n  });\n\n  it('开发的权限没有溢出到别的命名空间', async () => {\n    expect(await canI('list pods -n argocd', LIU)).toBe('no');\n  });\n\n  it('SRE 全集群只读', async () => {\n    expect(await canI('list pods --all-namespaces', CHEN)).toBe('yes');\n    expect(await canI('list deployments -n argocd', CHEN)).toBe('yes');\n  });\n\n  it('SRE 在 payments 里动得了工作负载，但删不掉命名空间', async () => {\n    expect(await canI('patch deployments -n payments', CHEN)).toBe('yes');\n    expect(await canI('delete pods -n payments', CHEN)).toBe('yes');\n    expect(await canI('delete namespaces', CHEN)).toBe('no');\n  });\n\n  it('CI 只能在 payments 里发布，碰不到 RBAC 与 Secret', async () => {\n    expect(await canI('create deployments -n payments', CI)).toBe('yes');\n    expect(await canI('create deployments -n argocd', CI)).toBe('no');\n    expect(await canI('create rolebindings -n payments', CI)).toBe('no');\n    expect(await canI('get secrets -n payments', CI)).toBe('no');\n  });\n\n  it('cluster-admin 不再绑给这三个主体', () => {\n    const bindings = list('ClusterRoleBinding')\n      .filter((binding) => binding.roleRef.name === 'cluster-admin');\n    const risky = bindings.flatMap((binding) => binding.subjects || [])\n      .filter((subject) => subject.kind !== 'Group' || !subject.name.startsWith('system:'));\n    expect(risky).toEqual([]);\n  });\n\n  it('管理员自己还进得去 —— 别把自己锁在外面', async () => {\n    const result = await sh('kubectl get pods -n payments');\n    expect(result.code).toBe(0);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "RBAC 和前面几关的策略有一个根本区别：**它只有允许，没有拒绝**。\n写不出「除了 Secret 之外都可以」这种规则 —— 想表达它，只能把 Secret 之外\n的都列出来。所以「加一条规则」永远只会让权限变大，收权限的唯一办法是\n**改或删已有的绑定**。前任那条 `ci-admin` 就是这个道理：在旁边再写一个\n小角色，一点用都没有。\n\n另一个值得记住的是**认证与鉴权是两件事**。OIDC 只负责回答「你是谁」——\n它给出一个用户名和一组 group，之后集群里发生什么，全看 RBAC。\n所以「接了 OIDC 之后大家还是什么都干不了」是完全正常的中间状态，\n不是接错了。反过来，OIDC 那边改了 group claim 的映射，集群这边的\n绑定会突然对不上 —— 这类故障查起来很费劲，因为两边都「没改过」。\n\n最后一条实践：`kubectl auth can-i --list --as=<user>` 应该成为交付前的\n固定动作。人对自己写的 RBAC 的判断准确率相当低，而这条命令是直接问\n服务端要答案，不是猜。\n",
+          "en": "RBAC differs from the policies in earlier stages in one fundamental way: **it\nonly allows, it never denies**. There is no way to write \"anything except\nSecrets\"; you must enumerate everything else. So adding a rule can only widen\naccess, and the only way to reduce it is to **change or delete an existing\nbinding**. That is why the leftover `ci-admin` matters: writing a smaller role\nbeside it accomplishes nothing.\n\nThe other thing worth internalising is that **authentication and authorization\nare separate**. OIDC only answers \"who are you\", producing a username and a set\nof groups; what happens next is entirely RBAC. \"Everyone can log in and still do\nnothing\" is therefore a perfectly normal intermediate state, not a broken\nintegration. Conversely, when the identity provider changes how it maps group\nclaims, cluster bindings silently stop matching, and that is painful to diagnose\nbecause neither side \"changed anything\".\n\nOne practice worth adopting: run `kubectl auth can-i --list --as=<user>` before\ncalling an RBAC change done. People are remarkably bad at predicting what their\nown rules permit, and this asks the server instead of guessing.\n"
+        },
+        "primer": {
+          "zh": "一个请求打到 apiserver，要过两道关，它们回答的是完全不同的问题。`认证`回答「你是谁」：客户端证书、ServiceAccount 的 token、或者 OIDC 发下来的 id_token，形式不同，产物都是同一个东西：一个用户名加一组 `group`。`鉴权`回答「你能不能做这件事」，这才是 RBAC 的活。所以「接了 OIDC 之后大家还是什么都干不了」是正常的中间状态，不是接错了。\n\nRBAC 有四个对象，两两成对：`Role` 与 `ClusterRole` 描述「能对什么资源做什么动作」，`RoleBinding` 与 `ClusterRoleBinding` 描述「谁拿到这套权限」。最容易记混的组合是 `RoleBinding` 引用 `ClusterRole`：这时权限的**范围由 Binding 决定**，拿到的只是那一个命名空间里的权限。这是「一套只读角色复用到每个命名空间」的标准写法，不必给每个命名空间各抄一份 Role。\n\n规则里有几处不是望文生义的。动词上，`get` 和 `list` 是两件事，只写 `get` 的规则挡不住也放不开 `list`；`watch` 又是第三件。资源上，看日志和进容器是**子资源**，要写成 `pods/log`（动词 `get`）和 `pods/exec`（动词 `create`，不是 get）。`resourceNames` 能把权限限定到具体对象，但它只对指名道姓的请求生效；`list` 与 `watch` 没有名字，带 `resourceNames` 的规则对它们一律不匹配。\n\n最关键的一条：RBAC **只有允许，没有拒绝**。写不出「除了 Secret 之外都可以」，只能把 Secret 之外的都列出来。这意味着加规则永远只会让权限变大，收权限的唯一办法是改掉或删掉已有的绑定；在一条 cluster-admin 绑定旁边再写一个小角色，一点用都没有。检查的办法是 `kubectl auth can-i <动词> <资源> --as=<用户> --as-group=<组>`，加 `--list` 会把这个身份能做的事全列出来。人对自己写的 RBAC 判断准确率相当低，这条命令是直接问服务端要答案。",
+          "en": "A request reaching the apiserver passes two gates that answer completely different questions. `Authentication` answers \"who are you\": a client certificate, a ServiceAccount token, or an OIDC id_token, all producing the same thing, a username plus a set of `groups`. `Authorization` answers \"may you do this\", and that is RBAC job. So \"we wired up OIDC and everyone still cannot do anything\" is a normal intermediate state, not a broken integration.\n\nRBAC has four objects in two pairs. `Role` and `ClusterRole` describe what verbs apply to what resources; `RoleBinding` and `ClusterRoleBinding` describe who gets them. The combination people misremember is a `RoleBinding` referencing a `ClusterRole`: **scope comes from the binding**, so the subject gains those permissions in that one namespace. This is the standard way to reuse one read-only role across namespaces instead of copying a Role into each.\n\nSeveral details in a rule are not what they look like. On verbs, `get` and `list` are separate, so a rule granting only `get` neither blocks nor permits `list`, and `watch` is a third. On resources, reading logs and execing are **subresources**, written `pods/log` (verb `get`) and `pods/exec` (verb `create`, not get). `resourceNames` narrows a rule to specific objects, but only for requests that name one: `list` and `watch` carry no name, so such rules never match them.\n\nThe most important property: RBAC **only allows, it never denies**. There is no way to say \"anything except Secrets\"; you enumerate everything else. Adding rules can therefore only widen access, and the only way to reduce it is to change or delete an existing binding, which is why writing a smaller role next to a cluster-admin binding accomplishes nothing. To check, use `kubectl auth can-i <verb> <resource> --as=<user> --as-group=<group>`, and add `--list` to print everything that identity can do. People predict their own RBAC badly; this command asks the server instead."
         }
       }
     ]

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -277,6 +277,13 @@ export interface OpsWorldSpec {
    */
   baseImages?: Record<string, 'node' | 'python' | 'static'>;
   registries?: OpsRegistrySpec[];
+  /**
+   * 集群认哪些身份。
+   *
+   * key 是 kubeconfig 里的 token。一旦声明了这张表，集群就开始按 RBAC 鉴权 ——
+   * 不声明就是「这个世界不讲 RBAC」，所有请求都是 cluster-admin。
+   */
+  users?: Record<string, { username: string; groups?: string[] }>;
   /** 内网的 Git 仓库。GitOps 里那份 YAML 就住在这儿。 */
   gitRepositories?: OpsGitRepositorySpec[];
   machine?: OpsMachineSpec;

--- a/src/lib/opslab/apiserver/http.ts
+++ b/src/lib/opslab/apiserver/http.ts
@@ -11,7 +11,7 @@
  */
 import { Registry } from './registry';
 import { Scheme, ResourceDefinition } from './scheme';
-import { ApiError, badRequest, invalid, notFound, toStatus } from './errors';
+import { ApiError, badRequest, forbidden, invalid, notFound, toStatus } from './errors';
 import { renderTable, wantsTable } from './tables';
 import type { KubeObject, PropagationPolicy, WatchEventOut } from './types';
 
@@ -29,12 +29,44 @@ export interface ApiServerDeps {
    * 和真集群把它转给 kubelet 是同一个分工。
    */
   exec?: ExecHandler;
+  /**
+   * token -> 身份。不给就是「这个世界没配认证」，所有请求都是 cluster-admin。
+   *
+   * 真集群里这一步由 OIDC / 客户端证书 / ServiceAccount token 完成，形式不同，
+   * 产物都是同一个东西：一个用户名加一组 group。
+   */
+  authenticate?(token: string | undefined): UserInfo | undefined;
+  /** 鉴权。不给就是不鉴权。 */
+  authorize?(user: UserInfo, attributes: ResourceAttributes): { allowed: boolean; reason: string };
 }
 import { openApiDocument, openApiRoot } from './openapi';
 import type { PatchType } from './patch';
 import { createExecSession, parseExecRequest, type ExecHandler } from './exec';
 import type { StreamSession, UpgradeRequest } from '../net';
 import { parseYaml } from '../yaml';
+import {
+  ANONYMOUS, CLUSTER_ADMIN, forbiddenMessage,
+  type ResourceAttributes, type UserInfo,
+} from '../rbac';
+
+/**
+ * HTTP 方法 -> RBAC 的 verb。
+ *
+ * 有两处不是一一对应：GET 不带名字是 list（带名字才是 get），
+ * DELETE 不带名字是 deletecollection。规则里只写了 `get` 的人
+ * 常常发现自己 list 不了。
+ */
+export function verbFor(method: string, parsed: ParsedPath, params: URLSearchParams): string {
+  if (params.get('watch') === 'true' || params.get('watch') === '1') return 'watch';
+  switch (method) {
+    case 'GET': return parsed.name ? 'get' : 'list';
+    case 'POST': return 'create';
+    case 'PUT': return 'update';
+    case 'PATCH': return 'patch';
+    case 'DELETE': return parsed.name ? 'delete' : 'deletecollection';
+    default: return method.toLowerCase();
+  }
+}
 
 /** apply 的载荷：先按 JSON 试，不行再按 YAML */
 function parseYamlBody(raw: string): unknown {
@@ -148,6 +180,8 @@ export class ApiServer {
   private readonly now: () => number;
   private readonly version: { major: string; minor: string; gitVersion: string };
   private readonly exec?: ExecHandler;
+  private readonly authenticate?: ApiServerDeps['authenticate'];
+  private readonly authorizeFn?: ApiServerDeps['authorize'];
   /** 收到的请求，调试与测试用 */
   readonly requestLog: string[] = [];
 
@@ -157,6 +191,102 @@ export class ApiServer {
     this.now = deps.now;
     this.version = deps.version ?? { major: '1', minor: '36', gitVersion: 'v1.36.0' };
     this.exec = deps.exec;
+    this.authenticate = deps.authenticate;
+    this.authorizeFn = deps.authorize;
+  }
+
+  /**
+   * `kubectl auth can-i`。
+   *
+   * SelfSubjectAccessReview 问的是「**我**能不能」，SubjectAccessReview 问的是
+   * 「某某能不能」（后者本身需要权限，一般只有管理员用得了）。
+   * 两者的回答都写在 `status.allowed` 里，HTTP 状态码永远是 201 ——
+   * 「不允许」不是一个错误，是一个答案。
+   */
+  private async handleAccessReview(init: RequestInit, forOther: boolean): Promise<Response> {
+    const raw = await this.readBodyRaw(init);
+    let body: any;
+    try {
+      body = raw ? JSON.parse(raw) : {};
+    } catch {
+      return statusResponse(badRequest('the object provided is unrecognized'));
+    }
+    const requester = this.identify(init);
+    const spec = body.spec ?? {};
+    const subject: UserInfo = forOther
+      ? { username: spec.user ?? 'system:anonymous', groups: spec.groups ?? [] }
+      : requester;
+
+    const attributes: ResourceAttributes = spec.resourceAttributes
+      ? {
+          verb: spec.resourceAttributes.verb ?? 'get',
+          group: spec.resourceAttributes.group ?? '',
+          resource: spec.resourceAttributes.resource,
+          subresource: spec.resourceAttributes.subresource,
+          namespace: spec.resourceAttributes.namespace,
+          name: spec.resourceAttributes.name,
+        }
+      : {
+          verb: spec.nonResourceAttributes?.verb ?? 'get',
+          path: spec.nonResourceAttributes?.path ?? '/',
+        };
+
+    const result = this.authorizeFn
+      ? this.authorizeFn(subject, attributes)
+      : { allowed: true, reason: 'no authorizer configured' };
+
+    return json({
+      kind: forOther ? 'SubjectAccessReview' : 'SelfSubjectAccessReview',
+      apiVersion: 'authorization.k8s.io/v1',
+      metadata: { creationTimestamp: null },
+      spec,
+      status: { allowed: result.allowed, reason: result.reason },
+    }, 201);
+  }
+
+  /**
+   * 认证。
+   *
+   * 从 `Authorization: Bearer <token>` 取身份。没有配认证器的世界里，
+   * 每个请求都是 cluster-admin —— 前面十几关不需要为此各配一套 RBAC。
+   */
+  private identify(init: RequestInit): UserInfo {
+    if (!this.authenticate) return CLUSTER_ADMIN;
+    const header = headerOf(init, 'authorization') ?? '';
+    const token = header.startsWith('Bearer ') ? header.slice('Bearer '.length) : undefined;
+    const user = this.authenticate(token) ?? ANONYMOUS;
+
+    /**
+     * `--as` / `--as-group`：冒充。
+     *
+     * 这是检查别人权限的标准做法 —— 管理员不用拿到对方的凭据，就能问
+     * 「他到底能不能做这件事」。真集群里冒充本身也是一种权限
+     * （对 users / groups 的 impersonate），不是谁都能用。
+     */
+    const impersonateUser = headerOf(init, 'impersonate-user');
+    if (!impersonateUser) return user;
+    const allowed = this.authorizeFn?.(user, {
+      verb: 'impersonate', group: '', resource: 'users', name: impersonateUser,
+    });
+    if (allowed && !allowed.allowed) return user;   // 没这个权限就按自己的身份来，随后会被拒
+    const groups = headerOf(init, 'impersonate-group');
+    return {
+      username: impersonateUser,
+      groups: [...(groups ? groups.split(',').map((entry) => entry.trim()) : []), 'system:authenticated'],
+    };
+  }
+
+  /**
+   * 鉴权。允许就返回 undefined，拒绝就返回一个 403 响应。
+   *
+   * 消息一字不差抄真 apiserver —— 学员会把它直接搜出去，
+   * 而这句话本身把「谁、想做什么、在哪个组、哪个命名空间」说全了。
+   */
+  private checkAccess(user: UserInfo, attributes: ResourceAttributes): Response | undefined {
+    if (!this.authorizeFn) return undefined;
+    const result = this.authorizeFn(user, attributes);
+    if (result.allowed) return undefined;
+    return statusResponse(forbidden(forbiddenMessage(user, attributes)));
   }
 
   /**
@@ -234,6 +364,14 @@ export class ApiServer {
       return json(this.apiResourceList(groupVersionMatch[1], groupVersionMatch[2]));
     }
 
+    // `kubectl auth can-i` 走这条路。它问的是「我能不能」，不是「给我」。
+    if (path === '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews' && method === 'POST') {
+      return this.handleAccessReview(init, false);
+    }
+    if (path === '/apis/authorization.k8s.io/v1/subjectaccessreviews' && method === 'POST') {
+      return this.handleAccessReview(init, true);
+    }
+
     const parsed = parsePath(path);
     if (!parsed) {
       return statusResponse(badRequest(`the server could not find the requested resource (${path})`));
@@ -251,6 +389,17 @@ export class ApiServer {
     }
 
     const params = url.searchParams;
+    const user = this.identify(init);
+    const denied = this.checkAccess(user, {
+      verb: verbFor(method, parsed, params),
+      group: parsed.group,
+      resource: parsed.resource,
+      subresource: parsed.subresource,
+      namespace: parsed.namespace,
+      name: parsed.name,
+    });
+    if (denied) return denied;
+
     if (params.get('watch') === 'true' || params.get('watch') === '1') {
       return this.handleWatch(definition, parsed, params);
     }

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -23,6 +23,9 @@ import {
   ISTIOD_LABEL, MESH_RESOURCES, WAYPOINT_CLASS, ZTUNNEL_LABEL, isAmbient, traverseMesh,
   type MeshPeer, type MeshView,
 } from '../mesh';
+import {
+  CLUSTERROLEBINDINGS, CLUSTERROLES, RBAC_RESOURCES, ROLEBINDINGS, ROLES, authorize,
+} from '../rbac';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -74,6 +77,14 @@ export interface ClusterOptions {
   gitSource?: import('../argocd').RepoResolver;
   /** 仓库有新提交时叫一声（webhook）。 */
   gitSubscribe?: (listener: () => void) => void;
+  /**
+   * token -> 身份。
+   *
+   * 一旦给了这张表，这个集群就开始鉴权：不在表里的 token 是匿名用户，
+   * 而匿名用户什么都干不了。不给就是「这个世界不讲 RBAC」，
+   * 所有请求都是 cluster-admin —— 前面十几关不必为此各配一套角色。
+   */
+  users?: Record<string, { username: string; groups?: string[] }>;
   /** Service 的 VIP 从哪个网段分。默认 10.96.0.0/12，和真集群一样。 */
   serviceCidr?: string;
   /** `kubectl exec` 落到哪。不给就是这个集群不支持 exec。 */
@@ -129,7 +140,7 @@ export class Cluster {
     this.store = createStore();
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
-      ...MESH_RESOURCES,
+      ...MESH_RESOURCES, ...RBAC_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -140,6 +151,25 @@ export class Cluster {
     });
     this.apiServer = createApiServer({
       registry: this.registry, scheme: this.scheme, now,
+      ...(options.users
+        ? {
+            authenticate: (token) => {
+              if (!token) return undefined;
+              const found = options.users![token];
+              if (!found) return undefined;
+              return {
+                username: found.username,
+                groups: [...(found.groups ?? []), 'system:authenticated'],
+              };
+            },
+            authorize: (user, attributes) => authorize({
+              roles: () => this.registry.list(ROLES).items,
+              roleBindings: () => this.registry.list(ROLEBINDINGS).items,
+              clusterRoles: () => this.registry.list(CLUSTERROLES).items,
+              clusterRoleBindings: () => this.registry.list(CLUSTERROLEBINDINGS).items,
+            }, user, attributes),
+          }
+        : {}),
       exec: (request, stdin) => {
         if (!this.execHandler) throw new Error('exec 没有接上');
         return this.execHandler(request, stdin);

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -102,6 +102,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     resolveImage: (image) => lookupPushedImage(image),
     externalHosts,
     addressPools: spec.addressPools,
+    users: spec.users,
     /**
      * Argo CD 从这里取仓库内容。
      *

--- a/src/lib/opslab/rbac/authorize.ts
+++ b/src/lib/opslab/rbac/authorize.ts
@@ -1,0 +1,179 @@
+/**
+ * RBAC 的判定
+ *
+ * 规则本身很简单：**只有允许，没有拒绝**。一条请求只要被任意一条规则命中
+ * 就放行，没被命中就拒绝。写不出「除了 X 都可以」这种规则 —— 想表达它，
+ * 只能把 X 之外的都列出来。这是 RBAC 与 NetworkPolicy、AuthorizationPolicy
+ * 最大的区别，也是很多人第一次写策略时的错觉来源。
+ */
+import type { KubeObject } from '../apiserver';
+import type { UserInfo } from './resources';
+
+export interface ResourceAttributes {
+  verb: string;
+  group?: string;
+  resource?: string;
+  subresource?: string;
+  namespace?: string;
+  name?: string;
+  /** 非资源请求，如 `/healthz` */
+  path?: string;
+}
+
+export interface AuthorizeResult {
+  allowed: boolean;
+  /** 命中的角色，写进 `auth can-i -v` 与审计里 */
+  reason: string;
+}
+
+export interface RbacView {
+  roles(): KubeObject[];
+  roleBindings(): KubeObject[];
+  clusterRoles(): KubeObject[];
+  clusterRoleBindings(): KubeObject[];
+}
+
+/** `system:masters` 组绕过 RBAC —— 真集群也是这么实现的 */
+export const SUPERUSER_GROUP = 'system:masters';
+
+export function authorize(
+  view: RbacView,
+  user: UserInfo,
+  attributes: ResourceAttributes
+): AuthorizeResult {
+  if (user.groups.includes(SUPERUSER_GROUP)) {
+    return { allowed: true, reason: 'RBAC: allowed by group "system:masters"' };
+  }
+
+  const clusterRoles = new Map(view.clusterRoles().map((role) => [role.metadata.name!, role]));
+  const roles = new Map(view.roles().map(
+    (role) => [`${role.metadata.namespace}/${role.metadata.name}`, role]
+  ));
+
+  // ClusterRoleBinding：给的是全集群的权限，命名空间不限
+  for (const binding of view.clusterRoleBindings()) {
+    if (!bindsUser(binding, user)) continue;
+    const role = clusterRoles.get(roleRefName(binding));
+    if (!role) continue;
+    if (rulesAllow(rulesOf(role), attributes)) {
+      return {
+        allowed: true,
+        reason: `RBAC: allowed by ClusterRoleBinding "${binding.metadata.name}" `
+          + `of ClusterRole "${role.metadata.name}"`,
+      };
+    }
+  }
+
+  // RoleBinding：范围是 binding 自己所在的命名空间，哪怕它引用的是 ClusterRole
+  for (const binding of view.roleBindings()) {
+    if (binding.metadata.namespace !== attributes.namespace) continue;
+    if (!bindsUser(binding, user)) continue;
+    const ref = ((binding.spec ?? binding) as any).roleRef ?? {};
+    const role = ref.kind === 'ClusterRole'
+      ? clusterRoles.get(ref.name)
+      : roles.get(`${binding.metadata.namespace}/${ref.name}`);
+    if (!role) continue;
+    if (rulesAllow(rulesOf(role), attributes)) {
+      return {
+        allowed: true,
+        reason: `RBAC: allowed by RoleBinding "${binding.metadata.namespace}/${binding.metadata.name}" `
+          + `of ${ref.kind} "${ref.name}"`,
+      };
+    }
+  }
+
+  /**
+   * 拒绝时不给理由。
+   *
+   * 真 RBAC 授权器对「没匹配上」返回的是 NoOpinion 且理由为空，于是
+   * `kubectl auth can-i` 打出来就是一个干净的 `no`。给了理由的话它会变成
+   * `no - ...`，和真集群对不上。要看细节应该去看 403 的那句话，那里说全了。
+   */
+  return { allowed: false, reason: '' };
+}
+
+function roleRefName(binding: KubeObject): string {
+  return ((binding as any).roleRef ?? {}).name ?? '';
+}
+
+function rulesOf(role: KubeObject): any[] {
+  return (role as any).rules ?? [];
+}
+
+/** subjects 里有没有这个用户（或它所在的组、或它的 ServiceAccount） */
+export function bindsUser(binding: KubeObject, user: UserInfo): boolean {
+  const subjects: any[] = (binding as any).subjects ?? [];
+  return subjects.some((subject) => {
+    if (subject.kind === 'User') return subject.name === user.username;
+    if (subject.kind === 'Group') return user.groups.includes(subject.name);
+    if (subject.kind === 'ServiceAccount') {
+      return user.username === `system:serviceaccount:${subject.namespace}:${subject.name}`;
+    }
+    return false;
+  });
+}
+
+export function rulesAllow(rules: any[], attributes: ResourceAttributes): boolean {
+  return rules.some((rule) => ruleAllows(rule, attributes));
+}
+
+function ruleAllows(rule: any, attributes: ResourceAttributes): boolean {
+  if (!matches(rule.verbs ?? [], attributes.verb)) return false;
+
+  if (attributes.path) {
+    return matches(rule.nonResourceURLs ?? [], attributes.path, true);
+  }
+
+  if (!matches(rule.apiGroups ?? [], attributes.group ?? '')) return false;
+
+  // 子资源写成 `pods/log`。规则里没写子资源时，不覆盖子资源请求。
+  const wanted = attributes.subresource
+    ? `${attributes.resource}/${attributes.subresource}`
+    : attributes.resource ?? '';
+  if (!matches(rule.resources ?? [], wanted)) return false;
+
+  /**
+   * resourceNames 限定到具体对象。
+   *
+   * 只对「指名道姓」的请求生效：list / watch / create 没有名字，
+   * 带 resourceNames 的规则对它们一律不生效 —— 这条经常让人以为
+   * 「我明明允许了这个 Secret，为什么 list 不出来」。
+   */
+  const names: string[] = rule.resourceNames ?? [];
+  if (names.length > 0) {
+    if (!attributes.name) return false;
+    if (!names.includes(attributes.name)) return false;
+  }
+  return true;
+}
+
+/** `*` 通配；非资源 URL 额外支持结尾的 `/*` */
+function matches(patterns: string[], value: string, pathStyle = false): boolean {
+  return patterns.some((pattern) => {
+    if (pattern === '*') return true;
+    if (pathStyle && pattern.endsWith('/*')) return value.startsWith(pattern.slice(0, -1));
+    return pattern === value;
+  });
+}
+
+/**
+ * 403 的消息。
+ *
+ * 一字不差地抄真 apiserver —— 学员会把这句话直接搜出去，
+ * 而这句话本身也把「谁、想做什么、在哪个组、哪个命名空间」说全了。
+ */
+export function forbiddenMessage(user: UserInfo, attributes: ResourceAttributes): string {
+  if (attributes.path) {
+    return `forbidden: User ${JSON.stringify(user.username)} cannot ${attributes.verb} path `
+      + `${JSON.stringify(attributes.path)}`;
+  }
+  const resource = attributes.subresource
+    ? `${attributes.resource}/${attributes.subresource}`
+    : attributes.resource;
+  const scope = attributes.namespace
+    ? ` in the namespace ${JSON.stringify(attributes.namespace)}`
+    : ' at the cluster scope';
+  return `${resource} is forbidden: User ${JSON.stringify(user.username)} cannot ${attributes.verb} `
+    + `resource ${JSON.stringify(attributes.resource)} in API group ${JSON.stringify(attributes.group ?? '')}`
+    + scope;
+}

--- a/src/lib/opslab/rbac/index.ts
+++ b/src/lib/opslab/rbac/index.ts
@@ -1,0 +1,7 @@
+export {
+  ROLES, ROLEBINDINGS, CLUSTERROLES, CLUSTERROLEBINDINGS, RBAC_RESOURCES,
+  ANONYMOUS, CLUSTER_ADMIN,
+} from './resources';
+export type { UserInfo } from './resources';
+export { authorize, bindsUser, rulesAllow, forbiddenMessage, SUPERUSER_GROUP } from './authorize';
+export type { AuthorizeResult, RbacView, ResourceAttributes } from './authorize';

--- a/src/lib/opslab/rbac/resources.ts
+++ b/src/lib/opslab/rbac/resources.ts
@@ -1,0 +1,55 @@
+/**
+ * RBAC 的对象
+ *
+ * 四个类型，两两成对：`Role` / `ClusterRole` 说「能对什么做什么」，
+ * `RoleBinding` / `ClusterRoleBinding` 说「谁拿到这套权限」。
+ *
+ * 最容易记混的是 RoleBinding 引用 ClusterRole 这种组合：权限的**范围**
+ * 由 Binding 决定，不由 Role 决定。用 RoleBinding 绑一个 ClusterRole，
+ * 拿到的只是那一个命名空间里的权限 —— 这正是「一套只读角色复用到每个
+ * 命名空间」的标准做法。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const ROLES: ResourceDefinition = {
+  group: 'rbac.authorization.k8s.io', version: 'v1', resource: 'roles',
+  singular: 'role', kind: 'Role', namespaced: true, shortNames: [],
+};
+
+export const ROLEBINDINGS: ResourceDefinition = {
+  group: 'rbac.authorization.k8s.io', version: 'v1', resource: 'rolebindings',
+  singular: 'rolebinding', kind: 'RoleBinding', namespaced: true, shortNames: [],
+};
+
+export const CLUSTERROLES: ResourceDefinition = {
+  group: 'rbac.authorization.k8s.io', version: 'v1', resource: 'clusterroles',
+  singular: 'clusterrole', kind: 'ClusterRole', namespaced: false, shortNames: [],
+};
+
+export const CLUSTERROLEBINDINGS: ResourceDefinition = {
+  group: 'rbac.authorization.k8s.io', version: 'v1', resource: 'clusterrolebindings',
+  singular: 'clusterrolebinding', kind: 'ClusterRoleBinding', namespaced: false, shortNames: [],
+};
+
+export const RBAC_RESOURCES: ResourceDefinition[] = [
+  ROLES, ROLEBINDINGS, CLUSTERROLES, CLUSTERROLEBINDINGS,
+];
+
+/** 谁在发这个请求 */
+export interface UserInfo {
+  username: string;
+  groups: string[];
+  uid?: string;
+}
+
+/** 未认证的请求。真集群里这类请求只能碰 /healthz 之类。 */
+export const ANONYMOUS: UserInfo = {
+  username: 'system:anonymous',
+  groups: ['system:unauthenticated'],
+};
+
+/** 绕过一切鉴权的身份。没有配 RBAC 的世界里，所有请求都是它。 */
+export const CLUSTER_ADMIN: UserInfo = {
+  username: 'kubernetes-admin',
+  groups: ['system:masters', 'system:authenticated'],
+};

--- a/tests/opslab/kubectl-integration.test.ts
+++ b/tests/opslab/kubectl-integration.test.ts
@@ -375,3 +375,87 @@ describeIfBuilt('跳板机 -> Pod -> 集群网络', () => {
     expect(direct.stdout).toBe('');
   });
 });
+
+/**
+ * `kubectl auth can-i` 与 403
+ *
+ * `can-i` 不是本地算的，它 POST 一个 SelfSubjectAccessReview 让服务端回答。
+ * 所以这一组同时在验两件事：我们的 RBAC 判定，以及 kubectl 认不认这个回答。
+ */
+describeIfBuilt('真 kubectl 遇上 RBAC', () => {
+  jest.setTimeout(120_000);
+
+  const RBAC_WORLD = {
+    namespaces: ['default', 'shop'],
+    users: {
+      'dev-token': { username: 'dev@corp.internal', groups: ['developers'] },
+    },
+    objects: [
+      {
+        apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole',
+        metadata: { name: 'pod-reader' },
+        rules: [{ apiGroups: [''], resources: ['pods'], verbs: ['get', 'list'] }],
+      },
+      {
+        apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'RoleBinding',
+        metadata: { name: 'dev-reader', namespace: 'shop' },
+        subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+        roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'pod-reader' },
+      },
+    ],
+    machine: {
+      files: {
+        '/root/.kube/config': [
+          'apiVersion: v1',
+          'kind: Config',
+          'clusters:',
+          '- name: opslab',
+          '  cluster:',
+          '    server: https://apiserver.opslab:6443',
+          '    insecure-skip-tls-verify: true',
+          'contexts:',
+          '- name: dev',
+          '  context:',
+          '    cluster: opslab',
+          '    user: dev',
+          '    namespace: shop',
+          'current-context: dev',
+          'users:',
+          '- name: dev',
+          '  user:',
+          '    token: dev-token',
+          '',
+        ].join('\n'),
+      },
+    },
+  };
+
+  it('can-i 对允许的操作说 yes', async () => {
+    const world = await createOpsWorld({ world: RBAC_WORLD as never, runtime: runtime() });
+    const result = await world.run('kubectl auth can-i list pods -n shop');
+    expect(result.stdout.trim()).toBe('yes');
+    expect(result.code).toBe(0);
+  });
+
+  it('can-i 对不允许的操作说 no，退出码非 0', async () => {
+    const world = await createOpsWorld({ world: RBAC_WORLD as never, runtime: runtime() });
+    const result = await world.run('kubectl auth can-i delete pods -n shop');
+    expect(result.stdout.trim()).toBe('no');
+    expect(result.code).not.toBe(0);
+  });
+
+  it('换个命名空间就不行 —— RoleBinding 只管 shop', async () => {
+    const world = await createOpsWorld({ world: RBAC_WORLD as never, runtime: runtime() });
+    const result = await world.run('kubectl auth can-i list pods -n default');
+    expect(result.stdout.trim()).toBe('no');
+  });
+
+  it('真的去做被拒的操作时，报的是 apiserver 那句 Forbidden', async () => {
+    const world = await createOpsWorld({ world: RBAC_WORLD as never, runtime: runtime() });
+    const result = await world.run('kubectl get secrets -n shop');
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('Error from server (Forbidden)');
+    expect(result.stderr).toContain('cannot list resource "secrets"');
+    expect(result.stderr).toContain('dev@corp.internal');
+  });
+});

--- a/tests/opslab/rbac.test.ts
+++ b/tests/opslab/rbac.test.ts
@@ -1,0 +1,222 @@
+/**
+ * RBAC
+ *
+ * 三件最容易搞错的事：
+ *  1. **只有允许，没有拒绝** —— 写不出「除了 X 都可以」；
+ *  2. RoleBinding 引用 ClusterRole 时，范围由 **Binding** 决定；
+ *  3. `get` 不等于 `list`，`resourceNames` 对 list 一律不生效。
+ */
+import { authorize, forbiddenMessage, type RbacView, type UserInfo } from '../../src/lib/opslab/rbac';
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+function view(objects: {
+  roles?: unknown[]; roleBindings?: unknown[]; clusterRoles?: unknown[]; clusterRoleBindings?: unknown[];
+}): RbacView {
+  return {
+    roles: () => (objects.roles ?? []) as KubeObject[],
+    roleBindings: () => (objects.roleBindings ?? []) as KubeObject[],
+    clusterRoles: () => (objects.clusterRoles ?? []) as KubeObject[],
+    clusterRoleBindings: () => (objects.clusterRoleBindings ?? []) as KubeObject[],
+  };
+}
+
+const DEV: UserInfo = { username: 'dev@corp.internal', groups: ['developers', 'system:authenticated'] };
+
+const READER = {
+  metadata: { name: 'reader' },
+  rules: [{ apiGroups: [''], resources: ['pods'], verbs: ['get', 'list'] }],
+};
+
+describe('规则匹配', () => {
+  it('没有任何规则命中就是拒绝 —— RBAC 只有允许', () => {
+    expect(authorize(view({}), DEV, { verb: 'get', resource: 'pods', namespace: 'shop' }))
+      .toMatchObject({ allowed: false });
+  });
+
+  it('ClusterRoleBinding 给的是全集群的权限', () => {
+    const decision = authorize(view({
+      clusterRoles: [READER],
+      clusterRoleBindings: [{
+        metadata: { name: 'dev-reader' },
+        subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+        roleRef: { kind: 'ClusterRole', name: 'reader' },
+      }],
+    }), DEV, { verb: 'list', resource: 'pods', namespace: 'anywhere' });
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toContain('ClusterRoleBinding "dev-reader"');
+  });
+
+  it('RoleBinding 引用 ClusterRole：范围由 Binding 决定，不由 Role 决定', () => {
+    const world = view({
+      clusterRoles: [READER],
+      roleBindings: [{
+        metadata: { name: 'dev-reader', namespace: 'shop' },
+        subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+        roleRef: { kind: 'ClusterRole', name: 'reader' },
+      }],
+    });
+    expect(authorize(world, DEV, { verb: 'list', resource: 'pods', namespace: 'shop' }).allowed).toBe(true);
+    expect(authorize(world, DEV, { verb: 'list', resource: 'pods', namespace: 'payments' }).allowed).toBe(false);
+  });
+
+  it('按组绑定', () => {
+    const decision = authorize(view({
+      clusterRoles: [READER],
+      clusterRoleBindings: [{
+        metadata: { name: 'devs' },
+        subjects: [{ kind: 'Group', name: 'developers' }],
+        roleRef: { kind: 'ClusterRole', name: 'reader' },
+      }],
+    }), DEV, { verb: 'get', resource: 'pods', name: 'x', namespace: 'shop' });
+    expect(decision.allowed).toBe(true);
+  });
+
+  it('ServiceAccount 的用户名是 system:serviceaccount:<ns>:<name>', () => {
+    const sa: UserInfo = {
+      username: 'system:serviceaccount:shop:deployer',
+      groups: ['system:serviceaccounts', 'system:authenticated'],
+    };
+    const decision = authorize(view({
+      clusterRoles: [READER],
+      roleBindings: [{
+        metadata: { name: 'deployer', namespace: 'shop' },
+        subjects: [{ kind: 'ServiceAccount', name: 'deployer', namespace: 'shop' }],
+        roleRef: { kind: 'ClusterRole', name: 'reader' },
+      }],
+    }), sa, { verb: 'list', resource: 'pods', namespace: 'shop' });
+    expect(decision.allowed).toBe(true);
+  });
+
+  it('get 不等于 list —— 只写 get 的规则挡不住也放不开 list', () => {
+    const world = view({
+      clusterRoles: [{ metadata: { name: 'getter' }, rules: [{ apiGroups: [''], resources: ['pods'], verbs: ['get'] }] }],
+      clusterRoleBindings: [{
+        metadata: { name: 'b' }, subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+        roleRef: { kind: 'ClusterRole', name: 'getter' },
+      }],
+    });
+    expect(authorize(world, DEV, { verb: 'get', resource: 'pods', name: 'x', namespace: 'shop' }).allowed).toBe(true);
+    expect(authorize(world, DEV, { verb: 'list', resource: 'pods', namespace: 'shop' }).allowed).toBe(false);
+  });
+
+  it('resourceNames 只对指名道姓的请求生效，list 一律不匹配', () => {
+    const world = view({
+      clusterRoles: [{
+        metadata: { name: 'one-secret' },
+        rules: [{ apiGroups: [''], resources: ['secrets'], resourceNames: ['db'], verbs: ['get', 'list'] }],
+      }],
+      clusterRoleBindings: [{
+        metadata: { name: 'b' }, subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+        roleRef: { kind: 'ClusterRole', name: 'one-secret' },
+      }],
+    });
+    expect(authorize(world, DEV, { verb: 'get', resource: 'secrets', name: 'db', namespace: 'shop' }).allowed).toBe(true);
+    expect(authorize(world, DEV, { verb: 'get', resource: 'secrets', name: 'other', namespace: 'shop' }).allowed).toBe(false);
+    // list 没有名字，带 resourceNames 的规则对它不生效
+    expect(authorize(world, DEV, { verb: 'list', resource: 'secrets', namespace: 'shop' }).allowed).toBe(false);
+  });
+
+  it('子资源要单独写：pods/log', () => {
+    const world = view({
+      clusterRoles: [{
+        metadata: { name: 'logs' },
+        rules: [{ apiGroups: [''], resources: ['pods/log'], verbs: ['get'] }],
+      }],
+      clusterRoleBindings: [{
+        metadata: { name: 'b' }, subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+        roleRef: { kind: 'ClusterRole', name: 'logs' },
+      }],
+    });
+    expect(authorize(world, DEV, { verb: 'get', resource: 'pods', subresource: 'log', name: 'x', namespace: 'shop' }).allowed).toBe(true);
+    expect(authorize(world, DEV, { verb: 'get', resource: 'pods', name: 'x', namespace: 'shop' }).allowed).toBe(false);
+  });
+
+  it('system:masters 绕过一切', () => {
+    const admin: UserInfo = { username: 'kubernetes-admin', groups: ['system:masters'] };
+    expect(authorize(view({}), admin, { verb: 'delete', resource: 'namespaces', name: 'kube-system' }).allowed).toBe(true);
+  });
+
+  it('403 的话一字不差抄真 apiserver', () => {
+    expect(forbiddenMessage(DEV, { verb: 'list', resource: 'pods', group: '', namespace: 'payments' }))
+      .toBe('pods is forbidden: User "dev@corp.internal" cannot list resource "pods" in API group "" in the namespace "payments"');
+    expect(forbiddenMessage(DEV, { verb: 'delete', resource: 'nodes', group: '' }))
+      .toContain('at the cluster scope');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 集群里真的被挡住                                                    */
+/* ------------------------------------------------------------------ */
+
+const WORLD: OpsWorldSpec = {
+  namespaces: ['default', 'shop'],
+  users: {
+    'admin-token': { username: 'kubernetes-admin', groups: ['system:masters'] },
+    'dev-token': { username: 'dev@corp.internal', groups: ['developers'] },
+  },
+  objects: [
+    {
+      apiVersion: 'v1', kind: 'ConfigMap',
+      metadata: { name: 'settings', namespace: 'shop' }, data: { a: '1' },
+    },
+    {
+      apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole',
+      metadata: { name: 'configmap-reader' },
+      rules: [{ apiGroups: [''], resources: ['configmaps'], verbs: ['get', 'list'] }],
+    },
+    {
+      apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'RoleBinding',
+      metadata: { name: 'dev-reader', namespace: 'shop' },
+      subjects: [{ kind: 'User', name: 'dev@corp.internal' }],
+      roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'configmap-reader' },
+    },
+  ] as never,
+};
+
+describe('apiserver 真的会拒绝', () => {
+  async function server() {
+    const world = await createOpsWorld({ world: WORLD });
+    return world.cluster.apiServer;
+  }
+
+  const as = (token: string) => ({ headers: { authorization: `Bearer ${token}` } });
+
+  it('管理员什么都读得到', async () => {
+    const api = await server();
+    const response = await api.handle('/api/v1/namespaces/shop/configmaps', as('admin-token') as never);
+    expect(response.status).toBe(200);
+  });
+
+  it('dev 读得到 shop 的 configmap', async () => {
+    const api = await server();
+    const response = await api.handle('/api/v1/namespaces/shop/configmaps', as('dev-token') as never);
+    expect(response.status).toBe(200);
+  });
+
+  it('dev 读不到别的命名空间 —— RoleBinding 只管 shop', async () => {
+    const api = await server();
+    const response = await api.handle('/api/v1/namespaces/default/configmaps', as('dev-token') as never);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.message).toContain('cannot list resource "configmaps"');
+    expect(body.message).toContain('"default"');
+  });
+
+  it('dev 删不掉东西 —— 角色里没有 delete', async () => {
+    const api = await server();
+    const response = await api.handle(
+      '/api/v1/namespaces/shop/configmaps/settings',
+      { ...as('dev-token'), method: 'DELETE' } as never
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it('没有 token 就是匿名，什么都不行', async () => {
+    const api = await server();
+    const response = await api.handle('/api/v1/namespaces/shop/configmaps');
+    expect(response.status).toBe(403);
+    expect((await response.json()).message).toContain('system:anonymous');
+  });
+});


### PR DESCRIPTION
apiserver 之前对每个请求都放行。这一片补上认证与鉴权。

## 认证

从 `Authorization: Bearer <token>` 取身份。世界声明一张 token → 用户/组的表就算开了鉴权；不声明的世界所有请求都是 cluster-admin，**前面十五关行为不变**（默认 kubeconfig 的 token 映射到 `system:masters`）。

这是「opt into the dimension」的老套路，和第 10 关的 CNI 一样。

## 鉴权

完整的 RBAC：四个对象、verb 与 resource 的通配、子资源（`pods/log`）、`resourceNames`、`system:masters` 绕过。403 的那句话一字不差抄真 apiserver：

```
pods is forbidden: User "dev@corp.internal" cannot list resource "pods" in API group "" in the namespace "payments"
```

判定里钉住的三件容易搞错的事：

- **只有允许，没有拒绝**。加规则永远只会让权限变大 —— 这一关的场景就架在这上面：前任把 CI 的 ServiceAccount 直接绑了 cluster-admin，在旁边补一个小角色没有任何用，必须删掉那条绑定。
- **RoleBinding 引用 ClusterRole 时，范围由 Binding 决定**。
- **`get` 不等于 `list`；`resourceNames` 对 list 一律不生效**。

## `kubectl auth can-i`

它不是本地算的 —— kubectl POST 一个 SelfSubjectAccessReview 让服务端回答。实现了这个端点、给管理员用的 SubjectAccessReview，以及 `--as` / `--as-group` 的冒充（检查别人权限的标准做法）。

被 kubectl 纠正一次：`can-i get pods/log` 里的 `log` 被 kubectl 当成 Pod 的**名字**（`TYPE/NAME` 的写法），问子资源得用 `--subresource=log`。这条写进 hints 了。

另外拒绝时**不给理由** —— 真 RBAC 授权器对「没匹配上」返回空理由，于是 `can-i` 打出来是干净的 `no`；给了理由会变成 `no - ...`，和真集群对不上。

## 验证

15 个 RBAC 用例 + 4 个真 kubectl 用例（can-i 的 yes/no/退出码、被拒时的 Forbidden 原文）+ 3 个关卡反向验证。全量 1455 个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)