### PR TITLE
feat(opslab): 第 18 关 —— 把密钥搬出集群

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -36,6 +36,7 @@ const ZTUNNEL_IMAGE = 'docker.io/istio/ztunnel:1.28.1';
 const KYVERNO_IMAGE = 'ghcr.io/kyverno/kyverno:v1.16.0';
 // 一个从公网直接拿来的镜像，没人签过
 const UNSIGNED_IMAGE = 'docker.io/library/redis:7.4';
+const ESO_IMAGE = 'ghcr.io/external-secrets/external-secrets:v0.21.0';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -142,7 +143,7 @@ const WORLD = {
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
     'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
-    'kyverno',
+    'kyverno', 'external-secrets',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -185,6 +186,7 @@ const WORLD = {
     [ISTIOD_IMAGE]: { pullMs: 600, startupMs: 900, readyAfterMs: 400, listens: [15012] },
     [ZTUNNEL_IMAGE]: { pullMs: 400, startupMs: 500, readyAfterMs: 200, listens: [15008] },
     [KYVERNO_IMAGE]: { pullMs: 500, startupMs: 700, readyAfterMs: 300, listens: [9443] },
+    [ESO_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300, listens: [8080] },
     [UNSIGNED_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200, listens: [6379] },
     // 会话存储
     [SESSIONS_IMAGE]: {
@@ -249,6 +251,27 @@ const WORLD = {
     'oidc-liu': { username: 'oidc:liu@corp.internal', groups: ['oidc:developers'] },
     'oidc-chen': { username: 'oidc:chen@corp.internal', groups: ['oidc:sre'] },
     'ci-token': { username: 'system:serviceaccount:argocd:deployer', groups: ['system:serviceaccounts'] },
+  },
+  /**
+   * 内网的密钥库。
+   *
+   * 真正的密钥住在这儿 —— 不在集群里，也不在 Git 仓库里。
+   * 平台组已经把数据库口令放进去了，Kubernetes 认证还没开。
+   */
+  secretStore: {
+    address: 'https://openbao.corp.internal:8200',
+    data: {
+      'kv/payments/db': {
+        username: 'payments_app',
+        password: 'Ph4i-Quee0oh',
+        host: 'pg.corp.internal',
+      },
+    },
+    policies: {
+      'payments-read': { 'kv/payments/*': ['read', 'list'] },
+    },
+    // 平台组给运维发的 root 令牌。Kubernetes 认证还没开。
+    tokens: { 'bao-root-token': 'root' },
   },
   // 内网的 Git 服务。平台仓库是「本来就在」的东西，第 11 关往后都从它来。
   gitRepositories: [
@@ -5486,6 +5509,356 @@ const stage17 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 18 关                                                            */
+/* ------------------------------------------------------------------ */
+
+const ESO_PLATFORM = [
+  { apiVersion: 'v1', kind: 'ServiceAccount', metadata: { name: 'eso', namespace: 'payments' } },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'external-secrets', namespace: 'external-secrets',
+      labels: { 'app.kubernetes.io/name': 'external-secrets' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'external-secrets' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'external-secrets' } },
+        spec: { containers: [{ name: 'controller', image: ESO_IMAGE, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  },
+];
+
+/** 前任把口令直接写进了 Secret，还提交进了 Git */
+const HARDCODED_SECRET = {
+  apiVersion: 'v1', kind: 'Secret',
+  metadata: { name: 'db-credentials', namespace: 'payments' },
+  type: 'Opaque',
+  data: {
+    username: 'cGF5bWVudHNfYXBw',
+    // Ph4i-Quee0oh，base64 不是加密
+    password: 'UGg0aS1RdWVlMG9o',
+  },
+};
+
+/** 门户从这个 Secret 里拿数据库口令 */
+const PORTAL_WITH_DB = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'portal', namespace: 'payments' },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'portal' } },
+      template: {
+        metadata: { labels: { app: 'portal' } },
+        spec: {
+          containers: [{
+            name: 'web', image: PORTAL_IMAGE, ports: [{ containerPort: 8080 }],
+            env: [
+              { name: 'DB_USER', valueFrom: { secretKeyRef: { name: 'db-credentials', key: 'username' } } },
+              { name: 'DB_PASSWORD', valueFrom: { secretKeyRef: { name: 'db-credentials', key: 'password' } } },
+            ],
+          }],
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'portal', namespace: 'payments' },
+    spec: { clusterIP: '10.96.1.10', selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+];
+
+const ESO_STARTER = code`
+  # 目标：让 db-credentials 由 ESO 从 OpenBao 同步出来，
+  # 而不是有人手工创建、再提交进 Git。
+  #
+  # 口令在 kv/payments/db 下面，策略 payments-read 已经写好了。
+  # Kubernetes 认证还没开。
+`;
+
+const ESO_REFERENCE = code`
+  apiVersion: external-secrets.io/v1
+  kind: SecretStore
+  metadata:
+    name: openbao
+    namespace: payments
+  spec:
+    provider:
+      vault:
+        server: https://openbao.corp.internal:8200
+        path: kv
+        auth:
+          kubernetes:
+            role: payments
+            serviceAccountRef:
+              name: eso
+  ---
+  apiVersion: external-secrets.io/v1
+  kind: ExternalSecret
+  metadata:
+    name: db-credentials
+    namespace: payments
+  spec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: openbao
+      kind: SecretStore
+    target:
+      name: db-credentials
+    data:
+    - secretKey: username
+      remoteRef:
+        key: payments/db
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: payments/db
+        property: password
+`;
+
+const stage18 = {
+  id: 'external-secrets',
+  title: t('把密钥搬出集群', 'Move the Secrets Out of the Cluster'),
+  goal: t(
+    code`
+      安全评审第四条：数据库口令不该以任何形式存在于集群和 Git 仓库里。
+      现状是前任手工建了一个 Secret \`db-credentials\`，门户从它取值 ——
+      而那份 YAML 就躺在平台仓库里。**Kubernetes 的 Secret 只是 base64，
+      不是加密**，谁能 \`get secret\` 谁就看得到明文。
+
+      内网有一台 OpenBao（\`https://openbao.corp.internal:8200\`），口令已经放在
+      \`kv/payments/db\` 下面了，读它的策略 \`payments-read\` 也写好了。
+      External Secrets Operator 装好了。缺的是把这条路打通。
+
+      运维手上的 root 令牌是 \`bao-root-token\`。
+
+      ## 通关标准
+
+      1. \`db-credentials\` 由 ESO 同步出来，值和 OpenBao 里的一致；
+      2. 门户照常跑着，能从这个 Secret 取到口令；
+      3. ESO 用 **Kubernetes 认证**去 OpenBao 换令牌，不是拿一把静态令牌
+         （那把令牌本身又是一个要保管的密钥）；
+      4. 有人在 OpenBao 里轮转了口令之后，集群里会自己跟上；
+      5. 集群里不再有手工维护的那份明文。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      export BAO_ADDR=https://openbao.corp.internal:8200
+      export BAO_TOKEN=bao-root-token
+      bao kv get kv/payments/db
+      bao auth enable kubernetes
+      bao write auth/kubernetes/role/payments \\
+        bound_service_account_names=eso \\
+        bound_service_account_namespaces=payments \\
+        policies=payments-read
+      kubectl apply -f /root/infra/eso.yaml
+      kubectl describe externalsecret db-credentials -n payments
+      \`\`\`
+    `,
+    code`
+      Fourth item from the security review: the database password must not exist in
+      the cluster or in Git in any form. Today your predecessor hand-created a Secret
+      called \`db-credentials\` that the portal reads from, and that YAML sits in the
+      platform repository. **A Kubernetes Secret is base64, not encryption**: anyone
+      who can \`get secret\` reads the plaintext.
+
+      The intranet runs an OpenBao at \`https://openbao.corp.internal:8200\`. The
+      password already lives under \`kv/payments/db\` and a \`payments-read\` policy
+      exists. External Secrets Operator is installed. What is missing is the wiring.
+
+      The operator root token is \`bao-root-token\`.
+
+      ## Done when
+
+      1. \`db-credentials\` is produced by ESO and matches what OpenBao holds;
+      2. the portal still runs and still reads the password from that Secret;
+      3. ESO authenticates to OpenBao with **Kubernetes auth**, not a static token
+         (a static token is itself one more secret to look after);
+      4. rotating the password in OpenBao propagates into the cluster on its own;
+      5. no hand-maintained plaintext copy is left in the cluster.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      export BAO_ADDR=https://openbao.corp.internal:8200
+      export BAO_TOKEN=bao-root-token
+      bao kv get kv/payments/db
+      bao auth enable kubernetes
+      bao write auth/kubernetes/role/payments \\
+        bound_service_account_names=eso \\
+        bound_service_account_namespaces=payments \\
+        policies=payments-read
+      kubectl apply -f /root/infra/eso.yaml
+      kubectl describe externalsecret db-credentials -n payments
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('Secret 由 ESO 同步，不是手工建的', 'The Secret is synced by ESO, not hand-made'),
+    t('认证用 ServiceAccount，不是静态令牌', 'Authentication uses a ServiceAccount, not a static token'),
+    t('外部轮转之后集群自己跟上', 'Rotation outside propagates in on its own'),
+  ],
+  hints: [
+    t(
+      'KV v2 有一处容易绊人：挂载路径和读写路径不是一回事。引擎挂在 \`kv/\` 上，\`bao kv get kv/payments/db\` 实际读的是 \`kv/data/payments/db\`。SecretStore 里 \`path: kv\` 指的是挂载路径，\`remoteRef.key\` 里就不要再带 \`kv/\` 了。',
+      'KV v2 trips people on paths: the mount path and the read path differ. With the engine mounted at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore, `path: kv` is the mount, so `remoteRef.key` should not repeat `kv/`.'
+    ),
+    t(
+      'Kubernetes 认证要两步：先 \`bao auth enable kubernetes\` 打开这个方法，再写一个角色说明「哪些 ServiceAccount 能登录、登录后拿哪个策略」。三个参数缺一不可，最容易漏的是命名空间那个。',
+      'Kubernetes auth takes two steps: `bao auth enable kubernetes` turns the method on, then a role states which ServiceAccounts may log in and which policy they receive. All three parameters are required, and the namespaces one is the usual omission.'
+    ),
+    t(
+      'ESO 同步出来的 Secret 归控制器管。手改它没有意义 —— 下一轮同步会盖回去。同理，删掉 ExternalSecret，那份投影也跟着走。',
+      'The Secret ESO produces belongs to the controller. Editing it by hand is pointless because the next sync overwrites it, and deleting the ExternalSecret takes the projection with it.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '用静态令牌图省事：把 root 令牌塞进一个 Secret，让 SecretStore 从那儿读。这样一来集群里存的是一把**能读所有密钥的**令牌 —— 比原来那个只泄露一个口令的 Secret 更糟。判定检查 SecretStore 用的是哪种认证。',
+      'Reaching for a static token: putting the root token in a Secret and pointing the SecretStore at it. Now the cluster stores a credential that reads **every** secret, which is worse than the single leaked password you started with. The grader checks which auth method the SecretStore uses.'
+    ),
+    t(
+      '以为 Secret 是加密的。它只是 base64，\`kubectl get secret -o yaml\` 加一句 \`base64 -d\` 就是明文。集群里的 Secret 唯一的保护是 RBAC —— 这也是为什么第 16 关那些角色不能给出 Secret 的读权限。',
+      'Believing a Secret is encrypted. It is base64, and `kubectl get secret -o yaml` piped through `base64 -d` prints the plaintext. RBAC is the only protection a Secret has in the cluster, which is why the roles in the RBAC stage must not grant Secret reads.'
+    ),
+    t(
+      '把 \`refreshInterval\` 当成实时。轮转之后集群里不会立刻变，要等下一轮同步。真出事要立刻生效时，得主动触发一次（改一下 ExternalSecret 让它重新 reconcile），别干等。',
+      'Treating `refreshInterval` as realtime. After rotation the cluster lags until the next sync. When an incident needs it now, force a reconcile (touch the ExternalSecret) instead of waiting.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM, ...ESO_PLATFORM,
+      HARDCODED_SECRET, ...PORTAL_WITH_DB, PORTAL_ROUTE,
+    ],
+    files: { '/root/infra/eso.yaml': ESO_STARTER },
+    referenceFiles: { '/root/infra/eso.yaml': ESO_REFERENCE },
+    referenceCommands: [
+      'BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token bao auth enable kubernetes',
+      'BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token bao write'
+        + ' auth/kubernetes/role/payments bound_service_account_names=eso'
+        + ' bound_service_account_namespaces=payments policies=payments-read',
+      // 先把手工那份删掉，ESO 才好把自己那份建出来
+      'kubectl delete secret db-credentials -n payments',
+      'kubectl apply -f /root/infra/eso.yaml',
+    ],
+  },
+  specs: [
+    spec('external-secrets.spec.ts', code`
+      import { advance, get, list, sh } from '@ops/lab';
+
+      describe('把密钥搬出集群', () => {
+        it('Secret 由 ESO 同步出来', () => {
+          const external = get('ExternalSecret', 'db-credentials', 'payments');
+          expect(external).toBeTruthy();
+          const ready = external.status.conditions.find((entry) => entry.type === 'Ready');
+          expect(ready.status).toBe('True');
+
+          const secret = get('Secret', 'db-credentials', 'payments');
+          expect(secret).toBeTruthy();
+          const owner = (secret.metadata.ownerReferences || [])[0];
+          expect(owner.kind).toBe('ExternalSecret');
+        });
+
+        it('值和 OpenBao 里的一致', async () => {
+          const result = await sh(
+            'kubectl get secret db-credentials -n payments'
+            + " -o jsonpath='{.data.password}' | base64 -d"
+          );
+          expect(result.stdout.trim()).toBe('Ph4i-Quee0oh');
+        });
+
+        it('门户照常跑着', () => {
+          const deployment = get('Deployment', 'portal', 'payments');
+          expect(deployment.status.readyReplicas).toBe(2);
+        });
+
+        it('认证用的是 ServiceAccount，不是静态令牌', () => {
+          const stores = list('SecretStore', { namespace: 'payments' });
+          expect(stores.length).toBeGreaterThan(0);
+          for (const store of stores) {
+            const auth = store.spec.provider.vault.auth || {};
+            expect(auth.kubernetes).toBeTruthy();
+            expect(auth.tokenSecretRef).toBeFalsy();
+          }
+        });
+
+        it('集群里没有另一份手工维护的明文', () => {
+          const managed = list('Secret', { namespace: 'payments' })
+            .filter((secret) => (secret.data || {}).password !== undefined)
+            .filter((secret) => !(secret.metadata.ownerReferences || [])
+              .some((owner) => owner.kind === 'ExternalSecret'));
+          expect(managed).toEqual([]);
+        });
+
+        it('OpenBao 里轮转之后，集群自己跟上', async () => {
+          await sh(
+            'BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token'
+            + ' bao kv put kv/payments/db username=payments_app password=R0tated-N0w host=pg.corp.internal'
+          );
+          // 等一轮同步。ESO 是按 refreshInterval 拉的，不是实时的。
+          await advance(120000);
+          const result = await sh(
+            'kubectl get secret db-credentials -n payments'
+            + " -o jsonpath='{.data.password}' | base64 -d"
+          );
+          expect(result.stdout.trim()).toBe('R0tated-N0w');
+        });
+      });
+    `),
+  ],
+  focus: ['correctness', 'maintainability'],
+  extension: t(
+    code`
+      这一关解决的是 GitOps 与密钥管理的矛盾：**仓库要能被所有人读，密钥不能**。
+      External Secrets 的答案是让仓库里只放「去哪儿取」的说明，取到的东西
+      由控制器写进集群，谁都不用把明文提交上去。
+
+      要清楚它**没有**解决什么：同步出来的 Secret 在集群里仍然是 base64。
+      能 \`get secret\` 的人照样看得到明文。所以这一层必须和 RBAC 叠着用 ——
+      密钥搬出集群解决的是「不要泄露在 Git 里」，不是「集群里也看不到」。
+      再往上一层是 etcd 静态加密（EncryptionConfiguration），那管的是磁盘被
+      拷走的场景。三层各管一段，缺一不可。
+
+      认证方式的选择比工具选择更重要。静态令牌是个死循环：为了保护密钥，
+      你先得保护一把能读所有密钥的令牌。Kubernetes 认证跳出了这个循环 ——
+      身份由集群签发、短期有效、绑定到具体的 ServiceAccount，泄露一份
+      Pod 的 token 也只能拿到那个 SA 的权限。云上的 IRSA / Workload Identity
+      是同一个思路的不同实现。
+    `,
+    code`
+      This stage resolves the tension between GitOps and secret management:
+      **the repository must be readable by everyone, and secrets must not be.**
+      External Secrets answers it by keeping only "where to fetch it from" in Git,
+      with the controller writing the fetched value into the cluster, so nobody ever
+      commits plaintext.
+
+      Be clear about what it does **not** solve: the synced Secret is still base64
+      inside the cluster, and anyone who can \`get secret\` still reads it. So this
+      layer stacks with RBAC. Moving secrets out of the cluster addresses "do not leak
+      them through Git", not "nobody in the cluster can see them". One layer further up
+      is etcd encryption at rest (EncryptionConfiguration), which addresses a stolen
+      disk. Three layers, each covering a different exposure.
+
+      Choosing the authentication method matters more than choosing the tool. A static
+      token is circular: to protect your secrets you first have to protect a token that
+      reads all of them. Kubernetes auth breaks the circle, because identity is issued
+      by the cluster, short lived, and bound to a specific ServiceAccount, so a leaked
+      pod token buys only that ServiceAccount permissions. IRSA and Workload Identity
+      in the clouds are the same idea with different plumbing.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -5531,6 +5904,6 @@ module.exports = {
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
-    stage13, stage14, stage15, stage16, stage17,
+    stage13, stage14, stage15, stage16, stage17, stage18,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5619,7 +5619,8 @@
           "cert-manager",
           "argocd",
           "istio-system",
-          "kyverno"
+          "kyverno",
+          "external-secrets"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5724,6 +5725,14 @@
             "readyAfterMs": 300,
             "listens": [
               9443
+            ]
+          },
+          "ghcr.io/external-secrets/external-secrets:v0.21.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
             ]
           },
           "docker.io/library/redis:7.4": {
@@ -5868,6 +5877,27 @@
             "groups": [
               "system:serviceaccounts"
             ]
+          }
+        },
+        "secretStore": {
+          "address": "https://openbao.corp.internal:8200",
+          "data": {
+            "kv/payments/db": {
+              "username": "payments_app",
+              "password": "Ph4i-Quee0oh",
+              "host": "pg.corp.internal"
+            }
+          },
+          "policies": {
+            "payments-read": {
+              "kv/payments/*": [
+                "read",
+                "list"
+              ]
+            }
+          },
+          "tokens": {
+            "bao-root-token": "root"
           }
         },
         "gitRepositories": [
@@ -11133,6 +11163,506 @@
         "primer": {
           "zh": "`准入`是对象写进 etcd 之前的最后一道关。它和鉴权回答的问题不同：鉴权看「谁在做什么」，准入看**对象本身长什么样**：特权容器、没写 limits、镜像没签名，都是在这一层被拦下来的。这一层分两块：Kubernetes 内置的插件，和以 webhook 形式接进来的外部组件。\n\n`PSA`（Pod Security Admission）是内置的那块，2025 年起替代了被删掉的 PodSecurityPolicy。它只有三档预置标准：`privileged` 什么都不管，`baseline` 挡住已知的提权途径（特权容器、hostPath、host 命名空间、额外 capability），`restricted` 再加上强化要求（非 root、丢掉所有 capability、seccomp、禁止提权）。开关是命名空间上的标签，三种模式各自独立：`enforce` 拦下来，`audit` 记日志，`warn` 回一条警告。只打 `warn` 而以为拦住了，是这一层最常见的误会。另一件要记住的：**PSA 只看 Pod**，违规的 Deployment 照样 apply 得进去，然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里。\n\n`Kyverno` 是外部那块，管的是 PSA 表达不了的公司自定义规矩：必须有 owner 标签、镜像只能来自内网仓库、名字要符合约定。规则写在 `ClusterPolicy` 里，`validate.pattern` 是它自己那套结构匹配（`?*` 表示要有值，`!` 表示不能等于，`|` 是或），`validate.cel` 直接写 CEL 表达式。它是集群里的一个工作负载：停掉它，所有策略立刻失效，而 `kubectl get cpol` 照样看得见。能交给 PSA 的规则不要在这里重写一遍：上游发现新的提权途径时，PSA 会跟着升级，你的规则不会。\n\n供应链那条靠 `cosign`。要点是它签的是镜像的 **digest** 而不是 tag：换个 tag 指向同一个 digest，签名依然有效；tag 不变而 digest 变了，签名立刻失效。准入时由 Kyverno 的 `verifyImages` 拿公钥验。但这条保证的边界要说清楚：它只证明「这坨字节被某把私钥认过」，不证明镜像里没有漏洞，也不证明签它的人有资格签。所以密钥归属、轮转、以及 SBOM 与来源证明是配套的，只做验签的话，安全性就等于「有人签过」这四个字。",
           "en": "`Admission` is the last gate before an object reaches etcd. It answers a different question from authorization: authorization looks at who is doing what, while admission looks at **what the object contains**: a privileged container, missing limits, an unsigned image. The layer splits in two: plugins built into Kubernetes, and external components wired in as webhooks.\n\n`PSA` (Pod Security Admission) is the built-in half, replacing the removed PodSecurityPolicy. It offers exactly three preset levels: `privileged` checks nothing, `baseline` blocks known escalation paths (privileged containers, hostPath, host namespaces, extra capabilities), and `restricted` adds hardening (non-root, drop all capabilities, seccomp, no privilege escalation). The switch is a namespace label, and the three modes are independent: `enforce` blocks, `audit` records, `warn` returns a warning. Labelling only `warn` and believing it blocks is the classic mistake here. Also remember that **PSA only inspects Pods**: a violating Deployment applies cleanly and then yields no pods, with the reason sitting in the ReplicaSet events.\n\n`Kyverno` is the external half, covering what PSA cannot express: an owner label must exist, images must come from the internal registry, names must follow a convention. Rules live in a `ClusterPolicy`; `validate.pattern` is its own structural matching (`?*` requires a value, `!` negates, `|` is or) and `validate.cel` takes CEL expressions directly. It runs as a workload in the cluster, so stopping it disables every policy while `kubectl get cpol` still lists them. Do not reimplement PSA rules here: when upstream learns of a new escalation path, PSA follows on upgrade and your copy does not.\n\nThe supply-chain rule uses `cosign`. The key fact is that it signs the image **digest**, not the tag: retagging the same digest keeps the signature valid, while pushing new content under the same tag invalidates it immediately. At admission time Kyverno `verifyImages` checks it with the public key. Be clear about the boundary of that guarantee: it proves these bytes were vouched for by some private key, not that the image is free of vulnerabilities nor that the signer was entitled to sign. Key custody, rotation, SBOMs, and build provenance go with it; signature checking alone guarantees only that somebody signed."
+        }
+      },
+      {
+        "id": "external-secrets",
+        "title": {
+          "zh": "把密钥搬出集群",
+          "en": "Move the Secrets Out of the Cluster"
+        },
+        "goal": {
+          "zh": "安全评审第四条：数据库口令不该以任何形式存在于集群和 Git 仓库里。\n现状是前任手工建了一个 Secret `db-credentials`，门户从它取值 ——\n而那份 YAML 就躺在平台仓库里。**Kubernetes 的 Secret 只是 base64，\n不是加密**，谁能 `get secret` 谁就看得到明文。\n\n内网有一台 OpenBao（`https://openbao.corp.internal:8200`），口令已经放在\n`kv/payments/db` 下面了，读它的策略 `payments-read` 也写好了。\nExternal Secrets Operator 装好了。缺的是把这条路打通。\n\n运维手上的 root 令牌是 `bao-root-token`。\n\n## 通关标准\n\n1. `db-credentials` 由 ESO 同步出来，值和 OpenBao 里的一致；\n2. 门户照常跑着，能从这个 Secret 取到口令；\n3. ESO 用 **Kubernetes 认证**去 OpenBao 换令牌，不是拿一把静态令牌\n   （那把令牌本身又是一个要保管的密钥）；\n4. 有人在 OpenBao 里轮转了口令之后，集群里会自己跟上；\n5. 集群里不再有手工维护的那份明文。\n\n## 会用到的命令\n\n```bash\nexport BAO_ADDR=https://openbao.corp.internal:8200\nexport BAO_TOKEN=bao-root-token\nbao kv get kv/payments/db\nbao auth enable kubernetes\nbao write auth/kubernetes/role/payments \\\n  bound_service_account_names=eso \\\n  bound_service_account_namespaces=payments \\\n  policies=payments-read\nkubectl apply -f /root/infra/eso.yaml\nkubectl describe externalsecret db-credentials -n payments\n```\n",
+          "en": "Fourth item from the security review: the database password must not exist in\nthe cluster or in Git in any form. Today your predecessor hand-created a Secret\ncalled `db-credentials` that the portal reads from, and that YAML sits in the\nplatform repository. **A Kubernetes Secret is base64, not encryption**: anyone\nwho can `get secret` reads the plaintext.\n\nThe intranet runs an OpenBao at `https://openbao.corp.internal:8200`. The\npassword already lives under `kv/payments/db` and a `payments-read` policy\nexists. External Secrets Operator is installed. What is missing is the wiring.\n\nThe operator root token is `bao-root-token`.\n\n## Done when\n\n1. `db-credentials` is produced by ESO and matches what OpenBao holds;\n2. the portal still runs and still reads the password from that Secret;\n3. ESO authenticates to OpenBao with **Kubernetes auth**, not a static token\n   (a static token is itself one more secret to look after);\n4. rotating the password in OpenBao propagates into the cluster on its own;\n5. no hand-maintained plaintext copy is left in the cluster.\n\n## Commands you will need\n\n```bash\nexport BAO_ADDR=https://openbao.corp.internal:8200\nexport BAO_TOKEN=bao-root-token\nbao kv get kv/payments/db\nbao auth enable kubernetes\nbao write auth/kubernetes/role/payments \\\n  bound_service_account_names=eso \\\n  bound_service_account_namespaces=payments \\\n  policies=payments-read\nkubectl apply -f /root/infra/eso.yaml\nkubectl describe externalsecret db-credentials -n payments\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "Secret 由 ESO 同步，不是手工建的",
+            "en": "The Secret is synced by ESO, not hand-made"
+          },
+          {
+            "zh": "认证用 ServiceAccount，不是静态令牌",
+            "en": "Authentication uses a ServiceAccount, not a static token"
+          },
+          {
+            "zh": "外部轮转之后集群自己跟上",
+            "en": "Rotation outside propagates in on its own"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "KV v2 有一处容易绊人：挂载路径和读写路径不是一回事。引擎挂在 `kv/` 上，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里 `path: kv` 指的是挂载路径，`remoteRef.key` 里就不要再带 `kv/` 了。",
+            "en": "KV v2 trips people on paths: the mount path and the read path differ. With the engine mounted at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore, `path: kv` is the mount, so `remoteRef.key` should not repeat `kv/`."
+          },
+          {
+            "zh": "Kubernetes 认证要两步：先 `bao auth enable kubernetes` 打开这个方法，再写一个角色说明「哪些 ServiceAccount 能登录、登录后拿哪个策略」。三个参数缺一不可，最容易漏的是命名空间那个。",
+            "en": "Kubernetes auth takes two steps: `bao auth enable kubernetes` turns the method on, then a role states which ServiceAccounts may log in and which policy they receive. All three parameters are required, and the namespaces one is the usual omission."
+          },
+          {
+            "zh": "ESO 同步出来的 Secret 归控制器管。手改它没有意义 —— 下一轮同步会盖回去。同理，删掉 ExternalSecret，那份投影也跟着走。",
+            "en": "The Secret ESO produces belongs to the controller. Editing it by hand is pointless because the next sync overwrites it, and deleting the ExternalSecret takes the projection with it."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用静态令牌图省事：把 root 令牌塞进一个 Secret，让 SecretStore 从那儿读。这样一来集群里存的是一把**能读所有密钥的**令牌 —— 比原来那个只泄露一个口令的 Secret 更糟。判定检查 SecretStore 用的是哪种认证。",
+            "en": "Reaching for a static token: putting the root token in a Secret and pointing the SecretStore at it. Now the cluster stores a credential that reads **every** secret, which is worse than the single leaked password you started with. The grader checks which auth method the SecretStore uses."
+          },
+          {
+            "zh": "以为 Secret 是加密的。它只是 base64，`kubectl get secret -o yaml` 加一句 `base64 -d` 就是明文。集群里的 Secret 唯一的保护是 RBAC —— 这也是为什么第 16 关那些角色不能给出 Secret 的读权限。",
+            "en": "Believing a Secret is encrypted. It is base64, and `kubectl get secret -o yaml` piped through `base64 -d` prints the plaintext. RBAC is the only protection a Secret has in the cluster, which is why the roles in the RBAC stage must not grant Secret reads."
+          },
+          {
+            "zh": "把 `refreshInterval` 当成实时。轮转之后集群里不会立刻变，要等下一轮同步。真出事要立刻生效时，得主动触发一次（改一下 ExternalSecret 让它重新 reconcile），别干等。",
+            "en": "Treating `refreshInterval` as realtime. After rotation the cluster lags until the next sync. When an incident needs it now, force a reconcile (touch the ExternalSecret) instead of waiting."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "eso",
+                "namespace": "payments"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "external-secrets",
+                "namespace": "external-secrets",
+                "labels": {
+                  "app.kubernetes.io/name": "external-secrets"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "external-secrets"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "external-secrets"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "ghcr.io/external-secrets/external-secrets:v0.21.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Secret",
+              "metadata": {
+                "name": "db-credentials",
+                "namespace": "payments"
+              },
+              "type": "Opaque",
+              "data": {
+                "username": "cGF5bWVudHNfYXBw",
+                "password": "UGg0aS1RdWVlMG9o"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ],
+                        "env": [
+                          {
+                            "name": "DB_USER",
+                            "valueFrom": {
+                              "secretKeyRef": {
+                                "name": "db-credentials",
+                                "key": "username"
+                              }
+                            }
+                          },
+                          {
+                            "name": "DB_PASSWORD",
+                            "valueFrom": {
+                              "secretKeyRef": {
+                                "name": "db-credentials",
+                                "key": "password"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/eso.yaml": "# 目标：让 db-credentials 由 ESO 从 OpenBao 同步出来，\n# 而不是有人手工创建、再提交进 Git。\n#\n# 口令在 kv/payments/db 下面，策略 payments-read 已经写好了。\n# Kubernetes 认证还没开。\n"
+          },
+          "referenceFiles": {
+            "/root/infra/eso.yaml": "apiVersion: external-secrets.io/v1\nkind: SecretStore\nmetadata:\n  name: openbao\n  namespace: payments\nspec:\n  provider:\n    vault:\n      server: https://openbao.corp.internal:8200\n      path: kv\n      auth:\n        kubernetes:\n          role: payments\n          serviceAccountRef:\n            name: eso\n---\napiVersion: external-secrets.io/v1\nkind: ExternalSecret\nmetadata:\n  name: db-credentials\n  namespace: payments\nspec:\n  refreshInterval: 1m\n  secretStoreRef:\n    name: openbao\n    kind: SecretStore\n  target:\n    name: db-credentials\n  data:\n  - secretKey: username\n    remoteRef:\n      key: payments/db\n      property: username\n  - secretKey: password\n    remoteRef:\n      key: payments/db\n      property: password\n"
+          },
+          "referenceCommands": [
+            "BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token bao auth enable kubernetes",
+            "BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token bao write auth/kubernetes/role/payments bound_service_account_names=eso bound_service_account_namespaces=payments policies=payments-read",
+            "kubectl delete secret db-credentials -n payments",
+            "kubectl apply -f /root/infra/eso.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "external-secrets.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\ndescribe('把密钥搬出集群', () => {\n  it('Secret 由 ESO 同步出来', () => {\n    const external = get('ExternalSecret', 'db-credentials', 'payments');\n    expect(external).toBeTruthy();\n    const ready = external.status.conditions.find((entry) => entry.type === 'Ready');\n    expect(ready.status).toBe('True');\n\n    const secret = get('Secret', 'db-credentials', 'payments');\n    expect(secret).toBeTruthy();\n    const owner = (secret.metadata.ownerReferences || [])[0];\n    expect(owner.kind).toBe('ExternalSecret');\n  });\n\n  it('值和 OpenBao 里的一致', async () => {\n    const result = await sh(\n      'kubectl get secret db-credentials -n payments'\n      + \" -o jsonpath='{.data.password}' | base64 -d\"\n    );\n    expect(result.stdout.trim()).toBe('Ph4i-Quee0oh');\n  });\n\n  it('门户照常跑着', () => {\n    const deployment = get('Deployment', 'portal', 'payments');\n    expect(deployment.status.readyReplicas).toBe(2);\n  });\n\n  it('认证用的是 ServiceAccount，不是静态令牌', () => {\n    const stores = list('SecretStore', { namespace: 'payments' });\n    expect(stores.length).toBeGreaterThan(0);\n    for (const store of stores) {\n      const auth = store.spec.provider.vault.auth || {};\n      expect(auth.kubernetes).toBeTruthy();\n      expect(auth.tokenSecretRef).toBeFalsy();\n    }\n  });\n\n  it('集群里没有另一份手工维护的明文', () => {\n    const managed = list('Secret', { namespace: 'payments' })\n      .filter((secret) => (secret.data || {}).password !== undefined)\n      .filter((secret) => !(secret.metadata.ownerReferences || [])\n        .some((owner) => owner.kind === 'ExternalSecret'));\n    expect(managed).toEqual([]);\n  });\n\n  it('OpenBao 里轮转之后，集群自己跟上', async () => {\n    await sh(\n      'BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token'\n      + ' bao kv put kv/payments/db username=payments_app password=R0tated-N0w host=pg.corp.internal'\n    );\n    // 等一轮同步。ESO 是按 refreshInterval 拉的，不是实时的。\n    await advance(120000);\n    const result = await sh(\n      'kubectl get secret db-credentials -n payments'\n      + \" -o jsonpath='{.data.password}' | base64 -d\"\n    );\n    expect(result.stdout.trim()).toBe('R0tated-N0w');\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "这一关解决的是 GitOps 与密钥管理的矛盾：**仓库要能被所有人读，密钥不能**。\nExternal Secrets 的答案是让仓库里只放「去哪儿取」的说明，取到的东西\n由控制器写进集群，谁都不用把明文提交上去。\n\n要清楚它**没有**解决什么：同步出来的 Secret 在集群里仍然是 base64。\n能 `get secret` 的人照样看得到明文。所以这一层必须和 RBAC 叠着用 ——\n密钥搬出集群解决的是「不要泄露在 Git 里」，不是「集群里也看不到」。\n再往上一层是 etcd 静态加密（EncryptionConfiguration），那管的是磁盘被\n拷走的场景。三层各管一段，缺一不可。\n\n认证方式的选择比工具选择更重要。静态令牌是个死循环：为了保护密钥，\n你先得保护一把能读所有密钥的令牌。Kubernetes 认证跳出了这个循环 ——\n身份由集群签发、短期有效、绑定到具体的 ServiceAccount，泄露一份\nPod 的 token 也只能拿到那个 SA 的权限。云上的 IRSA / Workload Identity\n是同一个思路的不同实现。\n",
+          "en": "This stage resolves the tension between GitOps and secret management:\n**the repository must be readable by everyone, and secrets must not be.**\nExternal Secrets answers it by keeping only \"where to fetch it from\" in Git,\nwith the controller writing the fetched value into the cluster, so nobody ever\ncommits plaintext.\n\nBe clear about what it does **not** solve: the synced Secret is still base64\ninside the cluster, and anyone who can `get secret` still reads it. So this\nlayer stacks with RBAC. Moving secrets out of the cluster addresses \"do not leak\nthem through Git\", not \"nobody in the cluster can see them\". One layer further up\nis etcd encryption at rest (EncryptionConfiguration), which addresses a stolen\ndisk. Three layers, each covering a different exposure.\n\nChoosing the authentication method matters more than choosing the tool. A static\ntoken is circular: to protect your secrets you first have to protect a token that\nreads all of them. Kubernetes auth breaks the circle, because identity is issued\nby the cluster, short lived, and bound to a specific ServiceAccount, so a leaked\npod token buys only that ServiceAccount permissions. IRSA and Workload Identity\nin the clouds are the same idea with different plumbing.\n"
+        },
+        "primer": {
+          "zh": "先说清楚一件常被误解的事：Kubernetes 的 `Secret` **不是加密的**，它只是 base64。`kubectl get secret -o yaml` 拿到的值，接一句 `base64 -d` 就是明文。Secret 在集群里唯一的保护是 RBAC，也就是「谁有权 get 它」。所以把口令写进 Secret 并不算「保护」了它，只是换了个地方放。\n\n更麻烦的是 GitOps 带来的矛盾：仓库要能被所有人读，密钥不能。把 Secret 的 YAML 提交进 Git，等于把明文分发给每一个有仓库权限的人，而且留在历史里删不掉。`External Secrets Operator` 的答案是让仓库里只放「去哪儿取」的说明：`SecretStore` 说去哪个密钥库、用什么身份，`ExternalSecret` 说取哪几个键、放进哪个 Secret。真值由控制器在集群里生成，谁都不用提交明文。\n\n外部密钥库这里用 `OpenBao`（Vault 改协议之后 fork 出来的开源版本）。它的 KV v2 引擎有一处容易绊人：挂载路径和读写路径不是一回事，引擎挂在 `kv/` 上时，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里的 `path` 指的是挂载路径，`remoteRef.key` 里就不要再重复写它。另外 KV v2 保留版本历史，读到的默认是最新一版。\n\n认证方式的选择比工具选择更要紧。用静态令牌是个死循环：为了保护密钥，你得先保护一把能读所有密钥的令牌，而那把令牌只能存在集群里的另一个 Secret 里。`Kubernetes 认证`跳出了这个循环：身份由集群自己签发、短期有效、绑定到具体的 ServiceAccount，泄露一个 Pod 的 token 也只拿得到那个 SA 的权限。云上的 IRSA 与 Workload Identity 是同一思路的不同实现。最后记住 ESO 同步出来的 Secret 归控制器管：手改会被下一轮同步盖回去，`refreshInterval` 决定这一轮有多久。",
+          "en": "Start with a common misconception: a Kubernetes `Secret` is **not encrypted**, it is base64. Take the value from `kubectl get secret -o yaml`, pipe it through `base64 -d`, and there is the plaintext. The only protection a Secret has inside the cluster is RBAC, meaning who may get it. Putting a password into a Secret does not protect it, it relocates it.\n\nGitOps sharpens the problem: the repository must be readable by everyone and secrets must not be. Committing Secret YAML distributes plaintext to everyone with repository access and leaves it in history where deleting does not help. The `External Secrets Operator` answers by keeping only the instructions in Git: a `SecretStore` says which vault and which identity, an `ExternalSecret` says which keys to fetch into which Secret. The controller materialises the real values in the cluster and nobody commits plaintext.\n\nThe external store here is `OpenBao`, the open-source fork created after Vault changed its licence. Its KV v2 engine trips people on paths: the mount path and the read path differ, so with the engine at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore the `path` field is the mount, so `remoteRef.key` should not repeat it. KV v2 also keeps version history, and a read returns the latest version by default.\n\nChoosing the authentication method matters more than choosing the tool. A static token is circular: protecting your secrets requires protecting a token that reads all of them, and that token can only live in another Secret in the cluster. `Kubernetes auth` breaks the circle, because identity is issued by the cluster, short lived, and bound to a specific ServiceAccount, so a leaked pod token buys only that ServiceAccount permissions. IRSA and Workload Identity are the same idea in the clouds. Finally, the Secret ESO produces belongs to the controller: hand edits are overwritten on the next sync, and `refreshInterval` decides how long that takes."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1297,6 +1297,21 @@ const primers = {
       )
     ),
 
+    'external-secrets': t(
+      p(
+        '先说清楚一件常被误解的事：Kubernetes 的 `Secret` **不是加密的**，它只是 base64。`kubectl get secret -o yaml` 拿到的值，接一句 `base64 -d` 就是明文。Secret 在集群里唯一的保护是 RBAC，也就是「谁有权 get 它」。所以把口令写进 Secret 并不算「保护」了它，只是换了个地方放。',
+        '更麻烦的是 GitOps 带来的矛盾：仓库要能被所有人读，密钥不能。把 Secret 的 YAML 提交进 Git，等于把明文分发给每一个有仓库权限的人，而且留在历史里删不掉。`External Secrets Operator` 的答案是让仓库里只放「去哪儿取」的说明：`SecretStore` 说去哪个密钥库、用什么身份，`ExternalSecret` 说取哪几个键、放进哪个 Secret。真值由控制器在集群里生成，谁都不用提交明文。',
+        '外部密钥库这里用 `OpenBao`（Vault 改协议之后 fork 出来的开源版本）。它的 KV v2 引擎有一处容易绊人：挂载路径和读写路径不是一回事，引擎挂在 `kv/` 上时，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里的 `path` 指的是挂载路径，`remoteRef.key` 里就不要再重复写它。另外 KV v2 保留版本历史，读到的默认是最新一版。',
+        '认证方式的选择比工具选择更要紧。用静态令牌是个死循环：为了保护密钥，你得先保护一把能读所有密钥的令牌，而那把令牌只能存在集群里的另一个 Secret 里。`Kubernetes 认证`跳出了这个循环：身份由集群自己签发、短期有效、绑定到具体的 ServiceAccount，泄露一个 Pod 的 token 也只拿得到那个 SA 的权限。云上的 IRSA 与 Workload Identity 是同一思路的不同实现。最后记住 ESO 同步出来的 Secret 归控制器管：手改会被下一轮同步盖回去，`refreshInterval` 决定这一轮有多久。'
+      ),
+      p(
+        'Start with a common misconception: a Kubernetes `Secret` is **not encrypted**, it is base64. Take the value from `kubectl get secret -o yaml`, pipe it through `base64 -d`, and there is the plaintext. The only protection a Secret has inside the cluster is RBAC, meaning who may get it. Putting a password into a Secret does not protect it, it relocates it.',
+        'GitOps sharpens the problem: the repository must be readable by everyone and secrets must not be. Committing Secret YAML distributes plaintext to everyone with repository access and leaves it in history where deleting does not help. The `External Secrets Operator` answers by keeping only the instructions in Git: a `SecretStore` says which vault and which identity, an `ExternalSecret` says which keys to fetch into which Secret. The controller materialises the real values in the cluster and nobody commits plaintext.',
+        'The external store here is `OpenBao`, the open-source fork created after Vault changed its licence. Its KV v2 engine trips people on paths: the mount path and the read path differ, so with the engine at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore the `path` field is the mount, so `remoteRef.key` should not repeat it. KV v2 also keeps version history, and a read returns the latest version by default.',
+        'Choosing the authentication method matters more than choosing the tool. A static token is circular: protecting your secrets requires protecting a token that reads all of them, and that token can only live in another Secret in the cluster. `Kubernetes auth` breaks the circle, because identity is issued by the cluster, short lived, and bound to a specific ServiceAccount, so a leaked pod token buys only that ServiceAccount permissions. IRSA and Workload Identity are the same idea in the clouds. Finally, the Secret ESO produces belongs to the controller: hand edits are overwritten on the next sync, and `refreshInterval` decides how long that takes.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5619,7 +5619,8 @@
           "cert-manager",
           "argocd",
           "istio-system",
-          "kyverno"
+          "kyverno",
+          "external-secrets"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5724,6 +5725,14 @@
             "readyAfterMs": 300,
             "listens": [
               9443
+            ]
+          },
+          "ghcr.io/external-secrets/external-secrets:v0.21.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
             ]
           },
           "docker.io/library/redis:7.4": {
@@ -5868,6 +5877,27 @@
             "groups": [
               "system:serviceaccounts"
             ]
+          }
+        },
+        "secretStore": {
+          "address": "https://openbao.corp.internal:8200",
+          "data": {
+            "kv/payments/db": {
+              "username": "payments_app",
+              "password": "Ph4i-Quee0oh",
+              "host": "pg.corp.internal"
+            }
+          },
+          "policies": {
+            "payments-read": {
+              "kv/payments/*": [
+                "read",
+                "list"
+              ]
+            }
+          },
+          "tokens": {
+            "bao-root-token": "root"
           }
         },
         "gitRepositories": [
@@ -11133,6 +11163,506 @@
         "primer": {
           "zh": "`准入`是对象写进 etcd 之前的最后一道关。它和鉴权回答的问题不同：鉴权看「谁在做什么」，准入看**对象本身长什么样**：特权容器、没写 limits、镜像没签名，都是在这一层被拦下来的。这一层分两块：Kubernetes 内置的插件，和以 webhook 形式接进来的外部组件。\n\n`PSA`（Pod Security Admission）是内置的那块，2025 年起替代了被删掉的 PodSecurityPolicy。它只有三档预置标准：`privileged` 什么都不管，`baseline` 挡住已知的提权途径（特权容器、hostPath、host 命名空间、额外 capability），`restricted` 再加上强化要求（非 root、丢掉所有 capability、seccomp、禁止提权）。开关是命名空间上的标签，三种模式各自独立：`enforce` 拦下来，`audit` 记日志，`warn` 回一条警告。只打 `warn` 而以为拦住了，是这一层最常见的误会。另一件要记住的：**PSA 只看 Pod**，违规的 Deployment 照样 apply 得进去，然后一个 Pod 都起不来，原因在 ReplicaSet 的事件里。\n\n`Kyverno` 是外部那块，管的是 PSA 表达不了的公司自定义规矩：必须有 owner 标签、镜像只能来自内网仓库、名字要符合约定。规则写在 `ClusterPolicy` 里，`validate.pattern` 是它自己那套结构匹配（`?*` 表示要有值，`!` 表示不能等于，`|` 是或），`validate.cel` 直接写 CEL 表达式。它是集群里的一个工作负载：停掉它，所有策略立刻失效，而 `kubectl get cpol` 照样看得见。能交给 PSA 的规则不要在这里重写一遍：上游发现新的提权途径时，PSA 会跟着升级，你的规则不会。\n\n供应链那条靠 `cosign`。要点是它签的是镜像的 **digest** 而不是 tag：换个 tag 指向同一个 digest，签名依然有效；tag 不变而 digest 变了，签名立刻失效。准入时由 Kyverno 的 `verifyImages` 拿公钥验。但这条保证的边界要说清楚：它只证明「这坨字节被某把私钥认过」，不证明镜像里没有漏洞，也不证明签它的人有资格签。所以密钥归属、轮转、以及 SBOM 与来源证明是配套的，只做验签的话，安全性就等于「有人签过」这四个字。",
           "en": "`Admission` is the last gate before an object reaches etcd. It answers a different question from authorization: authorization looks at who is doing what, while admission looks at **what the object contains**: a privileged container, missing limits, an unsigned image. The layer splits in two: plugins built into Kubernetes, and external components wired in as webhooks.\n\n`PSA` (Pod Security Admission) is the built-in half, replacing the removed PodSecurityPolicy. It offers exactly three preset levels: `privileged` checks nothing, `baseline` blocks known escalation paths (privileged containers, hostPath, host namespaces, extra capabilities), and `restricted` adds hardening (non-root, drop all capabilities, seccomp, no privilege escalation). The switch is a namespace label, and the three modes are independent: `enforce` blocks, `audit` records, `warn` returns a warning. Labelling only `warn` and believing it blocks is the classic mistake here. Also remember that **PSA only inspects Pods**: a violating Deployment applies cleanly and then yields no pods, with the reason sitting in the ReplicaSet events.\n\n`Kyverno` is the external half, covering what PSA cannot express: an owner label must exist, images must come from the internal registry, names must follow a convention. Rules live in a `ClusterPolicy`; `validate.pattern` is its own structural matching (`?*` requires a value, `!` negates, `|` is or) and `validate.cel` takes CEL expressions directly. It runs as a workload in the cluster, so stopping it disables every policy while `kubectl get cpol` still lists them. Do not reimplement PSA rules here: when upstream learns of a new escalation path, PSA follows on upgrade and your copy does not.\n\nThe supply-chain rule uses `cosign`. The key fact is that it signs the image **digest**, not the tag: retagging the same digest keeps the signature valid, while pushing new content under the same tag invalidates it immediately. At admission time Kyverno `verifyImages` checks it with the public key. Be clear about the boundary of that guarantee: it proves these bytes were vouched for by some private key, not that the image is free of vulnerabilities nor that the signer was entitled to sign. Key custody, rotation, SBOMs, and build provenance go with it; signature checking alone guarantees only that somebody signed."
+        }
+      },
+      {
+        "id": "external-secrets",
+        "title": {
+          "zh": "把密钥搬出集群",
+          "en": "Move the Secrets Out of the Cluster"
+        },
+        "goal": {
+          "zh": "安全评审第四条：数据库口令不该以任何形式存在于集群和 Git 仓库里。\n现状是前任手工建了一个 Secret `db-credentials`，门户从它取值 ——\n而那份 YAML 就躺在平台仓库里。**Kubernetes 的 Secret 只是 base64，\n不是加密**，谁能 `get secret` 谁就看得到明文。\n\n内网有一台 OpenBao（`https://openbao.corp.internal:8200`），口令已经放在\n`kv/payments/db` 下面了，读它的策略 `payments-read` 也写好了。\nExternal Secrets Operator 装好了。缺的是把这条路打通。\n\n运维手上的 root 令牌是 `bao-root-token`。\n\n## 通关标准\n\n1. `db-credentials` 由 ESO 同步出来，值和 OpenBao 里的一致；\n2. 门户照常跑着，能从这个 Secret 取到口令；\n3. ESO 用 **Kubernetes 认证**去 OpenBao 换令牌，不是拿一把静态令牌\n   （那把令牌本身又是一个要保管的密钥）；\n4. 有人在 OpenBao 里轮转了口令之后，集群里会自己跟上；\n5. 集群里不再有手工维护的那份明文。\n\n## 会用到的命令\n\n```bash\nexport BAO_ADDR=https://openbao.corp.internal:8200\nexport BAO_TOKEN=bao-root-token\nbao kv get kv/payments/db\nbao auth enable kubernetes\nbao write auth/kubernetes/role/payments \\\n  bound_service_account_names=eso \\\n  bound_service_account_namespaces=payments \\\n  policies=payments-read\nkubectl apply -f /root/infra/eso.yaml\nkubectl describe externalsecret db-credentials -n payments\n```\n",
+          "en": "Fourth item from the security review: the database password must not exist in\nthe cluster or in Git in any form. Today your predecessor hand-created a Secret\ncalled `db-credentials` that the portal reads from, and that YAML sits in the\nplatform repository. **A Kubernetes Secret is base64, not encryption**: anyone\nwho can `get secret` reads the plaintext.\n\nThe intranet runs an OpenBao at `https://openbao.corp.internal:8200`. The\npassword already lives under `kv/payments/db` and a `payments-read` policy\nexists. External Secrets Operator is installed. What is missing is the wiring.\n\nThe operator root token is `bao-root-token`.\n\n## Done when\n\n1. `db-credentials` is produced by ESO and matches what OpenBao holds;\n2. the portal still runs and still reads the password from that Secret;\n3. ESO authenticates to OpenBao with **Kubernetes auth**, not a static token\n   (a static token is itself one more secret to look after);\n4. rotating the password in OpenBao propagates into the cluster on its own;\n5. no hand-maintained plaintext copy is left in the cluster.\n\n## Commands you will need\n\n```bash\nexport BAO_ADDR=https://openbao.corp.internal:8200\nexport BAO_TOKEN=bao-root-token\nbao kv get kv/payments/db\nbao auth enable kubernetes\nbao write auth/kubernetes/role/payments \\\n  bound_service_account_names=eso \\\n  bound_service_account_namespaces=payments \\\n  policies=payments-read\nkubectl apply -f /root/infra/eso.yaml\nkubectl describe externalsecret db-credentials -n payments\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "Secret 由 ESO 同步，不是手工建的",
+            "en": "The Secret is synced by ESO, not hand-made"
+          },
+          {
+            "zh": "认证用 ServiceAccount，不是静态令牌",
+            "en": "Authentication uses a ServiceAccount, not a static token"
+          },
+          {
+            "zh": "外部轮转之后集群自己跟上",
+            "en": "Rotation outside propagates in on its own"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "KV v2 有一处容易绊人：挂载路径和读写路径不是一回事。引擎挂在 `kv/` 上，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里 `path: kv` 指的是挂载路径，`remoteRef.key` 里就不要再带 `kv/` 了。",
+            "en": "KV v2 trips people on paths: the mount path and the read path differ. With the engine mounted at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore, `path: kv` is the mount, so `remoteRef.key` should not repeat `kv/`."
+          },
+          {
+            "zh": "Kubernetes 认证要两步：先 `bao auth enable kubernetes` 打开这个方法，再写一个角色说明「哪些 ServiceAccount 能登录、登录后拿哪个策略」。三个参数缺一不可，最容易漏的是命名空间那个。",
+            "en": "Kubernetes auth takes two steps: `bao auth enable kubernetes` turns the method on, then a role states which ServiceAccounts may log in and which policy they receive. All three parameters are required, and the namespaces one is the usual omission."
+          },
+          {
+            "zh": "ESO 同步出来的 Secret 归控制器管。手改它没有意义 —— 下一轮同步会盖回去。同理，删掉 ExternalSecret，那份投影也跟着走。",
+            "en": "The Secret ESO produces belongs to the controller. Editing it by hand is pointless because the next sync overwrites it, and deleting the ExternalSecret takes the projection with it."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用静态令牌图省事：把 root 令牌塞进一个 Secret，让 SecretStore 从那儿读。这样一来集群里存的是一把**能读所有密钥的**令牌 —— 比原来那个只泄露一个口令的 Secret 更糟。判定检查 SecretStore 用的是哪种认证。",
+            "en": "Reaching for a static token: putting the root token in a Secret and pointing the SecretStore at it. Now the cluster stores a credential that reads **every** secret, which is worse than the single leaked password you started with. The grader checks which auth method the SecretStore uses."
+          },
+          {
+            "zh": "以为 Secret 是加密的。它只是 base64，`kubectl get secret -o yaml` 加一句 `base64 -d` 就是明文。集群里的 Secret 唯一的保护是 RBAC —— 这也是为什么第 16 关那些角色不能给出 Secret 的读权限。",
+            "en": "Believing a Secret is encrypted. It is base64, and `kubectl get secret -o yaml` piped through `base64 -d` prints the plaintext. RBAC is the only protection a Secret has in the cluster, which is why the roles in the RBAC stage must not grant Secret reads."
+          },
+          {
+            "zh": "把 `refreshInterval` 当成实时。轮转之后集群里不会立刻变，要等下一轮同步。真出事要立刻生效时，得主动触发一次（改一下 ExternalSecret 让它重新 reconcile），别干等。",
+            "en": "Treating `refreshInterval` as realtime. After rotation the cluster lags until the next sync. When an incident needs it now, force a reconcile (touch the ExternalSecret) instead of waiting."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "ServiceAccount",
+              "metadata": {
+                "name": "eso",
+                "namespace": "payments"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "external-secrets",
+                "namespace": "external-secrets",
+                "labels": {
+                  "app.kubernetes.io/name": "external-secrets"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "external-secrets"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "external-secrets"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "ghcr.io/external-secrets/external-secrets:v0.21.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Secret",
+              "metadata": {
+                "name": "db-credentials",
+                "namespace": "payments"
+              },
+              "type": "Opaque",
+              "data": {
+                "username": "cGF5bWVudHNfYXBw",
+                "password": "UGg0aS1RdWVlMG9o"
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ],
+                        "env": [
+                          {
+                            "name": "DB_USER",
+                            "valueFrom": {
+                              "secretKeyRef": {
+                                "name": "db-credentials",
+                                "key": "username"
+                              }
+                            }
+                          },
+                          {
+                            "name": "DB_PASSWORD",
+                            "valueFrom": {
+                              "secretKeyRef": {
+                                "name": "db-credentials",
+                                "key": "password"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/eso.yaml": "# 目标：让 db-credentials 由 ESO 从 OpenBao 同步出来，\n# 而不是有人手工创建、再提交进 Git。\n#\n# 口令在 kv/payments/db 下面，策略 payments-read 已经写好了。\n# Kubernetes 认证还没开。\n"
+          },
+          "referenceFiles": {
+            "/root/infra/eso.yaml": "apiVersion: external-secrets.io/v1\nkind: SecretStore\nmetadata:\n  name: openbao\n  namespace: payments\nspec:\n  provider:\n    vault:\n      server: https://openbao.corp.internal:8200\n      path: kv\n      auth:\n        kubernetes:\n          role: payments\n          serviceAccountRef:\n            name: eso\n---\napiVersion: external-secrets.io/v1\nkind: ExternalSecret\nmetadata:\n  name: db-credentials\n  namespace: payments\nspec:\n  refreshInterval: 1m\n  secretStoreRef:\n    name: openbao\n    kind: SecretStore\n  target:\n    name: db-credentials\n  data:\n  - secretKey: username\n    remoteRef:\n      key: payments/db\n      property: username\n  - secretKey: password\n    remoteRef:\n      key: payments/db\n      property: password\n"
+          },
+          "referenceCommands": [
+            "BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token bao auth enable kubernetes",
+            "BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token bao write auth/kubernetes/role/payments bound_service_account_names=eso bound_service_account_namespaces=payments policies=payments-read",
+            "kubectl delete secret db-credentials -n payments",
+            "kubectl apply -f /root/infra/eso.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "external-secrets.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\ndescribe('把密钥搬出集群', () => {\n  it('Secret 由 ESO 同步出来', () => {\n    const external = get('ExternalSecret', 'db-credentials', 'payments');\n    expect(external).toBeTruthy();\n    const ready = external.status.conditions.find((entry) => entry.type === 'Ready');\n    expect(ready.status).toBe('True');\n\n    const secret = get('Secret', 'db-credentials', 'payments');\n    expect(secret).toBeTruthy();\n    const owner = (secret.metadata.ownerReferences || [])[0];\n    expect(owner.kind).toBe('ExternalSecret');\n  });\n\n  it('值和 OpenBao 里的一致', async () => {\n    const result = await sh(\n      'kubectl get secret db-credentials -n payments'\n      + \" -o jsonpath='{.data.password}' | base64 -d\"\n    );\n    expect(result.stdout.trim()).toBe('Ph4i-Quee0oh');\n  });\n\n  it('门户照常跑着', () => {\n    const deployment = get('Deployment', 'portal', 'payments');\n    expect(deployment.status.readyReplicas).toBe(2);\n  });\n\n  it('认证用的是 ServiceAccount，不是静态令牌', () => {\n    const stores = list('SecretStore', { namespace: 'payments' });\n    expect(stores.length).toBeGreaterThan(0);\n    for (const store of stores) {\n      const auth = store.spec.provider.vault.auth || {};\n      expect(auth.kubernetes).toBeTruthy();\n      expect(auth.tokenSecretRef).toBeFalsy();\n    }\n  });\n\n  it('集群里没有另一份手工维护的明文', () => {\n    const managed = list('Secret', { namespace: 'payments' })\n      .filter((secret) => (secret.data || {}).password !== undefined)\n      .filter((secret) => !(secret.metadata.ownerReferences || [])\n        .some((owner) => owner.kind === 'ExternalSecret'));\n    expect(managed).toEqual([]);\n  });\n\n  it('OpenBao 里轮转之后，集群自己跟上', async () => {\n    await sh(\n      'BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=bao-root-token'\n      + ' bao kv put kv/payments/db username=payments_app password=R0tated-N0w host=pg.corp.internal'\n    );\n    // 等一轮同步。ESO 是按 refreshInterval 拉的，不是实时的。\n    await advance(120000);\n    const result = await sh(\n      'kubectl get secret db-credentials -n payments'\n      + \" -o jsonpath='{.data.password}' | base64 -d\"\n    );\n    expect(result.stdout.trim()).toBe('R0tated-N0w');\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "correctness",
+          "maintainability"
+        ],
+        "extension": {
+          "zh": "这一关解决的是 GitOps 与密钥管理的矛盾：**仓库要能被所有人读，密钥不能**。\nExternal Secrets 的答案是让仓库里只放「去哪儿取」的说明，取到的东西\n由控制器写进集群，谁都不用把明文提交上去。\n\n要清楚它**没有**解决什么：同步出来的 Secret 在集群里仍然是 base64。\n能 `get secret` 的人照样看得到明文。所以这一层必须和 RBAC 叠着用 ——\n密钥搬出集群解决的是「不要泄露在 Git 里」，不是「集群里也看不到」。\n再往上一层是 etcd 静态加密（EncryptionConfiguration），那管的是磁盘被\n拷走的场景。三层各管一段，缺一不可。\n\n认证方式的选择比工具选择更重要。静态令牌是个死循环：为了保护密钥，\n你先得保护一把能读所有密钥的令牌。Kubernetes 认证跳出了这个循环 ——\n身份由集群签发、短期有效、绑定到具体的 ServiceAccount，泄露一份\nPod 的 token 也只能拿到那个 SA 的权限。云上的 IRSA / Workload Identity\n是同一个思路的不同实现。\n",
+          "en": "This stage resolves the tension between GitOps and secret management:\n**the repository must be readable by everyone, and secrets must not be.**\nExternal Secrets answers it by keeping only \"where to fetch it from\" in Git,\nwith the controller writing the fetched value into the cluster, so nobody ever\ncommits plaintext.\n\nBe clear about what it does **not** solve: the synced Secret is still base64\ninside the cluster, and anyone who can `get secret` still reads it. So this\nlayer stacks with RBAC. Moving secrets out of the cluster addresses \"do not leak\nthem through Git\", not \"nobody in the cluster can see them\". One layer further up\nis etcd encryption at rest (EncryptionConfiguration), which addresses a stolen\ndisk. Three layers, each covering a different exposure.\n\nChoosing the authentication method matters more than choosing the tool. A static\ntoken is circular: to protect your secrets you first have to protect a token that\nreads all of them. Kubernetes auth breaks the circle, because identity is issued\nby the cluster, short lived, and bound to a specific ServiceAccount, so a leaked\npod token buys only that ServiceAccount permissions. IRSA and Workload Identity\nin the clouds are the same idea with different plumbing.\n"
+        },
+        "primer": {
+          "zh": "先说清楚一件常被误解的事：Kubernetes 的 `Secret` **不是加密的**，它只是 base64。`kubectl get secret -o yaml` 拿到的值，接一句 `base64 -d` 就是明文。Secret 在集群里唯一的保护是 RBAC，也就是「谁有权 get 它」。所以把口令写进 Secret 并不算「保护」了它，只是换了个地方放。\n\n更麻烦的是 GitOps 带来的矛盾：仓库要能被所有人读，密钥不能。把 Secret 的 YAML 提交进 Git，等于把明文分发给每一个有仓库权限的人，而且留在历史里删不掉。`External Secrets Operator` 的答案是让仓库里只放「去哪儿取」的说明：`SecretStore` 说去哪个密钥库、用什么身份，`ExternalSecret` 说取哪几个键、放进哪个 Secret。真值由控制器在集群里生成，谁都不用提交明文。\n\n外部密钥库这里用 `OpenBao`（Vault 改协议之后 fork 出来的开源版本）。它的 KV v2 引擎有一处容易绊人：挂载路径和读写路径不是一回事，引擎挂在 `kv/` 上时，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里的 `path` 指的是挂载路径，`remoteRef.key` 里就不要再重复写它。另外 KV v2 保留版本历史，读到的默认是最新一版。\n\n认证方式的选择比工具选择更要紧。用静态令牌是个死循环：为了保护密钥，你得先保护一把能读所有密钥的令牌，而那把令牌只能存在集群里的另一个 Secret 里。`Kubernetes 认证`跳出了这个循环：身份由集群自己签发、短期有效、绑定到具体的 ServiceAccount，泄露一个 Pod 的 token 也只拿得到那个 SA 的权限。云上的 IRSA 与 Workload Identity 是同一思路的不同实现。最后记住 ESO 同步出来的 Secret 归控制器管：手改会被下一轮同步盖回去，`refreshInterval` 决定这一轮有多久。",
+          "en": "Start with a common misconception: a Kubernetes `Secret` is **not encrypted**, it is base64. Take the value from `kubectl get secret -o yaml`, pipe it through `base64 -d`, and there is the plaintext. The only protection a Secret has inside the cluster is RBAC, meaning who may get it. Putting a password into a Secret does not protect it, it relocates it.\n\nGitOps sharpens the problem: the repository must be readable by everyone and secrets must not be. Committing Secret YAML distributes plaintext to everyone with repository access and leaves it in history where deleting does not help. The `External Secrets Operator` answers by keeping only the instructions in Git: a `SecretStore` says which vault and which identity, an `ExternalSecret` says which keys to fetch into which Secret. The controller materialises the real values in the cluster and nobody commits plaintext.\n\nThe external store here is `OpenBao`, the open-source fork created after Vault changed its licence. Its KV v2 engine trips people on paths: the mount path and the read path differ, so with the engine at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore the `path` field is the mount, so `remoteRef.key` should not repeat it. KV v2 also keeps version history, and a read returns the latest version by default.\n\nChoosing the authentication method matters more than choosing the tool. A static token is circular: protecting your secrets requires protecting a token that reads all of them, and that token can only live in another Secret in the cluster. `Kubernetes auth` breaks the circle, because identity is issued by the cluster, short lived, and bound to a specific ServiceAccount, so a leaked pod token buys only that ServiceAccount permissions. IRSA and Workload Identity are the same idea in the clouds. Finally, the Secret ESO produces belongs to the controller: hand edits are overwritten on the next sync, and `refreshInterval` decides how long that takes."
         }
       }
     ]

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -224,6 +224,23 @@ export interface OpsImageSpec {
   enforcesNetworkPolicy?: boolean;
 }
 
+/** 内网的密钥库（OpenBao） */
+export interface OpsSecretStoreSpec {
+  /** 地址，如 `https://openbao.corp.internal:8200` */
+  address: string;
+  /** 初始内容：路径 -> 键值 */
+  data?: Record<string, Record<string, string>>;
+  /** 策略：名字 -> 路径 -> 能力 */
+  policies?: Record<string, Record<string, string[]>>;
+  /** 发好的静态令牌：token -> 策略名 */
+  tokens?: Record<string, string>;
+  /**
+   * Kubernetes 认证的角色。不声明就是「这台还没开 Kubernetes auth」，
+   * ESO 只能用静态令牌 —— 而那本身又是一个要保管的密钥。
+   */
+  kubernetesRoles?: Record<string, { boundServiceAccounts: string[]; policy: string }>;
+}
+
 /** 内网 Git 服务上的一个仓库 */
 export interface OpsGitRepositorySpec {
   /** 完整 URL，如 `https://git.corp.internal/platform/apps` */
@@ -286,6 +303,8 @@ export interface OpsWorldSpec {
   users?: Record<string, { username: string; groups?: string[] }>;
   /** 内网的 Git 仓库。GitOps 里那份 YAML 就住在这儿。 */
   gitRepositories?: OpsGitRepositorySpec[];
+  /** 内网的密钥库。真正的密钥住在这儿，集群里只有投影。 */
+  secretStore?: OpsSecretStoreSpec;
   machine?: OpsMachineSpec;
   /** 集群外的名字：`git.corp.internal` -> ['10.10.0.30'] */
   externalHosts?: Record<string, string[]>;

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -29,6 +29,7 @@ import {
 import {
   CLUSTERROLEBINDINGS, CLUSTERROLES, RBAC_RESOURCES, ROLEBINDINGS, ROLES, authorize,
 } from '../rbac';
+import { ESO_RESOURCES, ExternalSecretsController } from '../secrets';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -88,6 +89,8 @@ export interface ClusterOptions {
    * 所有请求都是 cluster-admin —— 前面十几关不必为此各配一套角色。
    */
   users?: Record<string, { username: string; groups?: string[] }>;
+  /** 去外部密钥库取值。由世界注入 —— 集群自己不认识 OpenBao。 */
+  fetchSecret?: import('../secrets').SecretFetcher;
   /** 镜像签名库。由世界注入，和镜像仓库一样是集群外的东西。 */
   signatures?: import('../admission').SignatureStore;
   /** Service 的 VIP 从哪个网段分。默认 10.96.0.0/12，和真集群一样。 */
@@ -145,7 +148,7 @@ export class Cluster {
     this.store = createStore();
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
-      ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES,
+      ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -589,6 +592,10 @@ export class Cluster {
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发
       new CertManagerController(context),
+      // 密钥：真值住在集群外面，这里只维护一份投影
+      ...(this.options.fetchSecret
+        ? [new ExternalSecretsController(context, { fetch: this.options.fetchSecret })]
+        : []),
       // GitOps：仓库里那份 YAML 才是期望状态，集群里的对象是它的投影
       ...(this.options.gitSource
         ? [new ArgoCdController(context, {

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -23,6 +23,7 @@ import { materializePki } from './pki';
 import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } from '../git';
 import { createIstioctlCommand } from '../mesh';
 import { SignatureStore, createCosignCommand } from '../admission';
+import { OpenBao, createBaoCommand } from '../secrets';
 import { currentNamespaceOf } from './view';
 import { DEFAULT_KUBECONFIG_PATH } from '../wasm';
 import { createExecHandler } from './podshell';
@@ -45,6 +46,8 @@ export interface OpsWorld {
   git: GitNetwork;
   /** 镜像签名 */
   signatures: SignatureStore;
+  /** 内网密钥库。世界没声明就是 undefined。 */
+  bao?: OpenBao;
   /** 装上的真 CLI 名字，如 ['kubectl','helm'] */
   applets: string[];
   /** 敲一条命令，然后让世界自己往前走到静止 */
@@ -66,6 +69,22 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   const clusterAgeMs = spec.clusterAgeDays !== undefined
     ? spec.clusterAgeDays * 24 * 60 * 60_000
     : DEFAULT_CLUSTER_AGE_MS;
+
+  /**
+   * 内网的密钥库。
+   *
+   * 和镜像仓库、Git 服务一样是**集群外**的东西 —— 这正是它存在的意义：
+   * 密钥不在集群里，集群里只有一份由 ESO 维护的投影。
+   */
+  const bao = spec.secretStore ? new OpenBao(spec.secretStore.address) : undefined;
+  if (bao && spec.secretStore) {
+    for (const [name, rules] of Object.entries(spec.secretStore.policies ?? {})) {
+      bao.addPolicy(name, { rules });
+    }
+    for (const [path, data] of Object.entries(spec.secretStore.data ?? {})) bao.write(path, data);
+    for (const [token, policy] of Object.entries(spec.secretStore.tokens ?? {})) bao.addToken(token, policy);
+    if (spec.secretStore.kubernetesRoles) bao.enableKubernetesAuth(spec.secretStore.kubernetesRoles);
+  }
 
   // 镜像签名。和镜像仓库一样是集群外的东西，cosign 往里写，Kyverno 从里读。
   const signatures = new SignatureStore();
@@ -113,6 +132,50 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     addressPools: spec.addressPools,
     users: spec.users,
     signatures,
+    /**
+     * ESO 去密钥库取值。
+     *
+     * 认证走 SecretStore 里写的那种方式：`kubernetes` 用 ServiceAccount 换
+     * 令牌（集群里该用的），`tokenSecretRef` 直接从一个 Secret 里读静态令牌
+     * （常见但不好 —— 那把令牌本身又是一个要保管的密钥）。
+     */
+    fetchSecret: ({ store, namespace, key, property }) => {
+      if (!bao) return { error: 'no secret store configured in this world' };
+      const provider = ((store.spec ?? {}) as any).provider?.vault ?? {};
+      if (provider.server && provider.server !== bao.address) {
+        return { error: `cannot connect to ${provider.server}: no such host` };
+      }
+      const auth = provider.auth ?? {};
+      let token: string | undefined;
+      if (auth.kubernetes) {
+        const serviceAccount = auth.kubernetes.serviceAccountRef?.name ?? 'default';
+        const login = bao.loginKubernetes(auth.kubernetes.role ?? '', `${namespace}/${serviceAccount}`);
+        if ('error' in login) return { error: login.error };
+        token = login.token;
+      } else if (auth.tokenSecretRef) {
+        const definition = cluster.scheme.get({ group: '', version: 'v1', resource: 'secrets' });
+        const holder = definition && cluster.registry.list(definition, { namespace }).items
+          .find((item) => item.metadata.name === auth.tokenSecretRef.name);
+        const encoded = ((holder ?? {}) as any).data?.[auth.tokenSecretRef.key ?? 'token'];
+        token = encoded ? atob(encoded) : undefined;
+        if (!token) return { error: `token secret "${auth.tokenSecretRef.name}" not found or empty` };
+      } else {
+        return { error: 'no auth method configured on the SecretStore' };
+      }
+
+      const mount = provider.path ? `${provider.path}/` : '';
+      const full = `${mount}${key}`;
+      if (!bao.allows(token, full, 'read')) {
+        return { error: `permission denied on ${full}` };
+      }
+      const data = bao.read(full);
+      if (!data) return { error: `no value found at ${full}` };
+      if (property) {
+        if (data[property] === undefined) return { error: `key "${property}" not found at ${full}` };
+        return { value: data[property] };
+      }
+      return { value: JSON.stringify(data) };
+    },
     /**
      * Argo CD 从这里取仓库内容。
      *
@@ -200,6 +263,12 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
   }
 
   machine.install('openssl', createOpensslCommand());
+
+  if (bao) {
+    machine.install('bao', createBaoCommand({
+      server: (address) => (address.replace(/\/+$/, '') === bao.address ? bao : undefined),
+    }));
+  }
 
   machine.install('cosign', createCosignCommand({
     signatures,
@@ -305,6 +374,7 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     registries,
     git,
     signatures,
+    bao,
     applets,
     now: () => cluster.wallClock(),
     async run(command: string) {

--- a/src/lib/opslab/machine/shell/coreutils.ts
+++ b/src/lib/opslab/machine/shell/coreutils.ts
@@ -88,7 +88,39 @@ function readInputs(context: CommandContext, values: string[]): { text: string; 
 const lines = (text: string): string[] => (text === '' ? [] : text.replace(/\n$/, '').split('\n'));
 const join = (values: string[]): string => (values.length ? `${values.join('\n')}\n` : '');
 
+/** 读一个文件，读不到就返回一个失败结果（给 base64 这类既收 stdin 又收文件名的命令用） */
+function readOrFail(context: CommandContext, file: string): string | CommandResult {
+  const target = resolve(context, file);
+  if (!context.vfs.exists(target)) return fail(`base64: ${file}: No such file or directory`, 1);
+  return context.vfs.readFile(target);
+}
+
 export const COREUTILS: Record<string, CommandHandler> = {
+  /**
+   * base64
+   *
+   * Kubernetes 的 Secret 是 base64，不是加密 —— 学员要能自己一句
+   * `... | base64 -d` 把这件事看明白，所以这个命令不能少。
+   */
+  base64: (context) => {
+    const decode = context.argv.includes('-d') || context.argv.includes('--decode');
+    const file = context.argv.find((entry) => !entry.startsWith('-'));
+    const input = file ? readOrFail(context, file) : context.stdin;
+    if (typeof input !== 'string') return input;
+    try {
+      if (!decode) {
+        let binary = '';
+        for (const byte of new TextEncoder().encode(input)) binary += String.fromCharCode(byte);
+        return { stdout: `${btoa(binary)}\n` };
+      }
+      const clean = input.replace(/\s+/g, '');
+      const binary = atob(clean);
+      return { stdout: new TextDecoder().decode(Uint8Array.from(binary, (ch) => ch.charCodeAt(0))) };
+    } catch {
+      return fail('base64: invalid input', 1);
+    }
+  },
+
   ls: (context) => {
     const args = parseArgs(context.argv);
     const targets = args.values.length ? args.values : ['.'];

--- a/src/lib/opslab/secrets/baocli.ts
+++ b/src/lib/opslab/secrets/baocli.ts
@@ -1,0 +1,283 @@
+/**
+ * `bao`
+ *
+ * OpenBao 的 CLI。只做 KV v2 与状态查询 —— 集群这边的活由 ESO 干，
+ * 人用 CLI 主要是往里放东西、以及确认自己放对了地方。
+ *
+ * `BAO_ADDR` 与 `BAO_TOKEN` 两个环境变量的行为和真 CLI 一致：不设地址就报
+ * 连不上，不设令牌就是 permission denied。这两个错很常见，值得原样保留。
+ */
+import type { CommandHandler, CommandResult } from '../machine/shell/shell';
+import type { OpenBao } from './openbao';
+
+export interface BaoCliOptions {
+  server(address: string): OpenBao | undefined;
+}
+
+export function createBaoCommand(options: BaoCliOptions): CommandHandler {
+  return ({ argv, env }) => {
+    const address = env.BAO_ADDR ?? env.VAULT_ADDR;
+    const token = env.BAO_TOKEN ?? env.VAULT_TOKEN;
+    const [command, ...rest] = argv;
+
+    if (command === 'version' || command === '--version') {
+      return { stdout: 'OpenBao v2.4.1\n' };
+    }
+    if (!command) return { stdout: USAGE };
+
+    if (!address) {
+      return {
+        stderr: 'Error checking seal status: Get "/v1/sys/seal-status": '
+          + 'unsupported protocol scheme ""\n\n'
+          + 'BAO_ADDR 没设。先 export BAO_ADDR=https://<host>:8200\n',
+        code: 2,
+      };
+    }
+    const server = options.server(address);
+    if (!server) {
+      return {
+        stderr: `Error making API request.\n\nURL: GET ${address}/v1/sys/seal-status\n`
+          + `Code: -1. Errors:\n\n* dial tcp: lookup ${hostOf(address)}: no such host\n`,
+        code: 2,
+      };
+    }
+
+    if (command === 'status') {
+      return {
+        stdout: [
+          'Key             Value',
+          '---             -----',
+          'Seal Type       shamir',
+          'Initialized     true',
+          'Sealed          false',
+          'Storage Type    raft',
+          'Version         2.4.1',
+          `Cluster Name    ${hostOf(address)}`,
+          '',
+        ].join('\n'),
+      };
+    }
+
+    if (!token) {
+      return {
+        stderr: 'Error making API request.\n\nCode: 400. Errors:\n\n* missing client token\n',
+        code: 2,
+      };
+    }
+    if (!server.policyOf(token)) {
+      return {
+        stderr: 'Error making API request.\n\nCode: 403. Errors:\n\n* permission denied\n',
+        code: 2,
+      };
+    }
+
+    if (command === 'kv') return kv(server, token, rest);
+    if (command === 'auth') return auth(server, token, rest);
+    if (command === 'write') return write(server, token, rest);
+    if (command === 'read') return read(server, token, rest);
+
+    return { stderr: `Unknown command: ${command}\n${USAGE}`, code: 1 };
+  };
+}
+
+const USAGE = `Usage: bao <command> [args]
+
+Common commands:
+    status     Print seal and HA status
+    kv         Interact with the key/value store
+    auth       Interact with auth methods
+    read       Read data from OpenBao
+    write      Write data, configuration, and secrets
+`;
+
+/**
+ * `bao auth enable kubernetes`
+ *
+ * 开了这个方法，集群里的工作负载才能拿自己的 ServiceAccount 换令牌 ——
+ * 不用再保管一把长期有效的静态令牌。
+ */
+function auth(server: OpenBao, token: string, argv: string[]): CommandResult {
+  const [action, ...rest] = argv;
+  const positional = rest.filter((entry) => !entry.startsWith('-'));
+  if (action === 'list') {
+    return {
+      stdout: [
+        'Path           Type          Description',
+        '----           ----          -----------',
+        'token/         token         token based credentials',
+        ...(server.kubernetesAuthEnabled
+          ? ['kubernetes/    kubernetes    n/a']
+          : []),
+        '',
+      ].join('\n'),
+    };
+  }
+  if (action !== 'enable') return { stderr: `Unknown auth subcommand: ${action ?? ''}\n`, code: 1 };
+  if (server.policyOf(token) !== 'root') {
+    return { stderr: denied('sys/auth').stderr, code: 2 };
+  }
+  if (positional[0] !== 'kubernetes') {
+    return { stderr: `Error enabling ${positional[0] ?? ''}: 这个世界只做了 kubernetes 认证\n`, code: 1 };
+  }
+  server.enableKubernetesAuth();
+  return { stdout: 'Success! Enabled kubernetes auth method at: kubernetes/\n' };
+}
+
+/**
+ * `bao write auth/kubernetes/role/<name> ...`
+ *
+ * 角色说的是「哪些 ServiceAccount 能登录、登录后拿哪个策略」。
+ * 三个参数里最容易写错的是命名空间那个：漏了它，谁都登不进来。
+ */
+function write(server: OpenBao, token: string, argv: string[]): CommandResult {
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  const path = positional[0] ?? '';
+  const match = /^auth\/kubernetes\/role\/(.+)$/.exec(path);
+  if (!match) {
+    return { stderr: `Error writing data to ${path}: 这个世界只做了 auth/kubernetes/role/<name>\n`, code: 2 };
+  }
+  if (server.policyOf(token) !== 'root') return denied(path);
+  if (!server.kubernetesAuthEnabled) {
+    return {
+      stderr: `Error writing data to ${path}: Error making API request.\n\n`
+        + 'Code: 404. Errors:\n\n* no handler for route "auth/kubernetes/role". '
+        + '先 bao auth enable kubernetes\n',
+      code: 2,
+    };
+  }
+
+  const fields: Record<string, string> = {};
+  for (const entry of positional.slice(1)) {
+    const index = entry.indexOf('=');
+    if (index > 0) fields[entry.slice(0, index)] = entry.slice(index + 1);
+  }
+  const names = split(fields.bound_service_account_names);
+  const namespaces = split(fields.bound_service_account_namespaces);
+  const policy = split(fields.policies)[0];
+  if (names.length === 0 || namespaces.length === 0 || !policy) {
+    return {
+      stderr: `Error writing data to ${path}: bound_service_account_names、`
+        + 'bound_service_account_namespaces、policies 三个都要给\n',
+      code: 2,
+    };
+  }
+  if (!server.hasPolicy(policy) && policy !== 'root') {
+    return { stderr: `Error writing data to ${path}: policy "${policy}" does not exist\n`, code: 2 };
+  }
+
+  const bound = namespaces.flatMap((namespace) => names.map((name) => `${namespace}/${name}`));
+  server.addKubernetesRole(match[1], { boundServiceAccounts: bound, policy });
+  return { stdout: `Success! Data written to: ${path}\n` };
+}
+
+function read(server: OpenBao, token: string, argv: string[]): CommandResult {
+  const path = argv.filter((entry) => !entry.startsWith('-'))[0] ?? '';
+  const match = /^auth\/kubernetes\/role\/(.+)$/.exec(path);
+  if (!match) return { stderr: `No value found at ${path}\n`, code: 2 };
+  if (server.policyOf(token) !== 'root') return denied(path);
+  const role = server.kubernetesRole(match[1]);
+  if (!role) return { stderr: `No value found at ${path}\n`, code: 2 };
+  return {
+    stdout: [
+      '====== Data ======',
+      'Key                                 Value',
+      '---                                 -----',
+      `bound_service_account_names         [${role.boundServiceAccounts.map((entry) => entry.split('/')[1]).join(' ')}]`,
+      `bound_service_account_namespaces    [${[...new Set(role.boundServiceAccounts.map((entry) => entry.split('/')[0]))].join(' ')}]`,
+      `policies                            [${role.policy}]`,
+      '',
+    ].join('\n'),
+  };
+}
+
+function split(value: string | undefined): string[] {
+  return (value ?? '').split(',').map((entry) => entry.trim()).filter(Boolean);
+}
+
+function kv(server: OpenBao, token: string, argv: string[]): CommandResult {
+  const [action, ...rest] = argv;
+  const positional = rest.filter((entry) => !entry.startsWith('-'));
+  const path = positional[0];
+
+  if (action === 'put') {
+    if (!path) return { stderr: 'Error: a path is required\n', code: 1 };
+    if (!server.allows(token, path, 'create') && !server.allows(token, path, 'update')) {
+      return denied(path);
+    }
+    const data: Record<string, string> = {};
+    for (const entry of positional.slice(1)) {
+      const index = entry.indexOf('=');
+      if (index > 0) data[entry.slice(0, index)] = entry.slice(index + 1);
+    }
+    const version = server.write(path, data);
+    return { stdout: versionTable(path, version) };
+  }
+
+  if (action === 'get') {
+    if (!path) return { stderr: 'Error: a path is required\n', code: 1 };
+    if (!server.allows(token, path, 'read')) return denied(path);
+    const data = server.read(path);
+    if (!data) return { stderr: `No value found at ${path}\n`, code: 2 };
+    const field = flag(rest, '-field');
+    if (field) {
+      return data[field] === undefined
+        ? { stderr: `Error: field "${field}" not present in secret\n`, code: 1 }
+        : { stdout: `${data[field]}\n` };
+    }
+    const rows = Object.entries(data).sort(([a], [b]) => (a < b ? -1 : 1));
+    const width = Math.max(4, ...rows.map(([key]) => key.length));
+    return {
+      stdout: [
+        `====== Data ======`,
+        `${'Key'.padEnd(width)}    Value`,
+        `${'---'.padEnd(width)}    -----`,
+        ...rows.map(([key, value]) => `${key.padEnd(width)}    ${value}`),
+        '',
+      ].join('\n'),
+    };
+  }
+
+  if (action === 'list') {
+    const prefix = path ?? '';
+    if (!server.allows(token, `${prefix}/`, 'list')) return denied(prefix);
+    const keys = server.list(prefix);
+    return { stdout: keys.length ? `Keys\n----\n${keys.join('\n')}\n` : `No value found at ${prefix}\n` };
+  }
+
+  return { stderr: `Unknown kv subcommand: ${action ?? ''}\n`, code: 1 };
+}
+
+function denied(path: string): CommandResult {
+  return {
+    stderr: `Error making API request.\n\nCode: 403. Errors:\n\n`
+      + `* 1 error occurred:\n\t* permission denied on ${path}\n\n`,
+    code: 2,
+  };
+}
+
+function versionTable(path: string, version: number): string {
+  return [
+    `====== Secret Path ======`,
+    `${path}/data`,
+    '',
+    '======= Metadata =======',
+    'Key                Value',
+    '---                -----',
+    'created_time       2026-03-02T09:00:00Z',
+    'deletion_time      n/a',
+    'destroyed          false',
+    `version            ${version}`,
+    '',
+  ].join('\n');
+}
+
+function flag(argv: string[], name: string): string | undefined {
+  const inline = argv.find((entry) => entry.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+function hostOf(address: string): string {
+  return address.replace(/^[a-z]+:\/\//, '').split(/[:/]/)[0];
+}

--- a/src/lib/opslab/secrets/controller.ts
+++ b/src/lib/opslab/secrets/controller.ts
@@ -1,0 +1,287 @@
+/**
+ * External Secrets 的控制器
+ *
+ * 干的事很简单：按 ExternalSecret 的说明去外部密钥库取值，写成一个普通的
+ * Kubernetes Secret。价值在于**密钥不再存在于集群里**（除了这份投影），
+ * 也不再存在于 Git 仓库里 —— GitOps 与密钥管理的矛盾就是这么化解的。
+ *
+ * 两个容易被忽略的行为，这里都照真的实现：
+ *  1. **`refreshInterval` 决定多久同步一次**。外部改了值，集群里不会立刻变。
+ *  2. **同步出来的 Secret 归控制器管**。有人手改了它，下一次同步会盖回去。
+ */
+import type { KubeObject } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS, SECRETS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { CLUSTERSECRETSTORES, ESO_LABEL, EXTERNALSECRETS, SECRETSTORES } from './resources';
+
+/** 从密钥库取一个值 */
+export type SecretFetcher = (input: {
+  /** SecretStore 的 provider 配置 */
+  store: KubeObject;
+  /** ExternalSecret 所在命名空间，Kubernetes auth 要用 */
+  namespace: string;
+  key: string;
+  property?: string;
+}) => { value: string } | { error: string };
+
+export interface ExternalSecretsOptions {
+  fetch: SecretFetcher;
+}
+
+/** ESO 默认的同步间隔 */
+export const DEFAULT_REFRESH_MS = 60_000;
+
+export class ExternalSecretsController extends Controller {
+  private externalSecrets: Informer;
+  private stores: Informer;
+  private clusterStores: Informer;
+  private deployments: Informer;
+  private poll: number;
+  private stopped = false;
+
+  constructor(context: ControllerContext, private readonly options: ExternalSecretsOptions) {
+    super(context, 'external-secrets');
+    this.externalSecrets = new Informer(this.registry, EXTERNALSECRETS);
+    this.stores = this.track(new Informer(this.registry, SECRETSTORES));
+    this.clusterStores = this.track(new Informer(this.registry, CLUSTERSECRETSTORES));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.watch(this.externalSecrets);
+    for (const informer of [this.stores, this.clusterStores, this.deployments]) {
+      informer.onChange(() => this.enqueueAll());
+    }
+    /**
+     * 定期重取。标成 background —— 它「永远有下一次」，
+     * 算成前台的话世界就再也静不下来了。
+     */
+    this.poll = this.kernel.setInterval(() => this.enqueueAll(), DEFAULT_REFRESH_MS, {
+      background: true,
+      label: 'external-secrets:refresh',
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.kernel.clearTimer(this.poll);
+    super.stop();
+  }
+
+  private enqueueAll(): void {
+    if (this.stopped) return;
+    for (const item of this.externalSecrets.list()) this.enqueue(objectKey(item));
+  }
+
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[ESO_LABEL.key] !== ESO_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let external: KubeObject;
+    try {
+      external = this.registry.get(EXTERNALSECRETS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) { this.removeSecret(namespace, name); return; }
+      throw error;
+    }
+    if (external.metadata.deletionTimestamp) { this.removeSecret(namespace, name); return; }
+
+    const spec = (external.spec ?? {}) as any;
+    const store = this.storeFor(spec.secretStoreRef, namespace);
+    if (!store) {
+      await this.fail(external, 'InvalidProviderConfig',
+        `could not get SecretStore "${spec.secretStoreRef?.name}": not found`);
+      return;
+    }
+
+    const data: Record<string, string> = {};
+    for (const entry of spec.data ?? []) {
+      const outcome = this.options.fetch({
+        store,
+        namespace: namespace ?? 'default',
+        key: entry.remoteRef?.key ?? '',
+        property: entry.remoteRef?.property,
+      });
+      if ('error' in outcome) {
+        await this.fail(external, 'SecretSyncedError', outcome.error);
+        return;
+      }
+      data[entry.secretKey] = outcome.value;
+    }
+
+    /**
+     * dataFrom：把远端那个路径下的所有键一次性取过来。
+     * 比逐个列出来省事，代价是「集群里这个 Secret 有哪些键」不再一目了然。
+     */
+    for (const entry of spec.dataFrom ?? []) {
+      const outcome = this.options.fetch({
+        store,
+        namespace: namespace ?? 'default',
+        key: entry.extract?.key ?? '',
+      });
+      if ('error' in outcome) {
+        await this.fail(external, 'SecretSyncedError', outcome.error);
+        return;
+      }
+      try {
+        Object.assign(data, JSON.parse(outcome.value) as Record<string, string>);
+      } catch {
+        await this.fail(external, 'SecretSyncedError', 'remote value is not a key/value map');
+        return;
+      }
+    }
+
+    const changed = this.writeSecret(external, namespace ?? 'default', data);
+    await this.succeed(external, changed);
+  }
+
+  /**
+   * ExternalSecret 没了，它维护的那份投影也要走。
+   *
+   * 这里显式删而不是靠 ownerReference 的级联回收：集群里没有通用的
+   * 垃圾回收器，各个控制器自己收拾自己建的东西（Gateway 的 Service 也一样）。
+   * 不收拾的话集群里会留下一个没人认领的密钥，而且它不会再被更新 ——
+   * 比没有更危险。
+   */
+  private removeSecret(namespace: string | undefined, name: string): void {
+    if (!namespace) return;
+    let secrets: KubeObject[];
+    try {
+      secrets = this.registry.list(SECRETS, { namespace }).items;
+    } catch {
+      return;
+    }
+    for (const secret of secrets) {
+      const owned = (secret.metadata.ownerReferences ?? []).some(
+        (ref) => ref.kind === 'ExternalSecret' && ref.name === name
+      );
+      if (!owned) continue;
+      try {
+        this.registry.delete(SECRETS, namespace, secret.metadata.name);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+  }
+
+  private storeFor(ref: any, namespace?: string): KubeObject | undefined {
+    if (!ref?.name) return undefined;
+    if (ref.kind === 'ClusterSecretStore') {
+      return this.clusterStores.list().find((item) => item.metadata.name === ref.name);
+    }
+    return this.stores.list().find(
+      (item) => item.metadata.namespace === namespace && item.metadata.name === ref.name
+    );
+  }
+
+  /**
+   * 写出目标 Secret。
+   *
+   * 加 ownerReference：ExternalSecret 删掉的时候这份投影跟着走，
+   * 不会在集群里留下一个没人认领的密钥。
+   */
+  private writeSecret(external: KubeObject, namespace: string, data: Record<string, string>): boolean {
+    const spec = (external.spec ?? {}) as any;
+    const name = spec.target?.name ?? external.metadata.name!;
+    const encoded = Object.fromEntries(
+      Object.entries(data).map(([key, value]) => [key, base64(value)])
+    );
+    const desired: KubeObject = {
+      apiVersion: 'v1', kind: 'Secret',
+      metadata: {
+        name, namespace,
+        labels: { 'reconcile.external-secrets.io/managed': 'true' },
+        ownerReferences: [{
+          apiVersion: 'external-secrets.io/v1', kind: 'ExternalSecret',
+          name: external.metadata.name!, uid: external.metadata.uid!,
+          controller: true, blockOwnerDeletion: true,
+        }],
+      },
+      type: spec.target?.template?.type ?? 'Opaque',
+      data: encoded,
+    } as KubeObject;
+
+    let live: KubeObject | undefined;
+    try {
+      live = this.registry.get(SECRETS, namespace, name);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+    if (!live) {
+      this.registry.create(SECRETS, namespace, desired);
+      return true;
+    }
+    // 手改过的会在这里被盖回去 —— 这份 Secret 归控制器管
+    if (JSON.stringify((live as any).data ?? {}) === JSON.stringify(encoded)) return false;
+    this.registry.update(SECRETS, namespace, name, { ...live, data: encoded } as KubeObject);
+    return true;
+  }
+
+  /**
+   * 写成功状态。
+   *
+   * `refreshTime` 只在这一轮真的改了东西时才更新。每轮都写的话，
+   * 状态每次都不一样 -> 触发 watch -> 再 reconcile -> 再写，世界永远静不下来。
+   * 真 ESO 靠的是定时器驱动，不会这样自激；我们的控制器是事件驱动的，
+   * 所以「状态里不要放每次都变的值」是一条硬约束。
+   */
+  private async succeed(external: KubeObject, changed: boolean): Promise<void> {
+    const previous = ((external.status ?? {}) as { refreshTime?: string }).refreshTime;
+    await this.writeStatus(external, {
+      conditions: [{
+        type: 'Ready', status: 'True', reason: 'SecretSynced',
+        message: 'secret synced',
+        lastTransitionTime: previous && !changed ? previous : this.timestamp(),
+      }],
+      refreshTime: changed || !previous ? this.timestamp() : previous,
+      /**
+       * 记的是 generation 不是 resourceVersion。
+       *
+       * resourceVersion 每写一次状态就变一次，把它写进状态里等于让状态
+       * 永远和上一轮不同 —— 于是 watch 一直被触发，世界静不下来。
+       * generation 只在 spec 变的时候动，正是这里想表达的意思。
+       */
+      syncedGeneration: external.metadata.generation,
+    });
+  }
+
+  private async fail(external: KubeObject, reason: string, message: string): Promise<void> {
+    // 同样不能每轮都换时间戳，否则失败状态会把世界卡在自激里
+    const previous = ((external.status ?? {}) as any).conditions?.[0];
+    const unchanged = previous?.reason === reason && previous?.message === message;
+    await this.writeStatus(external, {
+      conditions: [{
+        type: 'Ready', status: 'False', reason, message,
+        lastTransitionTime: unchanged ? previous.lastTransitionTime : this.timestamp(),
+      }],
+    });
+    this.context.recordEvent({
+      object: external, type: 'Warning', reason, message,
+    });
+  }
+
+  private timestamp(): string {
+    return new Date(this.context.now()).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  }
+
+  private async writeStatus(external: KubeObject, status: Record<string, unknown>): Promise<void> {
+    await ignoreConflict(() => {
+      updateStatusIfChanged(
+        this.registry, EXTERNALSECRETS,
+        external.metadata.namespace, external.metadata.name!, status
+      );
+    });
+  }
+}
+
+function base64(value: string): string {
+  let binary = '';
+  for (const byte of new TextEncoder().encode(value)) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}

--- a/src/lib/opslab/secrets/index.ts
+++ b/src/lib/opslab/secrets/index.ts
@@ -1,0 +1,16 @@
+/**
+ * 密钥不该住在集群里
+ *
+ * Kubernetes 的 Secret 只是 base64，不是加密：谁能 `get secret` 谁就看得到
+ * 明文。把密钥放进 Git 更糟。External Secrets 的做法是让真值住在外部的
+ * 密钥库里，集群里只留一份由控制器维护的投影。
+ */
+export { OpenBao } from './openbao';
+export type { BaoAuthKubernetes, BaoLoginResult, BaoPolicy } from './openbao';
+export {
+  SECRETSTORES, CLUSTERSECRETSTORES, EXTERNALSECRETS, ESO_RESOURCES, ESO_LABEL,
+} from './resources';
+export { ExternalSecretsController, DEFAULT_REFRESH_MS } from './controller';
+export type { ExternalSecretsOptions, SecretFetcher } from './controller';
+export { createBaoCommand } from './baocli';
+export type { BaoCliOptions } from './baocli';

--- a/src/lib/opslab/secrets/openbao.ts
+++ b/src/lib/opslab/secrets/openbao.ts
@@ -1,0 +1,166 @@
+/**
+ * OpenBao
+ *
+ * Vault 在 2023 年改成 BUSL 之后 fork 出来的开源版本，接口与 Vault 兼容。
+ * 这里做的是 KV v2 引擎与两种认证方式，够撑起「密钥住在集群外面」这件事。
+ *
+ * KV v2 有一处容易绊人：读写路径和挂载路径不一样。挂在 `secret/` 上的引擎，
+ * 写的时候路径是 `secret/data/<path>`，`bao kv put secret/<path>` 只是替你
+ * 把 `data/` 插进去了。ESO 的 SecretStore 里写错这一层是最常见的配置错误。
+ */
+export interface BaoAuthKubernetes {
+  /** 允许哪些 ServiceAccount 登录，形如 `argocd/deployer` */
+  boundServiceAccounts: string[];
+  /** 登录后拿到哪个策略 */
+  policy: string;
+}
+
+export interface BaoPolicy {
+  /** 路径 -> 允许的能力（read / create / update / list / delete） */
+  rules: Record<string, string[]>;
+}
+
+export interface BaoLoginResult {
+  token: string;
+  policy: string;
+}
+
+/**
+ * 一个 OpenBao 实例。
+ *
+ * 数据全在内存里，和镜像仓库、Git 服务一样是「集群外的东西」——
+ * 世界拥有它，集群只能通过网络访问。
+ */
+export class OpenBao {
+  /** path -> 版本列表，最后一个是最新的 */
+  private readonly kv = new Map<string, Array<Record<string, string>>>();
+  private readonly policies = new Map<string, BaoPolicy>();
+  private readonly tokens = new Map<string, string>();
+  private roles = new Map<string, BaoAuthKubernetes>();
+  private tokenSeq = 0;
+  /** 认证方式开没开。没开的话 Kubernetes auth 登录会被拒。 */
+  kubernetesAuthEnabled = false;
+
+  constructor(readonly address: string) {}
+
+  /* ---------------- 策略与令牌 ---------------- */
+
+  addPolicy(name: string, policy: BaoPolicy): void {
+    this.policies.set(name, policy);
+  }
+
+  /** 直接登记一把令牌。关卡里预先发好的那些走这里。 */
+  addToken(token: string, policy: string): void {
+    this.tokens.set(token, policy);
+  }
+
+  /** 发一把静态令牌。root 令牌就是这么来的。 */
+  issueToken(policy: string): string {
+    this.tokenSeq += 1;
+    const token = `bao-${policy}-${this.tokenSeq}`;
+    this.tokens.set(token, policy);
+    return token;
+  }
+
+  enableKubernetesAuth(roles: Record<string, BaoAuthKubernetes> = {}): void {
+    this.kubernetesAuthEnabled = true;
+    for (const [name, role] of Object.entries(roles)) this.roles.set(name, role);
+  }
+
+  /** 加一个角色。`bao write auth/kubernetes/role/<name> ...` 走这里。 */
+  addKubernetesRole(name: string, role: BaoAuthKubernetes): void {
+    this.roles.set(name, role);
+  }
+
+  kubernetesRole(name: string): BaoAuthKubernetes | undefined {
+    return this.roles.get(name);
+  }
+
+  hasPolicy(name: string): boolean {
+    return this.policies.has(name);
+  }
+
+  /**
+   * ServiceAccount 换令牌。
+   *
+   * 这才是集群里该用的方式：没有需要自己保管的长期凭据，
+   * 身份来自 Kubernetes 自己签发的 token，OpenBao 这边只认「哪个 SA」。
+   */
+  loginKubernetes(role: string, serviceAccount: string): BaoLoginResult | { error: string } {
+    if (!this.kubernetesAuthEnabled) {
+      return { error: 'permission denied: kubernetes auth method is not enabled' };
+    }
+    const found = this.roles.get(role);
+    if (!found) return { error: `role "${role}" could not be found` };
+    if (!found.boundServiceAccounts.includes(serviceAccount)) {
+      return { error: `service account "${serviceAccount}" is not authorized for role "${role}"` };
+    }
+    return { token: this.issueToken(found.policy), policy: found.policy };
+  }
+
+  policyOf(token: string): string | undefined {
+    return this.tokens.get(token);
+  }
+
+  /* ---------------- KV v2 ---------------- */
+
+  /** 写一版。KV v2 保留历史，所以这是 append 不是覆盖。 */
+  write(path: string, data: Record<string, string>): number {
+    const versions = this.kv.get(normalize(path)) ?? [];
+    versions.push({ ...data });
+    this.kv.set(normalize(path), versions);
+    return versions.length;
+  }
+
+  /** 读最新一版；`version` 可以指定历史版本 */
+  read(path: string, version?: number): Record<string, string> | undefined {
+    const versions = this.kv.get(normalize(path));
+    if (!versions || versions.length === 0) return undefined;
+    const index = version ? version - 1 : versions.length - 1;
+    return versions[index];
+  }
+
+  versions(path: string): number {
+    return this.kv.get(normalize(path))?.length ?? 0;
+  }
+
+  list(prefix = ''): string[] {
+    const clean = normalize(prefix);
+    return [...this.kv.keys()]
+      .filter((path) => path.startsWith(clean))
+      .sort();
+  }
+
+  /** 这把令牌能不能对这个路径做这件事 */
+  allows(token: string, path: string, capability: string): boolean {
+    const policyName = this.tokens.get(token);
+    if (!policyName) return false;
+    if (policyName === 'root') return true;
+    const policy = this.policies.get(policyName);
+    if (!policy) return false;
+    return Object.entries(policy.rules).some(([pattern, capabilities]) => {
+      if (!capabilities.includes(capability) && !capabilities.includes('*')) return false;
+      return pathMatches(pattern, normalize(path));
+    });
+  }
+}
+
+/** KV v2 的路径里那一层 `data/` 是引擎加的，存储时归一化掉 */
+function normalize(path: string): string {
+  return path.replace(/^\/+/, '').replace(/^([^/]+)\/data\//, '$1/');
+}
+
+/** OpenBao 的策略路径支持结尾的 `*` 与单层的 `+` */
+function pathMatches(pattern: string, path: string): boolean {
+  const normalized = normalize(pattern);
+  if (normalized.endsWith('*')) return path.startsWith(normalized.slice(0, -1));
+  if (normalized.includes('+')) {
+    const regex = new RegExp(`^${normalized.split('+').map(escapeRegex).join('[^/]+')}$`);
+    return regex.test(path);
+  }
+  return normalized === path;
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/lib/opslab/secrets/resources.ts
+++ b/src/lib/opslab/secrets/resources.ts
@@ -1,0 +1,33 @@
+/**
+ * External Secrets Operator 的 CRD
+ *
+ * 两个对象：`SecretStore` 说「去哪儿取、用什么身份」，`ExternalSecret` 说
+ * 「取哪几个、放进哪个 Secret」。集群里的 Secret 由控制器生成，人不该手写它 ——
+ * 手写的那份下一次同步就被覆盖了。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const SECRETSTORES: ResourceDefinition = {
+  group: 'external-secrets.io', version: 'v1', resource: 'secretstores',
+  singular: 'secretstore', kind: 'SecretStore', namespaced: true,
+  shortNames: ['ss'], subresources: ['status'],
+};
+
+export const CLUSTERSECRETSTORES: ResourceDefinition = {
+  group: 'external-secrets.io', version: 'v1', resource: 'clustersecretstores',
+  singular: 'clustersecretstore', kind: 'ClusterSecretStore', namespaced: false,
+  shortNames: ['css'], subresources: ['status'],
+};
+
+export const EXTERNALSECRETS: ResourceDefinition = {
+  group: 'external-secrets.io', version: 'v1', resource: 'externalsecrets',
+  singular: 'externalsecret', kind: 'ExternalSecret', namespaced: true,
+  shortNames: ['es'], subresources: ['status'],
+};
+
+export const ESO_RESOURCES: ResourceDefinition[] = [
+  SECRETSTORES, CLUSTERSECRETSTORES, EXTERNALSECRETS,
+];
+
+/** ESO 的控制面。没有它，ExternalSecret 就只是一条声明。 */
+export const ESO_LABEL = { key: 'app.kubernetes.io/name', value: 'external-secrets' };

--- a/tests/opslab/secrets.test.ts
+++ b/tests/opslab/secrets.test.ts
@@ -1,0 +1,314 @@
+/**
+ * 密钥不该住在集群里
+ *
+ * Kubernetes 的 Secret 只是 base64，不是加密。真值住在外部密钥库，
+ * 集群里只留一份由 ESO 维护的投影。
+ *
+ * 这一组要钉住的行为：认证方式的差别、路径与策略、同步的时机、
+ * 以及「手改了投影会被盖回去」。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import { OpenBao, DEFAULT_REFRESH_MS } from '../../src/lib/opslab/secrets';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+describe('OpenBao', () => {
+  function bench() {
+    const bao = new OpenBao('https://openbao.corp.internal:8200');
+    bao.addPolicy('reader', { rules: { 'kv/payments/*': ['read', 'list'] } });
+    bao.addPolicy('writer', { rules: { 'kv/payments/*': ['read', 'create', 'update'] } });
+    bao.write('kv/payments/db', { username: 'app', password: 's3cr3t' });
+    return bao;
+  }
+
+  it('KV v2 保留历史，读的是最新一版', () => {
+    const bao = bench();
+    bao.write('kv/payments/db', { username: 'app', password: 'rotated' });
+    expect(bao.versions('kv/payments/db')).toBe(2);
+    expect(bao.read('kv/payments/db')!.password).toBe('rotated');
+    expect(bao.read('kv/payments/db', 1)!.password).toBe('s3cr3t');
+  });
+
+  it('路径里的 data/ 是引擎加的，两种写法指同一个东西', () => {
+    const bao = bench();
+    expect(bao.read('kv/data/payments/db')).toEqual(bao.read('kv/payments/db'));
+  });
+
+  it('策略按路径与能力判', () => {
+    const bao = bench();
+    const reader = bao.issueToken('reader');
+    expect(bao.allows(reader, 'kv/payments/db', 'read')).toBe(true);
+    expect(bao.allows(reader, 'kv/payments/db', 'update')).toBe(false);
+    expect(bao.allows(reader, 'kv/analytics/db', 'read')).toBe(false);
+  });
+
+  it('root 什么都能做', () => {
+    const bao = bench();
+    expect(bao.allows(bao.issueToken('root'), 'anything/at/all', 'update')).toBe(true);
+  });
+
+  it('没开 Kubernetes auth 时登录被拒', () => {
+    const bao = bench();
+    expect(bao.loginKubernetes('eso', 'external-secrets/eso')).toEqual({
+      error: 'permission denied: kubernetes auth method is not enabled',
+    });
+  });
+
+  it('开了之后只认绑定过的 ServiceAccount', () => {
+    const bao = bench();
+    bao.enableKubernetesAuth({
+      eso: { boundServiceAccounts: ['external-secrets/eso'], policy: 'reader' },
+    });
+    expect(bao.loginKubernetes('eso', 'external-secrets/eso')).toMatchObject({ policy: 'reader' });
+    expect(bao.loginKubernetes('eso', 'payments/portal')).toMatchObject({
+      error: expect.stringContaining('not authorized'),
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 集群里                                                              */
+/* ------------------------------------------------------------------ */
+
+const ESO_IMAGE = 'ghcr.io/external-secrets/external-secrets:v0.21.0';
+
+const ESO_PLATFORM = [
+  { apiVersion: 'v1', kind: 'ServiceAccount', metadata: { name: 'eso', namespace: 'external-secrets' } },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'external-secrets', namespace: 'external-secrets',
+      labels: { 'app.kubernetes.io/name': 'external-secrets' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'external-secrets' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'external-secrets' } },
+        spec: { serviceAccountName: 'eso', containers: [{ name: 'controller', image: ESO_IMAGE }] },
+      },
+    },
+  },
+];
+
+const STORE = {
+  apiVersion: 'external-secrets.io/v1', kind: 'SecretStore',
+  metadata: { name: 'openbao', namespace: 'payments' },
+  spec: {
+    provider: {
+      vault: {
+        server: 'https://openbao.corp.internal:8200',
+        path: 'kv',
+        auth: { kubernetes: { role: 'payments', serviceAccountRef: { name: 'default' } } },
+      },
+    },
+  },
+};
+
+const EXTERNAL = {
+  apiVersion: 'external-secrets.io/v1', kind: 'ExternalSecret',
+  metadata: { name: 'db', namespace: 'payments' },
+  spec: {
+    refreshInterval: '1m',
+    secretStoreRef: { name: 'openbao', kind: 'SecretStore' },
+    target: { name: 'db-credentials' },
+    data: [
+      { secretKey: 'username', remoteRef: { key: 'payments/db', property: 'username' } },
+      { secretKey: 'password', remoteRef: { key: 'payments/db', property: 'password' } },
+    ],
+  },
+};
+
+function spec(objects: unknown[] = [], roles = true): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'payments', 'external-secrets'],
+    images: { [ESO_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 } },
+    secretStore: {
+      address: 'https://openbao.corp.internal:8200',
+      data: { 'kv/payments/db': { username: 'app', password: 's3cr3t' } },
+      policies: { 'payments-read': { 'kv/payments/*': ['read', 'list'] } },
+      tokens: {},
+      ...(roles
+        ? { kubernetesRoles: { payments: { boundServiceAccounts: ['payments/default'], policy: 'payments-read' } } }
+        : {}),
+    },
+    objects: objects as never,
+  };
+}
+
+const SECRETS = { group: '', version: 'v1', resource: 'secrets' } as const;
+const EXTERNALSECRETS = { group: 'external-secrets.io', version: 'v1', resource: 'externalsecrets' } as const;
+
+const decode = (value: string) => atob(value);
+
+async function build(objects: unknown[], roles = true) {
+  return createOpsWorld({ world: spec(objects, roles) });
+}
+
+const secretOf = (w: Awaited<ReturnType<typeof build>>): KubeObject | undefined => {
+  try {
+    return w.cluster.registry.get(w.cluster.scheme.mustGet(SECRETS), 'payments', 'db-credentials');
+  } catch {
+    return undefined;
+  }
+};
+
+const statusOf = (w: Awaited<ReturnType<typeof build>>) =>
+  (w.cluster.registry.get(w.cluster.scheme.mustGet(EXTERNALSECRETS), 'payments', 'db').status ?? {}) as any;
+
+describe('External Secrets', () => {
+  it('同步出一个普通的 Secret，值来自密钥库', async () => {
+    const w = await build([...ESO_PLATFORM, STORE, EXTERNAL]);
+    const secret = secretOf(w)!;
+    expect(secret).toBeTruthy();
+    expect(decode((secret as any).data.username)).toBe('app');
+    expect(decode((secret as any).data.password)).toBe('s3cr3t');
+    expect(statusOf(w).conditions[0]).toMatchObject({ type: 'Ready', status: 'True', reason: 'SecretSynced' });
+  });
+
+  it('控制面不在，ExternalSecret 就只是一条声明', async () => {
+    const w = await build([STORE, EXTERNAL]);
+    expect(secretOf(w)).toBeUndefined();
+  });
+
+  it('SecretStore 找不到时，状态里写清楚原因', async () => {
+    const w = await build([...ESO_PLATFORM, EXTERNAL]);
+    expect(secretOf(w)).toBeUndefined();
+    expect(statusOf(w).conditions[0]).toMatchObject({ status: 'False', reason: 'InvalidProviderConfig' });
+  });
+
+  it('没开 Kubernetes auth 时同步失败，而且说得出为什么', async () => {
+    const w = await build([...ESO_PLATFORM, STORE, EXTERNAL], false);
+    expect(secretOf(w)).toBeUndefined();
+    expect(statusOf(w).conditions[0].message).toContain('kubernetes auth method is not enabled');
+  });
+
+  it('SA 没被绑定就登录不上', async () => {
+    const store = {
+      ...STORE,
+      spec: {
+        provider: {
+          vault: {
+            ...STORE.spec.provider.vault,
+            auth: { kubernetes: { role: 'payments', serviceAccountRef: { name: 'intruder' } } },
+          },
+        },
+      },
+    };
+    const w = await build([...ESO_PLATFORM, store, EXTERNAL]);
+    expect(statusOf(w).conditions[0].message).toContain('not authorized');
+  });
+
+  it('策略管不到的路径取不出来', async () => {
+    const external = {
+      ...EXTERNAL,
+      spec: {
+        ...EXTERNAL.spec,
+        data: [{ secretKey: 'x', remoteRef: { key: 'analytics/db', property: 'password' } }],
+      },
+    };
+    const w = await build([...ESO_PLATFORM, STORE, external]);
+    expect(statusOf(w).conditions[0].message).toContain('permission denied');
+  });
+
+  it('外部轮转之后，下一轮同步跟上 —— 但不是立刻', async () => {
+    const w = await build([...ESO_PLATFORM, STORE, EXTERNAL]);
+    w.bao!.write('kv/payments/db', { username: 'app', password: 'rotated' });
+
+    // 还没到刷新时间，集群里还是旧的
+    await w.cluster.settle();
+    expect(decode((secretOf(w) as any).data.password)).toBe('s3cr3t');
+
+    await w.cluster.advanceBy(DEFAULT_REFRESH_MS);
+    expect(decode((secretOf(w) as any).data.password)).toBe('rotated');
+  });
+
+  it('手改了这份投影会被盖回去 —— 它归控制器管', async () => {
+    const w = await build([...ESO_PLATFORM, STORE, EXTERNAL]);
+    const definition = w.cluster.scheme.mustGet(SECRETS);
+    const live = w.cluster.registry.get(definition, 'payments', 'db-credentials');
+    w.cluster.registry.update(definition, 'payments', 'db-credentials', {
+      ...live, data: { username: btoa('hacked'), password: btoa('hacked') },
+    } as never);
+
+    await w.cluster.advanceBy(DEFAULT_REFRESH_MS);
+    expect(decode((secretOf(w) as any).data.username)).toBe('app');
+  });
+
+  it('dataFrom 一次性把整个路径取过来', async () => {
+    const external = {
+      ...EXTERNAL,
+      spec: {
+        ...EXTERNAL.spec,
+        data: undefined,
+        dataFrom: [{ extract: { key: 'payments/db' } }],
+      },
+    };
+    const w = await build([...ESO_PLATFORM, STORE, external]);
+    const secret = secretOf(w)!;
+    expect(Object.keys((secret as any).data).sort()).toEqual(['password', 'username']);
+  });
+
+  it('ExternalSecret 删掉，投影跟着走', async () => {
+    const w = await build([...ESO_PLATFORM, STORE, EXTERNAL]);
+    expect(secretOf(w)).toBeTruthy();
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(EXTERNALSECRETS), 'payments', 'db');
+    await w.cluster.settle();
+    expect(secretOf(w)).toBeUndefined();
+  });
+});
+
+describe('bao 命令', () => {
+  async function shell() {
+    return build([...ESO_PLATFORM]);
+  }
+
+  it('没设 BAO_ADDR 时说清楚', async () => {
+    const w = await shell();
+    const result = await w.run('bao status');
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('BAO_ADDR 没设');
+  });
+
+  it('地址解析不到时报的是 no such host', async () => {
+    const w = await shell();
+    const result = await w.run('BAO_ADDR=https://nope.corp.internal:8200 bao status');
+    expect(result.stderr).toContain('no such host');
+  });
+
+  it('没令牌是 400，令牌不对是 403', async () => {
+    const w = await shell();
+    const base = 'BAO_ADDR=https://openbao.corp.internal:8200';
+    expect((await w.run(`${base} bao kv get kv/payments/db`)).stderr).toContain('missing client token');
+    expect((await w.run(`${base} BAO_TOKEN=nope bao kv get kv/payments/db`)).stderr).toContain('permission denied');
+  });
+
+  it('拿到令牌就读得出来，-field 只打一个值', async () => {
+    const w = await shell();
+    const token = w.bao!.issueToken('root');
+    const base = `BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=${token}`;
+    const table = await w.run(`${base} bao kv get kv/payments/db`);
+    expect(table.stdout).toContain('password');
+    expect(table.stdout).toContain('s3cr3t');
+
+    const field = await w.run(`${base} bao kv get -field=password kv/payments/db`);
+    expect(field.stdout.trim()).toBe('s3cr3t');
+  });
+
+  it('写进去的东西 ESO 取得到', async () => {
+    const w = await build([...ESO_PLATFORM, STORE, {
+      ...EXTERNAL,
+      spec: {
+        ...EXTERNAL.spec,
+        data: [{ secretKey: 'apiKey', remoteRef: { key: 'payments/gateway', property: 'apiKey' } }],
+      },
+    }]);
+    const token = w.bao!.issueToken('root');
+    await w.run(
+      `BAO_ADDR=https://openbao.corp.internal:8200 BAO_TOKEN=${token} `
+      + 'bao kv put kv/payments/gateway apiKey=abc123'
+    );
+    await w.cluster.advanceBy(DEFAULT_REFRESH_MS);
+    expect(decode((secretOf(w) as any).data.apiKey)).toBe('abc123');
+  });
+});


### PR DESCRIPTION
Kubernetes 的 Secret 只是 base64，不是加密。把它的 YAML 提交进 Git，等于把明文分发给每个有仓库权限的人，而且留在历史里删不掉。这一关解决 GitOps 与密钥管理的矛盾：**仓库里只放「去哪儿取」，真值由控制器写进集群**。

## 做进来的

**OpenBao**（`secrets/openbao.ts`）—— 集群外的服务，和镜像仓库、Git 一样。KV v2 带版本历史，策略按路径与能力判，Kubernetes 认证用 ServiceAccount 换令牌。路径那一层坑照真的保留：引擎挂在 `kv/`，实际读的是 `kv/data/...`，SecretStore 里写重复了就取不到。

**`bao` CLI** —— status / kv get|put|list / auth enable kubernetes / write role。三种失败各说各的话：`BAO_ADDR` 没设、地址解析不到、令牌无权。

**External Secrets 控制器** —— 集群里的工作负载，停掉就不同步。同步出来的 Secret 归控制器管：手改会被下一轮盖回去，ExternalSecret 删了投影跟着走。

**`base64` coreutil** —— 学员得能自己 `kubectl get secret -o yaml | base64 -d` 把「Secret 不是加密」这件事看明白。

## 踩了同一个坑两次

事件驱动的控制器里，**状态里不能放每次都变的值**，否则 watch 自激、世界永远静不下来：

1. `refreshTime` 每轮都刷新 → 改成只在真的同步了新值时才更新；
2. `syncedResourceVersion` → 写状态本身就会把 resourceVersion 改掉，改用 `generation`（只在 spec 变时动）。

第二个尤其隐蔽，注释里写清楚了。

## 判定挡什么

**静态令牌**。把 root 令牌塞进一个 Secret、让 SecretStore 从那儿读，也能跑通 —— 但那是把「一个口令泄露」换成「一把能读所有密钥的令牌泄露」。判定检查 SecretStore 用的是哪种认证。

**轮转要能自己跟上**：在 OpenBao 里改了口令，`advance(120s)` 之后集群里的值要变。

## 验证

21 个密钥用例 + 3 个关卡反向验证。全量 1509 个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)