### PR TITLE
feat(opslab): 第 17 关 —— 把规矩写成策略

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,5 +24,16 @@ const customJestConfig = {
   maxWorkers: 1, // Run tests sequentially to avoid conflicts
 }
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig)
+/**
+ * createJestConfig 返回的是一个异步函数（next/jest 要先读 next.config.js）。
+ * 这里再包一层是为了改 transformIgnorePatterns —— next/jest 默认整个
+ * node_modules 都不转译，而 @marcbachmann/cel-js 是纯 ESM 包，
+ * 不转译的话 require 它会直接报「Cannot use import statement outside a module」。
+ */
+module.exports = async () => {
+  const config = await createJestConfig(customJestConfig)()
+  config.transformIgnorePatterns = (config.transformIgnorePatterns || []).map((pattern) =>
+    pattern === '/node_modules/' ? '/node_modules/(?!@marcbachmann/)' : pattern
+  )
+  return config
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mantine/core": "7.6.1",
         "@mantine/hooks": "7.6.1",
         "@mantine/notifications": "7.6.1",
+        "@marcbachmann/cel-js": "^8.0.0",
         "@monaco-editor/react": "^4.7.0",
         "@reduxjs/toolkit": "^2.0.1",
         "@tabler/icons-react": "^3.36.1",
@@ -2143,6 +2144,18 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@marcbachmann/cel-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@marcbachmann/cel-js/-/cel-js-8.0.0.tgz",
+      "integrity": "sha512-oaTrAziGr3zDLFiMt/yLU3nZuRMawyWQB5X1a0I7s9eGy3JYzX9l8ZXXHyMd64nzbeVFZTewuUShwsZQdK6UCA==",
+      "license": "MIT",
+      "bin": {
+        "cel-evaluate": "bin/cel-evaluate.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@mermaid-js/parser": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@mantine/core": "7.6.1",
     "@mantine/hooks": "7.6.1",
     "@mantine/notifications": "7.6.1",
+    "@marcbachmann/cel-js": "^8.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@reduxjs/toolkit": "^2.0.1",
     "@tabler/icons-react": "^3.36.1",

--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -33,6 +33,9 @@ const EXPORTER_MIRROR = 'harbor.corp.internal/mirror/settlement-exporter:1.4.2';
 const SESSIONS_IMAGE = 'harbor.corp.internal/team/sessions:1.8.0';
 const ISTIOD_IMAGE = 'docker.io/istio/pilot:1.28.1';
 const ZTUNNEL_IMAGE = 'docker.io/istio/ztunnel:1.28.1';
+const KYVERNO_IMAGE = 'ghcr.io/kyverno/kyverno:v1.16.0';
+// 一个从公网直接拿来的镜像，没人签过
+const UNSIGNED_IMAGE = 'docker.io/library/redis:7.4';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -139,6 +142,7 @@ const WORLD = {
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
     'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
+    'kyverno',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -180,6 +184,8 @@ const WORLD = {
     // 服务网格的控制面与数据面
     [ISTIOD_IMAGE]: { pullMs: 600, startupMs: 900, readyAfterMs: 400, listens: [15012] },
     [ZTUNNEL_IMAGE]: { pullMs: 400, startupMs: 500, readyAfterMs: 200, listens: [15008] },
+    [KYVERNO_IMAGE]: { pullMs: 500, startupMs: 700, readyAfterMs: 300, listens: [9443] },
+    [UNSIGNED_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200, listens: [6379] },
     // 会话存储
     [SESSIONS_IMAGE]: {
       pullMs: 300, startupMs: 500, readyAfterMs: 200,
@@ -5048,6 +5054,438 @@ const stage16 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 17 关                                                            */
+/* ------------------------------------------------------------------ */
+
+const KYVERNO_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'kyverno-admission-controller', namespace: 'kyverno',
+      labels: { 'app.kubernetes.io/name': 'kyverno' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'kyverno' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'kyverno' } },
+        spec: { containers: [{ name: 'kyverno', image: KYVERNO_IMAGE, ports: [{ containerPort: 9443 }] }] },
+      },
+    },
+  },
+];
+
+/** 前任图省事跑起来的一个缓存，特权容器 + hostPath */
+const SLOPPY_CACHE = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name: 'cache', namespace: 'payments' },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { app: 'cache' } },
+    template: {
+      metadata: { labels: { app: 'cache' } },
+      spec: {
+        containers: [{
+          name: 'redis', image: UNSIGNED_IMAGE,
+          ports: [{ containerPort: 6379 }],
+          securityContext: { privileged: true },
+        }],
+        volumes: [{ name: 'data', hostPath: { path: '/var/lib/redis' } }],
+      },
+    },
+  },
+};
+
+const POLICY_STARTER = code`
+  # 三条规矩要落成策略。想清楚哪一条该交给 PSA，哪一条只能靠 Kyverno。
+  #
+  #   1. 不许特权容器、不许 hostPath
+  #   2. 每个工作负载都要有 owner 标签
+  #   3. 镜像只能来自内网仓库，而且必须签过名
+`;
+
+const POLICY_REFERENCE = code`
+  # 第 2、3 条：PSA 表达不了，交给 Kyverno
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: require-owner
+  spec:
+    validationFailureAction: Enforce
+    rules:
+    - name: owner-label
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+            namespaces:
+            - payments
+      validate:
+        message: "每个工作负载都要带 owner 标签"
+        pattern:
+          metadata:
+            labels:
+              owner: "?*"
+  ---
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: internal-registry-only
+  spec:
+    validationFailureAction: Enforce
+    rules:
+    - name: registry
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+            namespaces:
+            - payments
+      validate:
+        message: "镜像只能来自 harbor.corp.internal"
+        pattern:
+          spec:
+            containers:
+            - image: "harbor.corp.internal/*"
+`;
+
+/**
+ * 验签策略要把公钥现填进去。
+ *
+ * `cosign generate-key-pair` 每次生成的密钥不一样，所以公钥不能写死在文件里。
+ * heredoc 里的 `$(sed ...)` 负责把 PEM 按 YAML 的块标量缩进补齐。
+ */
+const VERIFY_POLICY_COMMAND = [
+  'cat > /root/infra/verify.yaml <<EOF',
+  'apiVersion: kyverno.io/v1',
+  'kind: ClusterPolicy',
+  'metadata:',
+  '  name: verify-images',
+  'spec:',
+  '  validationFailureAction: Enforce',
+  '  rules:',
+  '  - name: signed',
+  '    match:',
+  '      any:',
+  '      - resources:',
+  '          kinds:',
+  '          - Pod',
+  '          namespaces:',
+  '          - payments',
+  '    verifyImages:',
+  '    - imageReferences:',
+  '      - "harbor.corp.internal/*"',
+  '      attestors:',
+  '      - entries:',
+  '        - keys:',
+  '            publicKeys: |',
+  "$(sed 's/^/              /' /root/cosign.pub)",
+  'EOF',
+].join('\n');
+
+/** 前任那个缓存改好之后的样子：内网镜像、非特权、带 owner */
+const CACHE_FIXED = code`
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: cache
+    namespace: payments
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: cache
+    template:
+      metadata:
+        labels:
+          app: cache
+          owner: payments
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+        - name: redis
+          image: harbor.corp.internal/team/sessions:1.8.0
+          ports:
+          - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
+`;
+
+const stage17 = {
+  id: 'policy-as-code',
+  title: t('把规矩写成策略', 'Turn the Rules Into Policy'),
+  goal: t(
+    code`
+      安全评审给了三条规矩，从今往后由集群自己把关，不靠人 review：
+
+      1. \`payments\` 里不许跑特权容器，不许挂 hostPath；
+      2. 每个工作负载都要带 \`owner\` 标签；
+      3. 镜像只能来自 \`harbor.corp.internal\`，而且必须**签过名**。
+
+      现场有个反面教材：前任跑起来的 \`cache\`，用的是公网拉的 redis、
+      开了特权、挂了宿主机目录、没有 owner 标签 —— 四条全占。
+
+      Kyverno 已经装好。签名用 \`cosign\`，密钥自己生成。
+
+      ## 通关标准
+
+      1. 三条规矩都落成策略并且真的拦得住；
+      2. \`cache\` 改好并跑起来（不是删掉了事）；
+      3. 违规的东西 apply 上去会被拒，报错能看懂；
+      4. 第 1 条用 PSA 的档位做，不是自己写 Kyverno 规则重复造一遍。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl label namespace payments pod-security.kubernetes.io/enforce=restricted
+      cosign generate-key-pair
+      cosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0
+      kubectl apply -f /root/infra/policy.yaml
+      kubectl get cpol
+      kubectl apply -f /root/infra/cache.yaml
+      \`\`\`
+    `,
+    code`
+      The security review handed down three rules, to be enforced by the cluster from
+      now on rather than by human review:
+
+      1. no privileged containers and no hostPath volumes in \`payments\`;
+      2. every workload carries an \`owner\` label;
+      3. images come only from \`harbor.corp.internal\`, and must be **signed**.
+
+      There is a live counter-example: the \`cache\` your predecessor started runs a
+      redis pulled from the public internet, privileged, with a host directory mounted,
+      and no owner label. All four at once.
+
+      Kyverno is installed. Use \`cosign\` for signatures and generate your own key.
+
+      ## Done when
+
+      1. all three rules exist as policy and actually block;
+      2. \`cache\` is fixed and running, not deleted;
+      3. a violating manifest is rejected with a message you can act on;
+      4. rule 1 uses PSA levels rather than a hand-written Kyverno rule reimplementing
+         them.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl label namespace payments pod-security.kubernetes.io/enforce=restricted
+      cosign generate-key-pair
+      cosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0
+      kubectl apply -f /root/infra/policy.yaml
+      kubectl get cpol
+      kubectl apply -f /root/infra/cache.yaml
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('三条规矩都由集群自己把关', 'All three rules enforced by the cluster'),
+    t('反面教材改好了，不是删掉了事', 'The counter-example is fixed, not deleted'),
+    t('该用 PSA 的用 PSA', 'PSA where PSA belongs'),
+  ],
+  hints: [
+    t(
+      'PSA 是三档预置标准，靠命名空间标签开启，不写规则：\`restricted\` 已经包含「不许特权、不许 hostPath」以及更多。它挡不住的是「必须有 owner 标签」这种公司自定义的规矩 —— 那才是 Kyverno 的活。',
+      'PSA offers three preset levels switched on by a namespace label, with no rules to write: `restricted` already covers "no privileged, no hostPath" and more. What it cannot express is a company-specific rule like "must carry an owner label", and that is what Kyverno is for.'
+    ),
+    t(
+      'PSA 只看 **Pod**。给命名空间打上 \`enforce=restricted\` 之后，违规的 Deployment 照样 apply 得进去 —— 然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里（\`kubectl describe rs\`）。',
+      'PSA only inspects **Pods**. After labelling the namespace `enforce=restricted`, a violating Deployment still applies cleanly and then produces no pods at all; the reason sits in the ReplicaSet events (`kubectl describe rs`).'
+    ),
+    t(
+      '签名签的是镜像的 **digest**，不是 tag。所以先把镜像推进内网仓库、再签，顺序反了签的就是另一个东西。Kyverno 的 \`verifyImages\` 里填的是公钥，不是私钥。',
+      'A signature covers the image **digest**, not the tag. Push to the internal registry first and sign after; the other order signs something else. The `publicKeys` field in Kyverno `verifyImages` takes the public key, not the private one.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '用 Kyverno 再写一遍「不许特权容器」。能用，但那是在维护一份和上游 PSA 并行的实现 —— 上游加了新的提权途径，你的规则不会跟着更新。能交给 PSA 的就交给它。',
+      'Reimplementing "no privileged containers" as a Kyverno rule. It works, but it means maintaining a parallel copy of upstream PSA: when upstream adds a newly discovered escalation path, your rule does not follow. Hand to PSA what PSA covers.'
+    ),
+    t(
+      '把 \`validationFailureAction\` 写成 \`Audit\` 就以为拦住了。Audit 只记录，对象照样进集群 —— 和 PSA 那边只打 \`warn\` 标签是同一个误会。',
+      'Setting `validationFailureAction: Audit` and believing it blocks. Audit only records; the object still lands. It is the same misunderstanding as labelling a namespace with only `warn` on the PSA side.'
+    ),
+    t(
+      '把违规的 \`cache\` 删掉交差。删掉当然不违规了，但业务也没了 —— 判定要求它跑着。策略的意义是让人把东西改对，不是把东西删光。',
+      'Deleting the offending `cache` and calling it done. Nothing violates once nothing runs, but the workload is gone too, and the grader requires it running. Policy exists to make things correct, not to make them disappear.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM, ...KYVERNO_PLATFORM,
+      ...PORTAL_WORKLOAD, PORTAL_ROUTE, SLOPPY_CACHE,
+    ],
+    files: {
+      '/root/infra/policy.yaml': POLICY_STARTER,
+      '/root/infra/cache.yaml': CACHE_FIXED,
+    },
+    referenceFiles: { '/root/infra/policy.yaml': POLICY_REFERENCE },
+    referenceCommands: [
+      'cosign generate-key-pair',
+      'cosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0',
+      // 公钥要现填 —— 每次生成的密钥都不一样，写死在文件里没有意义
+      VERIFY_POLICY_COMMAND,
+      'kubectl label namespace payments pod-security.kubernetes.io/enforce=restricted',
+      'kubectl apply -f /root/infra/policy.yaml',
+      'kubectl apply -f /root/infra/verify.yaml',
+      /**
+       * 这里是 replace 不是 apply。
+       *
+       * `cache` 最初不是 apply 建出来的（没有 last-applied 注解），
+       * 这时候 apply 走的是两路合并：新清单里没写的字段（privileged、
+       * hostPath 卷）会**原样留着**。kubectl 自己会警告这一点。
+       * replace 是整体替换，对象变成清单里的样子。
+       */
+      'kubectl replace -f /root/infra/cache.yaml',
+    ],
+  },
+  specs: [
+    spec('policy-as-code.spec.ts', code`
+      import { get, list, sh } from '@ops/lab';
+
+      const violating = (name, patch) => JSON.stringify({
+        apiVersion: 'v1', kind: 'Pod',
+        metadata: { name, namespace: 'payments', labels: { owner: 'payments' } },
+        spec: {
+          securityContext: { runAsNonRoot: true, seccompProfile: { type: 'RuntimeDefault' } },
+          containers: [{
+            name: 'app', image: 'harbor.corp.internal/team/sessions:1.8.0',
+            securityContext: {
+              allowPrivilegeEscalation: false, runAsNonRoot: true,
+              capabilities: { drop: ['ALL'] },
+            },
+          }],
+          ...patch,
+        },
+      });
+
+      const apply = async (json) => sh("echo '" + json + "' | kubectl apply -f -");
+
+      describe('策略即代码', () => {
+        it('特权容器进不来', async () => {
+          const result = await apply(violating('privileged-probe', {
+            containers: [{
+              name: 'app', image: 'harbor.corp.internal/team/sessions:1.8.0',
+              securityContext: { privileged: true },
+            }],
+          }));
+          expect(result.code).not.toBe(0);
+          expect(result.stderr).toContain('PodSecurity');
+        });
+
+        it('hostPath 进不来', async () => {
+          const result = await apply(violating('hostpath-probe', {
+            volumes: [{ name: 'root', hostPath: { path: '/' } }],
+          }));
+          expect(result.code).not.toBe(0);
+        });
+
+        it('没有 owner 标签进不来', async () => {
+          const json = violating('no-owner', {}).replace('"owner":"payments"', '"tier":"cache"');
+          const result = await apply(json);
+          expect(result.code).not.toBe(0);
+          expect(result.stderr).toContain('owner');
+        });
+
+        it('公网镜像进不来', async () => {
+          const json = violating('public-image', {})
+            .replace(/harbor.corp.internal\\/team\\/sessions:1.8.0/g, 'docker.io/library/redis:7.4');
+          const result = await apply(json);
+          expect(result.code).not.toBe(0);
+        });
+
+        it('没签名的内网镜像也进不来', async () => {
+          const json = violating('unsigned', {})
+            .replace(/harbor.corp.internal\\/team\\/sessions:1.8.0/g, 'harbor.corp.internal/team/reports:2.1.0');
+          const result = await apply(json);
+          expect(result.code).not.toBe(0);
+          expect(result.stderr).toContain('not signed');
+        });
+
+        it('规规矩矩的 Pod 进得来', async () => {
+          const result = await apply(violating('good-probe', {}));
+          expect(result.code).toBe(0);
+        });
+
+        it('cache 改好了并且跑着 —— 不是删掉了事', () => {
+          const deployment = get('Deployment', 'cache', 'payments');
+          expect(deployment).toBeTruthy();
+          expect(deployment.status.readyReplicas).toBeGreaterThan(0);
+        });
+
+        it('第 1 条交给了 PSA，不是自己写一遍', () => {
+          const namespace = get('Namespace', 'payments');
+          const level = namespace.metadata.labels['pod-security.kubernetes.io/enforce'];
+          expect(['baseline', 'restricted']).toContain(level);
+        });
+
+        it('策略是 Enforce 不是 Audit', () => {
+          const policies = list('ClusterPolicy');
+          expect(policies.length).toBeGreaterThan(0);
+          for (const policy of policies) {
+            expect(policy.spec.validationFailureAction || 'Enforce').toBe('Enforce');
+          }
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'maintainability'],
+  extension: t(
+    code`
+      两层策略的分工值得记清楚。**PSA** 是 Kubernetes 内置的，三档预置标准，
+      靠命名空间标签开关，卸不掉也改不了 —— 它的价值恰恰在这里：上游发现了
+      新的提权途径，你升级集群就自动跟上，不需要维护任何规则。
+      **Kyverno**（以及 ValidatingAdmissionPolicy）管的是公司自己的规矩：
+      标签、镜像来源、命名约定、成本归属。能交给 PSA 的别自己写。
+
+      供应链那条最容易被做成摆设。签名签的是 **digest**，所以它保证的是
+      「这一坨字节被某把私钥认过」，不多也不少。它**不**保证镜像里没有漏洞，
+      也不保证签它的人有资格签。真正要配套的是：谁持有私钥、密钥怎么轮转、
+      以及验签之外还要看 SBOM 与来源证明（SLSA provenance）。
+      只做验签而不管密钥归属，安全性等于「有人签过」这四个字。
+
+      最后一点关于推行：策略上线永远从 \`Audit\` 开始，看几天报表，
+      把存量违规改完，再切 \`Enforce\`。直接 Enforce 的后果不是策略被绕过，
+      是有人半夜把策略删了 —— 那比没有策略更糟，因为没人知道它被删了。
+    `,
+    code`
+      The division of labour between the two layers is worth internalising. **PSA** is
+      built into Kubernetes: three preset levels toggled by a namespace label, neither
+      removable nor customisable, and that rigidity is the point. When upstream learns
+      of a new escalation path, upgrading the cluster picks it up with no rules for you
+      to maintain. **Kyverno** (and ValidatingAdmissionPolicy) covers company-specific
+      rules: labels, image provenance, naming conventions, cost attribution. Hand to
+      PSA what PSA covers.
+
+      The supply-chain rule is the easiest to turn into theatre. A signature covers the
+      **digest**, so it guarantees exactly one thing: these bytes were vouched for by
+      some private key. It does **not** say the image is free of vulnerabilities, nor
+      that whoever signed was entitled to. What has to come with it is key custody, a
+      rotation story, and looking beyond signatures at SBOMs and build provenance
+      (SLSA). Verifying signatures without governing the keys means the guarantee is
+      literally "somebody signed this".
+
+      One note on rollout: ship policies as \`Audit\` first, watch the reports for a few
+      days, fix the existing violations, then switch to \`Enforce\`. Going straight to
+      Enforce does not get the policy bypassed; it gets the policy deleted at 2am,
+      which is worse than having none, because nobody knows it is gone.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -5093,6 +5531,6 @@ module.exports = {
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
-    stage13, stage14, stage15, stage16,
+    stage13, stage14, stage15, stage16, stage17,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5618,7 +5618,8 @@
           "ingress-nginx",
           "cert-manager",
           "argocd",
-          "istio-system"
+          "istio-system",
+          "kyverno"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5715,6 +5716,22 @@
             "readyAfterMs": 200,
             "listens": [
               15008
+            ]
+          },
+          "ghcr.io/kyverno/kyverno:v1.16.0": {
+            "pullMs": 500,
+            "startupMs": 700,
+            "readyAfterMs": 300,
+            "listens": [
+              9443
+            ]
+          },
+          "docker.io/library/redis:7.4": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "listens": [
+              6379
             ]
           },
           "harbor.corp.internal/team/sessions:1.8.0": {
@@ -10606,6 +10623,516 @@
         "primer": {
           "zh": "一个请求打到 apiserver，要过两道关，它们回答的是完全不同的问题。`认证`回答「你是谁」：客户端证书、ServiceAccount 的 token、或者 OIDC 发下来的 id_token，形式不同，产物都是同一个东西：一个用户名加一组 `group`。`鉴权`回答「你能不能做这件事」，这才是 RBAC 的活。所以「接了 OIDC 之后大家还是什么都干不了」是正常的中间状态，不是接错了。\n\nRBAC 有四个对象，两两成对：`Role` 与 `ClusterRole` 描述「能对什么资源做什么动作」，`RoleBinding` 与 `ClusterRoleBinding` 描述「谁拿到这套权限」。最容易记混的组合是 `RoleBinding` 引用 `ClusterRole`：这时权限的**范围由 Binding 决定**，拿到的只是那一个命名空间里的权限。这是「一套只读角色复用到每个命名空间」的标准写法，不必给每个命名空间各抄一份 Role。\n\n规则里有几处不是望文生义的。动词上，`get` 和 `list` 是两件事，只写 `get` 的规则挡不住也放不开 `list`；`watch` 又是第三件。资源上，看日志和进容器是**子资源**，要写成 `pods/log`（动词 `get`）和 `pods/exec`（动词 `create`，不是 get）。`resourceNames` 能把权限限定到具体对象，但它只对指名道姓的请求生效；`list` 与 `watch` 没有名字，带 `resourceNames` 的规则对它们一律不匹配。\n\n最关键的一条：RBAC **只有允许，没有拒绝**。写不出「除了 Secret 之外都可以」，只能把 Secret 之外的都列出来。这意味着加规则永远只会让权限变大，收权限的唯一办法是改掉或删掉已有的绑定；在一条 cluster-admin 绑定旁边再写一个小角色，一点用都没有。检查的办法是 `kubectl auth can-i <动词> <资源> --as=<用户> --as-group=<组>`，加 `--list` 会把这个身份能做的事全列出来。人对自己写的 RBAC 判断准确率相当低，这条命令是直接问服务端要答案。",
           "en": "A request reaching the apiserver passes two gates that answer completely different questions. `Authentication` answers \"who are you\": a client certificate, a ServiceAccount token, or an OIDC id_token, all producing the same thing, a username plus a set of `groups`. `Authorization` answers \"may you do this\", and that is RBAC job. So \"we wired up OIDC and everyone still cannot do anything\" is a normal intermediate state, not a broken integration.\n\nRBAC has four objects in two pairs. `Role` and `ClusterRole` describe what verbs apply to what resources; `RoleBinding` and `ClusterRoleBinding` describe who gets them. The combination people misremember is a `RoleBinding` referencing a `ClusterRole`: **scope comes from the binding**, so the subject gains those permissions in that one namespace. This is the standard way to reuse one read-only role across namespaces instead of copying a Role into each.\n\nSeveral details in a rule are not what they look like. On verbs, `get` and `list` are separate, so a rule granting only `get` neither blocks nor permits `list`, and `watch` is a third. On resources, reading logs and execing are **subresources**, written `pods/log` (verb `get`) and `pods/exec` (verb `create`, not get). `resourceNames` narrows a rule to specific objects, but only for requests that name one: `list` and `watch` carry no name, so such rules never match them.\n\nThe most important property: RBAC **only allows, it never denies**. There is no way to say \"anything except Secrets\"; you enumerate everything else. Adding rules can therefore only widen access, and the only way to reduce it is to change or delete an existing binding, which is why writing a smaller role next to a cluster-admin binding accomplishes nothing. To check, use `kubectl auth can-i <verb> <resource> --as=<user> --as-group=<group>`, and add `--list` to print everything that identity can do. People predict their own RBAC badly; this command asks the server instead."
+        }
+      },
+      {
+        "id": "policy-as-code",
+        "title": {
+          "zh": "把规矩写成策略",
+          "en": "Turn the Rules Into Policy"
+        },
+        "goal": {
+          "zh": "安全评审给了三条规矩，从今往后由集群自己把关，不靠人 review：\n\n1. `payments` 里不许跑特权容器，不许挂 hostPath；\n2. 每个工作负载都要带 `owner` 标签；\n3. 镜像只能来自 `harbor.corp.internal`，而且必须**签过名**。\n\n现场有个反面教材：前任跑起来的 `cache`，用的是公网拉的 redis、\n开了特权、挂了宿主机目录、没有 owner 标签 —— 四条全占。\n\nKyverno 已经装好。签名用 `cosign`，密钥自己生成。\n\n## 通关标准\n\n1. 三条规矩都落成策略并且真的拦得住；\n2. `cache` 改好并跑起来（不是删掉了事）；\n3. 违规的东西 apply 上去会被拒，报错能看懂；\n4. 第 1 条用 PSA 的档位做，不是自己写 Kyverno 规则重复造一遍。\n\n## 会用到的命令\n\n```bash\nkubectl label namespace payments pod-security.kubernetes.io/enforce=restricted\ncosign generate-key-pair\ncosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0\nkubectl apply -f /root/infra/policy.yaml\nkubectl get cpol\nkubectl apply -f /root/infra/cache.yaml\n```\n",
+          "en": "The security review handed down three rules, to be enforced by the cluster from\nnow on rather than by human review:\n\n1. no privileged containers and no hostPath volumes in `payments`;\n2. every workload carries an `owner` label;\n3. images come only from `harbor.corp.internal`, and must be **signed**.\n\nThere is a live counter-example: the `cache` your predecessor started runs a\nredis pulled from the public internet, privileged, with a host directory mounted,\nand no owner label. All four at once.\n\nKyverno is installed. Use `cosign` for signatures and generate your own key.\n\n## Done when\n\n1. all three rules exist as policy and actually block;\n2. `cache` is fixed and running, not deleted;\n3. a violating manifest is rejected with a message you can act on;\n4. rule 1 uses PSA levels rather than a hand-written Kyverno rule reimplementing\n   them.\n\n## Commands you will need\n\n```bash\nkubectl label namespace payments pod-security.kubernetes.io/enforce=restricted\ncosign generate-key-pair\ncosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0\nkubectl apply -f /root/infra/policy.yaml\nkubectl get cpol\nkubectl apply -f /root/infra/cache.yaml\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "三条规矩都由集群自己把关",
+            "en": "All three rules enforced by the cluster"
+          },
+          {
+            "zh": "反面教材改好了，不是删掉了事",
+            "en": "The counter-example is fixed, not deleted"
+          },
+          {
+            "zh": "该用 PSA 的用 PSA",
+            "en": "PSA where PSA belongs"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "PSA 是三档预置标准，靠命名空间标签开启，不写规则：`restricted` 已经包含「不许特权、不许 hostPath」以及更多。它挡不住的是「必须有 owner 标签」这种公司自定义的规矩 —— 那才是 Kyverno 的活。",
+            "en": "PSA offers three preset levels switched on by a namespace label, with no rules to write: `restricted` already covers \"no privileged, no hostPath\" and more. What it cannot express is a company-specific rule like \"must carry an owner label\", and that is what Kyverno is for."
+          },
+          {
+            "zh": "PSA 只看 **Pod**。给命名空间打上 `enforce=restricted` 之后，违规的 Deployment 照样 apply 得进去 —— 然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里（`kubectl describe rs`）。",
+            "en": "PSA only inspects **Pods**. After labelling the namespace `enforce=restricted`, a violating Deployment still applies cleanly and then produces no pods at all; the reason sits in the ReplicaSet events (`kubectl describe rs`)."
+          },
+          {
+            "zh": "签名签的是镜像的 **digest**，不是 tag。所以先把镜像推进内网仓库、再签，顺序反了签的就是另一个东西。Kyverno 的 `verifyImages` 里填的是公钥，不是私钥。",
+            "en": "A signature covers the image **digest**, not the tag. Push to the internal registry first and sign after; the other order signs something else. The `publicKeys` field in Kyverno `verifyImages` takes the public key, not the private one."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用 Kyverno 再写一遍「不许特权容器」。能用，但那是在维护一份和上游 PSA 并行的实现 —— 上游加了新的提权途径，你的规则不会跟着更新。能交给 PSA 的就交给它。",
+            "en": "Reimplementing \"no privileged containers\" as a Kyverno rule. It works, but it means maintaining a parallel copy of upstream PSA: when upstream adds a newly discovered escalation path, your rule does not follow. Hand to PSA what PSA covers."
+          },
+          {
+            "zh": "把 `validationFailureAction` 写成 `Audit` 就以为拦住了。Audit 只记录，对象照样进集群 —— 和 PSA 那边只打 `warn` 标签是同一个误会。",
+            "en": "Setting `validationFailureAction: Audit` and believing it blocks. Audit only records; the object still lands. It is the same misunderstanding as labelling a namespace with only `warn` on the PSA side."
+          },
+          {
+            "zh": "把违规的 `cache` 删掉交差。删掉当然不违规了，但业务也没了 —— 判定要求它跑着。策略的意义是让人把东西改对，不是把东西删光。",
+            "en": "Deleting the offending `cache` and calling it done. Nothing violates once nothing runs, but the workload is gone too, and the grader requires it running. Policy exists to make things correct, not to make them disappear."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "kyverno-admission-controller",
+                "namespace": "kyverno",
+                "labels": {
+                  "app.kubernetes.io/name": "kyverno"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "kyverno"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "kyverno"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "kyverno",
+                        "image": "ghcr.io/kyverno/kyverno:v1.16.0",
+                        "ports": [
+                          {
+                            "containerPort": 9443
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cache",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "cache"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "cache"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "redis",
+                        "image": "docker.io/library/redis:7.4",
+                        "ports": [
+                          {
+                            "containerPort": 6379
+                          }
+                        ],
+                        "securityContext": {
+                          "privileged": true
+                        }
+                      }
+                    ],
+                    "volumes": [
+                      {
+                        "name": "data",
+                        "hostPath": {
+                          "path": "/var/lib/redis"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/policy.yaml": "# 三条规矩要落成策略。想清楚哪一条该交给 PSA，哪一条只能靠 Kyverno。\n#\n#   1. 不许特权容器、不许 hostPath\n#   2. 每个工作负载都要有 owner 标签\n#   3. 镜像只能来自内网仓库，而且必须签过名\n",
+            "/root/infra/cache.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: cache\n  namespace: payments\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: cache\n  template:\n    metadata:\n      labels:\n        app: cache\n        owner: payments\n    spec:\n      securityContext:\n        runAsNonRoot: true\n        seccompProfile:\n          type: RuntimeDefault\n      containers:\n      - name: redis\n        image: harbor.corp.internal/team/sessions:1.8.0\n        ports:\n        - containerPort: 8080\n        securityContext:\n          allowPrivilegeEscalation: false\n          runAsNonRoot: true\n          capabilities:\n            drop:\n            - ALL\n"
+          },
+          "referenceFiles": {
+            "/root/infra/policy.yaml": "# 第 2、3 条：PSA 表达不了，交给 Kyverno\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: require-owner\nspec:\n  validationFailureAction: Enforce\n  rules:\n  - name: owner-label\n    match:\n      any:\n      - resources:\n          kinds:\n          - Pod\n          namespaces:\n          - payments\n    validate:\n      message: \"每个工作负载都要带 owner 标签\"\n      pattern:\n        metadata:\n          labels:\n            owner: \"?*\"\n---\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: internal-registry-only\nspec:\n  validationFailureAction: Enforce\n  rules:\n  - name: registry\n    match:\n      any:\n      - resources:\n          kinds:\n          - Pod\n          namespaces:\n          - payments\n    validate:\n      message: \"镜像只能来自 harbor.corp.internal\"\n      pattern:\n        spec:\n          containers:\n          - image: \"harbor.corp.internal/*\"\n"
+          },
+          "referenceCommands": [
+            "cosign generate-key-pair",
+            "cosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0",
+            "cat > /root/infra/verify.yaml <<EOF\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: verify-images\nspec:\n  validationFailureAction: Enforce\n  rules:\n  - name: signed\n    match:\n      any:\n      - resources:\n          kinds:\n          - Pod\n          namespaces:\n          - payments\n    verifyImages:\n    - imageReferences:\n      - \"harbor.corp.internal/*\"\n      attestors:\n      - entries:\n        - keys:\n            publicKeys: |\n$(sed 's/^/              /' /root/cosign.pub)\nEOF",
+            "kubectl label namespace payments pod-security.kubernetes.io/enforce=restricted",
+            "kubectl apply -f /root/infra/policy.yaml",
+            "kubectl apply -f /root/infra/verify.yaml",
+            "kubectl replace -f /root/infra/cache.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "policy-as-code.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst violating = (name, patch) => JSON.stringify({\n  apiVersion: 'v1', kind: 'Pod',\n  metadata: { name, namespace: 'payments', labels: { owner: 'payments' } },\n  spec: {\n    securityContext: { runAsNonRoot: true, seccompProfile: { type: 'RuntimeDefault' } },\n    containers: [{\n      name: 'app', image: 'harbor.corp.internal/team/sessions:1.8.0',\n      securityContext: {\n        allowPrivilegeEscalation: false, runAsNonRoot: true,\n        capabilities: { drop: ['ALL'] },\n      },\n    }],\n    ...patch,\n  },\n});\n\nconst apply = async (json) => sh(\"echo '\" + json + \"' | kubectl apply -f -\");\n\ndescribe('策略即代码', () => {\n  it('特权容器进不来', async () => {\n    const result = await apply(violating('privileged-probe', {\n      containers: [{\n        name: 'app', image: 'harbor.corp.internal/team/sessions:1.8.0',\n        securityContext: { privileged: true },\n      }],\n    }));\n    expect(result.code).not.toBe(0);\n    expect(result.stderr).toContain('PodSecurity');\n  });\n\n  it('hostPath 进不来', async () => {\n    const result = await apply(violating('hostpath-probe', {\n      volumes: [{ name: 'root', hostPath: { path: '/' } }],\n    }));\n    expect(result.code).not.toBe(0);\n  });\n\n  it('没有 owner 标签进不来', async () => {\n    const json = violating('no-owner', {}).replace('\"owner\":\"payments\"', '\"tier\":\"cache\"');\n    const result = await apply(json);\n    expect(result.code).not.toBe(0);\n    expect(result.stderr).toContain('owner');\n  });\n\n  it('公网镜像进不来', async () => {\n    const json = violating('public-image', {})\n      .replace(/harbor.corp.internal\\/team\\/sessions:1.8.0/g, 'docker.io/library/redis:7.4');\n    const result = await apply(json);\n    expect(result.code).not.toBe(0);\n  });\n\n  it('没签名的内网镜像也进不来', async () => {\n    const json = violating('unsigned', {})\n      .replace(/harbor.corp.internal\\/team\\/sessions:1.8.0/g, 'harbor.corp.internal/team/reports:2.1.0');\n    const result = await apply(json);\n    expect(result.code).not.toBe(0);\n    expect(result.stderr).toContain('not signed');\n  });\n\n  it('规规矩矩的 Pod 进得来', async () => {\n    const result = await apply(violating('good-probe', {}));\n    expect(result.code).toBe(0);\n  });\n\n  it('cache 改好了并且跑着 —— 不是删掉了事', () => {\n    const deployment = get('Deployment', 'cache', 'payments');\n    expect(deployment).toBeTruthy();\n    expect(deployment.status.readyReplicas).toBeGreaterThan(0);\n  });\n\n  it('第 1 条交给了 PSA，不是自己写一遍', () => {\n    const namespace = get('Namespace', 'payments');\n    const level = namespace.metadata.labels['pod-security.kubernetes.io/enforce'];\n    expect(['baseline', 'restricted']).toContain(level);\n  });\n\n  it('策略是 Enforce 不是 Audit', () => {\n    const policies = list('ClusterPolicy');\n    expect(policies.length).toBeGreaterThan(0);\n    for (const policy of policies) {\n      expect(policy.spec.validationFailureAction || 'Enforce').toBe('Enforce');\n    }\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "两层策略的分工值得记清楚。**PSA** 是 Kubernetes 内置的，三档预置标准，\n靠命名空间标签开关，卸不掉也改不了 —— 它的价值恰恰在这里：上游发现了\n新的提权途径，你升级集群就自动跟上，不需要维护任何规则。\n**Kyverno**（以及 ValidatingAdmissionPolicy）管的是公司自己的规矩：\n标签、镜像来源、命名约定、成本归属。能交给 PSA 的别自己写。\n\n供应链那条最容易被做成摆设。签名签的是 **digest**，所以它保证的是\n「这一坨字节被某把私钥认过」，不多也不少。它**不**保证镜像里没有漏洞，\n也不保证签它的人有资格签。真正要配套的是：谁持有私钥、密钥怎么轮转、\n以及验签之外还要看 SBOM 与来源证明（SLSA provenance）。\n只做验签而不管密钥归属，安全性等于「有人签过」这四个字。\n\n最后一点关于推行：策略上线永远从 `Audit` 开始，看几天报表，\n把存量违规改完，再切 `Enforce`。直接 Enforce 的后果不是策略被绕过，\n是有人半夜把策略删了 —— 那比没有策略更糟，因为没人知道它被删了。\n",
+          "en": "The division of labour between the two layers is worth internalising. **PSA** is\nbuilt into Kubernetes: three preset levels toggled by a namespace label, neither\nremovable nor customisable, and that rigidity is the point. When upstream learns\nof a new escalation path, upgrading the cluster picks it up with no rules for you\nto maintain. **Kyverno** (and ValidatingAdmissionPolicy) covers company-specific\nrules: labels, image provenance, naming conventions, cost attribution. Hand to\nPSA what PSA covers.\n\nThe supply-chain rule is the easiest to turn into theatre. A signature covers the\n**digest**, so it guarantees exactly one thing: these bytes were vouched for by\nsome private key. It does **not** say the image is free of vulnerabilities, nor\nthat whoever signed was entitled to. What has to come with it is key custody, a\nrotation story, and looking beyond signatures at SBOMs and build provenance\n(SLSA). Verifying signatures without governing the keys means the guarantee is\nliterally \"somebody signed this\".\n\nOne note on rollout: ship policies as `Audit` first, watch the reports for a few\ndays, fix the existing violations, then switch to `Enforce`. Going straight to\nEnforce does not get the policy bypassed; it gets the policy deleted at 2am,\nwhich is worse than having none, because nobody knows it is gone.\n"
+        },
+        "primer": {
+          "zh": "`准入`是对象写进 etcd 之前的最后一道关。它和鉴权回答的问题不同：鉴权看「谁在做什么」，准入看**对象本身长什么样**：特权容器、没写 limits、镜像没签名，都是在这一层被拦下来的。这一层分两块：Kubernetes 内置的插件，和以 webhook 形式接进来的外部组件。\n\n`PSA`（Pod Security Admission）是内置的那块，2025 年起替代了被删掉的 PodSecurityPolicy。它只有三档预置标准：`privileged` 什么都不管，`baseline` 挡住已知的提权途径（特权容器、hostPath、host 命名空间、额外 capability），`restricted` 再加上强化要求（非 root、丢掉所有 capability、seccomp、禁止提权）。开关是命名空间上的标签，三种模式各自独立：`enforce` 拦下来，`audit` 记日志，`warn` 回一条警告。只打 `warn` 而以为拦住了，是这一层最常见的误会。另一件要记住的：**PSA 只看 Pod**，违规的 Deployment 照样 apply 得进去，然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里。\n\n`Kyverno` 是外部那块，管的是 PSA 表达不了的公司自定义规矩：必须有 owner 标签、镜像只能来自内网仓库、名字要符合约定。规则写在 `ClusterPolicy` 里，`validate.pattern` 是它自己那套结构匹配（`?*` 表示要有值，`!` 表示不能等于，`|` 是或），`validate.cel` 直接写 CEL 表达式。它是集群里的一个工作负载：停掉它，所有策略立刻失效，而 `kubectl get cpol` 照样看得见。能交给 PSA 的规则不要在这里重写一遍：上游发现新的提权途径时，PSA 会跟着升级，你的规则不会。\n\n供应链那条靠 `cosign`。要点是它签的是镜像的 **digest** 而不是 tag：换个 tag 指向同一个 digest，签名依然有效；tag 不变而 digest 变了，签名立刻失效。准入时由 Kyverno 的 `verifyImages` 拿公钥验。但这条保证的边界要说清楚：它只证明「这坨字节被某把私钥认过」，不证明镜像里没有漏洞，也不证明签它的人有资格签。所以密钥归属、轮转、以及 SBOM 与来源证明是配套的，只做验签的话，安全性就等于「有人签过」这四个字。",
+          "en": "`Admission` is the last gate before an object reaches etcd. It answers a different question from authorization: authorization looks at who is doing what, while admission looks at **what the object contains**: a privileged container, missing limits, an unsigned image. The layer splits in two: plugins built into Kubernetes, and external components wired in as webhooks.\n\n`PSA` (Pod Security Admission) is the built-in half, replacing the removed PodSecurityPolicy. It offers exactly three preset levels: `privileged` checks nothing, `baseline` blocks known escalation paths (privileged containers, hostPath, host namespaces, extra capabilities), and `restricted` adds hardening (non-root, drop all capabilities, seccomp, no privilege escalation). The switch is a namespace label, and the three modes are independent: `enforce` blocks, `audit` records, `warn` returns a warning. Labelling only `warn` and believing it blocks is the classic mistake here. Also remember that **PSA only inspects Pods**: a violating Deployment applies cleanly and then yields no pods, with the reason sitting in the ReplicaSet events.\n\n`Kyverno` is the external half, covering what PSA cannot express: an owner label must exist, images must come from the internal registry, names must follow a convention. Rules live in a `ClusterPolicy`; `validate.pattern` is its own structural matching (`?*` requires a value, `!` negates, `|` is or) and `validate.cel` takes CEL expressions directly. It runs as a workload in the cluster, so stopping it disables every policy while `kubectl get cpol` still lists them. Do not reimplement PSA rules here: when upstream learns of a new escalation path, PSA follows on upgrade and your copy does not.\n\nThe supply-chain rule uses `cosign`. The key fact is that it signs the image **digest**, not the tag: retagging the same digest keeps the signature valid, while pushing new content under the same tag invalidates it immediately. At admission time Kyverno `verifyImages` checks it with the public key. Be clear about the boundary of that guarantee: it proves these bytes were vouched for by some private key, not that the image is free of vulnerabilities nor that the signer was entitled to sign. Key custody, rotation, SBOMs, and build provenance go with it; signature checking alone guarantees only that somebody signed."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1282,6 +1282,21 @@ const primers = {
       )
     ),
 
+    'policy-as-code': t(
+      p(
+        '`准入`是对象写进 etcd 之前的最后一道关。它和鉴权回答的问题不同：鉴权看「谁在做什么」，准入看**对象本身长什么样**：特权容器、没写 limits、镜像没签名，都是在这一层被拦下来的。这一层分两块：Kubernetes 内置的插件，和以 webhook 形式接进来的外部组件。',
+        '`PSA`（Pod Security Admission）是内置的那块，2025 年起替代了被删掉的 PodSecurityPolicy。它只有三档预置标准：`privileged` 什么都不管，`baseline` 挡住已知的提权途径（特权容器、hostPath、host 命名空间、额外 capability），`restricted` 再加上强化要求（非 root、丢掉所有 capability、seccomp、禁止提权）。开关是命名空间上的标签，三种模式各自独立：`enforce` 拦下来，`audit` 记日志，`warn` 回一条警告。只打 `warn` 而以为拦住了，是这一层最常见的误会。另一件要记住的：**PSA 只看 Pod**，违规的 Deployment 照样 apply 得进去，然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里。',
+        '`Kyverno` 是外部那块，管的是 PSA 表达不了的公司自定义规矩：必须有 owner 标签、镜像只能来自内网仓库、名字要符合约定。规则写在 `ClusterPolicy` 里，`validate.pattern` 是它自己那套结构匹配（`?*` 表示要有值，`!` 表示不能等于，`|` 是或），`validate.cel` 直接写 CEL 表达式。它是集群里的一个工作负载：停掉它，所有策略立刻失效，而 `kubectl get cpol` 照样看得见。能交给 PSA 的规则不要在这里重写一遍：上游发现新的提权途径时，PSA 会跟着升级，你的规则不会。',
+        '供应链那条靠 `cosign`。要点是它签的是镜像的 **digest** 而不是 tag：换个 tag 指向同一个 digest，签名依然有效；tag 不变而 digest 变了，签名立刻失效。准入时由 Kyverno 的 `verifyImages` 拿公钥验。但这条保证的边界要说清楚：它只证明「这坨字节被某把私钥认过」，不证明镜像里没有漏洞，也不证明签它的人有资格签。所以密钥归属、轮转、以及 SBOM 与来源证明是配套的，只做验签的话，安全性就等于「有人签过」这四个字。'
+      ),
+      p(
+        '`Admission` is the last gate before an object reaches etcd. It answers a different question from authorization: authorization looks at who is doing what, while admission looks at **what the object contains**: a privileged container, missing limits, an unsigned image. The layer splits in two: plugins built into Kubernetes, and external components wired in as webhooks.',
+        '`PSA` (Pod Security Admission) is the built-in half, replacing the removed PodSecurityPolicy. It offers exactly three preset levels: `privileged` checks nothing, `baseline` blocks known escalation paths (privileged containers, hostPath, host namespaces, extra capabilities), and `restricted` adds hardening (non-root, drop all capabilities, seccomp, no privilege escalation). The switch is a namespace label, and the three modes are independent: `enforce` blocks, `audit` records, `warn` returns a warning. Labelling only `warn` and believing it blocks is the classic mistake here. Also remember that **PSA only inspects Pods**: a violating Deployment applies cleanly and then yields no pods, with the reason sitting in the ReplicaSet events.',
+        '`Kyverno` is the external half, covering what PSA cannot express: an owner label must exist, images must come from the internal registry, names must follow a convention. Rules live in a `ClusterPolicy`; `validate.pattern` is its own structural matching (`?*` requires a value, `!` negates, `|` is or) and `validate.cel` takes CEL expressions directly. It runs as a workload in the cluster, so stopping it disables every policy while `kubectl get cpol` still lists them. Do not reimplement PSA rules here: when upstream learns of a new escalation path, PSA follows on upgrade and your copy does not.',
+        'The supply-chain rule uses `cosign`. The key fact is that it signs the image **digest**, not the tag: retagging the same digest keeps the signature valid, while pushing new content under the same tag invalidates it immediately. At admission time Kyverno `verifyImages` checks it with the public key. Be clear about the boundary of that guarantee: it proves these bytes were vouched for by some private key, not that the image is free of vulnerabilities nor that the signer was entitled to sign. Key custody, rotation, SBOMs, and build provenance go with it; signature checking alone guarantees only that somebody signed.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5618,7 +5618,8 @@
           "ingress-nginx",
           "cert-manager",
           "argocd",
-          "istio-system"
+          "istio-system",
+          "kyverno"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5715,6 +5716,22 @@
             "readyAfterMs": 200,
             "listens": [
               15008
+            ]
+          },
+          "ghcr.io/kyverno/kyverno:v1.16.0": {
+            "pullMs": 500,
+            "startupMs": 700,
+            "readyAfterMs": 300,
+            "listens": [
+              9443
+            ]
+          },
+          "docker.io/library/redis:7.4": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "listens": [
+              6379
             ]
           },
           "harbor.corp.internal/team/sessions:1.8.0": {
@@ -10606,6 +10623,516 @@
         "primer": {
           "zh": "一个请求打到 apiserver，要过两道关，它们回答的是完全不同的问题。`认证`回答「你是谁」：客户端证书、ServiceAccount 的 token、或者 OIDC 发下来的 id_token，形式不同，产物都是同一个东西：一个用户名加一组 `group`。`鉴权`回答「你能不能做这件事」，这才是 RBAC 的活。所以「接了 OIDC 之后大家还是什么都干不了」是正常的中间状态，不是接错了。\n\nRBAC 有四个对象，两两成对：`Role` 与 `ClusterRole` 描述「能对什么资源做什么动作」，`RoleBinding` 与 `ClusterRoleBinding` 描述「谁拿到这套权限」。最容易记混的组合是 `RoleBinding` 引用 `ClusterRole`：这时权限的**范围由 Binding 决定**，拿到的只是那一个命名空间里的权限。这是「一套只读角色复用到每个命名空间」的标准写法，不必给每个命名空间各抄一份 Role。\n\n规则里有几处不是望文生义的。动词上，`get` 和 `list` 是两件事，只写 `get` 的规则挡不住也放不开 `list`；`watch` 又是第三件。资源上，看日志和进容器是**子资源**，要写成 `pods/log`（动词 `get`）和 `pods/exec`（动词 `create`，不是 get）。`resourceNames` 能把权限限定到具体对象，但它只对指名道姓的请求生效；`list` 与 `watch` 没有名字，带 `resourceNames` 的规则对它们一律不匹配。\n\n最关键的一条：RBAC **只有允许，没有拒绝**。写不出「除了 Secret 之外都可以」，只能把 Secret 之外的都列出来。这意味着加规则永远只会让权限变大，收权限的唯一办法是改掉或删掉已有的绑定；在一条 cluster-admin 绑定旁边再写一个小角色，一点用都没有。检查的办法是 `kubectl auth can-i <动词> <资源> --as=<用户> --as-group=<组>`，加 `--list` 会把这个身份能做的事全列出来。人对自己写的 RBAC 判断准确率相当低，这条命令是直接问服务端要答案。",
           "en": "A request reaching the apiserver passes two gates that answer completely different questions. `Authentication` answers \"who are you\": a client certificate, a ServiceAccount token, or an OIDC id_token, all producing the same thing, a username plus a set of `groups`. `Authorization` answers \"may you do this\", and that is RBAC job. So \"we wired up OIDC and everyone still cannot do anything\" is a normal intermediate state, not a broken integration.\n\nRBAC has four objects in two pairs. `Role` and `ClusterRole` describe what verbs apply to what resources; `RoleBinding` and `ClusterRoleBinding` describe who gets them. The combination people misremember is a `RoleBinding` referencing a `ClusterRole`: **scope comes from the binding**, so the subject gains those permissions in that one namespace. This is the standard way to reuse one read-only role across namespaces instead of copying a Role into each.\n\nSeveral details in a rule are not what they look like. On verbs, `get` and `list` are separate, so a rule granting only `get` neither blocks nor permits `list`, and `watch` is a third. On resources, reading logs and execing are **subresources**, written `pods/log` (verb `get`) and `pods/exec` (verb `create`, not get). `resourceNames` narrows a rule to specific objects, but only for requests that name one: `list` and `watch` carry no name, so such rules never match them.\n\nThe most important property: RBAC **only allows, it never denies**. There is no way to say \"anything except Secrets\"; you enumerate everything else. Adding rules can therefore only widen access, and the only way to reduce it is to change or delete an existing binding, which is why writing a smaller role next to a cluster-admin binding accomplishes nothing. To check, use `kubectl auth can-i <verb> <resource> --as=<user> --as-group=<group>`, and add `--list` to print everything that identity can do. People predict their own RBAC badly; this command asks the server instead."
+        }
+      },
+      {
+        "id": "policy-as-code",
+        "title": {
+          "zh": "把规矩写成策略",
+          "en": "Turn the Rules Into Policy"
+        },
+        "goal": {
+          "zh": "安全评审给了三条规矩，从今往后由集群自己把关，不靠人 review：\n\n1. `payments` 里不许跑特权容器，不许挂 hostPath；\n2. 每个工作负载都要带 `owner` 标签；\n3. 镜像只能来自 `harbor.corp.internal`，而且必须**签过名**。\n\n现场有个反面教材：前任跑起来的 `cache`，用的是公网拉的 redis、\n开了特权、挂了宿主机目录、没有 owner 标签 —— 四条全占。\n\nKyverno 已经装好。签名用 `cosign`，密钥自己生成。\n\n## 通关标准\n\n1. 三条规矩都落成策略并且真的拦得住；\n2. `cache` 改好并跑起来（不是删掉了事）；\n3. 违规的东西 apply 上去会被拒，报错能看懂；\n4. 第 1 条用 PSA 的档位做，不是自己写 Kyverno 规则重复造一遍。\n\n## 会用到的命令\n\n```bash\nkubectl label namespace payments pod-security.kubernetes.io/enforce=restricted\ncosign generate-key-pair\ncosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0\nkubectl apply -f /root/infra/policy.yaml\nkubectl get cpol\nkubectl apply -f /root/infra/cache.yaml\n```\n",
+          "en": "The security review handed down three rules, to be enforced by the cluster from\nnow on rather than by human review:\n\n1. no privileged containers and no hostPath volumes in `payments`;\n2. every workload carries an `owner` label;\n3. images come only from `harbor.corp.internal`, and must be **signed**.\n\nThere is a live counter-example: the `cache` your predecessor started runs a\nredis pulled from the public internet, privileged, with a host directory mounted,\nand no owner label. All four at once.\n\nKyverno is installed. Use `cosign` for signatures and generate your own key.\n\n## Done when\n\n1. all three rules exist as policy and actually block;\n2. `cache` is fixed and running, not deleted;\n3. a violating manifest is rejected with a message you can act on;\n4. rule 1 uses PSA levels rather than a hand-written Kyverno rule reimplementing\n   them.\n\n## Commands you will need\n\n```bash\nkubectl label namespace payments pod-security.kubernetes.io/enforce=restricted\ncosign generate-key-pair\ncosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0\nkubectl apply -f /root/infra/policy.yaml\nkubectl get cpol\nkubectl apply -f /root/infra/cache.yaml\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "三条规矩都由集群自己把关",
+            "en": "All three rules enforced by the cluster"
+          },
+          {
+            "zh": "反面教材改好了，不是删掉了事",
+            "en": "The counter-example is fixed, not deleted"
+          },
+          {
+            "zh": "该用 PSA 的用 PSA",
+            "en": "PSA where PSA belongs"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "PSA 是三档预置标准，靠命名空间标签开启，不写规则：`restricted` 已经包含「不许特权、不许 hostPath」以及更多。它挡不住的是「必须有 owner 标签」这种公司自定义的规矩 —— 那才是 Kyverno 的活。",
+            "en": "PSA offers three preset levels switched on by a namespace label, with no rules to write: `restricted` already covers \"no privileged, no hostPath\" and more. What it cannot express is a company-specific rule like \"must carry an owner label\", and that is what Kyverno is for."
+          },
+          {
+            "zh": "PSA 只看 **Pod**。给命名空间打上 `enforce=restricted` 之后，违规的 Deployment 照样 apply 得进去 —— 然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里（`kubectl describe rs`）。",
+            "en": "PSA only inspects **Pods**. After labelling the namespace `enforce=restricted`, a violating Deployment still applies cleanly and then produces no pods at all; the reason sits in the ReplicaSet events (`kubectl describe rs`)."
+          },
+          {
+            "zh": "签名签的是镜像的 **digest**，不是 tag。所以先把镜像推进内网仓库、再签，顺序反了签的就是另一个东西。Kyverno 的 `verifyImages` 里填的是公钥，不是私钥。",
+            "en": "A signature covers the image **digest**, not the tag. Push to the internal registry first and sign after; the other order signs something else. The `publicKeys` field in Kyverno `verifyImages` takes the public key, not the private one."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用 Kyverno 再写一遍「不许特权容器」。能用，但那是在维护一份和上游 PSA 并行的实现 —— 上游加了新的提权途径，你的规则不会跟着更新。能交给 PSA 的就交给它。",
+            "en": "Reimplementing \"no privileged containers\" as a Kyverno rule. It works, but it means maintaining a parallel copy of upstream PSA: when upstream adds a newly discovered escalation path, your rule does not follow. Hand to PSA what PSA covers."
+          },
+          {
+            "zh": "把 `validationFailureAction` 写成 `Audit` 就以为拦住了。Audit 只记录，对象照样进集群 —— 和 PSA 那边只打 `warn` 标签是同一个误会。",
+            "en": "Setting `validationFailureAction: Audit` and believing it blocks. Audit only records; the object still lands. It is the same misunderstanding as labelling a namespace with only `warn` on the PSA side."
+          },
+          {
+            "zh": "把违规的 `cache` 删掉交差。删掉当然不违规了，但业务也没了 —— 判定要求它跑着。策略的意义是让人把东西改对，不是把东西删光。",
+            "en": "Deleting the offending `cache` and calling it done. Nothing violates once nothing runs, but the workload is gone too, and the grader requires it running. Policy exists to make things correct, not to make them disappear."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "kyverno-admission-controller",
+                "namespace": "kyverno",
+                "labels": {
+                  "app.kubernetes.io/name": "kyverno"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "kyverno"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "kyverno"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "kyverno",
+                        "image": "ghcr.io/kyverno/kyverno:v1.16.0",
+                        "ports": [
+                          {
+                            "containerPort": 9443
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cache",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "cache"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "cache"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "redis",
+                        "image": "docker.io/library/redis:7.4",
+                        "ports": [
+                          {
+                            "containerPort": 6379
+                          }
+                        ],
+                        "securityContext": {
+                          "privileged": true
+                        }
+                      }
+                    ],
+                    "volumes": [
+                      {
+                        "name": "data",
+                        "hostPath": {
+                          "path": "/var/lib/redis"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/policy.yaml": "# 三条规矩要落成策略。想清楚哪一条该交给 PSA，哪一条只能靠 Kyverno。\n#\n#   1. 不许特权容器、不许 hostPath\n#   2. 每个工作负载都要有 owner 标签\n#   3. 镜像只能来自内网仓库，而且必须签过名\n",
+            "/root/infra/cache.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: cache\n  namespace: payments\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: cache\n  template:\n    metadata:\n      labels:\n        app: cache\n        owner: payments\n    spec:\n      securityContext:\n        runAsNonRoot: true\n        seccompProfile:\n          type: RuntimeDefault\n      containers:\n      - name: redis\n        image: harbor.corp.internal/team/sessions:1.8.0\n        ports:\n        - containerPort: 8080\n        securityContext:\n          allowPrivilegeEscalation: false\n          runAsNonRoot: true\n          capabilities:\n            drop:\n            - ALL\n"
+          },
+          "referenceFiles": {
+            "/root/infra/policy.yaml": "# 第 2、3 条：PSA 表达不了，交给 Kyverno\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: require-owner\nspec:\n  validationFailureAction: Enforce\n  rules:\n  - name: owner-label\n    match:\n      any:\n      - resources:\n          kinds:\n          - Pod\n          namespaces:\n          - payments\n    validate:\n      message: \"每个工作负载都要带 owner 标签\"\n      pattern:\n        metadata:\n          labels:\n            owner: \"?*\"\n---\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: internal-registry-only\nspec:\n  validationFailureAction: Enforce\n  rules:\n  - name: registry\n    match:\n      any:\n      - resources:\n          kinds:\n          - Pod\n          namespaces:\n          - payments\n    validate:\n      message: \"镜像只能来自 harbor.corp.internal\"\n      pattern:\n        spec:\n          containers:\n          - image: \"harbor.corp.internal/*\"\n"
+          },
+          "referenceCommands": [
+            "cosign generate-key-pair",
+            "cosign sign --key cosign.key harbor.corp.internal/team/sessions:1.8.0",
+            "cat > /root/infra/verify.yaml <<EOF\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: verify-images\nspec:\n  validationFailureAction: Enforce\n  rules:\n  - name: signed\n    match:\n      any:\n      - resources:\n          kinds:\n          - Pod\n          namespaces:\n          - payments\n    verifyImages:\n    - imageReferences:\n      - \"harbor.corp.internal/*\"\n      attestors:\n      - entries:\n        - keys:\n            publicKeys: |\n$(sed 's/^/              /' /root/cosign.pub)\nEOF",
+            "kubectl label namespace payments pod-security.kubernetes.io/enforce=restricted",
+            "kubectl apply -f /root/infra/policy.yaml",
+            "kubectl apply -f /root/infra/verify.yaml",
+            "kubectl replace -f /root/infra/cache.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "policy-as-code.spec.ts",
+            "content": "import { get, list, sh } from '@ops/lab';\n\nconst violating = (name, patch) => JSON.stringify({\n  apiVersion: 'v1', kind: 'Pod',\n  metadata: { name, namespace: 'payments', labels: { owner: 'payments' } },\n  spec: {\n    securityContext: { runAsNonRoot: true, seccompProfile: { type: 'RuntimeDefault' } },\n    containers: [{\n      name: 'app', image: 'harbor.corp.internal/team/sessions:1.8.0',\n      securityContext: {\n        allowPrivilegeEscalation: false, runAsNonRoot: true,\n        capabilities: { drop: ['ALL'] },\n      },\n    }],\n    ...patch,\n  },\n});\n\nconst apply = async (json) => sh(\"echo '\" + json + \"' | kubectl apply -f -\");\n\ndescribe('策略即代码', () => {\n  it('特权容器进不来', async () => {\n    const result = await apply(violating('privileged-probe', {\n      containers: [{\n        name: 'app', image: 'harbor.corp.internal/team/sessions:1.8.0',\n        securityContext: { privileged: true },\n      }],\n    }));\n    expect(result.code).not.toBe(0);\n    expect(result.stderr).toContain('PodSecurity');\n  });\n\n  it('hostPath 进不来', async () => {\n    const result = await apply(violating('hostpath-probe', {\n      volumes: [{ name: 'root', hostPath: { path: '/' } }],\n    }));\n    expect(result.code).not.toBe(0);\n  });\n\n  it('没有 owner 标签进不来', async () => {\n    const json = violating('no-owner', {}).replace('\"owner\":\"payments\"', '\"tier\":\"cache\"');\n    const result = await apply(json);\n    expect(result.code).not.toBe(0);\n    expect(result.stderr).toContain('owner');\n  });\n\n  it('公网镜像进不来', async () => {\n    const json = violating('public-image', {})\n      .replace(/harbor.corp.internal\\/team\\/sessions:1.8.0/g, 'docker.io/library/redis:7.4');\n    const result = await apply(json);\n    expect(result.code).not.toBe(0);\n  });\n\n  it('没签名的内网镜像也进不来', async () => {\n    const json = violating('unsigned', {})\n      .replace(/harbor.corp.internal\\/team\\/sessions:1.8.0/g, 'harbor.corp.internal/team/reports:2.1.0');\n    const result = await apply(json);\n    expect(result.code).not.toBe(0);\n    expect(result.stderr).toContain('not signed');\n  });\n\n  it('规规矩矩的 Pod 进得来', async () => {\n    const result = await apply(violating('good-probe', {}));\n    expect(result.code).toBe(0);\n  });\n\n  it('cache 改好了并且跑着 —— 不是删掉了事', () => {\n    const deployment = get('Deployment', 'cache', 'payments');\n    expect(deployment).toBeTruthy();\n    expect(deployment.status.readyReplicas).toBeGreaterThan(0);\n  });\n\n  it('第 1 条交给了 PSA，不是自己写一遍', () => {\n    const namespace = get('Namespace', 'payments');\n    const level = namespace.metadata.labels['pod-security.kubernetes.io/enforce'];\n    expect(['baseline', 'restricted']).toContain(level);\n  });\n\n  it('策略是 Enforce 不是 Audit', () => {\n    const policies = list('ClusterPolicy');\n    expect(policies.length).toBeGreaterThan(0);\n    for (const policy of policies) {\n      expect(policy.spec.validationFailureAction || 'Enforce').toBe('Enforce');\n    }\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "两层策略的分工值得记清楚。**PSA** 是 Kubernetes 内置的，三档预置标准，\n靠命名空间标签开关，卸不掉也改不了 —— 它的价值恰恰在这里：上游发现了\n新的提权途径，你升级集群就自动跟上，不需要维护任何规则。\n**Kyverno**（以及 ValidatingAdmissionPolicy）管的是公司自己的规矩：\n标签、镜像来源、命名约定、成本归属。能交给 PSA 的别自己写。\n\n供应链那条最容易被做成摆设。签名签的是 **digest**，所以它保证的是\n「这一坨字节被某把私钥认过」，不多也不少。它**不**保证镜像里没有漏洞，\n也不保证签它的人有资格签。真正要配套的是：谁持有私钥、密钥怎么轮转、\n以及验签之外还要看 SBOM 与来源证明（SLSA provenance）。\n只做验签而不管密钥归属，安全性等于「有人签过」这四个字。\n\n最后一点关于推行：策略上线永远从 `Audit` 开始，看几天报表，\n把存量违规改完，再切 `Enforce`。直接 Enforce 的后果不是策略被绕过，\n是有人半夜把策略删了 —— 那比没有策略更糟，因为没人知道它被删了。\n",
+          "en": "The division of labour between the two layers is worth internalising. **PSA** is\nbuilt into Kubernetes: three preset levels toggled by a namespace label, neither\nremovable nor customisable, and that rigidity is the point. When upstream learns\nof a new escalation path, upgrading the cluster picks it up with no rules for you\nto maintain. **Kyverno** (and ValidatingAdmissionPolicy) covers company-specific\nrules: labels, image provenance, naming conventions, cost attribution. Hand to\nPSA what PSA covers.\n\nThe supply-chain rule is the easiest to turn into theatre. A signature covers the\n**digest**, so it guarantees exactly one thing: these bytes were vouched for by\nsome private key. It does **not** say the image is free of vulnerabilities, nor\nthat whoever signed was entitled to. What has to come with it is key custody, a\nrotation story, and looking beyond signatures at SBOMs and build provenance\n(SLSA). Verifying signatures without governing the keys means the guarantee is\nliterally \"somebody signed this\".\n\nOne note on rollout: ship policies as `Audit` first, watch the reports for a few\ndays, fix the existing violations, then switch to `Enforce`. Going straight to\nEnforce does not get the policy bypassed; it gets the policy deleted at 2am,\nwhich is worse than having none, because nobody knows it is gone.\n"
+        },
+        "primer": {
+          "zh": "`准入`是对象写进 etcd 之前的最后一道关。它和鉴权回答的问题不同：鉴权看「谁在做什么」，准入看**对象本身长什么样**：特权容器、没写 limits、镜像没签名，都是在这一层被拦下来的。这一层分两块：Kubernetes 内置的插件，和以 webhook 形式接进来的外部组件。\n\n`PSA`（Pod Security Admission）是内置的那块，2025 年起替代了被删掉的 PodSecurityPolicy。它只有三档预置标准：`privileged` 什么都不管，`baseline` 挡住已知的提权途径（特权容器、hostPath、host 命名空间、额外 capability），`restricted` 再加上强化要求（非 root、丢掉所有 capability、seccomp、禁止提权）。开关是命名空间上的标签，三种模式各自独立：`enforce` 拦下来，`audit` 记日志，`warn` 回一条警告。只打 `warn` 而以为拦住了，是这一层最常见的误会。另一件要记住的：**PSA 只看 Pod**，违规的 Deployment 照样 apply 得进去，然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里。\n\n`Kyverno` 是外部那块，管的是 PSA 表达不了的公司自定义规矩：必须有 owner 标签、镜像只能来自内网仓库、名字要符合约定。规则写在 `ClusterPolicy` 里，`validate.pattern` 是它自己那套结构匹配（`?*` 表示要有值，`!` 表示不能等于，`|` 是或），`validate.cel` 直接写 CEL 表达式。它是集群里的一个工作负载：停掉它，所有策略立刻失效，而 `kubectl get cpol` 照样看得见。能交给 PSA 的规则不要在这里重写一遍：上游发现新的提权途径时，PSA 会跟着升级，你的规则不会。\n\n供应链那条靠 `cosign`。要点是它签的是镜像的 **digest** 而不是 tag：换个 tag 指向同一个 digest，签名依然有效；tag 不变而 digest 变了，签名立刻失效。准入时由 Kyverno 的 `verifyImages` 拿公钥验。但这条保证的边界要说清楚：它只证明「这坨字节被某把私钥认过」，不证明镜像里没有漏洞，也不证明签它的人有资格签。所以密钥归属、轮转、以及 SBOM 与来源证明是配套的，只做验签的话，安全性就等于「有人签过」这四个字。",
+          "en": "`Admission` is the last gate before an object reaches etcd. It answers a different question from authorization: authorization looks at who is doing what, while admission looks at **what the object contains**: a privileged container, missing limits, an unsigned image. The layer splits in two: plugins built into Kubernetes, and external components wired in as webhooks.\n\n`PSA` (Pod Security Admission) is the built-in half, replacing the removed PodSecurityPolicy. It offers exactly three preset levels: `privileged` checks nothing, `baseline` blocks known escalation paths (privileged containers, hostPath, host namespaces, extra capabilities), and `restricted` adds hardening (non-root, drop all capabilities, seccomp, no privilege escalation). The switch is a namespace label, and the three modes are independent: `enforce` blocks, `audit` records, `warn` returns a warning. Labelling only `warn` and believing it blocks is the classic mistake here. Also remember that **PSA only inspects Pods**: a violating Deployment applies cleanly and then yields no pods, with the reason sitting in the ReplicaSet events.\n\n`Kyverno` is the external half, covering what PSA cannot express: an owner label must exist, images must come from the internal registry, names must follow a convention. Rules live in a `ClusterPolicy`; `validate.pattern` is its own structural matching (`?*` requires a value, `!` negates, `|` is or) and `validate.cel` takes CEL expressions directly. It runs as a workload in the cluster, so stopping it disables every policy while `kubectl get cpol` still lists them. Do not reimplement PSA rules here: when upstream learns of a new escalation path, PSA follows on upgrade and your copy does not.\n\nThe supply-chain rule uses `cosign`. The key fact is that it signs the image **digest**, not the tag: retagging the same digest keeps the signature valid, while pushing new content under the same tag invalidates it immediately. At admission time Kyverno `verifyImages` checks it with the public key. Be clear about the boundary of that guarantee: it proves these bytes were vouched for by some private key, not that the image is free of vulnerabilities nor that the signer was entitled to sign. Key custody, rotation, SBOMs, and build provenance go with it; signature checking alone guarantees only that somebody signed."
         }
       }
     ]

--- a/src/lib/opslab/admission/cosign.ts
+++ b/src/lib/opslab/admission/cosign.ts
@@ -1,0 +1,90 @@
+/**
+ * cosign
+ *
+ * 签的不是镜像内容，是**镜像的 digest**。这一点值得强调：签名和 tag 无关，
+ * 换个 tag 指向同一个 digest，签名照样有效；而 tag 不变、digest 变了
+ * （有人重新推了一版），签名立刻失效。供应链安全靠的就是这个不可变的锚点。
+ *
+ * 我们用现成的 RSA + SHA-256 做真签名 —— 拿到公钥的人真的能验，
+ * 换一个 digest 真的验不过。签名存在镜像仓库里，和真 cosign 一样
+ * （真 cosign 存成 `sha256-<digest>.sig` 这个 tag）。
+ */
+import { sha256Hex } from '../crypto/digest';
+import { parsePrivateKeyPem, publicKeyPem, parsePublicKeyPem } from '../crypto/x509';
+import { sign, verify } from '../crypto/rsa';
+
+/** 一条签名记录 */
+export interface Signature {
+  /** 被签的 digest，形如 `sha256:abc...` */
+  digest: string;
+  /** base64 的签名 */
+  signature: string;
+  /** 签它的公钥（PEM），便于展示「谁签的」 */
+  publicKey: string;
+}
+
+/** 签名库：镜像仓库的一部分 */
+export class SignatureStore {
+  private readonly byDigest = new Map<string, Signature[]>();
+
+  add(signature: Signature): void {
+    const list = this.byDigest.get(signature.digest) ?? [];
+    if (!list.some((entry) => entry.signature === signature.signature)) list.push(signature);
+    this.byDigest.set(signature.digest, list);
+  }
+
+  get(digest: string): Signature[] {
+    return this.byDigest.get(digest) ?? [];
+  }
+
+  /** 这个 digest 有没有被这把公钥签过 */
+  verify(digest: string, publicKeyPemText: string): boolean {
+    const key = parsePublicKeyPem(publicKeyPemText);
+    if (!key) return false;
+    const payload = payloadFor(digest);
+    return this.get(digest).some((entry) => verify(key, payload, fromBase64(entry.signature)));
+  }
+}
+
+/**
+ * 被签的那段字节。
+ *
+ * 真 cosign 签的是一个 simple signing 格式的 JSON payload，里面带着 digest。
+ * 我们保留同样的形状 —— 关键是「签的内容里含 digest」，而不是签 digest 本身，
+ * 这样同一个 digest 在不同仓库里的签名能被区分开。
+ */
+export function payloadFor(digest: string): Uint8Array {
+  const payload = JSON.stringify({
+    critical: { identity: { 'docker-reference': '' }, image: { 'docker-manifest-digest': digest }, type: 'cosign container image signature' },
+    optional: null,
+  });
+  return new TextEncoder().encode(payload);
+}
+
+export function signDigest(privateKeyPem: string, digest: string): Signature | undefined {
+  const key = parsePrivateKeyPem(privateKeyPem);
+  if (!key) return undefined;
+  return {
+    digest,
+    signature: toBase64(sign(key, payloadFor(digest))),
+    publicKey: publicKeyPem(key),
+  };
+}
+
+/** 镜像引用 -> digest。没有 digest 的镜像按引用本身取 sha256，稳定且确定。 */
+export function digestOf(image: string): string {
+  const explicit = /@(sha256:[0-9a-f]{64})$/.exec(image);
+  if (explicit) return explicit[1];
+  return `sha256:${sha256Hex(image)}`;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(text: string): Uint8Array {
+  const binary = atob(text);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}

--- a/src/lib/opslab/admission/cosigncli.ts
+++ b/src/lib/opslab/admission/cosigncli.ts
@@ -1,0 +1,124 @@
+/**
+ * `cosign`
+ *
+ * 三条命令就够用了：生成密钥对、签一个镜像、验一个镜像。
+ * 真 cosign 还做 keyless（Fulcio + Rekor），那套依赖公网的 CA 与透明日志，
+ * 在内网场景里本来也用不上。
+ */
+import type { CommandHandler } from '../machine/shell/shell';
+import { digestOf, signDigest, type SignatureStore } from './cosign';
+import { encodePrivateKeyPem, publicKeyPem } from '../crypto/x509';
+import { keyFor } from '../crypto/keys';
+
+export interface CosignOptions {
+  signatures: SignatureStore;
+  /** 镜像在不在仓库里。不在就没得签。 */
+  hasImage(image: string): boolean;
+}
+
+export function createCosignCommand(options: CosignOptions): CommandHandler {
+  return ({ argv, cwd, vfs }) => {
+    const [command, ...rest] = argv;
+    // 带值的选项要连它的值一起跳过，否则 `--key cosign.key` 里的文件名
+    // 会被当成位置参数（镜像引用）
+    const positional = positionalOf(rest, ['--key', '--certificate', '--output']);
+
+    switch (command) {
+      case 'version':
+        return { stdout: 'GitVersion:    v2.6.1\nGoVersion:     go1.27.0\n' };
+
+      case 'generate-key-pair': {
+        /**
+         * 真 cosign 会问密码。这里不问 —— 密码保护的是私钥文件本身，
+         * 和「签名能不能验」无关，问了只是多一步。
+         */
+        const key = keyFor(`cosign:${cwd}`);
+        vfs.writeFile(resolve(cwd, 'cosign.key'), encodePrivateKeyPem(key));
+        vfs.writeFile(resolve(cwd, 'cosign.pub'), publicKeyPem(key));
+        return { stderr: 'Private key written to cosign.key\nPublic key written to cosign.pub\n' };
+      }
+
+      case 'sign': {
+        const keyPath = flag(rest, '--key');
+        const image = positional[0];
+        if (!keyPath || !image) {
+          return { stderr: 'Error: --key and an image reference are required\n', code: 1 };
+        }
+        const full = resolve(cwd, keyPath);
+        if (!vfs.exists(full)) return { stderr: `Error: open ${keyPath}: no such file or directory\n`, code: 1 };
+        if (!options.hasImage(image)) {
+          return { stderr: `Error: signing ${image}: image not found in registry\n`, code: 1 };
+        }
+        const signature = signDigest(vfs.readFile(full), digestOf(image));
+        if (!signature) return { stderr: `Error: reading key: invalid private key\n`, code: 1 };
+        options.signatures.add(signature);
+        return {
+          stderr: `Pushing signature to: ${image.split(':')[0]}\n`,
+          stdout: '',
+        };
+      }
+
+      case 'verify': {
+        const keyPath = flag(rest, '--key');
+        const image = positional[0];
+        if (!keyPath || !image) {
+          return { stderr: 'Error: --key and an image reference are required\n', code: 1 };
+        }
+        const full = resolve(cwd, keyPath);
+        if (!vfs.exists(full)) return { stderr: `Error: open ${keyPath}: no such file or directory\n`, code: 1 };
+        const digest = digestOf(image);
+        if (!options.signatures.verify(digest, vfs.readFile(full))) {
+          return {
+            stderr: `Error: no matching signatures:\n\nmain.go:74: error during command execution: `
+              + `no matching signatures:\n`,
+            code: 1,
+          };
+        }
+        return {
+          stderr: `Verification for ${image} --\n`
+            + 'The following checks were performed on each of these signatures:\n'
+            + '  - The cosign claims were validated\n'
+            + '  - The signatures were verified against the specified public key\n',
+          stdout: `[{"critical":{"image":{"docker-manifest-digest":"${digest}"},`
+            + '"type":"cosign container image signature"},"optional":null}]\n',
+        };
+      }
+
+      default:
+        return {
+          stderr: 'Usage: cosign [generate-key-pair|sign|verify|version]\n',
+          code: command ? 1 : 0,
+        };
+    }
+  };
+}
+
+function positionalOf(argv: string[], valueFlags: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const entry = argv[i];
+    if (valueFlags.includes(entry)) { i += 1; continue; }
+    if (entry.startsWith('-')) continue;
+    out.push(entry);
+  }
+  return out;
+}
+
+function flag(argv: string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const inline = argv.find((entry) => entry.startsWith(`${name}=`));
+  return inline?.slice(name.length + 1);
+}
+
+function resolve(cwd: string, path: string): string {
+  if (path.startsWith('/')) return path;
+  const parts = `${cwd}/${path}`.split('/');
+  const out: string[] = [];
+  for (const part of parts) {
+    if (!part || part === '.') continue;
+    if (part === '..') out.pop();
+    else out.push(part);
+  }
+  return `/${out.join('/')}`;
+}

--- a/src/lib/opslab/admission/index.ts
+++ b/src/lib/opslab/admission/index.ts
@@ -1,0 +1,17 @@
+/**
+ * 准入：对象写进 etcd 之前的最后一道关
+ *
+ * 内置的（PodSecurity）直接在 apiserver 里；Kyverno 是集群里的一个工作负载，
+ * 停掉它策略就不再生效 —— 和 CNI、网格是同一条架构约束。
+ */
+export type { AdmissionOperation, AdmissionPlugin, AdmissionRequest, AdmissionResponse } from './types';
+export { PSA_LABELS, modesOf, violationsOf, psaMessage } from './psa';
+export type { PsaLevel, PsaModes } from './psa';
+export { createPsaValidator } from './plugin';
+export { CLUSTERPOLICIES, POLICYREPORTS, KYVERNO_RESOURCES, KYVERNO_LABEL } from './resources';
+export { reviewWithKyverno, matchesPattern } from './kyverno';
+export type { KyvernoContext, KyvernoOutcome } from './kyverno';
+export { SignatureStore, signDigest, digestOf, payloadFor } from './cosign';
+export type { Signature } from './cosign';
+export { createCosignCommand } from './cosigncli';
+export type { CosignOptions } from './cosigncli';

--- a/src/lib/opslab/admission/kyverno.ts
+++ b/src/lib/opslab/admission/kyverno.ts
@@ -1,0 +1,226 @@
+/**
+ * Kyverno
+ *
+ * 和 PSA 的分工：PSA 是三档写死的预置标准，靠命名空间标签开关；Kyverno 是
+ * 自定义规则，写在 `ClusterPolicy` 里。前者管「别做危险的事」，后者管
+ * 「按我们公司的规矩来」—— 必须有 owner 标签、镜像只能来自内网仓库、
+ * 镜像必须签过名。
+ *
+ * 它是集群里的一个工作负载：Deployment 停了，所有策略立刻失效，
+ * 而 `kubectl get cpol` 照样看得见。和 CNI、网格是同一条约束。
+ *
+ * 做进来的三种 validate：
+ *  - `pattern`：Kyverno 自己那套结构匹配，支持 `*`、`?*`、`!` 前缀与 `|` 或
+ *  - `cel`：CEL 表达式（用 @marcbachmann/cel-js 真求值）
+ *  - `deny.conditions`：按 CEL 求值，命中就拒绝
+ * 外加 `verifyImages`：镜像签名验证。
+ */
+import { evaluate } from '@marcbachmann/cel-js';
+import type { KubeObject, ResourceDefinition } from '../apiserver';
+
+export interface KyvernoContext {
+  /** 策略清单 */
+  policies(): KubeObject[];
+  /** 控制面在不在 */
+  installed(): boolean;
+  /** 这个镜像有没有被某把公钥签过 */
+  verifyImage(image: string, publicKey: string): boolean;
+}
+
+export interface KyvernoOutcome {
+  /** 拦下来的原因 */
+  denied?: string;
+  /** 不拦但要提醒（policy 的 validationFailureAction 是 Audit 时） */
+  warnings: string[];
+}
+
+export function reviewWithKyverno(
+  context: KyvernoContext,
+  input: { definition: ResourceDefinition; object: KubeObject; namespace?: string }
+): KyvernoOutcome {
+  const warnings: string[] = [];
+  if (!context.installed()) return { warnings };
+
+  for (const policy of context.policies()) {
+    const spec = (policy.spec ?? {}) as any;
+    const audit = (spec.validationFailureAction ?? 'Enforce') === 'Audit';
+    for (const rule of spec.rules ?? []) {
+      if (!ruleMatches(rule, input)) continue;
+      const failure = evaluateRule(context, rule, input);
+      if (!failure) continue;
+      const message = `policy ${policy.metadata.name}/${rule.name} `
+        + `for resource ${input.namespace ?? ''}/${input.object.metadata?.name}: '${failure}'`;
+      if (audit) warnings.push(message);
+      else return { denied: message, warnings };
+    }
+  }
+  return { warnings };
+}
+
+/* ------------------------------------------------------------------ */
+/* match                                                               */
+/* ------------------------------------------------------------------ */
+
+function ruleMatches(
+  rule: any,
+  input: { definition: ResourceDefinition; object: KubeObject; namespace?: string }
+): boolean {
+  const any = rule.match?.any as any[] | undefined;
+  const all = rule.match?.all as any[] | undefined;
+  const filters = any ?? all ?? (rule.match?.resources ? [{ resources: rule.match.resources }] : []);
+  if (filters.length === 0) return false;
+  const matched = all
+    ? filters.every((entry) => filterMatches(entry.resources ?? {}, input))
+    : filters.some((entry) => filterMatches(entry.resources ?? {}, input));
+  if (!matched) return false;
+
+  // exclude 命中就整条不适用
+  const excludes = (rule.exclude?.any as any[] | undefined) ?? [];
+  return !excludes.some((entry) => filterMatches(entry.resources ?? {}, input));
+}
+
+function filterMatches(
+  resources: any,
+  input: { definition: ResourceDefinition; object: KubeObject; namespace?: string }
+): boolean {
+  const kinds: string[] = resources.kinds ?? [];
+  if (kinds.length > 0) {
+    const wanted = [input.definition.kind, `${input.definition.group}/${input.definition.version}/${input.definition.kind}`];
+    if (!kinds.some((kind) => wanted.includes(kind) || kind === '*')) return false;
+  }
+  const namespaces: string[] = resources.namespaces ?? [];
+  if (namespaces.length > 0) {
+    if (!input.namespace) return false;
+    if (!namespaces.some((entry) => globMatch(entry, input.namespace!))) return false;
+  }
+  const selector = resources.selector?.matchLabels as Record<string, string> | undefined;
+  if (selector) {
+    const labels = input.object.metadata?.labels ?? {};
+    if (!Object.entries(selector).every(([key, value]) => labels[key] === value)) return false;
+  }
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* validate                                                            */
+/* ------------------------------------------------------------------ */
+
+function evaluateRule(
+  context: KyvernoContext,
+  rule: any,
+  input: { object: KubeObject; namespace?: string }
+): string | undefined {
+  if (rule.verifyImages) {
+    return verifyImages(context, rule.verifyImages, input.object);
+  }
+
+  const validate = rule.validate;
+  if (!validate) return undefined;
+  const message = validate.message ?? 'validation error';
+
+  if (validate.pattern) {
+    return matchesPattern(input.object, validate.pattern) ? undefined : message;
+  }
+  if (validate.cel?.expressions) {
+    for (const expression of validate.cel.expressions) {
+      if (!celTruthy(expression.expression, input.object)) {
+        return expression.message ?? message;
+      }
+    }
+    return undefined;
+  }
+  if (validate.deny?.conditions?.all) {
+    const all = validate.deny.conditions.all as any[];
+    const hit = all.every((condition) => conditionHolds(condition, input.object));
+    return hit ? message : undefined;
+  }
+  return undefined;
+}
+
+function celTruthy(expression: string, object: KubeObject): boolean {
+  try {
+    return evaluate(expression, { object, request: { object } }) === true;
+  } catch {
+    // 表达式写错了当作不通过 —— 静默放行比拦错更糟
+    return false;
+  }
+}
+
+function conditionHolds(condition: any, object: KubeObject): boolean {
+  if (typeof condition.key === 'string' && condition.key.startsWith('{{')) {
+    // Kyverno 的 JMESPath 变量。这里只支持它包着的 CEL 形式。
+    return celTruthy(condition.key.replace(/^\{\{|\}\}$/g, '').trim(), object);
+  }
+  return celTruthy(String(condition.key ?? 'false'), object);
+}
+
+/* ------------------------------------------------------------------ */
+/* verifyImages                                                        */
+/* ------------------------------------------------------------------ */
+
+function verifyImages(context: KyvernoContext, entries: any[], object: KubeObject): string | undefined {
+  const containers: any[] = [
+    ...((object.spec as any)?.containers ?? []),
+    ...((object.spec as any)?.template?.spec?.containers ?? []),
+  ];
+  for (const entry of entries) {
+    const globs: string[] = entry.imageReferences ?? ['*'];
+    const key = entry.attestors?.[0]?.entries?.[0]?.keys?.publicKeys;
+    if (!key) continue;
+    for (const container of containers) {
+      const image = String(container.image ?? '');
+      if (!globs.some((glob) => globMatch(glob, image))) continue;
+      if (!context.verifyImage(image, key)) {
+        return `image ${image} is not signed by the expected key`;
+      }
+    }
+  }
+  return undefined;
+}
+
+/* ------------------------------------------------------------------ */
+/* pattern                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Kyverno 的结构匹配。
+ *
+ * 规则里只写关心的字段，其余不管。几个约定：
+ *  - `*` 表示「这个字段得有值」，`?*` 也是；
+ *  - `!x` 表示「不能等于 x」；
+ *  - `a | b` 表示「等于其中之一」；
+ *  - 数组里写一项，表示**每一项都要满足**它。
+ */
+export function matchesPattern(value: unknown, pattern: unknown): boolean {
+  if (pattern === null || pattern === undefined) return true;
+
+  if (Array.isArray(pattern)) {
+    if (!Array.isArray(value)) return false;
+    return value.every((item) => pattern.some((entry) => matchesPattern(item, entry)));
+  }
+
+  if (typeof pattern === 'object') {
+    if (typeof value !== 'object' || value === null) return false;
+    return Object.entries(pattern as Record<string, unknown>).every(([key, child]) => {
+      const optional = key.endsWith('?');
+      const name = optional ? key.slice(0, -1) : key;
+      const actual = (value as Record<string, unknown>)[name];
+      if (actual === undefined) return optional;
+      return matchesPattern(actual, child);
+    });
+  }
+
+  const text = String(pattern);
+  if (text.includes('|')) {
+    return text.split('|').some((entry) => matchesPattern(value, entry.trim()));
+  }
+  if (text.startsWith('!')) return !matchesPattern(value, text.slice(1));
+  if (text === '*' || text === '?*') return value !== undefined && value !== null && value !== '';
+  return globMatch(text, String(value));
+}
+
+export function globMatch(pattern: string, value: string): boolean {
+  if (pattern === '*') return true;
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`).test(value);
+}

--- a/src/lib/opslab/admission/plugin.ts
+++ b/src/lib/opslab/admission/plugin.ts
@@ -1,0 +1,30 @@
+/**
+ * 把 PSA 接到 apiserver 上
+ *
+ * PSA 只看 **Pod**。给 Deployment 打的标签不会拦住 Deployment 本身 ——
+ * 它照样被收下，然后 ReplicaSet 控制器去建 Pod 的时候被拦，于是
+ * `kubectl get deploy` 显示 0/3，而错误藏在 ReplicaSet 的事件里。
+ * 这是真集群里的行为，也是这一层最容易困住人的地方。
+ */
+import type { KubeObject, Validator } from '../apiserver';
+import { modesOf, psaMessage, violationsOf } from './psa';
+
+export interface PsaOptions {
+  /** 按名字取命名空间对象 —— 标签写在它上面 */
+  namespace(name: string): KubeObject | undefined;
+}
+
+export function createPsaValidator(options: PsaOptions): Validator {
+  return {
+    name: 'PodSecurity',
+    review({ definition, namespace, object }) {
+      if (definition.group !== '' || definition.resource !== 'pods') return undefined;
+      if (!namespace) return undefined;
+      const modes = modesOf(options.namespace(namespace));
+      if (modes.enforce === 'privileged') return undefined;
+      const violations = violationsOf((object.spec ?? {}) as any, modes.enforce);
+      if (violations.length === 0) return undefined;
+      return psaMessage(modes.enforce, violations);
+    },
+  };
+}

--- a/src/lib/opslab/admission/psa.ts
+++ b/src/lib/opslab/admission/psa.ts
@@ -1,0 +1,138 @@
+/**
+ * Pod Security Admission
+ *
+ * PSP 在 1.25 已经删掉了，替代它的是 PSA：**三档预置标准，靠命名空间上的
+ * 标签开启**，没有自定义规则。想要自定义就得上 Kyverno 那一类。
+ *
+ *   privileged  什么都不管
+ *   baseline    挡住已知的提权途径（特权容器、hostPath、hostNetwork…）
+ *   restricted  再加上强化要求（非 root、丢掉所有 capability、seccomp…）
+ *
+ * 三种模式各自独立：`enforce` 拦下来，`audit` 记日志，`warn` 回一条警告。
+ * 只打 `warn` 标签而以为自己拦住了，是最常见的误会。
+ */
+import type { KubeObject } from '../apiserver';
+
+export type PsaLevel = 'privileged' | 'baseline' | 'restricted';
+
+export const PSA_LABELS = {
+  enforce: 'pod-security.kubernetes.io/enforce',
+  audit: 'pod-security.kubernetes.io/audit',
+  warn: 'pod-security.kubernetes.io/warn',
+} as const;
+
+export interface PsaModes {
+  enforce: PsaLevel;
+  audit?: PsaLevel;
+  warn?: PsaLevel;
+}
+
+export function modesOf(namespace: KubeObject | undefined): PsaModes {
+  const labels = namespace?.metadata.labels ?? {};
+  const level = (value: string | undefined): PsaLevel | undefined =>
+    value === 'baseline' || value === 'restricted' || value === 'privileged' ? value : undefined;
+  return {
+    enforce: level(labels[PSA_LABELS.enforce]) ?? 'privileged',
+    audit: level(labels[PSA_LABELS.audit]),
+    warn: level(labels[PSA_LABELS.warn]),
+  };
+}
+
+interface Container {
+  name?: string;
+  image?: string;
+  securityContext?: Record<string, any>;
+}
+
+/**
+ * 检查一个 Pod 的 spec。
+ *
+ * 返回的每一条都照抄真 PSA 的措辞 —— 那些话把「哪个容器、哪个字段、
+ * 该设成什么」说全了，学员照着改就行，不用去翻文档。
+ */
+export function violationsOf(podSpec: any, level: PsaLevel): string[] {
+  if (level === 'privileged') return [];
+  const out: string[] = [];
+  const containers: Container[] = [
+    ...(podSpec?.containers ?? []),
+    ...(podSpec?.initContainers ?? []),
+    ...(podSpec?.ephemeralContainers ?? []),
+  ];
+
+  /* ---------------- baseline ---------------- */
+
+  const privileged = containers.filter((container) => container.securityContext?.privileged === true);
+  if (privileged.length > 0) {
+    out.push(`privileged (${describe(privileged)} must not set securityContext.privileged=true)`);
+  }
+  if (podSpec?.hostNetwork === true || podSpec?.hostPID === true || podSpec?.hostIPC === true) {
+    const set = [
+      podSpec.hostNetwork === true && 'hostNetwork',
+      podSpec.hostPID === true && 'hostPID',
+      podSpec.hostIPC === true && 'hostIPC',
+    ].filter(Boolean).join(', ');
+    out.push(`host namespaces (${set}=true)`);
+  }
+  const hostPaths = (podSpec?.volumes ?? []).filter((volume: any) => volume.hostPath);
+  if (hostPaths.length > 0) {
+    out.push(`hostPath volumes (volume${hostPaths.length > 1 ? 's' : ''} `
+      + `${hostPaths.map((volume: any) => `"${volume.name}"`).join(', ')})`);
+  }
+  const added = containers.filter((container) =>
+    (container.securityContext?.capabilities?.add ?? [])
+      .some((capability: string) => !BASELINE_CAPABILITIES.includes(capability)));
+  if (added.length > 0) {
+    out.push(`unrestricted capabilities (${describe(added)} must not include capabilities beyond the default set)`);
+  }
+
+  if (level === 'baseline') return out;
+
+  /* ---------------- restricted ---------------- */
+
+  const escalating = containers.filter(
+    (container) => container.securityContext?.allowPrivilegeEscalation !== false
+  );
+  if (escalating.length > 0) {
+    out.push(`allowPrivilegeEscalation != false (${describe(escalating)} `
+      + 'must set securityContext.allowPrivilegeEscalation=false)');
+  }
+
+  const asRoot = containers.filter((container) =>
+    container.securityContext?.runAsNonRoot !== true && podSpec?.securityContext?.runAsNonRoot !== true);
+  if (asRoot.length > 0) {
+    out.push(`runAsNonRoot != true (pod or ${describe(asRoot)} `
+      + 'must set securityContext.runAsNonRoot=true)');
+  }
+
+  const keepsCapabilities = containers.filter((container) =>
+    !(container.securityContext?.capabilities?.drop ?? []).includes('ALL'));
+  if (keepsCapabilities.length > 0) {
+    out.push(`unrestricted capabilities (${describe(keepsCapabilities)} `
+      + 'must set securityContext.capabilities.drop=["ALL"])');
+  }
+
+  const seccomp = podSpec?.securityContext?.seccompProfile?.type;
+  const badSeccomp = containers.filter((container) => {
+    const type = container.securityContext?.seccompProfile?.type ?? seccomp;
+    return type !== 'RuntimeDefault' && type !== 'Localhost';
+  });
+  if (badSeccomp.length > 0) {
+    out.push('seccompProfile (pod or containers must set securityContext.seccompProfile.type '
+      + 'to "RuntimeDefault" or "Localhost")');
+  }
+
+  return out;
+}
+
+/** baseline 允许保留的 capability，只有这一个 */
+const BASELINE_CAPABILITIES = ['NET_BIND_SERVICE'];
+
+function describe(containers: Container[]): string {
+  const names = containers.map((container) => `"${container.name ?? '?'}"`);
+  return `container${names.length > 1 ? 's' : ''} ${names.join(', ')}`;
+}
+
+/** 真 PSA 的拒绝消息 */
+export function psaMessage(level: PsaLevel, violations: string[]): string {
+  return `violates PodSecurity "${level}:latest": ${violations.join(', ')}`;
+}

--- a/src/lib/opslab/admission/resources.ts
+++ b/src/lib/opslab/admission/resources.ts
@@ -1,0 +1,24 @@
+/**
+ * Kyverno 的 CRD
+ *
+ * `ClusterPolicy` 是集群级的，`Policy` 是命名空间级的。这里只做前者 ——
+ * 「公司的规矩」天然是全集群的，而两者的规则语法完全一样。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const CLUSTERPOLICIES: ResourceDefinition = {
+  group: 'kyverno.io', version: 'v1', resource: 'clusterpolicies',
+  singular: 'clusterpolicy', kind: 'ClusterPolicy', namespaced: false,
+  shortNames: ['cpol'], subresources: ['status'],
+};
+
+export const POLICYREPORTS: ResourceDefinition = {
+  group: 'wgpolicyk8s.io', version: 'v1alpha2', resource: 'policyreports',
+  singular: 'policyreport', kind: 'PolicyReport', namespaced: true,
+  shortNames: ['polr'],
+};
+
+export const KYVERNO_RESOURCES: ResourceDefinition[] = [CLUSTERPOLICIES, POLICYREPORTS];
+
+/** Kyverno 的控制面。没有它，策略一条都不执行。 */
+export const KYVERNO_LABEL = { key: 'app.kubernetes.io/name', value: 'kyverno' };

--- a/src/lib/opslab/admission/types.ts
+++ b/src/lib/opslab/admission/types.ts
@@ -1,0 +1,37 @@
+/**
+ * 准入
+ *
+ * 对象写进 etcd 之前的最后一道关。和鉴权的区别是：鉴权只看「谁在做什么」，
+ * 准入看**对象本身长什么样** —— 特权容器、没写 limits、镜像没签名，
+ * 都是在这一层被拦下的。
+ *
+ * 真集群里这一层由内置插件（PodSecurity）与 webhook（Kyverno、Gatekeeper）
+ * 组成，我们照同样的分工：内置的直接在 apiserver 里，Kyverno 是集群里的
+ * 一个工作负载 —— 停掉它，策略就不再生效。
+ */
+import type { KubeObject, ResourceDefinition } from '../apiserver';
+
+export type AdmissionOperation = 'CREATE' | 'UPDATE';
+
+export interface AdmissionRequest {
+  definition: ResourceDefinition;
+  namespace?: string;
+  operation: AdmissionOperation;
+  object: KubeObject;
+  /** UPDATE 时的旧对象 */
+  oldObject?: KubeObject;
+}
+
+export interface AdmissionResponse {
+  allowed: boolean;
+  /** 拒绝的原因。会原样出现在 kubectl 的报错里，所以要能读。 */
+  message?: string;
+  /** 不拦，但要提醒。真 apiserver 通过 Warning 头带回来。 */
+  warnings?: string[];
+}
+
+export interface AdmissionPlugin {
+  /** 出现在报错里，学员据此知道是谁拦的 */
+  readonly name: string;
+  review(request: AdmissionRequest): AdmissionResponse;
+}

--- a/src/lib/opslab/apiserver/index.ts
+++ b/src/lib/opslab/apiserver/index.ts
@@ -13,7 +13,7 @@ export {
   parseFieldSelector,
   parseLabelSelector,
 } from './registry';
-export type { Defaulter, RegistryDeps } from './registry';
+export type { Defaulter, RegistryDeps, Validator } from './registry';
 export { Scheme, createScheme, storageKey, storagePrefix } from './scheme';
 export { ApiServer, createApiServer, parsePath } from './http';
 export type { ApiServerDeps } from './http';

--- a/src/lib/opslab/apiserver/registry.ts
+++ b/src/lib/opslab/apiserver/registry.ts
@@ -13,14 +13,7 @@ import {
   fieldSetOf, mergeApplied, ownedBy, pruneUnowned, recordOwnership, strippedForApply,
 } from './ssa';
 import { Store, WatchEvent } from '../store';
-import {
-  alreadyExists,
-  badRequest,
-  conflict,
-  invalid,
-  notFound,
-  tooOldResourceVersion,
-} from './errors';
+import { alreadyExists, badRequest, conflict, forbidden, invalid, notFound, tooOldResourceVersion } from './errors';
 import { CompactedError } from '../store';
 import { ResourceDefinition, Scheme, storageKey, storagePrefix } from './scheme';
 import type {
@@ -51,6 +44,24 @@ export interface Defaulter {
   apply(object: KubeObject, definition: ResourceDefinition, existing?: KubeObject): void;
 }
 
+/**
+ * 准入。对象写进 store 之前的最后一道关。
+ *
+ * 和 Defaulter 的区别是它只能说「不行」，不能改对象 —— 变更类的准入
+ * （mutating）走 Defaulter 那条路。
+ */
+export interface Validator {
+  readonly name: string;
+  /** 允许就返回 undefined；拒绝就返回一句能读的话 */
+  review(input: {
+    definition: ResourceDefinition;
+    namespace?: string;
+    operation: 'CREATE' | 'UPDATE';
+    object: KubeObject;
+    oldObject?: KubeObject;
+  }): string | undefined;
+}
+
 export interface RegistryDeps {
   store: Store;
   scheme: Scheme;
@@ -59,6 +70,7 @@ export interface RegistryDeps {
   /** 生成 uid，来自确定性随机数 */
   uid: () => string;
   defaulters?: Defaulter[];
+  validators?: Validator[];
 }
 
 function clone<T>(value: T): T {
@@ -191,6 +203,34 @@ export class Registry {
     this.defaulters.push(defaulter);
   }
 
+  private readonly validators: Validator[];
+
+  /** 装一道准入。PSA 与 Kyverno 都从这里进来。 */
+  addValidator(validator: Validator): void {
+    this.validators.push(validator);
+  }
+
+  /**
+   * 跑一遍准入。任何一道拦下来就抛 403。
+   *
+   * 报错的形状照抄真 apiserver：`<resource> "<name>" is forbidden: <原因>`，
+   * kubectl 会在前面补上 `Error from server (Forbidden): ...`。
+   */
+  private admit(
+    definition: ResourceDefinition,
+    namespace: string | undefined,
+    operation: 'CREATE' | 'UPDATE',
+    object: KubeObject,
+    oldObject?: KubeObject
+  ): void {
+    for (const validator of this.validators) {
+      const message = validator.review({ definition, namespace, operation, object, oldObject });
+      if (message) {
+        throw forbidden(`${definition.resource} "${object.metadata?.name ?? ''}" is forbidden: ${message}`);
+      }
+    }
+  }
+
   private applyDefaults(definition: ResourceDefinition, object: KubeObject, existing?: KubeObject): void {
     for (const defaulter of this.defaulters) {
       if (defaulter.matches(definition)) defaulter.apply(object, definition, existing);
@@ -199,6 +239,7 @@ export class Registry {
 
   constructor(deps: RegistryDeps) {
     this.defaulters = [...(deps.defaulters ?? [])];
+    this.validators = [...(deps.validators ?? [])];
     this.store = deps.store;
     this.scheme = deps.scheme;
     this.now = deps.now;
@@ -321,6 +362,7 @@ export class Registry {
     delete meta.deletionTimestamp;
 
     this.applyDefaults(definition, candidate);
+    this.admit(definition, namespace, 'CREATE', candidate);
 
     if (options.dryRun) return this.decorate(candidate, this.store.revision);
 
@@ -419,6 +461,7 @@ export class Registry {
     next.status = existing.status;
 
     this.applyDefaults(definition, next, existing);
+    this.admit(definition, namespace, 'UPDATE', next, existing);
 
     const specChanged = JSON.stringify(next.spec ?? null) !== JSON.stringify(existing.spec ?? null);
     meta.generation = (existing.metadata.generation ?? 1) + (specChanged ? 1 : 0);

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -17,6 +17,9 @@ import {
 } from '../apiserver';
 import { Controller, ControllerContext } from './framework';
 import { createServiceIpDefaulter } from './serviceip';
+import {
+  KYVERNO_LABEL, KYVERNO_RESOURCES, createPsaValidator, digestOf, reviewWithKyverno,
+} from '../admission';
 import { DaemonSetController } from './daemonset';
 import { ARGOCD_RESOURCES, ArgoCdController } from '../argocd';
 import {
@@ -85,6 +88,8 @@ export interface ClusterOptions {
    * 所有请求都是 cluster-admin —— 前面十几关不必为此各配一套角色。
    */
   users?: Record<string, { username: string; groups?: string[] }>;
+  /** 镜像签名库。由世界注入，和镜像仓库一样是集群外的东西。 */
+  signatures?: import('../admission').SignatureStore;
   /** Service 的 VIP 从哪个网段分。默认 10.96.0.0/12，和真集群一样。 */
   serviceCidr?: string;
   /** `kubectl exec` 落到哪。不给就是这个集群不支持 exec。 */
@@ -140,7 +145,7 @@ export class Cluster {
     this.store = createStore();
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
-      ...MESH_RESOURCES, ...RBAC_RESOURCES,
+      ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -195,6 +200,45 @@ export class Cluster {
     this.registry.addDefaulter(createServiceIpDefaulter({
       registry: this.registry, scheme: this.scheme, cidr: options.serviceCidr,
     }));
+
+    /**
+     * PodSecurity 是 apiserver 内置的准入，不是一个工作负载 ——
+     * 真集群里也一样，它没法被卸载，只能靠命名空间标签开关。
+     */
+    /**
+     * 顺序要紧：内置插件跑在 webhook 前面。
+     *
+     * 一个 Pod 同时违反 PSA 与 Kyverno 时，真集群报的是 PSA 那句话 ——
+     * 反过来的话学员会以为「先去加个 owner 标签」，改完才发现还有特权容器。
+     */
+    this.registry.addValidator(createPsaValidator({
+      namespace: (name) => {
+        const namespaces = this.scheme.get({ group: '', version: 'v1', resource: 'namespaces' });
+        if (!namespaces) return undefined;
+        return this.registry.list(namespaces).items.find((item) => item.metadata.name === name);
+      },
+    }));
+
+    /**
+     * Kyverno 是集群里的一个工作负载。
+     *
+     * Deployment 停了策略就不再执行，而 `kubectl get cpol` 照样看得见 ——
+     * 和 CNI、网格一样，这条约束在这里兑现。
+     */
+    this.registry.addValidator({
+      name: 'kyverno',
+      review: ({ definition, namespace, object }) => reviewWithKyverno({
+        installed: () => this.kyvernoInstalled(),
+        policies: () => {
+          const policies = this.scheme.get({
+            group: 'kyverno.io', version: 'v1', resource: 'clusterpolicies',
+          });
+          return policies ? this.registry.list(policies).items : [];
+        },
+        verifyImage: (image, publicKey) =>
+          this.options.signatures?.verify(digestOf(image), publicKey) ?? false,
+      }, { definition, object, namespace }).denied,
+    });
 
     this.seed();
   }
@@ -390,6 +434,15 @@ export class Cluster {
       serviceAccount: ((pod.spec ?? {}) as any).serviceAccountName ?? 'default',
       enrolled: isAmbient(object),
     };
+  }
+
+  /** Kyverno 的控制面在不在 */
+  private kyvernoInstalled(): boolean {
+    const deployments = this.scheme.get({ group: 'apps', version: 'v1', resource: 'deployments' });
+    if (!deployments) return false;
+    return this.registry.list(deployments).items.some((item) =>
+      item.metadata.labels?.[KYVERNO_LABEL.key] === KYVERNO_LABEL.value
+      && (((item.status ?? {}) as any).availableReplicas ?? 0) > 0);
   }
 
   imageBehaviorOf(image: string | undefined): ImageBehavior | undefined {

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -6,7 +6,7 @@
  * Endpoints 里只有 Ready 的 Pod）自然就对，不用逐个去仿。
  */
 import { Priority } from '../kernel';
-import { formatTimestamp, KubeObject, Registry, ResourceDefinition } from '../apiserver';
+import { ApiError, formatTimestamp, KubeObject, Registry, ResourceDefinition } from '../apiserver';
 import {
   Controller,
   ControllerContext,
@@ -316,9 +316,29 @@ export class ReplicaSetController extends Controller {
         message: `Created pod: ${pod.metadata.name}`,
       });
     } catch (error) {
-      if (!isConflict(error)) throw error;
+      if (isConflict(error)) return;
+      /**
+       * 被准入拦下来了（PodSecurity、Kyverno…）。
+       *
+       * 这不是控制器的错，重试也没用 —— 记一条事件就停手。真集群里
+       * `kubectl get deploy` 会一直显示 0/N，而原因只在 ReplicaSet 的
+       * 事件里，这一条不记的话现场就彻底没线索了。
+       */
+      if (isForbidden(error)) {
+        this.context.recordEvent({
+          object: replicaSet, type: 'Warning', reason: 'FailedCreate',
+          message: `Error creating: ${(error as Error).message}`,
+        });
+        return;
+      }
+      throw error;
     }
   }
+}
+
+/** 403：准入拒绝。重试没有意义，得让人看见。 */
+function isForbidden(error: unknown): boolean {
+  return error instanceof ApiError && (error as ApiError).code === 403;
 }
 
 export function isPodReady(pod: KubeObject): boolean {
@@ -402,11 +422,32 @@ export class DeploymentController extends Controller {
       return sum + Math.max(0, alive - intended);
     }, 0);
 
+    /**
+     * 先把旧 RS 里「本来就起不来」的那部分收掉。
+     *
+     * 一个旧 RS 声称要 3 个副本、实际一个 ready 的都没有（镜像拉不到、
+     * 被准入拦下、探针一直不过），那 3 个名额纯粹是占着位置：缩掉它们
+     * 不会让可用数下降一分。不做这一步的话，滚动更新会卡死 ——
+     * 新版本要等旧版本腾位置，而旧版本永远腾不出来，因为它压根没起来。
+     * 真 k8s 里这一步叫 cleanupUnhealthyReplicas。
+     */
+    for (const rs of old) {
+      const intended = (rs.spec as any)?.replicas ?? 0;
+      if (intended === 0) continue;
+      const healthy = this.readyOf(rs);
+      if (healthy >= intended) continue;
+      this.scale(rs, healthy);
+    }
+
+    const oldReplicasNow = this.ownedReplicaSets(deployment)
+      .filter((rs) => rs.metadata.uid !== current.metadata.uid)
+      .reduce((sum, rs) => sum + ((rs.spec as any)?.replicas ?? 0), 0);
+
     // 先扩新的（不超过 desired + maxSurge）
-    const surgeRoom = desired + maxSurge - (currentReplicas + oldReplicas);
+    const surgeRoom = desired + maxSurge - (currentReplicas + oldReplicasNow);
     if (currentReplicas < desired && surgeRoom > 0) {
       this.scale(current, Math.min(desired, currentReplicas + surgeRoom));
-    } else if (oldReplicas > 0) {
+    } else if (oldReplicasNow > 0) {
       // 再缩旧的，但一次最多缩到「可用数不低于 desired - maxUnavailable」为止
       const room = availableNow - inFlightScaleDown - (desired - maxUnavailable);
       if (room > 0) {

--- a/src/lib/opslab/crypto/x509.ts
+++ b/src/lib/opslab/crypto/x509.ts
@@ -182,6 +182,32 @@ function encodePublicKey(key: RsaKeyPair): Uint8Array {
 }
 
 /**
+ * 导出成 SPKI 的 `PUBLIC KEY`。
+ *
+ * cosign 的 `cosign.pub` 就是这个格式，openssl 与真 cosign 都读得懂。
+ */
+export function publicKeyPem(key: Pick<RsaKeyPair, 'n' | 'e'>): string {
+  return toPem('PUBLIC KEY', encodePublicKey(key as RsaKeyPair));
+}
+
+/** 从 SPKI PEM 里把公钥读回来。验签只要 n 和 e。 */
+export function parsePublicKeyPem(pem: string): { n: string; e: string } | undefined {
+  const match = /-----BEGIN PUBLIC KEY-----([\s\S]*?)-----END PUBLIC KEY-----/.exec(pem);
+  if (!match) return undefined;
+  try {
+    const root = parseDer(base64ToBytes(match[1].replace(/\s+/g, '')));
+    // SEQUENCE { AlgorithmIdentifier, BIT STRING { RSAPublicKey } }
+    const bits = root.children![1];
+    // BIT STRING 的第一个字节是「未用位数」，跳过
+    const inner = parseDer(bits.value.subarray(1));
+    const [n, e] = inner.children!.map((node) => bytesToBase64url(trimLeadingZeros(node.value)));
+    return { n, e };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * 导出成 PKCS#1 的 `RSA PRIVATE KEY`。
  *
  * 结构完整（带 CRT 参数），openssl 读得懂，我们自己也解析得回来 ——

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -22,6 +22,7 @@ import { createOpensslCommand } from './openssl';
 import { materializePki } from './pki';
 import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } from '../git';
 import { createIstioctlCommand } from '../mesh';
+import { SignatureStore, createCosignCommand } from '../admission';
 import { currentNamespaceOf } from './view';
 import { DEFAULT_KUBECONFIG_PATH } from '../wasm';
 import { createExecHandler } from './podshell';
@@ -42,6 +43,8 @@ export interface OpsWorld {
   registries: RegistryNetwork;
   /** 内网 Git 服务 */
   git: GitNetwork;
+  /** 镜像签名 */
+  signatures: SignatureStore;
   /** 装上的真 CLI 名字，如 ['kubectl','helm'] */
   applets: string[];
   /** 敲一条命令，然后让世界自己往前走到静止 */
@@ -63,6 +66,12 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   const clusterAgeMs = spec.clusterAgeDays !== undefined
     ? spec.clusterAgeDays * 24 * 60 * 60_000
     : DEFAULT_CLUSTER_AGE_MS;
+
+  // 镜像签名。和镜像仓库一样是集群外的东西，cosign 往里写，Kyverno 从里读。
+  const signatures = new SignatureStore();
+  const declaredImages = new Set(
+    Object.keys(mergeImages(spec.images, stage.images)).map(normalizeReference)
+  );
 
   // 先声明，下面 createCluster 要用；仓库对象在它之后才建得出来
   let lookupPushedImage: (image: string) => ReturnType<typeof behaviorOfImage> | undefined = () => undefined;
@@ -103,6 +112,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     externalHosts,
     addressPools: spec.addressPools,
     users: spec.users,
+    signatures,
     /**
      * Argo CD 从这里取仓库内容。
      *
@@ -191,6 +201,23 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
 
   machine.install('openssl', createOpensslCommand());
 
+  machine.install('cosign', createCosignCommand({
+    signatures,
+    /**
+     * 签之前先确认这个镜像存在。
+     *
+     * 三个来源：本地构建出来的、关卡声明过的、以及推到内网仓库里的。
+     * 不存在的镜像 cosign 会直接报错 —— 不然「签了但签的是个不存在的东西」
+     * 会一路混到准入那一层才炸。
+     */
+    hasImage: (image) => {
+      if (images.get(image)) return true;
+      if (declaredImages.has(normalizeReference(image))) return true;
+      const parsed = parseReference(image);
+      return Boolean(parsed && registries.has(parsed.registry));
+    },
+  }));
+
   machine.install('istioctl', createIstioctlCommand({
     view: () => cluster.istioView(),
     namespace: () => (machine.vfs.exists(DEFAULT_KUBECONFIG_PATH)
@@ -277,6 +304,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     images,
     registries,
     git,
+    signatures,
     applets,
     now: () => cluster.wallClock(),
     async run(command: string) {

--- a/tests/opslab/admission.test.ts
+++ b/tests/opslab/admission.test.ts
@@ -1,0 +1,363 @@
+/**
+ * 准入
+ *
+ * 两层，分工不同：
+ *  - **PSA** 是内置的，三档写死的标准，靠命名空间标签开关，卸不掉；
+ *  - **Kyverno** 是集群里的一个工作负载，写自定义规则，停掉就不生效。
+ *
+ * 还有一条贯穿两层的事实：PSA 只看 Pod。给 Deployment 打标签拦不住
+ * Deployment，它照样被收下，然后控制器建 Pod 时被拦 —— `kubectl get deploy`
+ * 显示 0/N，原因藏在 ReplicaSet 的事件里。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import {
+  digestOf, matchesPattern, modesOf, psaMessage, signDigest, violationsOf, SignatureStore,
+} from '../../src/lib/opslab/admission';
+import { encodePrivateKeyPem, publicKeyPem } from '../../src/lib/opslab/crypto/x509';
+import { keyFor } from '../../src/lib/opslab/crypto/keys';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+const APP = 'harbor.corp.internal/team/portal:1.4.0';
+const KYVERNO_IMAGE = 'ghcr.io/kyverno/kyverno:v1.16.0';
+
+describe('PodSecurity 的档位', () => {
+  const bad = {
+    containers: [{ name: 'app', image: APP, securityContext: { privileged: true } }],
+    hostNetwork: true,
+    volumes: [{ name: 'root', hostPath: { path: '/' } }],
+  };
+
+  it('privileged 什么都不管', () => {
+    expect(violationsOf(bad, 'privileged')).toEqual([]);
+  });
+
+  it('baseline 挡住特权、host 命名空间与 hostPath', () => {
+    const violations = violationsOf(bad, 'baseline').join(' ');
+    expect(violations).toContain('privileged');
+    expect(violations).toContain('hostNetwork=true');
+    expect(violations).toContain('hostPath volumes');
+  });
+
+  it('一个规规矩矩的 Pod 过 baseline 但过不了 restricted', () => {
+    const plain = { containers: [{ name: 'app', image: APP }] };
+    expect(violationsOf(plain, 'baseline')).toEqual([]);
+    const restricted = violationsOf(plain, 'restricted').join(' ');
+    expect(restricted).toContain('allowPrivilegeEscalation != false');
+    expect(restricted).toContain('runAsNonRoot != true');
+    expect(restricted).toContain('capabilities.drop=["ALL"]');
+    expect(restricted).toContain('seccompProfile');
+  });
+
+  it('四样都补齐就过 restricted', () => {
+    const good = {
+      securityContext: { runAsNonRoot: true, seccompProfile: { type: 'RuntimeDefault' } },
+      containers: [{
+        name: 'app', image: APP,
+        securityContext: {
+          allowPrivilegeEscalation: false,
+          runAsNonRoot: true,
+          capabilities: { drop: ['ALL'] },
+        },
+      }],
+    };
+    expect(violationsOf(good, 'restricted')).toEqual([]);
+  });
+
+  it('标签决定档位，enforce 与 warn 是两件事', () => {
+    expect(modesOf({ metadata: { name: 'x', labels: {} } } as never)).toEqual({ enforce: 'privileged' });
+    expect(modesOf({
+      metadata: {
+        name: 'x',
+        labels: {
+          'pod-security.kubernetes.io/warn': 'restricted',
+          'pod-security.kubernetes.io/enforce': 'baseline',
+        },
+      },
+    } as never)).toMatchObject({ enforce: 'baseline', warn: 'restricted' });
+  });
+
+  it('拒绝消息照抄真 PSA', () => {
+    expect(psaMessage('restricted', ['runAsNonRoot != true (…)']))
+      .toBe('violates PodSecurity "restricted:latest": runAsNonRoot != true (…)');
+  });
+});
+
+describe('Kyverno 的 pattern 匹配', () => {
+  it('* 表示这个字段得有值', () => {
+    expect(matchesPattern({ metadata: { labels: { owner: 'pay' } } }, { metadata: { labels: { owner: '?*' } } })).toBe(true);
+    expect(matchesPattern({ metadata: { labels: {} } }, { metadata: { labels: { owner: '?*' } } })).toBe(false);
+  });
+
+  it('! 表示不能等于', () => {
+    expect(matchesPattern({ image: 'nginx:1.27' }, { image: '!*:latest' })).toBe(true);
+    expect(matchesPattern({ image: 'nginx:latest' }, { image: '!*:latest' })).toBe(false);
+  });
+
+  it('| 是或', () => {
+    expect(matchesPattern({ tier: 'web' }, { tier: 'web | api' })).toBe(true);
+    expect(matchesPattern({ tier: 'db' }, { tier: 'web | api' })).toBe(false);
+  });
+
+  it('数组里写一项，表示每一项都要满足', () => {
+    const pattern = { containers: [{ image: 'harbor.corp.internal/*' }] };
+    expect(matchesPattern({ containers: [{ image: 'harbor.corp.internal/a:1' }, { image: 'harbor.corp.internal/b:2' }] }, pattern)).toBe(true);
+    expect(matchesPattern({ containers: [{ image: 'harbor.corp.internal/a:1' }, { image: 'docker.io/b:2' }] }, pattern)).toBe(false);
+  });
+
+  it('带 ? 的键是可选的', () => {
+    expect(matchesPattern({ spec: {} }, { spec: { 'replicas?': '*' } })).toBe(true);
+  });
+});
+
+describe('cosign 的签名是真的', () => {
+  const key = keyFor('cosign-test');
+  const pem = encodePrivateKeyPem(key);
+  const pub = publicKeyPem(key);
+
+  it('签一个 digest，用公钥验得过', () => {
+    const store = new SignatureStore();
+    const digest = digestOf(APP);
+    store.add(signDigest(pem, digest)!);
+    expect(store.verify(digest, pub)).toBe(true);
+  });
+
+  it('换一个 digest 就验不过 —— 签的是内容不是名字', () => {
+    const store = new SignatureStore();
+    store.add(signDigest(pem, digestOf(APP))!);
+    expect(store.verify(digestOf('harbor.corp.internal/team/portal:1.5.0'), pub)).toBe(false);
+  });
+
+  it('换一把公钥也验不过', () => {
+    const store = new SignatureStore();
+    store.add(signDigest(pem, digestOf(APP))!);
+    expect(store.verify(digestOf(APP), publicKeyPem(keyFor('someone-else')))).toBe(false);
+  });
+
+  it('带 @sha256: 的引用直接用那个 digest', () => {
+    const explicit = `harbor.corp.internal/team/portal@sha256:${'a'.repeat(64)}`;
+    expect(digestOf(explicit)).toBe(`sha256:${'a'.repeat(64)}`);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 集群里真的被拦住                                                    */
+/* ------------------------------------------------------------------ */
+
+const KYVERNO_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'kyverno', namespace: 'kyverno', labels: { 'app.kubernetes.io/name': 'kyverno' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'kyverno' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'kyverno' } },
+        spec: { containers: [{ name: 'kyverno', image: KYVERNO_IMAGE }] },
+      },
+    },
+  },
+];
+
+function spec(options: { objects?: unknown[]; nsLabels?: Record<string, string> } = {}): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'kyverno'],
+    images: {
+      [APP]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [KYVERNO_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: [
+      {
+        apiVersion: 'v1', kind: 'Namespace',
+        metadata: { name: 'shop', labels: options.nsLabels ?? {} },
+        status: { phase: 'Active' },
+      },
+      ...(options.objects ?? []),
+    ] as never,
+  };
+}
+
+const POD = {
+  apiVersion: 'v1', kind: 'Pod',
+  metadata: { name: 'probe', namespace: 'shop' },
+  spec: { containers: [{ name: 'app', image: APP }] },
+};
+
+async function build(options: Parameters<typeof spec>[0] = {}) {
+  return createOpsWorld({ world: spec(options) });
+}
+
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+
+describe('PSA 在集群里真的拦', () => {
+  it('没打标签的命名空间什么都收', async () => {
+    const w = await build();
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never)).not.toThrow();
+  });
+
+  it('restricted 之下普通 Pod 被拒，报的话能照着改', async () => {
+    const w = await build({ nsLabels: { 'pod-security.kubernetes.io/enforce': 'restricted' } });
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never))
+      .toThrow(/violates PodSecurity "restricted:latest"/);
+  });
+
+  it('只打 warn 标签拦不住 —— 这是最常见的误会', async () => {
+    const w = await build({ nsLabels: { 'pod-security.kubernetes.io/warn': 'restricted' } });
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never)).not.toThrow();
+  });
+
+  it('Deployment 本身收得下，Pod 起不来，原因在 ReplicaSet 的事件里', async () => {
+    const w = await build({
+      nsLabels: { 'pod-security.kubernetes.io/enforce': 'restricted' },
+      objects: [{
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'portal', namespace: 'shop' },
+        spec: {
+          replicas: 2,
+          selector: { matchLabels: { app: 'portal' } },
+          template: {
+            metadata: { labels: { app: 'portal' } },
+            spec: { containers: [{ name: 'app', image: APP }] },
+          },
+        },
+      }],
+    });
+    const pods = w.cluster.registry.list(w.cluster.scheme.mustGet(PODS), { namespace: 'shop' });
+    expect(pods.items).toHaveLength(0);
+
+    const events = w.cluster.registry.list(
+      w.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'events' }), { namespace: 'shop' }
+    ).items;
+    const failure = events.find((event) => (event as any).reason === 'FailedCreate');
+    expect(failure).toBeTruthy();
+    expect((failure as any).message).toContain('violates PodSecurity');
+  });
+});
+
+describe('Kyverno 在集群里真的拦', () => {
+  const REQUIRE_OWNER = {
+    apiVersion: 'kyverno.io/v1', kind: 'ClusterPolicy',
+    metadata: { name: 'require-owner' },
+    spec: {
+      validationFailureAction: 'Enforce',
+      rules: [{
+        name: 'owner-label',
+        match: { any: [{ resources: { kinds: ['Pod'], namespaces: ['shop'] } }] },
+        validate: {
+          message: 'every pod must carry an owner label',
+          pattern: { metadata: { labels: { owner: '?*' } } },
+        },
+      }],
+    },
+  };
+
+  it('控制面在，策略生效', async () => {
+    const w = await build({ objects: [...KYVERNO_PLATFORM, REQUIRE_OWNER] });
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never))
+      .toThrow(/every pod must carry an owner label/);
+  });
+
+  it('控制面不在，同一条策略一点用都没有', async () => {
+    const w = await build({ objects: [REQUIRE_OWNER] });
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never)).not.toThrow();
+  });
+
+  it('带 owner 标签就放行', async () => {
+    const w = await build({ objects: [...KYVERNO_PLATFORM, REQUIRE_OWNER] });
+    const ok = { ...POD, metadata: { ...POD.metadata, labels: { owner: 'payments' } } };
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', ok as never)).not.toThrow();
+  });
+
+  it('Audit 只警告不拦', async () => {
+    const audit = {
+      ...REQUIRE_OWNER,
+      spec: { ...REQUIRE_OWNER.spec, validationFailureAction: 'Audit' },
+    };
+    const w = await build({ objects: [...KYVERNO_PLATFORM, audit] });
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never)).not.toThrow();
+  });
+
+  it('CEL 表达式真的被求值', async () => {
+    const policy = {
+      apiVersion: 'kyverno.io/v1', kind: 'ClusterPolicy',
+      metadata: { name: 'small-only' },
+      spec: {
+        rules: [{
+          name: 'replicas',
+          match: { any: [{ resources: { kinds: ['Deployment'] } }] },
+          validate: {
+            cel: {
+              expressions: [{
+                expression: 'object.spec.replicas <= 3',
+                message: 'at most 3 replicas outside production',
+              }],
+            },
+          },
+        }],
+      },
+    };
+    const w = await build({ objects: [...KYVERNO_PLATFORM, policy] });
+    const deployment = (replicas: number) => ({
+      apiVersion: 'apps/v1', kind: 'Deployment',
+      metadata: { name: `d${replicas}`, namespace: 'shop' },
+      spec: {
+        replicas,
+        selector: { matchLabels: { app: 'x' } },
+        template: { metadata: { labels: { app: 'x' } }, spec: { containers: [{ name: 'a', image: APP }] } },
+      },
+    });
+    const deployments = w.cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' });
+    expect(() => w.cluster.registry.create(deployments, 'shop', deployment(2) as never)).not.toThrow();
+    expect(() => w.cluster.registry.create(deployments, 'shop', deployment(9) as never))
+      .toThrow(/at most 3 replicas outside production/);
+  });
+
+  it('exclude 命中的资源不适用', async () => {
+    const policy = {
+      ...REQUIRE_OWNER,
+      spec: {
+        ...REQUIRE_OWNER.spec,
+        rules: [{
+          ...REQUIRE_OWNER.spec.rules[0],
+          exclude: { any: [{ resources: { namespaces: ['shop'] } }] },
+        }],
+      },
+    };
+    const w = await build({ objects: [...KYVERNO_PLATFORM, policy] });
+    expect(() => w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', POD as never)).not.toThrow();
+  });
+});
+
+describe('cosign 命令', () => {
+  it('生成密钥、签、验，一条龙', async () => {
+    const w = await createOpsWorld({
+      world: {
+        namespaces: ['default'],
+        images: { [APP]: {} },
+        registries: [{ host: 'harbor.corp.internal', anonymousPull: true, projects: ['team'] }],
+      } as never,
+    });
+    expect((await w.run('cosign generate-key-pair')).stderr).toContain('cosign.pub');
+    expect(w.machine.vfs.readFile('/root/cosign.pub')).toContain('BEGIN PUBLIC KEY');
+
+    const signed = await w.run(`cosign sign --key cosign.key ${APP}`);
+    expect(signed.code).toBe(0);
+
+    const verified = await w.run(`cosign verify --key cosign.pub ${APP}`);
+    expect(verified.code).toBe(0);
+    expect(verified.stderr).toContain('The signatures were verified against the specified public key');
+  });
+
+  it('没签过的镜像验不过', async () => {
+    const w = await createOpsWorld({
+      world: {
+        namespaces: ['default'],
+        images: { [APP]: {} },
+        registries: [{ host: 'harbor.corp.internal', anonymousPull: true, projects: ['team'] }],
+      } as never,
+    });
+    await w.run('cosign generate-key-pair');
+    const result = await w.run(`cosign verify --key cosign.pub ${APP}`);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('no matching signatures');
+  });
+});


### PR DESCRIPTION
准入这一层做进来了。它和鉴权回答的问题不同：鉴权看「谁在做什么」，准入看**对象本身长什么样**。

## 三块

**PSA**（内置，`admission/psa.ts`）。三档预置标准，靠命名空间标签开关，卸不掉 —— 这份僵硬正是它的价值：上游发现新的提权途径，升级集群就自动跟上。拒绝消息照抄真 PSA，把「哪个容器、哪个字段、该设成什么」说全了。

**Kyverno**（集群里的工作负载，`admission/kyverno.ts`）。`validate.pattern`（`?*` 要有值、`!` 取反、`|` 是或、数组里写一项表示每项都要满足）、`validate.cel`（用 `@marcbachmann/cel-js` 真求值）、`verifyImages`。停掉它策略立刻失效，而 `kubectl get cpol` 照样看得见。

**cosign**（`admission/cosign.ts` + CLI）。签的是镜像 **digest**，用已有的 RSA + SHA-256 真签真验：换个 digest 验不过，换把公钥也验不过。

顺序有讲究：**内置插件跑在 webhook 前面**。一个 Pod 同时违反两边时真集群报的是 PSA 那句话，反过来会让人先去加 owner 标签，改完才发现还有特权容器。

## 途中修了一个真 bug

滚动更新在「旧 RS 一个 Pod 都起不来」时会**卡死**：新版本要等旧版本腾位置，而旧版本永远腾不出来（它的 Pod 被 PSA 拦着，一个都没建成）。真 k8s 里对应的步骤叫 `cleanupUnhealthyReplicas` —— 先把旧 RS 里本来就起不来的名额收掉，那些名额不占可用数。

## 被 kubectl 教育了一次

参考解一开始用 `kubectl apply -f cache.yaml` 去覆盖违规的 Deployment，结果 Pod 还是被 PSA 拦。原因是 `cache` 最初不是 apply 建出来的（没有 last-applied 注解），这时 apply 走两路合并：新清单里**没写**的字段（`privileged: true`、那个 hostPath 卷）原样留着。kubectl 自己会警告这一点。

这是真行为，不是我们的 bug —— 于是参考解改用 `kubectl replace`，并把它写进 pitfalls。

## 依赖

新增 `@marcbachmann/cel-js`（MIT，零依赖，227KB）。它是纯 ESM 包，`next/jest` 默认整个 node_modules 都不转译，所以 jest.config.js 里放开了它。`next build` 验过没问题。

## 验证

27 个准入用例（PSA 三档、pattern 匹配、签名真伪、集群里真的拦、Kyverno 停掉就失效）+ 3 个关卡反向验证。全量 1485 个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)