### PR TITLE
feat(opslab): 第 19 关 —— 让集群自己说出哪儿不对

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -37,6 +37,9 @@ const KYVERNO_IMAGE = 'ghcr.io/kyverno/kyverno:v1.16.0';
 // 一个从公网直接拿来的镜像，没人签过
 const UNSIGNED_IMAGE = 'docker.io/library/redis:7.4';
 const ESO_IMAGE = 'ghcr.io/external-secrets/external-secrets:v0.21.0';
+const PROMETHEUS_IMAGE = 'quay.io/prometheus/prometheus:v3.9.1';
+// 报表服务的一个坏版本：五分之一的请求 500
+const REPORTS_IMAGE_BAD = 'harbor.corp.internal/team/reports:2.3.0';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -143,7 +146,7 @@ const WORLD = {
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
     'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
-    'kyverno', 'external-secrets',
+    'kyverno', 'external-secrets', 'monitoring',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -154,6 +157,7 @@ const WORLD = {
       memoryUsage: '180Mi',
       handlesSigterm: true,
       runAsUser: 10001,
+      requestsPerSecond: 40,
     },
     // 平台组装的入口控制器与 PKI
     [ENVOY_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200, listens: [18000] },
@@ -187,6 +191,14 @@ const WORLD = {
     [ZTUNNEL_IMAGE]: { pullMs: 400, startupMs: 500, readyAfterMs: 200, listens: [15008] },
     [KYVERNO_IMAGE]: { pullMs: 500, startupMs: 700, readyAfterMs: 300, listens: [9443] },
     [ESO_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300, listens: [8080] },
+    [PROMETHEUS_IMAGE]: { pullMs: 600, startupMs: 900, readyAfterMs: 400, listens: [9090] },
+    [REPORTS_IMAGE_BAD]: {
+      pullMs: 500, startupMs: 800, readyAfterMs: 200,
+      listens: [9090], routes: { '/healthz': 200, '/metrics': 200 },
+      memoryUsage: '300Mi',
+      // 坏就坏在这里：五分之一的请求返回 5xx，但进程活着、探针照过
+      requestsPerSecond: 25, errorRatio: 0.2,
+    },
     [UNSIGNED_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200, listens: [6379] },
     // 会话存储
     [SESSIONS_IMAGE]: {
@@ -202,8 +214,9 @@ const WORLD = {
     [REPORTS_IMAGE]: {
       pullMs: 500, startupMs: 800, readyAfterMs: 200,
       listens: [9090],
-      routes: { '/healthz': 200 },
+      routes: { '/healthz': 200, '/metrics': 200 },
       memoryUsage: '900Mi',
+      requestsPerSecond: 25,
     },
   },
   // 本地已经有的基础镜像，写 Dockerfile 时 FROM 得着
@@ -563,7 +576,9 @@ const PORTAL_WORKLOAD = [
   },
   {
     apiVersion: 'v1', kind: 'Service',
-    metadata: { name: 'portal', namespace: 'payments' },
+    // Service 自己也带上 app 标签：ServiceMonitor 是按 Service 的标签选的，
+    // 只在 spec.selector 里写 app 是选不中它的
+    metadata: { name: 'portal', namespace: 'payments', labels: { app: 'portal' } },
     spec: { clusterIP: '10.96.1.10', selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
   },
 ];
@@ -5859,6 +5874,345 @@ const stage18 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 19 关                                                            */
+/* ------------------------------------------------------------------ */
+
+const MONITORING_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'prometheus', namespace: 'monitoring',
+      labels: { 'app.kubernetes.io/name': 'prometheus' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'prometheus' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'prometheus' } },
+        spec: { containers: [{ name: 'prometheus', image: PROMETHEUS_IMAGE, ports: [{ containerPort: 9090 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'monitoring.coreos.com/v1', kind: 'Prometheus',
+    metadata: { name: 'main', namespace: 'monitoring' },
+    spec: {
+      // 平台组的约定：只采带这个标签的 ServiceMonitor
+      serviceMonitorSelector: { matchLabels: { release: 'kube-prom' } },
+      replicas: 1,
+    },
+  },
+];
+
+/** 报表服务上了一个坏版本：进程活着、探针照过，但五分之一的请求 500 */
+const REPORTS_DEGRADED = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'reports', namespace: 'payments' },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'reports' } },
+      template: {
+        metadata: { labels: { app: 'reports' } },
+        spec: {
+          containers: [{
+            name: 'app', image: REPORTS_IMAGE_BAD,
+            ports: [{ containerPort: 9090 }],
+            resources: { requests: { memory: '256Mi' }, limits: { memory: '1Gi' } },
+          }],
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'reports', namespace: 'payments', labels: { app: 'reports' } },
+    spec: { selector: { app: 'reports' }, ports: [{ port: 80, targetPort: 9090 }] },
+  },
+];
+
+const MONITORING_STARTER = code`
+  # 采集与告警都还没配。
+  #
+  # 提示：Prometheus 实例上写着 serviceMonitorSelector，
+  #      去看看它要求 ServiceMonitor 带什么标签。
+`;
+
+const MONITORING_REFERENCE = code`
+  apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: reports
+    namespace: payments
+    labels:
+      release: kube-prom
+  spec:
+    selector:
+      matchLabels:
+        app: reports
+    endpoints:
+    - port: http
+  ---
+  apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: portal
+    namespace: payments
+    labels:
+      release: kube-prom
+  spec:
+    selector:
+      matchLabels:
+        app: portal
+    endpoints:
+    - port: http
+  ---
+  apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    name: payments
+    namespace: payments
+    labels:
+      release: kube-prom
+  spec:
+    groups:
+    - name: payments.rules
+      rules:
+      - alert: TargetDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} 的 {{ $labels.pod }} 采不到了"
+      - alert: HighErrorRate
+        expr: sum(rate(http_requests_total{code=~"5.."}[5m])) by (job)
+          / sum(rate(http_requests_total[5m])) by (job) > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} 的 5xx 比例是 {{ $value }}"
+`;
+
+const stage19 = {
+  id: 'metrics-and-alerts',
+  title: t('让集群自己说出哪儿不对', 'Let the Cluster Say What Is Wrong'),
+  goal: t(
+    code`
+      财务报了一个说不清的问题：「报表有时候打不开，刷新几次又好了」。
+      \`kubectl get pods\` 全是 Running，探针全过，日志里也没有异常堆栈 ——
+      因为进程确实活着，只是**一部分请求返回了 5xx**。
+
+      这类问题不看指标是查不出来的。Prometheus 装好了，但集群里一个
+      \`ServiceMonitor\` 都没有，一条告警规则也没有。
+
+      ## 通关标准
+
+      1. 门户与报表的指标都采得到（\`up\` 有它们的序列）；
+      2. 有一条按 **PromQL 求值**的错误率告警，能真的触发；
+      3. 有一条目标掉线的告警；
+      4. 两条都带 \`for\`，抖动不会立刻变成告警；
+      5. 规则文件过 \`promtool check rules\`。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl get prometheus -n monitoring -o yaml
+      kubectl apply -f /root/infra/monitoring.yaml
+      promtool check rules /root/infra/monitoring.yaml
+      promtool query instant http://localhost:9090 'up'
+      promtool query instant http://localhost:9090 'sum(rate(http_requests_total{code=~"5.."}[5m])) by (job)'
+      \`\`\`
+    `,
+    code`
+      Finance reports something vague: "the reports page sometimes fails, refreshing a
+      few times fixes it". \`kubectl get pods\` shows everything Running, probes pass,
+      and the logs hold no stack traces, because the process really is alive and only
+      **some requests return 5xx**.
+
+      Problems like this are invisible without metrics. Prometheus is installed, but
+      the cluster has no \`ServiceMonitor\` and no alerting rules at all.
+
+      ## Done when
+
+      1. metrics from the portal and reports are being collected (\`up\` has series for
+         both);
+      2. an error-rate alert exists, evaluated as real **PromQL**, and it fires;
+      3. a target-down alert exists;
+      4. both carry \`for\`, so a blip does not become a page;
+      5. the rule file passes \`promtool check rules\`.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl get prometheus -n monitoring -o yaml
+      kubectl apply -f /root/infra/monitoring.yaml
+      promtool check rules /root/infra/monitoring.yaml
+      promtool query instant http://localhost:9090 'up'
+      promtool query instant http://localhost:9090 'sum(rate(http_requests_total{code=~"5.."}[5m])) by (job)'
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('指标采得到', 'Metrics are being collected'),
+    t('告警按 PromQL 求值并真的触发', 'Alerts evaluate as PromQL and fire'),
+    t('带 for，抖动不会变成告警', 'They carry for, so blips do not page'),
+  ],
+  hints: [
+    t(
+      '采集要过**两层**选择器：Prometheus 实例的 \`serviceMonitorSelector\` 先选中 ServiceMonitor，ServiceMonitor 的 \`selector\` 再选中 Service。少配哪一层都是一条指标都采不到，而两边看起来都很正常。',
+      'Collection passes **two** selectors: the Prometheus instance `serviceMonitorSelector` picks ServiceMonitors, and the ServiceMonitor `selector` picks Services. Miss either and nothing is collected, while both objects look perfectly fine.'
+    ),
+    t(
+      '错误率是**两个 rate 相除**，不是一个计数。分子分母都要先 \`sum ... by (job)\` 聚合到同一组标签上，否则两边配不上，表达式返回空 —— 而返回空的告警永远不会触发，也不会报错。',
+      'An error rate is **one rate divided by another**, not a count. Aggregate both sides with `sum ... by (job)` onto the same label set, or they will not match and the expression returns nothing. An alert whose expression returns nothing never fires and never complains.'
+    ),
+    t(
+      '写完先 \`promtool check rules\` 跑一遍，再 \`promtool query instant\` 把表达式单独查一次。apiserver 收 PrometheusRule 的时候**不校验表达式**，写错了照样收下。',
+      'Run `promtool check rules` first, then query the expression alone with `promtool query instant`. The apiserver does **not validate expressions** when accepting a PrometheusRule; a broken one is stored happily.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '用 \`http_requests_total{code=~"5.."} > 0\` 当告警。counter 只会涨，这条从第一个 5xx 起就永远成立 —— 而且它衡量的是「历史上出过多少错」，不是「现在错得多不多」。错误率永远要用 \`rate\` 加除法。',
+      'Alerting on `http_requests_total{code=~"5.."} > 0`. A counter only grows, so this is true forever after the first 5xx, and it measures how many errors ever happened rather than how bad things are now. Error rates always need `rate` and a division.'
+    ),
+    t(
+      '不写 \`for\`。一次采集抖动就会发一条告警，收告警的人很快就不看了 —— 而这比没有告警更糟，因为大家会以为「有人在盯着」。',
+      'Omitting `for`. A single scrape blip pages someone, and people stop reading alerts, which is worse than having none because everyone assumes somebody is watching.'
+    ),
+    t(
+      '以为指标里能看到一切。采集是**定时拉**的（默认 15 秒一次），只活了十秒的 Pod 很可能一个点都没采到。指标回答的是「持续的、按比例的」问题；一次性的、短暂的事件要看 Event 与日志。',
+      'Expecting metrics to show everything. Scraping is **periodic pull** (15s by default), so a pod that lived ten seconds may contribute no samples at all. Metrics answer sustained, proportional questions; one-off short events live in Events and logs.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM, ...MONITORING_PLATFORM,
+      ...PORTAL_WORKLOAD, PORTAL_ROUTE, ...REPORTS_DEGRADED,
+    ],
+    files: { '/root/infra/monitoring.yaml': MONITORING_STARTER },
+    referenceFiles: { '/root/infra/monitoring.yaml': MONITORING_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/monitoring.yaml',
+    ],
+  },
+  specs: [
+    spec('metrics-and-alerts.spec.ts', code`
+      import { advance, list, sh } from '@ops/lab';
+
+      const PROM = 'http://localhost:9090';
+
+      describe('指标与告警', () => {
+        it('门户与报表的指标都采得到', async () => {
+          await advance(300000);
+          const result = await sh("promtool query instant " + PROM + " 'up'");
+          expect(result.code).toBe(0);
+          expect(result.stdout).toContain('payments/reports');
+          expect(result.stdout).toContain('payments/portal');
+        });
+
+        it('规则文件是干净的', async () => {
+          const result = await sh('promtool check rules /root/infra/monitoring.yaml');
+          expect(result.code).toBe(0);
+          expect(result.stdout).toContain('SUCCESS');
+        });
+
+        it('错误率告警真的触发了', async () => {
+          await advance(1200000);
+          const rules = list('PrometheusRule', { namespace: 'payments' });
+          expect(rules.length).toBeGreaterThan(0);
+
+          const firing = list('Pod', { namespace: 'monitoring' });
+          expect(firing.length).toBeGreaterThan(0);
+
+          const result = await sh(
+            "promtool query instant " + PROM
+            + " 'sum(rate(http_requests_total{code=~\\"5..\\"}[5m])) by (job)"
+            + " / sum(rate(http_requests_total[5m])) by (job) > 0.05'"
+          );
+          expect(result.stdout).toContain('payments/reports');
+          // 门户没坏，不该出现在结果里
+          expect(result.stdout).not.toContain('payments/portal');
+        });
+
+        it('告警是按 PromQL 写的，而且带 for', () => {
+          const rules = list('PrometheusRule', { namespace: 'payments' })
+            .flatMap((rule) => (rule.spec.groups || []).flatMap((group) => group.rules || []))
+            .filter((rule) => rule.alert);
+          expect(rules.length).toBeGreaterThanOrEqual(2);
+          for (const rule of rules) {
+            expect(rule.for).toBeTruthy();
+          }
+          // 错误率那条必须是比率，不能是裸计数
+          const rate = rules.find((rule) => /rate\\(/.test(rule.expr) && rule.expr.includes('/'));
+          expect(rate).toBeTruthy();
+        });
+
+        it('有一条目标掉线的告警', () => {
+          const rules = list('PrometheusRule', { namespace: 'payments' })
+            .flatMap((rule) => (rule.spec.groups || []).flatMap((group) => group.rules || []));
+          expect(rules.some((rule) => /\\bup\\b/.test(rule.expr || ''))).toBe(true);
+        });
+
+        it('ServiceMonitor 带上了 Prometheus 要求的标签', () => {
+          const monitors = list('ServiceMonitor', { namespace: 'payments' });
+          expect(monitors.length).toBeGreaterThanOrEqual(2);
+          for (const monitor of monitors) {
+            expect(monitor.metadata.labels.release).toBe('kube-prom');
+          }
+        });
+      });
+    `),
+  ],
+  focus: ['observability', 'correctness'],
+  extension: t(
+    code`
+      这一关的场景之所以值得单独练，是因为它落在**监控的盲区之间**：
+      进程活着（探针过）、日志没异常（5xx 是正常返回不是崩溃）、
+      Pod 没重启（\`kubectl get\` 一片绿）。三个最常用的信号全说「没事」，
+      只有比例型指标看得出来。
+
+      三类信号各管一段，混着用才完整：**指标**回答「持续的、按比例的」问题
+      （错误率、延迟分位数、饱和度），代价是采样间隔之间的事看不见；
+      **日志**回答「这一次具体发生了什么」，代价是量大且没有聚合；
+      **链路追踪**回答「这一次请求在哪一跳慢了」，代价是采样率与埋点成本。
+      拿指标去查单次请求、拿日志去算错误率，都是用错了工具。
+
+      告警上有一条经验值得记：**告的应该是症状，不是原因**。
+      「错误率超过 5%」是症状，用户感受得到；「某个 Pod 内存高」是原因，
+      而且高内存不一定有影响。按原因告警的系统会在半夜叫醒一个人，
+      让他去看一个用户根本没感觉的指标 —— 几次之后就没人看告警了。
+    `,
+    code`
+      This scenario is worth practising because it falls **between the blind spots**:
+      the process is alive (probes pass), the logs are clean (a 5xx is a normal
+      response, not a crash), and no pod restarted (\`kubectl get\` is all green). The
+      three signals people reach for first all say "fine", and only a proportional
+      metric shows the problem.
+
+      Three signal types cover different ground and only work together. **Metrics**
+      answer sustained, proportional questions (error rate, latency quantiles,
+      saturation) at the cost of blindness between scrapes. **Logs** answer what
+      happened in one specific case, at the cost of volume and no aggregation.
+      **Traces** answer which hop was slow for one request, at the cost of sampling and
+      instrumentation. Using metrics to investigate a single request, or logs to
+      compute an error rate, is using the wrong tool.
+
+      One rule of thumb about alerting: **alert on symptoms, not causes**. "Error rate
+      above 5%" is a symptom users feel; "this pod uses a lot of memory" is a cause,
+      and high memory may have no effect at all. Alerting on causes wakes someone at
+      3am to look at a number no user noticed, and after a few of those nobody reads
+      the alerts any more.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -5904,6 +6258,6 @@ module.exports = {
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
-    stage13, stage14, stage15, stage16, stage17, stage18,
+    stage13, stage14, stage15, stage16, stage17, stage18, stage19,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5620,7 +5620,8 @@
           "argocd",
           "istio-system",
           "kyverno",
-          "external-secrets"
+          "external-secrets",
+          "monitoring"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5637,7 +5638,8 @@
             },
             "memoryUsage": "180Mi",
             "handlesSigterm": true,
-            "runAsUser": 10001
+            "runAsUser": 10001,
+            "requestsPerSecond": 40
           },
           "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2": {
             "pullMs": 300,
@@ -5735,6 +5737,29 @@
               8080
             ]
           },
+          "quay.io/prometheus/prometheus:v3.9.1": {
+            "pullMs": 600,
+            "startupMs": 900,
+            "readyAfterMs": 400,
+            "listens": [
+              9090
+            ]
+          },
+          "harbor.corp.internal/team/reports:2.3.0": {
+            "pullMs": 500,
+            "startupMs": 800,
+            "readyAfterMs": 200,
+            "listens": [
+              9090
+            ],
+            "routes": {
+              "/healthz": 200,
+              "/metrics": 200
+            },
+            "memoryUsage": "300Mi",
+            "requestsPerSecond": 25,
+            "errorRatio": 0.2
+          },
           "docker.io/library/redis:7.4": {
             "pullMs": 300,
             "startupMs": 400,
@@ -5776,9 +5801,11 @@
               9090
             ],
             "routes": {
-              "/healthz": 200
+              "/healthz": 200,
+              "/metrics": 200
             },
-            "memoryUsage": "900Mi"
+            "memoryUsage": "900Mi",
+            "requestsPerSecond": 25
           }
         },
         "baseImages": {
@@ -6735,7 +6762,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -7029,7 +7059,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -7441,7 +7474,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -8464,7 +8500,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -8890,7 +8929,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -9311,7 +9353,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -10492,7 +10537,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -11030,7 +11078,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -11663,6 +11714,547 @@
         "primer": {
           "zh": "先说清楚一件常被误解的事：Kubernetes 的 `Secret` **不是加密的**，它只是 base64。`kubectl get secret -o yaml` 拿到的值，接一句 `base64 -d` 就是明文。Secret 在集群里唯一的保护是 RBAC，也就是「谁有权 get 它」。所以把口令写进 Secret 并不算「保护」了它，只是换了个地方放。\n\n更麻烦的是 GitOps 带来的矛盾：仓库要能被所有人读，密钥不能。把 Secret 的 YAML 提交进 Git，等于把明文分发给每一个有仓库权限的人，而且留在历史里删不掉。`External Secrets Operator` 的答案是让仓库里只放「去哪儿取」的说明：`SecretStore` 说去哪个密钥库、用什么身份，`ExternalSecret` 说取哪几个键、放进哪个 Secret。真值由控制器在集群里生成，谁都不用提交明文。\n\n外部密钥库这里用 `OpenBao`（Vault 改协议之后 fork 出来的开源版本）。它的 KV v2 引擎有一处容易绊人：挂载路径和读写路径不是一回事，引擎挂在 `kv/` 上时，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里的 `path` 指的是挂载路径，`remoteRef.key` 里就不要再重复写它。另外 KV v2 保留版本历史，读到的默认是最新一版。\n\n认证方式的选择比工具选择更要紧。用静态令牌是个死循环：为了保护密钥，你得先保护一把能读所有密钥的令牌，而那把令牌只能存在集群里的另一个 Secret 里。`Kubernetes 认证`跳出了这个循环：身份由集群自己签发、短期有效、绑定到具体的 ServiceAccount，泄露一个 Pod 的 token 也只拿得到那个 SA 的权限。云上的 IRSA 与 Workload Identity 是同一思路的不同实现。最后记住 ESO 同步出来的 Secret 归控制器管：手改会被下一轮同步盖回去，`refreshInterval` 决定这一轮有多久。",
           "en": "Start with a common misconception: a Kubernetes `Secret` is **not encrypted**, it is base64. Take the value from `kubectl get secret -o yaml`, pipe it through `base64 -d`, and there is the plaintext. The only protection a Secret has inside the cluster is RBAC, meaning who may get it. Putting a password into a Secret does not protect it, it relocates it.\n\nGitOps sharpens the problem: the repository must be readable by everyone and secrets must not be. Committing Secret YAML distributes plaintext to everyone with repository access and leaves it in history where deleting does not help. The `External Secrets Operator` answers by keeping only the instructions in Git: a `SecretStore` says which vault and which identity, an `ExternalSecret` says which keys to fetch into which Secret. The controller materialises the real values in the cluster and nobody commits plaintext.\n\nThe external store here is `OpenBao`, the open-source fork created after Vault changed its licence. Its KV v2 engine trips people on paths: the mount path and the read path differ, so with the engine at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore the `path` field is the mount, so `remoteRef.key` should not repeat it. KV v2 also keeps version history, and a read returns the latest version by default.\n\nChoosing the authentication method matters more than choosing the tool. A static token is circular: protecting your secrets requires protecting a token that reads all of them, and that token can only live in another Secret in the cluster. `Kubernetes auth` breaks the circle, because identity is issued by the cluster, short lived, and bound to a specific ServiceAccount, so a leaked pod token buys only that ServiceAccount permissions. IRSA and Workload Identity are the same idea in the clouds. Finally, the Secret ESO produces belongs to the controller: hand edits are overwritten on the next sync, and `refreshInterval` decides how long that takes."
+        }
+      },
+      {
+        "id": "metrics-and-alerts",
+        "title": {
+          "zh": "让集群自己说出哪儿不对",
+          "en": "Let the Cluster Say What Is Wrong"
+        },
+        "goal": {
+          "zh": "财务报了一个说不清的问题：「报表有时候打不开，刷新几次又好了」。\n`kubectl get pods` 全是 Running，探针全过，日志里也没有异常堆栈 ——\n因为进程确实活着，只是**一部分请求返回了 5xx**。\n\n这类问题不看指标是查不出来的。Prometheus 装好了，但集群里一个\n`ServiceMonitor` 都没有，一条告警规则也没有。\n\n## 通关标准\n\n1. 门户与报表的指标都采得到（`up` 有它们的序列）；\n2. 有一条按 **PromQL 求值**的错误率告警，能真的触发；\n3. 有一条目标掉线的告警；\n4. 两条都带 `for`，抖动不会立刻变成告警；\n5. 规则文件过 `promtool check rules`。\n\n## 会用到的命令\n\n```bash\nkubectl get prometheus -n monitoring -o yaml\nkubectl apply -f /root/infra/monitoring.yaml\npromtool check rules /root/infra/monitoring.yaml\npromtool query instant http://localhost:9090 'up'\npromtool query instant http://localhost:9090 'sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)'\n```\n",
+          "en": "Finance reports something vague: \"the reports page sometimes fails, refreshing a\nfew times fixes it\". `kubectl get pods` shows everything Running, probes pass,\nand the logs hold no stack traces, because the process really is alive and only\n**some requests return 5xx**.\n\nProblems like this are invisible without metrics. Prometheus is installed, but\nthe cluster has no `ServiceMonitor` and no alerting rules at all.\n\n## Done when\n\n1. metrics from the portal and reports are being collected (`up` has series for\n   both);\n2. an error-rate alert exists, evaluated as real **PromQL**, and it fires;\n3. a target-down alert exists;\n4. both carry `for`, so a blip does not become a page;\n5. the rule file passes `promtool check rules`.\n\n## Commands you will need\n\n```bash\nkubectl get prometheus -n monitoring -o yaml\nkubectl apply -f /root/infra/monitoring.yaml\npromtool check rules /root/infra/monitoring.yaml\npromtool query instant http://localhost:9090 'up'\npromtool query instant http://localhost:9090 'sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)'\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "指标采得到",
+            "en": "Metrics are being collected"
+          },
+          {
+            "zh": "告警按 PromQL 求值并真的触发",
+            "en": "Alerts evaluate as PromQL and fire"
+          },
+          {
+            "zh": "带 for，抖动不会变成告警",
+            "en": "They carry for, so blips do not page"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "采集要过**两层**选择器：Prometheus 实例的 `serviceMonitorSelector` 先选中 ServiceMonitor，ServiceMonitor 的 `selector` 再选中 Service。少配哪一层都是一条指标都采不到，而两边看起来都很正常。",
+            "en": "Collection passes **two** selectors: the Prometheus instance `serviceMonitorSelector` picks ServiceMonitors, and the ServiceMonitor `selector` picks Services. Miss either and nothing is collected, while both objects look perfectly fine."
+          },
+          {
+            "zh": "错误率是**两个 rate 相除**，不是一个计数。分子分母都要先 `sum ... by (job)` 聚合到同一组标签上，否则两边配不上，表达式返回空 —— 而返回空的告警永远不会触发，也不会报错。",
+            "en": "An error rate is **one rate divided by another**, not a count. Aggregate both sides with `sum ... by (job)` onto the same label set, or they will not match and the expression returns nothing. An alert whose expression returns nothing never fires and never complains."
+          },
+          {
+            "zh": "写完先 `promtool check rules` 跑一遍，再 `promtool query instant` 把表达式单独查一次。apiserver 收 PrometheusRule 的时候**不校验表达式**，写错了照样收下。",
+            "en": "Run `promtool check rules` first, then query the expression alone with `promtool query instant`. The apiserver does **not validate expressions** when accepting a PrometheusRule; a broken one is stored happily."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用 `http_requests_total{code=~\"5..\"} > 0` 当告警。counter 只会涨，这条从第一个 5xx 起就永远成立 —— 而且它衡量的是「历史上出过多少错」，不是「现在错得多不多」。错误率永远要用 `rate` 加除法。",
+            "en": "Alerting on `http_requests_total{code=~\"5..\"} > 0`. A counter only grows, so this is true forever after the first 5xx, and it measures how many errors ever happened rather than how bad things are now. Error rates always need `rate` and a division."
+          },
+          {
+            "zh": "不写 `for`。一次采集抖动就会发一条告警，收告警的人很快就不看了 —— 而这比没有告警更糟，因为大家会以为「有人在盯着」。",
+            "en": "Omitting `for`. A single scrape blip pages someone, and people stop reading alerts, which is worse than having none because everyone assumes somebody is watching."
+          },
+          {
+            "zh": "以为指标里能看到一切。采集是**定时拉**的（默认 15 秒一次），只活了十秒的 Pod 很可能一个点都没采到。指标回答的是「持续的、按比例的」问题；一次性的、短暂的事件要看 Event 与日志。",
+            "en": "Expecting metrics to show everything. Scraping is **periodic pull** (15s by default), so a pod that lived ten seconds may contribute no samples at all. Metrics answer sustained, proportional questions; one-off short events live in Events and logs."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "Prometheus",
+              "metadata": {
+                "name": "main",
+                "namespace": "monitoring"
+              },
+              "spec": {
+                "serviceMonitorSelector": {
+                  "matchLabels": {
+                    "release": "kube-prom"
+                  }
+                },
+                "replicas": 1
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "reports",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "reports"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "reports"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/reports:2.3.0",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ],
+                        "resources": {
+                          "requests": {
+                            "memory": "256Mi"
+                          },
+                          "limits": {
+                            "memory": "1Gi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "reports",
+                "namespace": "payments",
+                "labels": {
+                  "app": "reports"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "app": "reports"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 9090
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/monitoring.yaml": "# 采集与告警都还没配。\n#\n# 提示：Prometheus 实例上写着 serviceMonitorSelector，\n#      去看看它要求 ServiceMonitor 带什么标签。\n"
+          },
+          "referenceFiles": {
+            "/root/infra/monitoring.yaml": "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: reports\n  namespace: payments\n  labels:\n    release: kube-prom\nspec:\n  selector:\n    matchLabels:\n      app: reports\n  endpoints:\n  - port: http\n---\napiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: portal\n  namespace: payments\n  labels:\n    release: kube-prom\nspec:\n  selector:\n    matchLabels:\n      app: portal\n  endpoints:\n  - port: http\n---\napiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n  name: payments\n  namespace: payments\n  labels:\n    release: kube-prom\nspec:\n  groups:\n  - name: payments.rules\n    rules:\n    - alert: TargetDown\n      expr: up == 0\n      for: 5m\n      labels:\n        severity: critical\n      annotations:\n        summary: \"{{ $labels.job }} 的 {{ $labels.pod }} 采不到了\"\n    - alert: HighErrorRate\n      expr: sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)\n        / sum(rate(http_requests_total[5m])) by (job) > 0.05\n      for: 10m\n      labels:\n        severity: critical\n      annotations:\n        summary: \"{{ $labels.job }} 的 5xx 比例是 {{ $value }}\"\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/monitoring.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "metrics-and-alerts.spec.ts",
+            "content": "import { advance, list, sh } from '@ops/lab';\n\nconst PROM = 'http://localhost:9090';\n\ndescribe('指标与告警', () => {\n  it('门户与报表的指标都采得到', async () => {\n    await advance(300000);\n    const result = await sh(\"promtool query instant \" + PROM + \" 'up'\");\n    expect(result.code).toBe(0);\n    expect(result.stdout).toContain('payments/reports');\n    expect(result.stdout).toContain('payments/portal');\n  });\n\n  it('规则文件是干净的', async () => {\n    const result = await sh('promtool check rules /root/infra/monitoring.yaml');\n    expect(result.code).toBe(0);\n    expect(result.stdout).toContain('SUCCESS');\n  });\n\n  it('错误率告警真的触发了', async () => {\n    await advance(1200000);\n    const rules = list('PrometheusRule', { namespace: 'payments' });\n    expect(rules.length).toBeGreaterThan(0);\n\n    const firing = list('Pod', { namespace: 'monitoring' });\n    expect(firing.length).toBeGreaterThan(0);\n\n    const result = await sh(\n      \"promtool query instant \" + PROM\n      + \" 'sum(rate(http_requests_total{code=~\\\"5..\\\"}[5m])) by (job)\"\n      + \" / sum(rate(http_requests_total[5m])) by (job) > 0.05'\"\n    );\n    expect(result.stdout).toContain('payments/reports');\n    // 门户没坏，不该出现在结果里\n    expect(result.stdout).not.toContain('payments/portal');\n  });\n\n  it('告警是按 PromQL 写的，而且带 for', () => {\n    const rules = list('PrometheusRule', { namespace: 'payments' })\n      .flatMap((rule) => (rule.spec.groups || []).flatMap((group) => group.rules || []))\n      .filter((rule) => rule.alert);\n    expect(rules.length).toBeGreaterThanOrEqual(2);\n    for (const rule of rules) {\n      expect(rule.for).toBeTruthy();\n    }\n    // 错误率那条必须是比率，不能是裸计数\n    const rate = rules.find((rule) => /rate\\(/.test(rule.expr) && rule.expr.includes('/'));\n    expect(rate).toBeTruthy();\n  });\n\n  it('有一条目标掉线的告警', () => {\n    const rules = list('PrometheusRule', { namespace: 'payments' })\n      .flatMap((rule) => (rule.spec.groups || []).flatMap((group) => group.rules || []));\n    expect(rules.some((rule) => /\\bup\\b/.test(rule.expr || ''))).toBe(true);\n  });\n\n  it('ServiceMonitor 带上了 Prometheus 要求的标签', () => {\n    const monitors = list('ServiceMonitor', { namespace: 'payments' });\n    expect(monitors.length).toBeGreaterThanOrEqual(2);\n    for (const monitor of monitors) {\n      expect(monitor.metadata.labels.release).toBe('kube-prom');\n    }\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "observability",
+          "correctness"
+        ],
+        "extension": {
+          "zh": "这一关的场景之所以值得单独练，是因为它落在**监控的盲区之间**：\n进程活着（探针过）、日志没异常（5xx 是正常返回不是崩溃）、\nPod 没重启（`kubectl get` 一片绿）。三个最常用的信号全说「没事」，\n只有比例型指标看得出来。\n\n三类信号各管一段，混着用才完整：**指标**回答「持续的、按比例的」问题\n（错误率、延迟分位数、饱和度），代价是采样间隔之间的事看不见；\n**日志**回答「这一次具体发生了什么」，代价是量大且没有聚合；\n**链路追踪**回答「这一次请求在哪一跳慢了」，代价是采样率与埋点成本。\n拿指标去查单次请求、拿日志去算错误率，都是用错了工具。\n\n告警上有一条经验值得记：**告的应该是症状，不是原因**。\n「错误率超过 5%」是症状，用户感受得到；「某个 Pod 内存高」是原因，\n而且高内存不一定有影响。按原因告警的系统会在半夜叫醒一个人，\n让他去看一个用户根本没感觉的指标 —— 几次之后就没人看告警了。\n",
+          "en": "This scenario is worth practising because it falls **between the blind spots**:\nthe process is alive (probes pass), the logs are clean (a 5xx is a normal\nresponse, not a crash), and no pod restarted (`kubectl get` is all green). The\nthree signals people reach for first all say \"fine\", and only a proportional\nmetric shows the problem.\n\nThree signal types cover different ground and only work together. **Metrics**\nanswer sustained, proportional questions (error rate, latency quantiles,\nsaturation) at the cost of blindness between scrapes. **Logs** answer what\nhappened in one specific case, at the cost of volume and no aggregation.\n**Traces** answer which hop was slow for one request, at the cost of sampling and\ninstrumentation. Using metrics to investigate a single request, or logs to\ncompute an error rate, is using the wrong tool.\n\nOne rule of thumb about alerting: **alert on symptoms, not causes**. \"Error rate\nabove 5%\" is a symptom users feel; \"this pod uses a lot of memory\" is a cause,\nand high memory may have no effect at all. Alerting on causes wakes someone at\n3am to look at a number no user noticed, and after a few of those nobody reads\nthe alerts any more.\n"
+        },
+        "primer": {
+          "zh": "`Prometheus` 是**拉**模型：它按配置找到一批目标，每隔一段时间（默认 15 秒）去每个目标的 `/metrics` 上采一次。数据模型很小：一条`序列`由指标名加一组标签唯一确定，值按时间点存。这个模型带来两个直接后果：两次采样之间发生的事看不见（只活十秒的 Pod 可能一个点都没有），以及目标挂掉之后它此前的指标还会在图上停留一个回看窗口（默认五分钟）才消失。\n\n在 Kubernetes 里，采集配置写成 `ServiceMonitor`：按标签选中一批 Service，去它们后面的 Pod 上拉。这里有个**两层选择器**的坑：Prometheus 实例自己有一个 `serviceMonitorSelector`，先由它选中 ServiceMonitor，再由 ServiceMonitor 的 `selector` 选中 Service。少配任何一层的结果都是一条指标都采不到，而两个对象看起来都完全正常。`up` 这个指标是 Prometheus 自己合成的，不来自目标，它是判断「采不采得到」的第一手依据。\n\n`PromQL` 里最要紧的区分是 `counter` 与 `gauge`。counter 只增不减（请求总数、错误总数），直接看它的值没有意义，要用 `rate(x[5m])` 求每秒增量；gauge 可以上下浮动（内存、队列长度），直接看瞬时值。错误率是**两个 rate 相除**：`sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`。两侧必须聚合到同一组标签上，否则配不上，表达式返回空，而返回空的告警永远不会触发，也不会报错。另外比较运算符是`过滤`不是求布尔值：`up == 0` 返回的是那些确实为 0 的序列。\n\n告警规则写在 `PrometheusRule` 里，`expr` 加 `for`。`for` 的意思是「条件持续成立这么久才真的告警」，中间处于 `pending`；条件一旦不成立就整条清掉，所以抖动不会累积。两条实践值得记：一是 apiserver 收 PrometheusRule 时**不校验表达式**，写错了照样收下，所以上线前要 `promtool check rules` 加 `promtool query instant` 各跑一遍；二是`告症状不告原因`：「错误率超过 5%」用户感受得到，「某个 Pod 内存高」不一定有影响，按原因告警的系统很快就没人看了。",
+          "en": "`Prometheus` is a **pull** model: it discovers a set of targets and scrapes `/metrics` on each at a fixed interval, 15 seconds by default. The data model is tiny: a `series` is identified by a metric name plus a set of labels, with values stored per timestamp. Two consequences follow directly. Anything happening between scrapes is invisible, so a pod that lived ten seconds may contribute no samples at all. And after a target dies, its earlier metrics linger for one lookback window (five minutes by default) before disappearing.\n\nIn Kubernetes the scrape config is a `ServiceMonitor`: select Services by label, scrape the pods behind them. There is a **two-selector** trap here: the Prometheus instance has its own `serviceMonitorSelector` which picks ServiceMonitors, and each ServiceMonitor has a `selector` which picks Services. Missing either layer collects nothing, while both objects look perfectly healthy. The `up` metric is synthesised by Prometheus rather than coming from the target, which makes it the first thing to check when nothing appears.\n\nThe distinction that matters most in `PromQL` is `counter` versus `gauge`. A counter only increases (requests served, errors returned) and its raw value means little; use `rate(x[5m])` for per-second increase. A gauge moves both ways (memory, queue depth) and is read directly. An error rate is **one rate divided by another**: `sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`. Both sides must be aggregated to the same label set or they will not match and the expression returns nothing, and an alert whose expression returns nothing never fires and never complains. Note also that comparison operators `filter` rather than produce booleans: `up == 0` returns the series that really are zero.\n\nAlerting rules live in a `PrometheusRule` as an `expr` plus a `for`. The `for` means the condition must hold that long before the alert really fires, staying `pending` meanwhile, and the whole thing clears the moment the condition stops holding, so blips do not accumulate. Two practices worth keeping: the apiserver does **not validate expressions** when accepting a PrometheusRule, so run `promtool check rules` and `promtool query instant` before shipping; and `alert on symptoms, not causes`, because users feel \"error rate above 5%\" while \"this pod uses a lot of memory\" may mean nothing, and cause-based alerting quickly stops being read."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1312,6 +1312,21 @@ const primers = {
       )
     ),
 
+    'metrics-and-alerts': t(
+      p(
+        '`Prometheus` 是**拉**模型：它按配置找到一批目标，每隔一段时间（默认 15 秒）去每个目标的 `/metrics` 上采一次。数据模型很小：一条`序列`由指标名加一组标签唯一确定，值按时间点存。这个模型带来两个直接后果：两次采样之间发生的事看不见（只活十秒的 Pod 可能一个点都没有），以及目标挂掉之后它此前的指标还会在图上停留一个回看窗口（默认五分钟）才消失。',
+        '在 Kubernetes 里，采集配置写成 `ServiceMonitor`：按标签选中一批 Service，去它们后面的 Pod 上拉。这里有个**两层选择器**的坑：Prometheus 实例自己有一个 `serviceMonitorSelector`，先由它选中 ServiceMonitor，再由 ServiceMonitor 的 `selector` 选中 Service。少配任何一层的结果都是一条指标都采不到，而两个对象看起来都完全正常。`up` 这个指标是 Prometheus 自己合成的，不来自目标，它是判断「采不采得到」的第一手依据。',
+        '`PromQL` 里最要紧的区分是 `counter` 与 `gauge`。counter 只增不减（请求总数、错误总数），直接看它的值没有意义，要用 `rate(x[5m])` 求每秒增量；gauge 可以上下浮动（内存、队列长度），直接看瞬时值。错误率是**两个 rate 相除**：`sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`。两侧必须聚合到同一组标签上，否则配不上，表达式返回空，而返回空的告警永远不会触发，也不会报错。另外比较运算符是`过滤`不是求布尔值：`up == 0` 返回的是那些确实为 0 的序列。',
+        '告警规则写在 `PrometheusRule` 里，`expr` 加 `for`。`for` 的意思是「条件持续成立这么久才真的告警」，中间处于 `pending`；条件一旦不成立就整条清掉，所以抖动不会累积。两条实践值得记：一是 apiserver 收 PrometheusRule 时**不校验表达式**，写错了照样收下，所以上线前要 `promtool check rules` 加 `promtool query instant` 各跑一遍；二是`告症状不告原因`：「错误率超过 5%」用户感受得到，「某个 Pod 内存高」不一定有影响，按原因告警的系统很快就没人看了。'
+      ),
+      p(
+        '`Prometheus` is a **pull** model: it discovers a set of targets and scrapes `/metrics` on each at a fixed interval, 15 seconds by default. The data model is tiny: a `series` is identified by a metric name plus a set of labels, with values stored per timestamp. Two consequences follow directly. Anything happening between scrapes is invisible, so a pod that lived ten seconds may contribute no samples at all. And after a target dies, its earlier metrics linger for one lookback window (five minutes by default) before disappearing.',
+        'In Kubernetes the scrape config is a `ServiceMonitor`: select Services by label, scrape the pods behind them. There is a **two-selector** trap here: the Prometheus instance has its own `serviceMonitorSelector` which picks ServiceMonitors, and each ServiceMonitor has a `selector` which picks Services. Missing either layer collects nothing, while both objects look perfectly healthy. The `up` metric is synthesised by Prometheus rather than coming from the target, which makes it the first thing to check when nothing appears.',
+        'The distinction that matters most in `PromQL` is `counter` versus `gauge`. A counter only increases (requests served, errors returned) and its raw value means little; use `rate(x[5m])` for per-second increase. A gauge moves both ways (memory, queue depth) and is read directly. An error rate is **one rate divided by another**: `sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`. Both sides must be aggregated to the same label set or they will not match and the expression returns nothing, and an alert whose expression returns nothing never fires and never complains. Note also that comparison operators `filter` rather than produce booleans: `up == 0` returns the series that really are zero.',
+        'Alerting rules live in a `PrometheusRule` as an `expr` plus a `for`. The `for` means the condition must hold that long before the alert really fires, staying `pending` meanwhile, and the whole thing clears the moment the condition stops holding, so blips do not accumulate. Two practices worth keeping: the apiserver does **not validate expressions** when accepting a PrometheusRule, so run `promtool check rules` and `promtool query instant` before shipping; and `alert on symptoms, not causes`, because users feel "error rate above 5%" while "this pod uses a lot of memory" may mean nothing, and cause-based alerting quickly stops being read.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5620,7 +5620,8 @@
           "argocd",
           "istio-system",
           "kyverno",
-          "external-secrets"
+          "external-secrets",
+          "monitoring"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5637,7 +5638,8 @@
             },
             "memoryUsage": "180Mi",
             "handlesSigterm": true,
-            "runAsUser": 10001
+            "runAsUser": 10001,
+            "requestsPerSecond": 40
           },
           "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2": {
             "pullMs": 300,
@@ -5735,6 +5737,29 @@
               8080
             ]
           },
+          "quay.io/prometheus/prometheus:v3.9.1": {
+            "pullMs": 600,
+            "startupMs": 900,
+            "readyAfterMs": 400,
+            "listens": [
+              9090
+            ]
+          },
+          "harbor.corp.internal/team/reports:2.3.0": {
+            "pullMs": 500,
+            "startupMs": 800,
+            "readyAfterMs": 200,
+            "listens": [
+              9090
+            ],
+            "routes": {
+              "/healthz": 200,
+              "/metrics": 200
+            },
+            "memoryUsage": "300Mi",
+            "requestsPerSecond": 25,
+            "errorRatio": 0.2
+          },
           "docker.io/library/redis:7.4": {
             "pullMs": 300,
             "startupMs": 400,
@@ -5776,9 +5801,11 @@
               9090
             ],
             "routes": {
-              "/healthz": 200
+              "/healthz": 200,
+              "/metrics": 200
             },
-            "memoryUsage": "900Mi"
+            "memoryUsage": "900Mi",
+            "requestsPerSecond": 25
           }
         },
         "baseImages": {
@@ -6735,7 +6762,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -7029,7 +7059,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -7441,7 +7474,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -8464,7 +8500,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -8890,7 +8929,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -9311,7 +9353,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -10492,7 +10537,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -11030,7 +11078,10 @@
               "kind": "Service",
               "metadata": {
                 "name": "portal",
-                "namespace": "payments"
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
               },
               "spec": {
                 "clusterIP": "10.96.1.10",
@@ -11663,6 +11714,547 @@
         "primer": {
           "zh": "先说清楚一件常被误解的事：Kubernetes 的 `Secret` **不是加密的**，它只是 base64。`kubectl get secret -o yaml` 拿到的值，接一句 `base64 -d` 就是明文。Secret 在集群里唯一的保护是 RBAC，也就是「谁有权 get 它」。所以把口令写进 Secret 并不算「保护」了它，只是换了个地方放。\n\n更麻烦的是 GitOps 带来的矛盾：仓库要能被所有人读，密钥不能。把 Secret 的 YAML 提交进 Git，等于把明文分发给每一个有仓库权限的人，而且留在历史里删不掉。`External Secrets Operator` 的答案是让仓库里只放「去哪儿取」的说明：`SecretStore` 说去哪个密钥库、用什么身份，`ExternalSecret` 说取哪几个键、放进哪个 Secret。真值由控制器在集群里生成，谁都不用提交明文。\n\n外部密钥库这里用 `OpenBao`（Vault 改协议之后 fork 出来的开源版本）。它的 KV v2 引擎有一处容易绊人：挂载路径和读写路径不是一回事，引擎挂在 `kv/` 上时，`bao kv get kv/payments/db` 实际读的是 `kv/data/payments/db`。SecretStore 里的 `path` 指的是挂载路径，`remoteRef.key` 里就不要再重复写它。另外 KV v2 保留版本历史，读到的默认是最新一版。\n\n认证方式的选择比工具选择更要紧。用静态令牌是个死循环：为了保护密钥，你得先保护一把能读所有密钥的令牌，而那把令牌只能存在集群里的另一个 Secret 里。`Kubernetes 认证`跳出了这个循环：身份由集群自己签发、短期有效、绑定到具体的 ServiceAccount，泄露一个 Pod 的 token 也只拿得到那个 SA 的权限。云上的 IRSA 与 Workload Identity 是同一思路的不同实现。最后记住 ESO 同步出来的 Secret 归控制器管：手改会被下一轮同步盖回去，`refreshInterval` 决定这一轮有多久。",
           "en": "Start with a common misconception: a Kubernetes `Secret` is **not encrypted**, it is base64. Take the value from `kubectl get secret -o yaml`, pipe it through `base64 -d`, and there is the plaintext. The only protection a Secret has inside the cluster is RBAC, meaning who may get it. Putting a password into a Secret does not protect it, it relocates it.\n\nGitOps sharpens the problem: the repository must be readable by everyone and secrets must not be. Committing Secret YAML distributes plaintext to everyone with repository access and leaves it in history where deleting does not help. The `External Secrets Operator` answers by keeping only the instructions in Git: a `SecretStore` says which vault and which identity, an `ExternalSecret` says which keys to fetch into which Secret. The controller materialises the real values in the cluster and nobody commits plaintext.\n\nThe external store here is `OpenBao`, the open-source fork created after Vault changed its licence. Its KV v2 engine trips people on paths: the mount path and the read path differ, so with the engine at `kv/`, `bao kv get kv/payments/db` actually reads `kv/data/payments/db`. In a SecretStore the `path` field is the mount, so `remoteRef.key` should not repeat it. KV v2 also keeps version history, and a read returns the latest version by default.\n\nChoosing the authentication method matters more than choosing the tool. A static token is circular: protecting your secrets requires protecting a token that reads all of them, and that token can only live in another Secret in the cluster. `Kubernetes auth` breaks the circle, because identity is issued by the cluster, short lived, and bound to a specific ServiceAccount, so a leaked pod token buys only that ServiceAccount permissions. IRSA and Workload Identity are the same idea in the clouds. Finally, the Secret ESO produces belongs to the controller: hand edits are overwritten on the next sync, and `refreshInterval` decides how long that takes."
+        }
+      },
+      {
+        "id": "metrics-and-alerts",
+        "title": {
+          "zh": "让集群自己说出哪儿不对",
+          "en": "Let the Cluster Say What Is Wrong"
+        },
+        "goal": {
+          "zh": "财务报了一个说不清的问题：「报表有时候打不开，刷新几次又好了」。\n`kubectl get pods` 全是 Running，探针全过，日志里也没有异常堆栈 ——\n因为进程确实活着，只是**一部分请求返回了 5xx**。\n\n这类问题不看指标是查不出来的。Prometheus 装好了，但集群里一个\n`ServiceMonitor` 都没有，一条告警规则也没有。\n\n## 通关标准\n\n1. 门户与报表的指标都采得到（`up` 有它们的序列）；\n2. 有一条按 **PromQL 求值**的错误率告警，能真的触发；\n3. 有一条目标掉线的告警；\n4. 两条都带 `for`，抖动不会立刻变成告警；\n5. 规则文件过 `promtool check rules`。\n\n## 会用到的命令\n\n```bash\nkubectl get prometheus -n monitoring -o yaml\nkubectl apply -f /root/infra/monitoring.yaml\npromtool check rules /root/infra/monitoring.yaml\npromtool query instant http://localhost:9090 'up'\npromtool query instant http://localhost:9090 'sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)'\n```\n",
+          "en": "Finance reports something vague: \"the reports page sometimes fails, refreshing a\nfew times fixes it\". `kubectl get pods` shows everything Running, probes pass,\nand the logs hold no stack traces, because the process really is alive and only\n**some requests return 5xx**.\n\nProblems like this are invisible without metrics. Prometheus is installed, but\nthe cluster has no `ServiceMonitor` and no alerting rules at all.\n\n## Done when\n\n1. metrics from the portal and reports are being collected (`up` has series for\n   both);\n2. an error-rate alert exists, evaluated as real **PromQL**, and it fires;\n3. a target-down alert exists;\n4. both carry `for`, so a blip does not become a page;\n5. the rule file passes `promtool check rules`.\n\n## Commands you will need\n\n```bash\nkubectl get prometheus -n monitoring -o yaml\nkubectl apply -f /root/infra/monitoring.yaml\npromtool check rules /root/infra/monitoring.yaml\npromtool query instant http://localhost:9090 'up'\npromtool query instant http://localhost:9090 'sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)'\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "指标采得到",
+            "en": "Metrics are being collected"
+          },
+          {
+            "zh": "告警按 PromQL 求值并真的触发",
+            "en": "Alerts evaluate as PromQL and fire"
+          },
+          {
+            "zh": "带 for，抖动不会变成告警",
+            "en": "They carry for, so blips do not page"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "采集要过**两层**选择器：Prometheus 实例的 `serviceMonitorSelector` 先选中 ServiceMonitor，ServiceMonitor 的 `selector` 再选中 Service。少配哪一层都是一条指标都采不到，而两边看起来都很正常。",
+            "en": "Collection passes **two** selectors: the Prometheus instance `serviceMonitorSelector` picks ServiceMonitors, and the ServiceMonitor `selector` picks Services. Miss either and nothing is collected, while both objects look perfectly fine."
+          },
+          {
+            "zh": "错误率是**两个 rate 相除**，不是一个计数。分子分母都要先 `sum ... by (job)` 聚合到同一组标签上，否则两边配不上，表达式返回空 —— 而返回空的告警永远不会触发，也不会报错。",
+            "en": "An error rate is **one rate divided by another**, not a count. Aggregate both sides with `sum ... by (job)` onto the same label set, or they will not match and the expression returns nothing. An alert whose expression returns nothing never fires and never complains."
+          },
+          {
+            "zh": "写完先 `promtool check rules` 跑一遍，再 `promtool query instant` 把表达式单独查一次。apiserver 收 PrometheusRule 的时候**不校验表达式**，写错了照样收下。",
+            "en": "Run `promtool check rules` first, then query the expression alone with `promtool query instant`. The apiserver does **not validate expressions** when accepting a PrometheusRule; a broken one is stored happily."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "用 `http_requests_total{code=~\"5..\"} > 0` 当告警。counter 只会涨，这条从第一个 5xx 起就永远成立 —— 而且它衡量的是「历史上出过多少错」，不是「现在错得多不多」。错误率永远要用 `rate` 加除法。",
+            "en": "Alerting on `http_requests_total{code=~\"5..\"} > 0`. A counter only grows, so this is true forever after the first 5xx, and it measures how many errors ever happened rather than how bad things are now. Error rates always need `rate` and a division."
+          },
+          {
+            "zh": "不写 `for`。一次采集抖动就会发一条告警，收告警的人很快就不看了 —— 而这比没有告警更糟，因为大家会以为「有人在盯着」。",
+            "en": "Omitting `for`. A single scrape blip pages someone, and people stop reading alerts, which is worse than having none because everyone assumes somebody is watching."
+          },
+          {
+            "zh": "以为指标里能看到一切。采集是**定时拉**的（默认 15 秒一次），只活了十秒的 Pod 很可能一个点都没采到。指标回答的是「持续的、按比例的」问题；一次性的、短暂的事件要看 Event 与日志。",
+            "en": "Expecting metrics to show everything. Scraping is **periodic pull** (15s by default), so a pod that lived ten seconds may contribute no samples at all. Metrics answer sustained, proportional questions; one-off short events live in Events and logs."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "Prometheus",
+              "metadata": {
+                "name": "main",
+                "namespace": "monitoring"
+              },
+              "spec": {
+                "serviceMonitorSelector": {
+                  "matchLabels": {
+                    "release": "kube-prom"
+                  }
+                },
+                "replicas": 1
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "reports",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 2,
+                "selector": {
+                  "matchLabels": {
+                    "app": "reports"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "reports"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "app",
+                        "image": "harbor.corp.internal/team/reports:2.3.0",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ],
+                        "resources": {
+                          "requests": {
+                            "memory": "256Mi"
+                          },
+                          "limits": {
+                            "memory": "1Gi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "reports",
+                "namespace": "payments",
+                "labels": {
+                  "app": "reports"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "app": "reports"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 9090
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/monitoring.yaml": "# 采集与告警都还没配。\n#\n# 提示：Prometheus 实例上写着 serviceMonitorSelector，\n#      去看看它要求 ServiceMonitor 带什么标签。\n"
+          },
+          "referenceFiles": {
+            "/root/infra/monitoring.yaml": "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: reports\n  namespace: payments\n  labels:\n    release: kube-prom\nspec:\n  selector:\n    matchLabels:\n      app: reports\n  endpoints:\n  - port: http\n---\napiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: portal\n  namespace: payments\n  labels:\n    release: kube-prom\nspec:\n  selector:\n    matchLabels:\n      app: portal\n  endpoints:\n  - port: http\n---\napiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n  name: payments\n  namespace: payments\n  labels:\n    release: kube-prom\nspec:\n  groups:\n  - name: payments.rules\n    rules:\n    - alert: TargetDown\n      expr: up == 0\n      for: 5m\n      labels:\n        severity: critical\n      annotations:\n        summary: \"{{ $labels.job }} 的 {{ $labels.pod }} 采不到了\"\n    - alert: HighErrorRate\n      expr: sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)\n        / sum(rate(http_requests_total[5m])) by (job) > 0.05\n      for: 10m\n      labels:\n        severity: critical\n      annotations:\n        summary: \"{{ $labels.job }} 的 5xx 比例是 {{ $value }}\"\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/monitoring.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "metrics-and-alerts.spec.ts",
+            "content": "import { advance, list, sh } from '@ops/lab';\n\nconst PROM = 'http://localhost:9090';\n\ndescribe('指标与告警', () => {\n  it('门户与报表的指标都采得到', async () => {\n    await advance(300000);\n    const result = await sh(\"promtool query instant \" + PROM + \" 'up'\");\n    expect(result.code).toBe(0);\n    expect(result.stdout).toContain('payments/reports');\n    expect(result.stdout).toContain('payments/portal');\n  });\n\n  it('规则文件是干净的', async () => {\n    const result = await sh('promtool check rules /root/infra/monitoring.yaml');\n    expect(result.code).toBe(0);\n    expect(result.stdout).toContain('SUCCESS');\n  });\n\n  it('错误率告警真的触发了', async () => {\n    await advance(1200000);\n    const rules = list('PrometheusRule', { namespace: 'payments' });\n    expect(rules.length).toBeGreaterThan(0);\n\n    const firing = list('Pod', { namespace: 'monitoring' });\n    expect(firing.length).toBeGreaterThan(0);\n\n    const result = await sh(\n      \"promtool query instant \" + PROM\n      + \" 'sum(rate(http_requests_total{code=~\\\"5..\\\"}[5m])) by (job)\"\n      + \" / sum(rate(http_requests_total[5m])) by (job) > 0.05'\"\n    );\n    expect(result.stdout).toContain('payments/reports');\n    // 门户没坏，不该出现在结果里\n    expect(result.stdout).not.toContain('payments/portal');\n  });\n\n  it('告警是按 PromQL 写的，而且带 for', () => {\n    const rules = list('PrometheusRule', { namespace: 'payments' })\n      .flatMap((rule) => (rule.spec.groups || []).flatMap((group) => group.rules || []))\n      .filter((rule) => rule.alert);\n    expect(rules.length).toBeGreaterThanOrEqual(2);\n    for (const rule of rules) {\n      expect(rule.for).toBeTruthy();\n    }\n    // 错误率那条必须是比率，不能是裸计数\n    const rate = rules.find((rule) => /rate\\(/.test(rule.expr) && rule.expr.includes('/'));\n    expect(rate).toBeTruthy();\n  });\n\n  it('有一条目标掉线的告警', () => {\n    const rules = list('PrometheusRule', { namespace: 'payments' })\n      .flatMap((rule) => (rule.spec.groups || []).flatMap((group) => group.rules || []));\n    expect(rules.some((rule) => /\\bup\\b/.test(rule.expr || ''))).toBe(true);\n  });\n\n  it('ServiceMonitor 带上了 Prometheus 要求的标签', () => {\n    const monitors = list('ServiceMonitor', { namespace: 'payments' });\n    expect(monitors.length).toBeGreaterThanOrEqual(2);\n    for (const monitor of monitors) {\n      expect(monitor.metadata.labels.release).toBe('kube-prom');\n    }\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "observability",
+          "correctness"
+        ],
+        "extension": {
+          "zh": "这一关的场景之所以值得单独练，是因为它落在**监控的盲区之间**：\n进程活着（探针过）、日志没异常（5xx 是正常返回不是崩溃）、\nPod 没重启（`kubectl get` 一片绿）。三个最常用的信号全说「没事」，\n只有比例型指标看得出来。\n\n三类信号各管一段，混着用才完整：**指标**回答「持续的、按比例的」问题\n（错误率、延迟分位数、饱和度），代价是采样间隔之间的事看不见；\n**日志**回答「这一次具体发生了什么」，代价是量大且没有聚合；\n**链路追踪**回答「这一次请求在哪一跳慢了」，代价是采样率与埋点成本。\n拿指标去查单次请求、拿日志去算错误率，都是用错了工具。\n\n告警上有一条经验值得记：**告的应该是症状，不是原因**。\n「错误率超过 5%」是症状，用户感受得到；「某个 Pod 内存高」是原因，\n而且高内存不一定有影响。按原因告警的系统会在半夜叫醒一个人，\n让他去看一个用户根本没感觉的指标 —— 几次之后就没人看告警了。\n",
+          "en": "This scenario is worth practising because it falls **between the blind spots**:\nthe process is alive (probes pass), the logs are clean (a 5xx is a normal\nresponse, not a crash), and no pod restarted (`kubectl get` is all green). The\nthree signals people reach for first all say \"fine\", and only a proportional\nmetric shows the problem.\n\nThree signal types cover different ground and only work together. **Metrics**\nanswer sustained, proportional questions (error rate, latency quantiles,\nsaturation) at the cost of blindness between scrapes. **Logs** answer what\nhappened in one specific case, at the cost of volume and no aggregation.\n**Traces** answer which hop was slow for one request, at the cost of sampling and\ninstrumentation. Using metrics to investigate a single request, or logs to\ncompute an error rate, is using the wrong tool.\n\nOne rule of thumb about alerting: **alert on symptoms, not causes**. \"Error rate\nabove 5%\" is a symptom users feel; \"this pod uses a lot of memory\" is a cause,\nand high memory may have no effect at all. Alerting on causes wakes someone at\n3am to look at a number no user noticed, and after a few of those nobody reads\nthe alerts any more.\n"
+        },
+        "primer": {
+          "zh": "`Prometheus` 是**拉**模型：它按配置找到一批目标，每隔一段时间（默认 15 秒）去每个目标的 `/metrics` 上采一次。数据模型很小：一条`序列`由指标名加一组标签唯一确定，值按时间点存。这个模型带来两个直接后果：两次采样之间发生的事看不见（只活十秒的 Pod 可能一个点都没有），以及目标挂掉之后它此前的指标还会在图上停留一个回看窗口（默认五分钟）才消失。\n\n在 Kubernetes 里，采集配置写成 `ServiceMonitor`：按标签选中一批 Service，去它们后面的 Pod 上拉。这里有个**两层选择器**的坑：Prometheus 实例自己有一个 `serviceMonitorSelector`，先由它选中 ServiceMonitor，再由 ServiceMonitor 的 `selector` 选中 Service。少配任何一层的结果都是一条指标都采不到，而两个对象看起来都完全正常。`up` 这个指标是 Prometheus 自己合成的，不来自目标，它是判断「采不采得到」的第一手依据。\n\n`PromQL` 里最要紧的区分是 `counter` 与 `gauge`。counter 只增不减（请求总数、错误总数），直接看它的值没有意义，要用 `rate(x[5m])` 求每秒增量；gauge 可以上下浮动（内存、队列长度），直接看瞬时值。错误率是**两个 rate 相除**：`sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`。两侧必须聚合到同一组标签上，否则配不上，表达式返回空，而返回空的告警永远不会触发，也不会报错。另外比较运算符是`过滤`不是求布尔值：`up == 0` 返回的是那些确实为 0 的序列。\n\n告警规则写在 `PrometheusRule` 里，`expr` 加 `for`。`for` 的意思是「条件持续成立这么久才真的告警」，中间处于 `pending`；条件一旦不成立就整条清掉，所以抖动不会累积。两条实践值得记：一是 apiserver 收 PrometheusRule 时**不校验表达式**，写错了照样收下，所以上线前要 `promtool check rules` 加 `promtool query instant` 各跑一遍；二是`告症状不告原因`：「错误率超过 5%」用户感受得到，「某个 Pod 内存高」不一定有影响，按原因告警的系统很快就没人看了。",
+          "en": "`Prometheus` is a **pull** model: it discovers a set of targets and scrapes `/metrics` on each at a fixed interval, 15 seconds by default. The data model is tiny: a `series` is identified by a metric name plus a set of labels, with values stored per timestamp. Two consequences follow directly. Anything happening between scrapes is invisible, so a pod that lived ten seconds may contribute no samples at all. And after a target dies, its earlier metrics linger for one lookback window (five minutes by default) before disappearing.\n\nIn Kubernetes the scrape config is a `ServiceMonitor`: select Services by label, scrape the pods behind them. There is a **two-selector** trap here: the Prometheus instance has its own `serviceMonitorSelector` which picks ServiceMonitors, and each ServiceMonitor has a `selector` which picks Services. Missing either layer collects nothing, while both objects look perfectly healthy. The `up` metric is synthesised by Prometheus rather than coming from the target, which makes it the first thing to check when nothing appears.\n\nThe distinction that matters most in `PromQL` is `counter` versus `gauge`. A counter only increases (requests served, errors returned) and its raw value means little; use `rate(x[5m])` for per-second increase. A gauge moves both ways (memory, queue depth) and is read directly. An error rate is **one rate divided by another**: `sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`. Both sides must be aggregated to the same label set or they will not match and the expression returns nothing, and an alert whose expression returns nothing never fires and never complains. Note also that comparison operators `filter` rather than produce booleans: `up == 0` returns the series that really are zero.\n\nAlerting rules live in a `PrometheusRule` as an `expr` plus a `for`. The `for` means the condition must hold that long before the alert really fires, staying `pending` meanwhile, and the whole thing clears the moment the condition stops holding, so blips do not accumulate. Two practices worth keeping: the apiserver does **not validate expressions** when accepting a PrometheusRule, so run `promtool check rules` and `promtool query instant` before shipping; and `alert on symptoms, not causes`, because users feel \"error rate above 5%\" while \"this pod uses a lot of memory\" may mean nothing, and cause-based alerting quickly stops being read."
         }
       }
     ]

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -222,6 +222,12 @@ export interface OpsImageSpec {
    * 一个维度：没有执行者时策略对象还在，但一个包都不拦。
    */
   enforcesNetworkPolicy?: boolean;
+  /**
+   * 稳定状态下每秒处理多少请求。指标从这里长出来，不是伪造的。
+   */
+  requestsPerSecond?: number;
+  /** 其中多少比例是 5xx。注入故障就是把这个数调上去。 */
+  errorRatio?: number;
 }
 
 /** 内网的密钥库（OpenBao） */

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -30,6 +30,7 @@ import {
   CLUSTERROLEBINDINGS, CLUSTERROLES, RBAC_RESOURCES, ROLEBINDINGS, ROLES, authorize,
 } from '../rbac';
 import { ESO_RESOURCES, ExternalSecretsController } from '../secrets';
+import { OBSERVABILITY_RESOURCES, PrometheusController } from '../observability';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -89,6 +90,8 @@ export interface ClusterOptions {
    * 所有请求都是 cluster-admin —— 前面十几关不必为此各配一套角色。
    */
   users?: Record<string, { username: string; groups?: string[] }>;
+  /** 每个采集目标这一轮贡献哪些指标。由世界注入 —— 指标从集群状态里长出来。 */
+  metrics?: import('../observability').MetricsSource;
   /** 去外部密钥库取值。由世界注入 —— 集群自己不认识 OpenBao。 */
   fetchSecret?: import('../secrets').SecretFetcher;
   /** 镜像签名库。由世界注入，和镜像仓库一样是集群外的东西。 */
@@ -131,6 +134,8 @@ export class Cluster {
   /** 网络：DNS、Service 转发、NetworkPolicy 判定，全都读 apiserver 里的对象 */
   readonly network: Network;
 
+  /** 监控。世界没配 metrics 就是 undefined。 */
+  prometheus?: PrometheusController;
   /** 由外面装上（createOpsWorld 会接一个 Pod 里的 shell 进来） */
   execHandler?: import('../apiserver').ExecHandler;
   private controllers: Controller[] = [];
@@ -149,6 +154,7 @@ export class Cluster {
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
+      ...OBSERVABILITY_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -592,6 +598,10 @@ export class Cluster {
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发
       new CertManagerController(context),
+      // 监控：采集是定时拉的，所以采样之间发生的事看不见
+      ...(this.options.metrics
+        ? [(this.prometheus = new PrometheusController(context, this.options.metrics))]
+        : []),
       // 密钥：真值住在集群外面，这里只维护一份投影
       ...(this.options.fetchSecret
         ? [new ExternalSecretsController(context, { fetch: this.options.fetchSecret })]

--- a/src/lib/opslab/controllers/runtime.ts
+++ b/src/lib/opslab/controllers/runtime.ts
@@ -75,6 +75,12 @@ export interface ImageBehavior {
    * 宿主不认识任何具体的 CNI。
    */
   enforcesNetworkPolicy?: boolean;
+  /**
+   * 稳定状态下每秒处理多少请求。指标从这里长出来，不是伪造的。
+   */
+  requestsPerSecond?: number;
+  /** 其中多少比例是 5xx。注入故障就是把这个数调上去。 */
+  errorRatio?: number;
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -24,6 +24,21 @@ import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } f
 import { createIstioctlCommand } from '../mesh';
 import { SignatureStore, createCosignCommand } from '../admission';
 import { OpenBao, createBaoCommand } from '../secrets';
+import { createPromtoolCommand } from '../observability';
+import { parseQuantity } from '../controllers';
+
+/**
+ * promtool 认哪些地址。
+ *
+ * 端口转发过来的、集群内的 Service 名，都指向同一个 Prometheus ——
+ * 学员用哪种写法都该能查到。
+ */
+const PROMETHEUS_ADDRESSES = [
+  'http://localhost:9090',
+  'http://127.0.0.1:9090',
+  'http://prometheus.monitoring.svc:9090',
+  'http://prometheus.monitoring.svc.cluster.local:9090',
+];
 import { currentNamespaceOf } from './view';
 import { DEFAULT_KUBECONFIG_PATH } from '../wasm';
 import { createExecHandler } from './podshell';
@@ -132,6 +147,52 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     addressPools: spec.addressPools,
     users: spec.users,
     signatures,
+    /**
+     * 指标从集群状态里长出来。
+     *
+     * 这几个是排查真正用得上的：`up`（由 Prometheus 合成，见控制器）、
+     * HTTP 请求计数与错误计数、容器内存。数值由镜像声明的行为决定，
+     * 于是「注入一个故障」就是改镜像行为或改副本数，而不是伪造指标。
+     */
+    metrics: {
+      sample: (target, at) => {
+        void at;
+        const pods = cluster.scheme.get({ group: '', version: 'v1', resource: 'pods' });
+        const pod = pods && cluster.registry.list(pods, { namespace: target.namespace }).items
+          .find((item) => item.metadata.name === target.pod);
+        if (!pod) return [];
+        const containers = ((pod.spec ?? {}) as any).containers ?? [];
+        const behavior = cluster.imageBehaviorOf(containers[0]?.image);
+        const out: Array<{ name: string; labels: Record<string, string>; value: number }> = [];
+
+        /**
+         * 请求计数是 counter，单调递增。
+         *
+         * 每一轮按「这个 Pod 已经跑了多久」算，于是它随时间线性增长，
+         * `rate()` 出来是一个稳定的值 —— Pod 重启之后从头开始，
+         * 正好让学员看到 counter 归零这件事。
+         */
+        const started = Date.parse(((pod.status ?? {}) as any).startTime ?? '') || cluster.wallClock();
+        const seconds = Math.max(0, (cluster.wallClock() - started) / 1000);
+        const rps = behavior?.requestsPerSecond ?? 10;
+        out.push({ name: 'http_requests_total', labels: { code: '200' }, value: Math.floor(seconds * rps) });
+        const errorRate = behavior?.errorRatio ?? 0;
+        out.push({
+          name: 'http_requests_total', labels: { code: '500' },
+          value: Math.floor(seconds * rps * errorRate),
+        });
+
+        const memory = behavior?.memoryUsage ? parseQuantity(behavior.memoryUsage) : undefined;
+        if (memory !== undefined) {
+          out.push({ name: 'container_memory_working_set_bytes', labels: {}, value: memory });
+        }
+        const limit = containers[0]?.resources?.limits?.memory;
+        if (limit) {
+          out.push({ name: 'container_spec_memory_limit_bytes', labels: {}, value: parseQuantity(limit) });
+        }
+        return out;
+      },
+    },
     /**
      * ESO 去密钥库取值。
      *
@@ -269,6 +330,13 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
       server: (address) => (address.replace(/\/+$/, '') === bao.address ? bao : undefined),
     }));
   }
+
+  machine.install('promtool', createPromtoolCommand({
+    tsdb: (address) => (PROMETHEUS_ADDRESSES.includes(address.replace(/\/+$/, ''))
+      ? cluster.prometheus?.tsdb
+      : undefined),
+    now: () => cluster.wallClock(),
+  }));
 
   machine.install('cosign', createCosignCommand({
     signatures,

--- a/src/lib/opslab/observability/controller.ts
+++ b/src/lib/opslab/observability/controller.ts
@@ -1,0 +1,192 @@
+/**
+ * Prometheus 这个工作负载
+ *
+ * 它做三件事，每 15 秒一轮：按 ServiceMonitor 找目标、采一轮指标、
+ * 拿 PrometheusRule 里的表达式求值决定告警。
+ *
+ * 「Prometheus 自己是集群里的一个 Pod」这件事在这里是有后果的：它挂了，
+ * 采集停了，而 `kubectl get servicemonitor` 照样列得出来 —— 和 CNI、网格、
+ * Kyverno 是同一条约束。更要紧的是**它挂了之后没有任何告警会触发**，
+ * 包括「Prometheus 挂了」这一条，所以真集群里总要有另一双眼睛盯着它。
+ */
+import {
+  Controller, ControllerContext, Informer,
+} from '../controllers/framework';
+import { DEPLOYMENTS, NAMESPACES, PODS, SERVICES } from '../controllers/resources';
+import { PROMETHEUSES, PROMETHEUSRULES, PROMETHEUS_LABEL, SERVICEMONITORS } from './resources';
+import { targetsOf, type ScrapeTarget } from './scrape';
+import { evaluate, parseDuration, PromqlError } from './promql';
+import { Tsdb, type Labels } from './tsdb';
+
+/** 默认采集间隔，和 kube-prometheus 一致 */
+export const SCRAPE_INTERVAL_MS = 15_000;
+
+export interface Alert {
+  name: string;
+  labels: Labels;
+  annotations: Record<string, string>;
+  /** pending 表示条件成立了但还没满 `for` */
+  state: 'pending' | 'firing';
+  /** 条件从什么时候开始成立 */
+  activeAt: number;
+  value: number;
+}
+
+export interface MetricsSource {
+  /** 这一轮每个目标额外贡献哪些指标。集群状态由世界那边算。 */
+  sample(target: ScrapeTarget, at: number): Array<{ name: string; labels: Labels; value: number }>;
+}
+
+export class PrometheusController extends Controller {
+  readonly tsdb = new Tsdb();
+  /** 当前处于 pending / firing 的告警，key 是 `<rule>/<labels>` */
+  readonly alerts = new Map<string, Alert>();
+
+  private monitors: Informer;
+  private rules: Informer;
+  private prometheuses: Informer;
+  private deployments: Informer;
+  private services: Informer;
+  private pods: Informer;
+  private namespaces: Informer;
+  private timer: number;
+  private stopped = false;
+
+  constructor(context: ControllerContext, private readonly source: MetricsSource) {
+    super(context, 'prometheus');
+    this.monitors = this.track(new Informer(this.registry, SERVICEMONITORS));
+    this.rules = this.track(new Informer(this.registry, PROMETHEUSRULES));
+    this.prometheuses = this.track(new Informer(this.registry, PROMETHEUSES));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.services = this.track(new Informer(this.registry, SERVICES));
+    this.pods = this.track(new Informer(this.registry, PODS));
+    this.namespaces = this.track(new Informer(this.registry, NAMESPACES));
+
+    /**
+     * 采集是定时的，不是事件驱动的 —— 这正是「采样之间的事看不见」的来源。
+     * 标成 background，否则世界永远静不下来。
+     */
+    this.timer = this.kernel.setInterval(() => this.scrape(), SCRAPE_INTERVAL_MS, {
+      background: true,
+      label: 'prometheus:scrape',
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.kernel.clearTimer(this.timer);
+    super.stop();
+  }
+
+  /** 这个控制器不按对象 reconcile，一切都在定时的 scrape 里 */
+  protected reconcile(): void {}
+
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[PROMETHEUS_LABEL.key] !== PROMETHEUS_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  /** 采一轮，然后按规则求值 */
+  scrape(): void {
+    if (this.stopped || !this.installed()) return;
+    const at = this.context.now();
+    const targets = this.targets();
+
+    for (const target of targets) {
+      // `up` 是 Prometheus 自己合成的指标，不来自目标
+      this.tsdb.append('up', target.labels, at, target.up ? 1 : 0);
+      if (!target.up) continue;
+      for (const metric of this.source.sample(target, at)) {
+        this.tsdb.append(metric.name, { ...target.labels, ...metric.labels }, at, metric.value);
+      }
+    }
+
+    this.evaluateRules(at);
+  }
+
+  targets(): ScrapeTarget[] {
+    return targetsOf({
+      serviceMonitors: () => this.monitors.list(),
+      services: (namespace) => this.services.list().filter(
+        (item) => !namespace || item.metadata.namespace === namespace
+      ),
+      pods: (namespace) => this.pods.list().filter(
+        (item) => !namespace || item.metadata.namespace === namespace
+      ),
+      namespaces: () => this.namespaces.list(),
+      prometheus: () => this.prometheuses.list()[0],
+    });
+  }
+
+  /**
+   * 告警求值。
+   *
+   * `for` 是这里唯一的状态：条件第一次成立时记下时间，进入 pending；
+   * 持续满 `for` 才转成 firing。条件一旦不成立就整条清掉 —— 抖动不会
+   * 累积成告警，这正是 `for` 存在的意义。
+   */
+  private evaluateRules(at: number): void {
+    const seen = new Set<string>();
+    for (const rule of this.rules.list()) {
+      for (const group of ((rule.spec ?? {}) as any).groups ?? []) {
+        for (const entry of group.rules ?? []) {
+          if (!entry.alert || !entry.expr) continue;
+          let results;
+          try {
+            results = evaluate(this.tsdb, entry.expr, at);
+          } catch (error) {
+            if (!(error instanceof PromqlError)) throw error;
+            this.context.recordEvent({
+              object: rule, type: 'Warning', reason: 'InvalidExpression',
+              message: `${entry.alert}: ${(error as Error).message}`,
+            });
+            continue;
+          }
+          const forMs = entry.for ? parseDuration(entry.for) : 0;
+          for (const result of results) {
+            const labels = { ...result.labels, ...(entry.labels ?? {}), alertname: entry.alert };
+            const key = `${entry.alert}/${JSON.stringify(labels)}`;
+            seen.add(key);
+            const existing = this.alerts.get(key);
+            const activeAt = existing?.activeAt ?? at;
+            this.alerts.set(key, {
+              name: entry.alert,
+              labels,
+              annotations: renderAnnotations(entry.annotations ?? {}, result.value, labels),
+              state: at - activeAt >= forMs ? 'firing' : 'pending',
+              activeAt,
+              value: result.value,
+            });
+          }
+        }
+      }
+    }
+    // 条件不再成立的告警直接消失，不留残影
+    for (const key of [...this.alerts.keys()]) {
+      if (!seen.has(key)) this.alerts.delete(key);
+    }
+  }
+
+  firing(): Alert[] {
+    return [...this.alerts.values()]
+      .filter((alert) => alert.state === 'firing')
+      .sort((a, b) => (a.name < b.name ? -1 : 1));
+  }
+}
+
+/** 注解里的 `{{ $value }}` 与 `{{ $labels.x }}` */
+function renderAnnotations(
+  annotations: Record<string, string>,
+  value: number,
+  labels: Labels
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, template] of Object.entries(annotations)) {
+    out[key] = template
+      .replace(/\{\{\s*\$value\s*\}\}/g, String(value))
+      .replace(/\{\{\s*\$labels\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g, (_, name: string) => labels[name] ?? '');
+  }
+  return out;
+}

--- a/src/lib/opslab/observability/index.ts
+++ b/src/lib/opslab/observability/index.ts
@@ -1,0 +1,20 @@
+/**
+ * 可观测性
+ *
+ * 采集是拉模型且定时的，于是「两次采样之间发生的事看不见」；
+ * 告警是对 PromQL 表达式定时求值，于是「表达式写错了不会报错，只是永不触发」。
+ * 这两条是这一层所有困惑的来源，也是这里要教的东西。
+ */
+export { Tsdb, seriesKey, matches, LOOKBACK_MS } from './tsdb';
+export type { Labels, Matcher, Sample, Series } from './tsdb';
+export { evaluate, parseDuration, counterDelta, PromqlError } from './promql';
+export type { InstantValue } from './promql';
+export {
+  SERVICEMONITORS, PROMETHEUSRULES, PROMETHEUSES, OBSERVABILITY_RESOURCES, PROMETHEUS_LABEL,
+} from './resources';
+export { targetsOf } from './scrape';
+export type { ScrapeTarget, ScrapeView } from './scrape';
+export { PrometheusController, SCRAPE_INTERVAL_MS } from './controller';
+export type { Alert, MetricsSource } from './controller';
+export { createPromtoolCommand } from './promtool';
+export type { PromtoolOptions } from './promtool';

--- a/src/lib/opslab/observability/promql.ts
+++ b/src/lib/opslab/observability/promql.ts
@@ -1,0 +1,459 @@
+/**
+ * PromQL 的一个子集
+ *
+ * 覆盖到「写得出一条真告警」为止：
+ *
+ *   up{job="portal"} == 0
+ *   rate(http_requests_total{code=~"5.."}[5m]) > 0.05
+ *   sum(rate(x[5m])) by (job) / sum(rate(y[5m])) by (job) > 0.01
+ *   100 * (1 - avg(container_memory_available) / avg(container_memory_limit)) > 90
+ *
+ * 不做的：子查询、offset、histogram_quantile、topk 之外的排序函数、
+ * 以及 range vector 直接作为结果返回（告警规则里也用不上）。
+ *
+ * `rate` 那一段值得单独说：它算的是**每秒**增量，而且只对 counter 有意义。
+ * counter 重启会归零，真 Prometheus 会检测这种回退并补偿 —— 这里也做了，
+ * 因为「Pod 重启之后 rate 冒出一个尖峰」正是不补偿的后果。
+ */
+import { Tsdb, matches, type Labels, type Matcher, type Sample, type Series } from './tsdb';
+
+export interface InstantValue {
+  labels: Labels;
+  value: number;
+}
+
+export class PromqlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PromqlError';
+  }
+}
+
+/** 在某个时刻求值，返回一组带标签的瞬时值 */
+export function evaluate(tsdb: Tsdb, expression: string, at: number): InstantValue[] {
+  const parser = new Parser(expression);
+  const node = parser.parseExpression();
+  parser.expectEnd();
+  return new Evaluator(tsdb, at).eval(node);
+}
+
+/* ------------------------------------------------------------------ */
+/* 语法树                                                              */
+/* ------------------------------------------------------------------ */
+
+type Node =
+  | { kind: 'number'; value: number }
+  | { kind: 'selector'; name: string; matchers: Matcher[]; windowMs?: number }
+  | { kind: 'binary'; op: string; left: Node; right: Node }
+  | { kind: 'unary'; op: string; operand: Node }
+  | { kind: 'call'; name: string; args: Node[] }
+  | { kind: 'aggregate'; op: string; by: string[]; without: string[]; operand: Node };
+
+const AGGREGATORS = ['sum', 'avg', 'min', 'max', 'count'];
+const FUNCTIONS = ['rate', 'increase', 'abs', 'ceil', 'floor', 'clamp_max', 'clamp_min'];
+
+class Parser {
+  private index = 0;
+  private readonly tokens: string[];
+
+  constructor(source: string) {
+    this.tokens = tokenize(source);
+  }
+
+  parseExpression(minPrecedence = 0): Node {
+    let left = this.parseUnary();
+    for (;;) {
+      const op = this.peek();
+      const precedence = PRECEDENCE[op ?? ''];
+      if (precedence === undefined || precedence < minPrecedence) break;
+      this.next();
+      const right = this.parseExpression(precedence + 1);
+      left = { kind: 'binary', op: op!, left, right };
+    }
+    return left;
+  }
+
+  private parseUnary(): Node {
+    if (this.peek() === '-') {
+      this.next();
+      return { kind: 'unary', op: '-', operand: this.parseUnary() };
+    }
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): Node {
+    const token = this.next();
+    if (token === undefined) throw new PromqlError('unexpected end of input');
+    if (token === '(') {
+      const inner = this.parseExpression();
+      this.expect(')');
+      return inner;
+    }
+    if (/^-?\d/.test(token)) return { kind: 'number', value: Number(token) };
+    if (!/^[a-zA-Z_:][a-zA-Z0-9_:]*$/.test(token)) {
+      throw new PromqlError(`unexpected token ${JSON.stringify(token)}`);
+    }
+
+    if (AGGREGATORS.includes(token)) return this.parseAggregate(token);
+    if (FUNCTIONS.includes(token) && this.peek() === '(') return this.parseCall(token);
+    return this.parseSelector(token);
+  }
+
+  private parseAggregate(op: string): Node {
+    // 分组子句可以写在括号前，也可以写在后面
+    let by: string[] = [];
+    let without: string[] = [];
+    if (this.peek() === 'by' || this.peek() === 'without') {
+      const clause = this.next()!;
+      const labels = this.parseLabelList();
+      if (clause === 'by') by = labels; else without = labels;
+    }
+    this.expect('(');
+    const operand = this.parseExpression();
+    this.expect(')');
+    if (this.peek() === 'by' || this.peek() === 'without') {
+      const clause = this.next()!;
+      const labels = this.parseLabelList();
+      if (clause === 'by') by = labels; else without = labels;
+    }
+    return { kind: 'aggregate', op, by, without, operand };
+  }
+
+  private parseLabelList(): string[] {
+    this.expect('(');
+    const labels: string[] = [];
+    while (this.peek() !== ')') {
+      const token = this.next();
+      if (token === undefined) throw new PromqlError('unterminated label list');
+      if (token !== ',') labels.push(token);
+    }
+    this.expect(')');
+    return labels;
+  }
+
+  private parseCall(name: string): Node {
+    this.expect('(');
+    const args: Node[] = [];
+    while (this.peek() !== ')') {
+      args.push(this.parseExpression());
+      if (this.peek() === ',') this.next();
+    }
+    this.expect(')');
+    return { kind: 'call', name, args };
+  }
+
+  private parseSelector(name: string): Node {
+    const matchers: Matcher[] = [];
+    if (this.peek() === '{') {
+      this.next();
+      while (this.peek() !== '}') {
+        const label = this.next();
+        const op = this.next();
+        const value = this.next();
+        if (!label || !op || value === undefined) throw new PromqlError('malformed label matcher');
+        if (!['=', '!=', '=~', '!~'].includes(op)) {
+          throw new PromqlError(`unexpected matcher operator ${JSON.stringify(op)}`);
+        }
+        matchers.push({ label, op: op as Matcher['op'], value: unquote(value) });
+        if (this.peek() === ',') this.next();
+      }
+      this.expect('}');
+    }
+    let windowMs: number | undefined;
+    if (this.peek() === '[') {
+      this.next();
+      const duration = this.next();
+      if (!duration) throw new PromqlError('missing range duration');
+      windowMs = parseDuration(duration);
+      this.expect(']');
+    }
+    return { kind: 'selector', name, matchers, windowMs };
+  }
+
+  private peek(): string | undefined {
+    return this.tokens[this.index];
+  }
+
+  private next(): string | undefined {
+    const token = this.tokens[this.index];
+    this.index += 1;
+    return token;
+  }
+
+  private expect(token: string): void {
+    const found = this.next();
+    if (found !== token) {
+      throw new PromqlError(`expected ${JSON.stringify(token)}, got ${JSON.stringify(found ?? 'end of input')}`);
+    }
+  }
+
+  expectEnd(): void {
+    if (this.index < this.tokens.length) {
+      throw new PromqlError(`unexpected trailing input ${JSON.stringify(this.tokens[this.index])}`);
+    }
+  }
+}
+
+const PRECEDENCE: Record<string, number> = {
+  or: 1, and: 2, unless: 2,
+  '==': 3, '!=': 3, '>': 3, '<': 3, '>=': 3, '<=': 3,
+  '+': 4, '-': 4,
+  '*': 5, '/': 5, '%': 5,
+};
+
+function tokenize(source: string): string[] {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    if (/\s/.test(char)) { index += 1; continue; }
+    if (char === '"' || char === "'") {
+      let end = index + 1;
+      while (end < source.length && source[end] !== char) end += 1;
+      tokens.push(source.slice(index, end + 1));
+      index = end + 1;
+      continue;
+    }
+    const two = source.slice(index, index + 2);
+    if (['==', '!=', '>=', '<=', '=~', '!~'].includes(two)) {
+      tokens.push(two);
+      index += 2;
+      continue;
+    }
+    if ('(){}[],+-*/%<>='.includes(char)) { tokens.push(char); index += 1; continue; }
+    const rest = source.slice(index);
+    const word = /^[a-zA-Z_:][a-zA-Z0-9_:]*/.exec(rest)?.[0]
+      ?? /^\d+(\.\d+)?([smhdwy])?/.exec(rest)?.[0];
+    if (!word) throw new PromqlError(`unexpected character ${JSON.stringify(char)}`);
+    tokens.push(word);
+    index += word.length;
+  }
+  return tokens;
+}
+
+function unquote(token: string): string {
+  if ((token.startsWith('"') && token.endsWith('"')) || (token.startsWith("'") && token.endsWith("'"))) {
+    return token.slice(1, -1);
+  }
+  return token;
+}
+
+export function parseDuration(text: string): number {
+  const match = /^(\d+(?:\.\d+)?)([smhdwy])$/.exec(text);
+  if (!match) throw new PromqlError(`invalid duration ${JSON.stringify(text)}`);
+  const unit = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000, y: 31_536_000_000 };
+  return Number(match[1]) * unit[match[2] as keyof typeof unit];
+}
+
+/* ------------------------------------------------------------------ */
+/* 求值                                                                */
+/* ------------------------------------------------------------------ */
+
+class Evaluator {
+  constructor(private readonly tsdb: Tsdb, private readonly at: number) {}
+
+  eval(node: Node): InstantValue[] {
+    switch (node.kind) {
+      case 'number':
+        return [{ labels: {}, value: node.value }];
+      case 'selector':
+        return this.selector(node);
+      case 'unary': {
+        return this.eval(node.operand).map((entry) => ({ ...entry, value: -entry.value }));
+      }
+      case 'call':
+        return this.call(node);
+      case 'aggregate':
+        return this.aggregate(node);
+      case 'binary':
+        return this.binary(node);
+      default:
+        throw new PromqlError('unsupported expression');
+    }
+  }
+
+  private selector(node: Extract<Node, { kind: 'selector' }>): InstantValue[] {
+    if (node.windowMs !== undefined) {
+      throw new PromqlError('range vector must be wrapped in rate() or increase()');
+    }
+    const out: InstantValue[] = [];
+    for (const series of this.tsdb.select(node.name, node.matchers)) {
+      const value = this.tsdb.valueAt(series, this.at);
+      if (value !== undefined) out.push({ labels: series.labels, value });
+    }
+    return out;
+  }
+
+  private call(node: Extract<Node, { kind: 'call' }>): InstantValue[] {
+    if (node.name === 'rate' || node.name === 'increase') {
+      const target = node.args[0];
+      if (target?.kind !== 'selector' || target.windowMs === undefined) {
+        throw new PromqlError(`${node.name}() 的参数必须是一个带时间窗的选择器，比如 x[5m]`);
+      }
+      const out: InstantValue[] = [];
+      for (const series of this.tsdb.select(target.name, target.matchers)) {
+        const samples = this.tsdb.range(series, this.at, target.windowMs);
+        const delta = counterDelta(samples);
+        if (delta === undefined) continue;
+        /**
+         * 除的是**实际覆盖的时间**，不是窗口长度。
+         *
+         * 窗口里第一个点和最后一个点之间才是真的观测区间；直接除窗口长度
+         * 会系统性地低估（窗口两端各差半个采集间隔）。真 Prometheus 的做法
+         * 是外推到窗口边缘，采样均匀时两者的结果一致，而除观测区间这一步
+         * 更容易解释，也不会在数据稀疏时凭空造出斜率。
+         */
+        const span = samples[samples.length - 1].at - samples[0].at;
+        if (span <= 0) continue;
+        const value = node.name === 'rate' ? delta / (span / 1000) : delta;
+        out.push({ labels: withoutName(series), value });
+      }
+      return out;
+    }
+
+    const values = this.eval(node.args[0] ?? { kind: 'number', value: 0 });
+    const second = node.args[1] ? this.eval(node.args[1])[0]?.value ?? 0 : 0;
+    const apply = (value: number): number => {
+      switch (node.name) {
+        case 'abs': return Math.abs(value);
+        case 'ceil': return Math.ceil(value);
+        case 'floor': return Math.floor(value);
+        case 'clamp_max': return Math.min(value, second);
+        case 'clamp_min': return Math.max(value, second);
+        default: throw new PromqlError(`unsupported function ${node.name}()`);
+      }
+    };
+    return values.map((entry) => ({ ...entry, value: apply(entry.value) }));
+  }
+
+  private aggregate(node: Extract<Node, { kind: 'aggregate' }>): InstantValue[] {
+    const values = this.eval(node.operand);
+    const groups = new Map<string, InstantValue[]>();
+    for (const entry of values) {
+      const labels = groupLabels(entry.labels, node.by, node.without);
+      const key = JSON.stringify(Object.entries(labels).sort(([a], [b]) => (a < b ? -1 : 1)));
+      groups.set(key, [...(groups.get(key) ?? []), { labels, value: entry.value }]);
+    }
+    const out: InstantValue[] = [];
+    for (const group of groups.values()) {
+      const numbers = group.map((entry) => entry.value);
+      const value = ((): number => {
+        switch (node.op) {
+          case 'sum': return numbers.reduce((a, b) => a + b, 0);
+          case 'avg': return numbers.reduce((a, b) => a + b, 0) / numbers.length;
+          case 'min': return Math.min(...numbers);
+          case 'max': return Math.max(...numbers);
+          case 'count': return numbers.length;
+          default: throw new PromqlError(`unsupported aggregator ${node.op}`);
+        }
+      })();
+      out.push({ labels: group[0].labels, value });
+    }
+    return out;
+  }
+
+  /**
+   * 二元运算。
+   *
+   * 标量参与运算时广播到每一条序列；两侧都是向量时按**标签完全相同**配对 ——
+   * 配不上的那些直接消失，不报错。这是 PromQL 里最容易让人困惑的行为：
+   * 一条 `a / b` 突然返回空，多半是两边的标签集不一样。
+   */
+  private binary(node: Extract<Node, { kind: 'binary' }>): InstantValue[] {
+    const left = this.eval(node.left);
+    const right = this.eval(node.right);
+    const comparison = ['==', '!=', '>', '<', '>=', '<='].includes(node.op);
+
+    const leftScalar = node.left.kind === 'number';
+    const rightScalar = node.right.kind === 'number';
+
+    if (rightScalar) {
+      const scalar = right[0]?.value ?? 0;
+      /**
+       * 比较运算是**过滤**，不是求布尔值。
+       *
+       * `up == 0` 返回的是那些值确实为 0 的序列，值仍然是 0，不是 1。
+       * 告警规则就是靠这个：表达式返回了序列就触发，返回空就不触发。
+       */
+      if (comparison) {
+        return left.filter((entry) => apply(node.op, entry.value, scalar) === 1);
+      }
+      return left.map((entry) => ({ labels: entry.labels, value: apply(node.op, entry.value, scalar) }));
+    }
+    if (leftScalar) {
+      const scalar = left[0]?.value ?? 0;
+      return right.map((entry) => ({ labels: entry.labels, value: apply(node.op, scalar, entry.value) }));
+    }
+
+    const byKey = new Map(right.map((entry) => [labelKey(entry.labels), entry]));
+    const out: InstantValue[] = [];
+    for (const entry of left) {
+      const other = byKey.get(labelKey(entry.labels));
+      if (!other) continue;   // 配不上就没有结果
+      const value = apply(node.op, entry.value, other.value);
+      if (comparison && value !== 1) continue;
+      out.push({ labels: entry.labels, value: comparison ? entry.value : value });
+    }
+    return out;
+  }
+}
+
+function apply(op: string, left: number, right: number): number {
+  switch (op) {
+    case '+': return left + right;
+    case '-': return left - right;
+    case '*': return left * right;
+    case '/': return right === 0 ? NaN : left / right;
+    case '%': return left % right;
+    case '==': return left === right ? 1 : 0;
+    case '!=': return left !== right ? 1 : 0;
+    case '>': return left > right ? 1 : 0;
+    case '<': return left < right ? 1 : 0;
+    case '>=': return left >= right ? 1 : 0;
+    case '<=': return left <= right ? 1 : 0;
+    case 'and': return right !== 0 ? left : NaN;
+    case 'or': return left;
+    default: throw new PromqlError(`unsupported operator ${op}`);
+  }
+}
+
+function labelKey(labels: Labels): string {
+  return JSON.stringify(
+    Object.entries(labels)
+      .filter(([key]) => key !== '__name__')
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+  );
+}
+
+function withoutName(series: Series): Labels {
+  const { ...labels } = series.labels;
+  return labels;
+}
+
+function groupLabels(labels: Labels, by: string[], without: string[]): Labels {
+  if (by.length > 0) {
+    return Object.fromEntries(by.filter((name) => labels[name] !== undefined).map((name) => [name, labels[name]]));
+  }
+  if (without.length > 0) {
+    return Object.fromEntries(Object.entries(labels).filter(([name]) => !without.includes(name)));
+  }
+  return {};
+}
+
+/**
+ * counter 在一个窗口里涨了多少。
+ *
+ * 中途归零（进程重启）要补偿，否则 rate 会算出一个负数，
+ * 或者重启后的第一个窗口出现一个假的尖峰。
+ */
+export function counterDelta(samples: Sample[]): number | undefined {
+  if (samples.length < 2) return undefined;
+  let delta = 0;
+  for (let i = 1; i < samples.length; i += 1) {
+    const step = samples[i].value - samples[i - 1].value;
+    delta += step >= 0 ? step : samples[i].value;
+  }
+  return delta;
+}
+
+export { matches };

--- a/src/lib/opslab/observability/promtool.ts
+++ b/src/lib/opslab/observability/promtool.ts
@@ -1,0 +1,146 @@
+/**
+ * `promtool`
+ *
+ * 真 promtool 会做的三件里，这里做两件：查一条 PromQL、检查规则文件。
+ * 第三件（单元测试规则）依赖一整套 YAML 夹具格式，教学价值不如前两件。
+ *
+ * `query instant` 打出来的格式照抄真 promtool —— 学员在这里练出来的读法
+ * 要能带走。
+ */
+import type { CommandHandler, CommandResult } from '../machine/shell/shell';
+import { evaluate, parseDuration, PromqlError } from './promql';
+import { Tsdb } from './tsdb';
+import { parseYamlAll } from '../yaml';
+
+export interface PromtoolOptions {
+  /** 去哪个 Prometheus 查。地址对不上就是连不上。 */
+  tsdb(address: string): Tsdb | undefined;
+  now(): number;
+}
+
+export function createPromtoolCommand(options: PromtoolOptions): CommandHandler {
+  return ({ argv, cwd, vfs }) => {
+    const [command, ...rest] = argv;
+    if (command === '--version' || command === 'version') {
+      return { stdout: 'promtool, version 3.9.1\n' };
+    }
+    if (command === 'query') return query(rest, options);
+    if (command === 'check') return check(rest, cwd, vfs);
+    return {
+      stdout: 'usage: promtool [<flags>] <command> [<args> ...]\n\n'
+        + '  query instant <server> <expr>   Run an instant query\n'
+        + '  check rules <file>              Check rule files for syntax errors\n',
+      code: command ? 1 : 0,
+    };
+  };
+}
+
+function query(argv: string[], options: PromtoolOptions): CommandResult {
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  if (positional[0] !== 'instant') {
+    return { stderr: 'promtool: 只做了 query instant\n', code: 1 };
+  }
+  const [, address, ...expression] = positional;
+  if (!address || expression.length === 0) {
+    return { stderr: 'usage: promtool query instant <server> <expr>\n', code: 1 };
+  }
+  const tsdb = options.tsdb(address);
+  if (!tsdb) {
+    return {
+      stderr: `query error: Post "${address}/api/v1/query": dial tcp: `
+        + `lookup ${hostOf(address)}: no such host\n`,
+      code: 1,
+    };
+  }
+  try {
+    const results = evaluate(tsdb, expression.join(' '), options.now());
+    if (results.length === 0) return { stdout: '' };
+    return {
+      stdout: results
+        .map((entry) => {
+          const labels = Object.entries(entry.labels)
+            .sort(([a], [b]) => (a < b ? -1 : 1))
+            .map(([key, value]) => `${key}="${value}"`)
+            .join(', ');
+          return `{${labels}} => ${format(entry.value)} @[${(options.now() / 1000).toFixed(3)}]`;
+        })
+        .join('\n') + '\n',
+    };
+  } catch (error) {
+    if (error instanceof PromqlError) {
+      return { stderr: `query error: ${error.message}\n`, code: 1 };
+    }
+    throw error;
+  }
+}
+
+/**
+ * `promtool check rules`
+ *
+ * 查的是**能不能解析**与**字段齐不齐**，不查语义。上线前跑一次能挡掉
+ * 一大半「规则装上去了但从不触发」的情况 —— 那多半是表达式写错了，
+ * 而 apiserver 收 PrometheusRule 的时候不会校验表达式。
+ */
+function check(argv: string[], cwd: string, vfs: { exists(path: string): boolean; readFile(path: string): string }): CommandResult {
+  const positional = argv.filter((entry) => !entry.startsWith('-'));
+  if (positional[0] !== 'rules' || !positional[1]) {
+    return { stderr: 'usage: promtool check rules <file>\n', code: 1 };
+  }
+  const path = positional[1].startsWith('/') ? positional[1] : `${cwd}/${positional[1]}`;
+  if (!vfs.exists(path)) {
+    return { stderr: `cannot read ${positional[1]}: no such file or directory\n`, code: 1 };
+  }
+
+  const problems: string[] = [];
+  let count = 0;
+  for (const document of parseYamlAll(vfs.readFile(path))) {
+    const groups = ((document as any)?.spec?.groups ?? (document as any)?.groups ?? []) as any[];
+    for (const group of groups) {
+      for (const rule of group.rules ?? []) {
+        count += 1;
+        const label = rule.alert ?? rule.record ?? '<unnamed>';
+        if (!rule.expr) {
+          problems.push(`  ${label}: field 'expr' must be set in rule`);
+          continue;
+        }
+        try {
+          // 只解析不求值：没有数据也能查出语法错
+          evaluate(emptyTsdb(), String(rule.expr), 0);
+        } catch (error) {
+          if (error instanceof PromqlError) {
+            problems.push(`  ${label}: could not parse expression: ${error.message}`);
+          } else throw error;
+        }
+        if (rule.for) {
+          try {
+            parseDuration(String(rule.for));
+          } catch {
+            problems.push(`  ${label}: invalid duration ${JSON.stringify(rule.for)} in 'for'`);
+          }
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    return {
+      stdout: `Checking ${positional[1]}\n  FAILED:\n${problems.join('\n')}\n`,
+      code: 1,
+    };
+  }
+  return { stdout: `Checking ${positional[1]}\n  SUCCESS: ${count} rules found\n` };
+}
+
+/** 只为语法检查用的空库。没有数据也能查出语法错。 */
+function emptyTsdb(): Tsdb {
+  return new Tsdb();
+}
+
+function format(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return String(Number(value.toFixed(6)));
+}
+
+function hostOf(address: string): string {
+  return address.replace(/^[a-z]+:\/\//, '').split(/[:/]/)[0];
+}

--- a/src/lib/opslab/observability/resources.ts
+++ b/src/lib/opslab/observability/resources.ts
@@ -1,0 +1,32 @@
+/**
+ * Prometheus Operator 与 OTel 的 CRD
+ *
+ * `ServiceMonitor` 是采集配置：按标签选中一批 Service，去它们后面的 Pod 上拉。
+ * 它最容易出的问题不是写错，而是**没被 Prometheus 选中** —— Prometheus 自己
+ * 也有一个 `serviceMonitorSelector`，两边对不上就一条指标都采不到，
+ * 而两边看起来都很正常。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const SERVICEMONITORS: ResourceDefinition = {
+  group: 'monitoring.coreos.com', version: 'v1', resource: 'servicemonitors',
+  singular: 'servicemonitor', kind: 'ServiceMonitor', namespaced: true, shortNames: ['smon'],
+};
+
+export const PROMETHEUSRULES: ResourceDefinition = {
+  group: 'monitoring.coreos.com', version: 'v1', resource: 'prometheusrules',
+  singular: 'prometheusrule', kind: 'PrometheusRule', namespaced: true, shortNames: ['promrule'],
+};
+
+export const PROMETHEUSES: ResourceDefinition = {
+  group: 'monitoring.coreos.com', version: 'v1', resource: 'prometheuses',
+  singular: 'prometheus', kind: 'Prometheus', namespaced: true, shortNames: ['prom'],
+  subresources: ['status'],
+};
+
+export const OBSERVABILITY_RESOURCES: ResourceDefinition[] = [
+  SERVICEMONITORS, PROMETHEUSRULES, PROMETHEUSES,
+];
+
+/** Prometheus 自己。没有它，ServiceMonitor 与 PrometheusRule 都只是声明。 */
+export const PROMETHEUS_LABEL = { key: 'app.kubernetes.io/name', value: 'prometheus' };

--- a/src/lib/opslab/observability/scrape.ts
+++ b/src/lib/opslab/observability/scrape.ts
@@ -1,0 +1,94 @@
+/**
+ * 采集
+ *
+ * Prometheus 是**拉**模型：它按 ServiceMonitor 找到目标，定期去每个目标的
+ * `/metrics` 上拉一次。这决定了两件事：
+ *
+ *  1. 采集间隔之间发生的事看不见。Pod 起来又挂掉、只活了十秒，
+ *     很可能一个点都没采到 —— 事后翻指标是翻不出来的，得看事件。
+ *  2. 目标挂掉之后，`up` 变成 0，而它此前的指标还会在图上停留一个
+ *     回看窗口（默认五分钟）才消失。
+ *
+ * 这里不实现 HTTP 抓取，指标由集群状态直接生成 —— 但**目标是谁、采不采得到**
+ * 完全按 ServiceMonitor 与选择器算，因为那才是这一层会出错的地方。
+ */
+import type { KubeObject } from '../apiserver';
+import type { Labels } from './tsdb';
+
+export interface ScrapeTarget {
+  /** `<namespace>/<service>` */
+  job: string;
+  namespace: string;
+  service: string;
+  pod: string;
+  /** 目标上不上得去。Pod 不 Running 就是 down。 */
+  up: boolean;
+  labels: Labels;
+}
+
+export interface ScrapeView {
+  serviceMonitors(): KubeObject[];
+  services(namespace?: string): KubeObject[];
+  pods(namespace?: string): KubeObject[];
+  namespaces(): KubeObject[];
+  /** Prometheus 实例自己的选择器 */
+  prometheus(): KubeObject | undefined;
+}
+
+/**
+ * 算出这一轮该采哪些目标。
+ *
+ * 两层选择器都要过：Prometheus 的 `serviceMonitorSelector` 选中 ServiceMonitor，
+ * ServiceMonitor 的 `selector` 选中 Service。少配一层是最常见的「采不到」原因。
+ */
+export function targetsOf(view: ScrapeView): ScrapeTarget[] {
+  const prometheus = view.prometheus();
+  const monitorSelector = ((prometheus?.spec ?? {}) as any)?.serviceMonitorSelector?.matchLabels as
+    Record<string, string> | undefined;
+  const namespaceSelector = ((prometheus?.spec ?? {}) as any)?.serviceMonitorNamespaceSelector?.matchLabels as
+    Record<string, string> | undefined;
+
+  const out: ScrapeTarget[] = [];
+  for (const monitor of view.serviceMonitors()) {
+    if (monitorSelector && !hasLabels(monitor.metadata.labels, monitorSelector)) continue;
+    if (namespaceSelector) {
+      const namespace = view.namespaces().find((item) => item.metadata.name === monitor.metadata.namespace);
+      if (!hasLabels(namespace?.metadata.labels, namespaceSelector)) continue;
+    }
+
+    const spec = (monitor.spec ?? {}) as any;
+    const wanted = spec.selector?.matchLabels as Record<string, string> | undefined;
+    const scope: string[] = spec.namespaceSelector?.matchNames ?? [monitor.metadata.namespace ?? 'default'];
+
+    for (const namespace of scope) {
+      for (const service of view.services(namespace)) {
+        if (!hasLabels(service.metadata.labels, wanted)) continue;
+        const selector = ((service.spec ?? {}) as any).selector as Record<string, string> | undefined;
+        for (const pod of view.pods(namespace)) {
+          if (!hasLabels(pod.metadata.labels, selector)) continue;
+          out.push({
+            job: `${namespace}/${service.metadata.name}`,
+            namespace,
+            service: service.metadata.name!,
+            pod: pod.metadata.name!,
+            up: ((pod.status ?? {}) as any).phase === 'Running',
+            labels: {
+              job: `${namespace}/${service.metadata.name}`,
+              namespace,
+              service: service.metadata.name!,
+              pod: pod.metadata.name!,
+              ...(pod.metadata.labels?.app ? { app: pod.metadata.labels.app } : {}),
+            },
+          });
+        }
+      }
+    }
+  }
+  return out.sort((a, b) => (`${a.job}/${a.pod}` < `${b.job}/${b.pod}` ? -1 : 1));
+}
+
+function hasLabels(labels: Record<string, string> | undefined, wanted: Record<string, string> | undefined): boolean {
+  if (!wanted) return true;
+  const actual = labels ?? {};
+  return Object.entries(wanted).every(([key, value]) => actual[key] === value);
+}

--- a/src/lib/opslab/observability/tsdb.ts
+++ b/src/lib/opslab/observability/tsdb.ts
@@ -1,0 +1,107 @@
+/**
+ * 一个够用的时序库
+ *
+ * Prometheus 的数据模型：一条序列由指标名加一组标签唯一确定，值按时间点存。
+ * 这里保留的是这个模型本身，以及采样间隔带来的后果 —— 两次采样之间发生的事
+ * 看不见，这是所有基于采样的监控共有的盲区，值得让学员撞一次。
+ *
+ * 不做的：远程写、压缩、乱序写入、直方图分位数的插值。
+ */
+
+export interface Labels {
+  [name: string]: string;
+}
+
+export interface Sample {
+  /** 虚拟墙钟，毫秒 */
+  at: number;
+  value: number;
+}
+
+export interface Series {
+  name: string;
+  labels: Labels;
+  samples: Sample[];
+}
+
+/** 一条序列的身份：指标名 + 排序后的标签 */
+export function seriesKey(name: string, labels: Labels): string {
+  const parts = Object.entries(labels)
+    .filter(([key]) => key !== '__name__')
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`);
+  return `${name}{${parts.join(',')}}`;
+}
+
+export class Tsdb {
+  private readonly series = new Map<string, Series>();
+
+  /** 采一个点。同一条序列按时间追加。 */
+  append(name: string, labels: Labels, at: number, value: number): void {
+    const key = seriesKey(name, labels);
+    const found = this.series.get(key);
+    if (found) {
+      found.samples.push({ at, value });
+      return;
+    }
+    this.series.set(key, { name, labels: { ...labels }, samples: [{ at, value }] });
+  }
+
+  all(): Series[] {
+    return [...this.series.values()].sort((a, b) =>
+      (seriesKey(a.name, a.labels) < seriesKey(b.name, b.labels) ? -1 : 1));
+  }
+
+  /** 按指标名与标签选择器取序列 */
+  select(name: string, matchers: Matcher[] = []): Series[] {
+    return this.all().filter((series) =>
+      series.name === name && matchers.every((matcher) => matches(matcher, series.labels)));
+  }
+
+  /**
+   * 某个时刻的瞬时值。
+   *
+   * 取的是**不晚于该时刻的最后一个点**，而且超过 5 分钟就当作没有数据 ——
+   * 和 Prometheus 的 lookback delta 一致。这条决定了「目标挂了之后，
+   * 它的指标还会在图上停留五分钟」。
+   */
+  valueAt(series: Series, at: number, lookbackMs = LOOKBACK_MS): number | undefined {
+    let found: Sample | undefined;
+    for (const sample of series.samples) {
+      if (sample.at > at) break;
+      found = sample;
+    }
+    if (!found) return undefined;
+    return at - found.at <= lookbackMs ? found.value : undefined;
+  }
+
+  /** 一个时间窗里的点，用于 rate / increase */
+  range(series: Series, at: number, windowMs: number): Sample[] {
+    return series.samples.filter((sample) => sample.at > at - windowMs && sample.at <= at);
+  }
+
+  get size(): number {
+    return this.series.size;
+  }
+}
+
+/** Prometheus 默认的回看窗口 */
+export const LOOKBACK_MS = 5 * 60_000;
+
+export interface Matcher {
+  label: string;
+  op: '=' | '!=' | '=~' | '!~';
+  value: string;
+}
+
+export function matches(matcher: Matcher, labels: Labels): boolean {
+  const actual = labels[matcher.label] ?? '';
+  switch (matcher.op) {
+    case '=': return actual === matcher.value;
+    case '!=': return actual !== matcher.value;
+    // Prometheus 的正则是完全匹配，不是搜索 —— 这一条常被忘记
+    case '=~': return new RegExp(`^(?:${matcher.value})$`).test(actual);
+    case '!~': return !new RegExp(`^(?:${matcher.value})$`).test(actual);
+    default: return false;
+  }
+}

--- a/tests/opslab/observability.test.ts
+++ b/tests/opslab/observability.test.ts
@@ -1,0 +1,345 @@
+/**
+ * 可观测性
+ *
+ * 两条贯穿始终的事实：
+ *  1. **采集是定时拉的** —— 两次采样之间发生的事看不见；
+ *  2. **告警是对表达式定时求值** —— 表达式写错了不会报错，只是永不触发。
+ *
+ * 这一组把 PromQL 的语义、采集目标的选择、以及 `for` 的行为逐条钉住。
+ */
+import { Tsdb, evaluate, counterDelta, parseDuration, targetsOf, PromqlError } from '../../src/lib/opslab/observability';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const T = (minutes: number) => minutes * 60_000;
+
+function bench() {
+  const tsdb = new Tsdb();
+  // 两个 Pod，一个健康一个挂了
+  for (let i = 0; i <= 10; i += 1) {
+    tsdb.append('up', { job: 'shop/portal', pod: 'portal-a' }, T(i), 1);
+    tsdb.append('up', { job: 'shop/portal', pod: 'portal-b' }, T(i), i < 5 ? 1 : 0);
+    tsdb.append('http_requests_total', { job: 'shop/portal', pod: 'portal-a', code: '200' }, T(i), i * 600);
+    tsdb.append('http_requests_total', { job: 'shop/portal', pod: 'portal-a', code: '500' }, T(i), i * 6);
+  }
+  return tsdb;
+}
+
+describe('时序库', () => {
+  it('同名不同标签是两条序列', () => {
+    const tsdb = bench();
+    expect(tsdb.select('up')).toHaveLength(2);
+    expect(tsdb.select('up', [{ label: 'pod', op: '=', value: 'portal-a' }])).toHaveLength(1);
+  });
+
+  it('正则匹配是完全匹配，不是搜索', () => {
+    const tsdb = new Tsdb();
+    tsdb.append('x', { code: '500' }, 0, 1);
+    tsdb.append('x', { code: '1500' }, 0, 1);
+    expect(tsdb.select('x', [{ label: 'code', op: '=~', value: '5..' }])).toHaveLength(1);
+  });
+
+  it('超过回看窗口就当作没有数据 —— 目标挂了指标还会留五分钟', () => {
+    const tsdb = new Tsdb();
+    tsdb.append('up', { pod: 'a' }, T(0), 1);
+    const series = tsdb.select('up')[0];
+    expect(tsdb.valueAt(series, T(4))).toBe(1);
+    expect(tsdb.valueAt(series, T(6))).toBeUndefined();
+  });
+});
+
+describe('PromQL', () => {
+  const at = T(10);
+
+  it('选择器加比较：== 是过滤，不是求布尔值', () => {
+    const tsdb = bench();
+    const down = evaluate(tsdb, 'up{job="shop/portal"} == 0', at);
+    expect(down).toHaveLength(1);
+    expect(down[0].labels.pod).toBe('portal-b');
+    expect(down[0].value).toBe(0);
+  });
+
+  it('rate 算的是每秒增量', () => {
+    const tsdb = bench();
+    // 每分钟涨 600，也就是每秒 10
+    const result = evaluate(tsdb, 'rate(http_requests_total{code="200"}[5m])', at);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBeCloseTo(10, 5);
+  });
+
+  it('counter 归零会被补偿，不会算出负数或假尖峰', () => {
+    expect(counterDelta([{ at: 0, value: 100 }, { at: 1, value: 120 }])).toBe(20);
+    // 中途重启：120 -> 5，涨的是 5 不是 -115
+    expect(counterDelta([{ at: 0, value: 120 }, { at: 1, value: 5 }, { at: 2, value: 25 }])).toBe(25);
+  });
+
+  it('sum by 分组', () => {
+    const tsdb = bench();
+    const result = evaluate(tsdb, 'sum(rate(http_requests_total[5m])) by (job)', at);
+    expect(result).toHaveLength(1);
+    expect(result[0].labels).toEqual({ job: 'shop/portal' });
+    expect(result[0].value).toBeCloseTo(10.1, 5);
+  });
+
+  it('错误率：两个向量相除，按标签配对', () => {
+    const tsdb = bench();
+    const result = evaluate(
+      tsdb,
+      'sum(rate(http_requests_total{code="500"}[5m])) by (job)'
+      + ' / sum(rate(http_requests_total[5m])) by (job)',
+      at
+    );
+    expect(result[0].value).toBeCloseTo(0.1 / 10.1, 6);
+  });
+
+  it('两边标签配不上时返回空 —— 这是 a / b 突然没结果的原因', () => {
+    const tsdb = new Tsdb();
+    tsdb.append('a', { job: 'x', pod: 'p' }, 0, 10);
+    tsdb.append('b', { job: 'x' }, 0, 2);
+    expect(evaluate(tsdb, 'a / b', 0)).toEqual([]);
+    // 先聚合掉多余的标签就能配上了
+    expect(evaluate(tsdb, 'sum(a) by (job) / sum(b) by (job)', 0)[0].value).toBe(5);
+  });
+
+  it('标量参与运算时广播', () => {
+    const tsdb = bench();
+    const result = evaluate(tsdb, '100 * rate(http_requests_total{code="500"}[5m])', at);
+    expect(result[0].value).toBeCloseTo(10, 5);
+  });
+
+  it('range vector 不能直接当结果', () => {
+    const tsdb = bench();
+    expect(() => evaluate(tsdb, 'http_requests_total[5m]', at)).toThrow(PromqlError);
+  });
+
+  it('语法错会抛，而不是静默返回空', () => {
+    const tsdb = bench();
+    expect(() => evaluate(tsdb, 'sum(rate(x[5m])', at)).toThrow(PromqlError);
+    expect(() => evaluate(tsdb, 'rate(up)', at)).toThrow(/带时间窗/);
+  });
+
+  it('时间单位', () => {
+    expect(parseDuration('30s')).toBe(30_000);
+    expect(parseDuration('5m')).toBe(300_000);
+    expect(parseDuration('2h')).toBe(7_200_000);
+    expect(() => parseDuration('5 minutes')).toThrow(PromqlError);
+  });
+});
+
+describe('采集目标', () => {
+  const monitor = (labels: Record<string, string>, selector: Record<string, string>): KubeObject => ({
+    apiVersion: 'monitoring.coreos.com/v1', kind: 'ServiceMonitor',
+    metadata: { name: 'portal', namespace: 'shop', labels },
+    spec: { selector: { matchLabels: selector } },
+  } as never);
+
+  const view = (options: { monitorLabels?: Record<string, string>; promSelector?: Record<string, string> } = {}) => ({
+    serviceMonitors: () => [monitor(options.monitorLabels ?? {}, { app: 'portal' })],
+    services: () => [{
+      apiVersion: 'v1', kind: 'Service',
+      metadata: { name: 'portal', namespace: 'shop', labels: { app: 'portal' } },
+      spec: { selector: { app: 'portal' } },
+    } as never],
+    pods: () => [
+      { apiVersion: 'v1', kind: 'Pod', metadata: { name: 'portal-a', namespace: 'shop', labels: { app: 'portal' } }, status: { phase: 'Running' } } as never,
+      { apiVersion: 'v1', kind: 'Pod', metadata: { name: 'portal-b', namespace: 'shop', labels: { app: 'portal' } }, status: { phase: 'Pending' } } as never,
+      { apiVersion: 'v1', kind: 'Pod', metadata: { name: 'other', namespace: 'shop', labels: { app: 'other' } }, status: { phase: 'Running' } } as never,
+    ],
+    namespaces: () => [{ apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'shop' } } as never],
+    prometheus: () => (options.promSelector
+      ? ({
+          apiVersion: 'monitoring.coreos.com/v1', kind: 'Prometheus',
+          metadata: { name: 'main', namespace: 'monitoring' },
+          spec: { serviceMonitorSelector: { matchLabels: options.promSelector } },
+        } as never)
+      : undefined),
+  });
+
+  it('按 Service 的标签选中，再按 Service 的 selector 找 Pod', () => {
+    const targets = targetsOf(view());
+    expect(targets.map((target) => target.pod)).toEqual(['portal-a', 'portal-b']);
+    expect(targets.find((target) => target.pod === 'portal-b')!.up).toBe(false);
+  });
+
+  it('Prometheus 自己的 serviceMonitorSelector 对不上就一条都采不到', () => {
+    expect(targetsOf(view({ promSelector: { release: 'kube-prom' } }))).toEqual([]);
+    expect(targetsOf(view({
+      promSelector: { release: 'kube-prom' },
+      monitorLabels: { release: 'kube-prom' },
+    }))).toHaveLength(2);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 集群里                                                              */
+/* ------------------------------------------------------------------ */
+
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import { SCRAPE_INTERVAL_MS } from '../../src/lib/opslab/observability';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+const PROM_IMAGE = 'quay.io/prometheus/prometheus:v3.9.1';
+const APP = 'harbor.corp.internal/team/portal:1.4.0';
+
+const PROM_PLATFORM = [
+  { apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'monitoring' }, status: { phase: 'Active' } },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'prometheus', namespace: 'monitoring', labels: { 'app.kubernetes.io/name': 'prometheus' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'prometheus' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'prometheus' } },
+        spec: { containers: [{ name: 'prometheus', image: PROM_IMAGE, ports: [{ containerPort: 9090 }] }] },
+      },
+    },
+  },
+];
+
+const WORKLOAD = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'portal', namespace: 'shop' },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'portal' } },
+      template: {
+        metadata: { labels: { app: 'portal' } },
+        spec: { containers: [{ name: 'web', image: APP, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'portal', namespace: 'shop', labels: { app: 'portal' } },
+    spec: { selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+];
+
+const MONITOR = {
+  apiVersion: 'monitoring.coreos.com/v1', kind: 'ServiceMonitor',
+  metadata: { name: 'portal', namespace: 'shop' },
+  spec: { selector: { matchLabels: { app: 'portal' } }, endpoints: [{ port: 'http' }] },
+};
+
+function spec(objects: unknown[], errorRatio = 0): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'shop'],
+    images: {
+      [APP]: { pullMs: 10, startupMs: 10, readyAfterMs: 10, requestsPerSecond: 20, errorRatio },
+      [PROM_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(objects: unknown[], errorRatio = 0) {
+  const world = await createOpsWorld({ world: spec(objects, errorRatio) });
+  // 采几轮，攒出足够算 rate 的点
+  await world.cluster.advanceBy(SCRAPE_INTERVAL_MS * 30);
+  return world;
+}
+
+describe('集群里的监控', () => {
+  it('采得到 up，也采得到应用指标', async () => {
+    const w = await build([...PROM_PLATFORM, ...WORKLOAD, MONITOR]);
+    const tsdb = w.cluster.prometheus!.tsdb;
+    expect(tsdb.select('up')).toHaveLength(2);
+    expect(tsdb.select('http_requests_total').length).toBeGreaterThan(0);
+  });
+
+  it('没有 ServiceMonitor 就什么都采不到', async () => {
+    const w = await build([...PROM_PLATFORM, ...WORKLOAD]);
+    expect(w.cluster.prometheus!.tsdb.select('up')).toHaveLength(0);
+  });
+
+  it('Prometheus 挂了，采集就停了 —— 而 ServiceMonitor 还在', async () => {
+    const w = await build([...WORKLOAD, MONITOR]);
+    expect(w.cluster.prometheus!.tsdb.size).toBe(0);
+    const monitors = w.cluster.registry.list(
+      w.cluster.scheme.mustGet({ group: 'monitoring.coreos.com', version: 'v1', resource: 'servicemonitors' }),
+      { namespace: 'shop' }
+    );
+    expect(monitors.items).toHaveLength(1);
+  });
+
+  it('告警按 PromQL 求值，for 没满只是 pending', async () => {
+    const rule = {
+      apiVersion: 'monitoring.coreos.com/v1', kind: 'PrometheusRule',
+      metadata: { name: 'portal', namespace: 'shop' },
+      spec: {
+        groups: [{
+          name: 'portal',
+          rules: [{
+            alert: 'HighErrorRate',
+            expr: 'sum(rate(http_requests_total{code="500"}[5m])) by (job)'
+              + ' / sum(rate(http_requests_total[5m])) by (job) > 0.05',
+            for: '10m',
+            labels: { severity: 'critical' },
+            annotations: { summary: '{{ $labels.job }} 的错误率是 {{ $value }}' },
+          }],
+        }],
+      },
+    };
+    const w = await build([...PROM_PLATFORM, ...WORKLOAD, MONITOR, rule], 0.2);
+    const prometheus = w.cluster.prometheus!;
+
+    // 才采了几分钟，for 还没满
+    const pending = [...prometheus.alerts.values()];
+    expect(pending.length).toBeGreaterThan(0);
+    expect(pending[0].state).toBe('pending');
+    expect(prometheus.firing()).toHaveLength(0);
+
+    await w.cluster.advanceBy(11 * 60_000);
+    const firing = prometheus.firing();
+    expect(firing).toHaveLength(1);
+    expect(firing[0].name).toBe('HighErrorRate');
+    expect(firing[0].labels.severity).toBe('critical');
+    expect(firing[0].annotations.summary).toContain('shop/portal 的错误率是');
+  });
+
+  it('错误率正常时一条都不触发', async () => {
+    const rule = {
+      apiVersion: 'monitoring.coreos.com/v1', kind: 'PrometheusRule',
+      metadata: { name: 'portal', namespace: 'shop' },
+      spec: {
+        groups: [{
+          name: 'portal',
+          rules: [{ alert: 'HighErrorRate', expr: 'sum(rate(http_requests_total{code="500"}[5m])) > 1' }],
+        }],
+      },
+    };
+    const w = await build([...PROM_PLATFORM, ...WORKLOAD, MONITOR, rule], 0);
+    await w.cluster.advanceBy(20 * 60_000);
+    expect(w.cluster.prometheus!.firing()).toHaveLength(0);
+  });
+
+  it('promtool 查得到，地址不对时说 no such host', async () => {
+    const w = await build([...PROM_PLATFORM, ...WORKLOAD, MONITOR]);
+    const good = await w.run("promtool query instant http://localhost:9090 'up'");
+    expect(good.code).toBe(0);
+    expect(good.stdout).toContain('job="shop/portal"');
+
+    const bad = await w.run("promtool query instant http://nope:9090 'up'");
+    expect(bad.code).toBe(1);
+    expect(bad.stderr).toContain('no such host');
+  });
+
+  it('promtool check rules 认得出写错的表达式', async () => {
+    const w = await build([...PROM_PLATFORM]);
+    w.machine.vfs.writeFile('/root/rules.yaml', [
+      'groups:',
+      '- name: portal',
+      '  rules:',
+      '  - alert: Broken',
+      '    expr: sum(rate(x[5m])',
+      '  - alert: Fine',
+      '    expr: up == 0',
+      '',
+    ].join('\n'));
+    const result = await w.run('promtool check rules /root/rules.yaml');
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('Broken');
+    expect(result.stdout).toContain('could not parse expression');
+  });
+});


### PR DESCRIPTION
## 场景

财务报了个说不清的问题：「报表有时候打不开，刷新几次又好了」。这一关的价值在于它**落在监控的盲区之间**：

- 进程活着 → 探针全过
- 5xx 是正常返回不是崩溃 → 日志里没有堆栈
- Pod 没重启 → `kubectl get` 一片绿

三个最常用的信号全说「没事」，只有比例型指标看得出来。

## 做进来的

**时序库**（`observability/tsdb.ts`）。一条序列 = 指标名 + 标签。回看窗口五分钟 —— 目标挂了它的指标还会在图上留一会儿，这是真行为，也是排查时容易被误导的地方。

**PromQL 求值器**（自己写的 tokenizer + 递归下降解析 + 求值）。覆盖到「写得出一条真告警」为止：四种标签匹配（`=~` 是**完全匹配**不是搜索）、`rate` / `increase`（counter 归零会补偿，否则重启后冒假尖峰）、`sum/avg/min/max/count` 加 `by`/`without`、向量间按标签配对（配不上就返回空，这正是 `a / b` 突然没结果的原因）、比较运算是**过滤**不是求布尔值。

**采集**。ServiceMonitor 的两层选择器都要过：Prometheus 实例的 `serviceMonitorSelector` 选 ServiceMonitor，ServiceMonitor 的 `selector` 选 Service。少配一层一条指标都采不到，而两个对象看起来都完全正常。

**告警**。`for` 是唯一的状态：条件持续成立才从 pending 转 firing，一旦不成立整条清掉，抖动不累积。

**promtool**。`query instant` 与 `check rules`。apiserver 收 PrometheusRule 时**不校验表达式**，写错了照样收下 —— check rules 补的就是这个洞。

## 被测试纠正一次

`rate` 的分母一开始写的是窗口长度，算出 8 而不是 10。正确的是除**实际覆盖的时间**（窗口里第一个点到最后一个点），除窗口长度会系统性低估（两端各差半个采集间隔）。真 Prometheus 靠外推到窗口边缘达到同样效果。

## 顺带

给门户的 Service 补了 `app` 标签。ServiceMonitor 是按 Service 的 **metadata.labels** 选的，只在 `spec.selector` 里写 app 选不中它 —— 这个坑差点变成关卡本身的 bug。

## 验证

22 个可观测性用例 + 3 个关卡反向验证。全量 1534 个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)