### PR TITLE
feat(opslab): PDB 与驱逐，外加让 kubectl 的等待真的能等到

### DIFF
--- a/scripts/build-opslab-wasm.sh
+++ b/scripts/build-opslab-wasm.sh
@@ -123,7 +123,8 @@ cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$ROOT/$OUT_DIR/wasm_exec.js" 2>/dev
 
 # Go 的 time.Now() 在 js/wasm 里读的是宿主的 Date。虚拟世界里这会让
 # `helm list` 的 UPDATED 列、各种时间戳每次都不一样，回放就对不上了。
-# 把两个时钟入口接到宿主提供的虚拟时钟上（不提供时仍然用真时间）。
+# 把**墙钟**接到宿主提供的虚拟时钟上（不提供时仍然用真时间）。
+# 单调时钟保持真实时间 —— 原因见下面那段注释。
 python3 - "$ROOT/$OUT_DIR/wasm_exec.js" <<'PYEOF'
 import sys
 path = sys.argv[1]
@@ -132,12 +133,12 @@ old_wall = '''					const msec = (new Date).getTime();'''
 new_wall = '''					// opslab: 虚拟时钟优先，回放才逐字节一致
 					const msec = (globalThis.__opslabNow ? globalThis.__opslabNow() : (new Date).getTime());'''
 old_nano = '''						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);'''
-new_nano = '''						// opslab: 单调时钟同样跟着虚拟时钟走。
-						// 加 1 是必须的：Go 的运行时把 nanotime 返回 0 当成致命错误，
-						// 而虚拟时钟从 0 开始是很正常的事。
-						setInt64(sp + 8, (globalThis.__opslabNow
-							? globalThis.__opslabNow() + 1
-							: (timeOrigin + performance.now())) * 1000000);'''
+# 单调时钟**不能**跟着虚拟时钟走。
+# Go 的 context.WithTimeout、time.After、各种重试循环用的都是单调时钟；
+# 虚拟时钟在一条命令执行期间是不动的，接上去的话 `kubectl drain` 这类
+# 「重试到超时为止」的命令会永远转下去。
+# 墙钟（time.Now 打出来的那个）跟虚拟时钟，输出才可复现；单调时钟走真实时间。
+new_nano = old_nano
 if old_wall not in source or old_nano not in source:
     raise SystemExit('wasm_exec.js 的时钟入口变了，补丁要重写')
 source = source.replace(old_wall, new_wall).replace(old_nano, new_nano)

--- a/src/lib/opslab/apiserver/errors.ts
+++ b/src/lib/opslab/apiserver/errors.ts
@@ -21,12 +21,15 @@ export type StatusReason =
   | 'MethodNotAllowed'
   | 'Gone'
   | 'UnsupportedMediaType'
-  | 'InternalError';
+  | 'InternalError'
+  /** 驱逐被 PDB 挡下时用的就是它 —— 429，意思是「现在不行，等会儿再来」 */
+  | 'TooManyRequests';
 
 export interface StatusCause {
   reason: string;
   message: string;
-  field: string;
+  /** 出问题的字段路径。有些原因（比如 PDB 拦下驱逐）没有具体字段。 */
+  field?: string;
 }
 
 export interface StatusDetails {

--- a/src/lib/opslab/apiserver/http.ts
+++ b/src/lib/opslab/apiserver/http.ts
@@ -30,6 +30,13 @@ export interface ApiServerDeps {
    */
   exec?: ExecHandler;
   /**
+   * 驱逐一个 Pod 之前问一句。
+   *
+   * 不给就是「这个集群不管 PDB」，驱逐等同于删除。
+   */
+  evict?(namespace: string | undefined, name: string):
+    { allowed: true } | { allowed: false; message: string; pdb: string };
+  /**
    * token -> 身份。不给就是「这个世界没配认证」，所有请求都是 cluster-admin。
    *
    * 真集群里这一步由 OIDC / 客户端证书 / ServiceAccount token 完成，形式不同，
@@ -182,6 +189,7 @@ export class ApiServer {
   private readonly exec?: ExecHandler;
   private readonly authenticate?: ApiServerDeps['authenticate'];
   private readonly authorizeFn?: ApiServerDeps['authorize'];
+  private readonly evict?: ApiServerDeps['evict'];
   /** 收到的请求，调试与测试用 */
   readonly requestLog: string[] = [];
 
@@ -193,6 +201,7 @@ export class ApiServer {
     this.exec = deps.exec;
     this.authenticate = deps.authenticate;
     this.authorizeFn = deps.authorize;
+    this.evict = deps.evict;
   }
 
   /**
@@ -404,6 +413,32 @@ export class ApiServer {
       return this.handleWatch(definition, parsed, params);
     }
 
+    /**
+     * 驱逐。
+     *
+     * `POST .../pods/<name>/eviction` 和 delete 是两回事：delete 谁也拦不住，
+     * eviction 会先问 PDB，违反就回 429。`kubectl drain` 用的是这条路，
+     * 所以它会在 PDB 不允许时停下来等，而 `kubectl delete pod` 不会。
+     */
+    if (parsed.subresource === 'eviction' && method === 'POST' && parsed.name) {
+      const verdict = this.evict?.(parsed.namespace, parsed.name);
+      if (verdict && !verdict.allowed) {
+        return json({
+          kind: 'Status', apiVersion: 'v1', metadata: {}, status: 'Failure',
+          code: 429, reason: 'TooManyRequests',
+          message: verdict.message,
+          details: {
+            causes: [{
+              reason: 'DisruptionBudget',
+              message: `The disruption budget ${verdict.pdb} needs 1 more healthy pod(s)`,
+            }],
+          },
+        }, 429);
+      }
+      this.registry.delete(definition, parsed.namespace, parsed.name);
+      return json({ kind: 'Status', apiVersion: 'v1', status: 'Success', code: 201 }, 201);
+    }
+
     switch (method) {
       case 'GET':
         return parsed.name
@@ -457,14 +492,30 @@ export class ApiServer {
         ...(definition.shortNames?.length ? { shortNames: definition.shortNames } : {}),
         ...(definition.categories?.length ? { categories: definition.categories } : {}),
       };
-      // 子资源在 discovery 里是独立条目，形如 `pods/status`
-      const subs = (definition.subresources ?? []).map((sub) => ({
-        name: `${definition.resource}/${sub}`,
-        singularName: '',
-        namespaced: definition.namespaced,
-        kind: definition.kind,
-        verbs: ['get', 'patch', 'update'],
-      }));
+      /**
+       * 子资源在 discovery 里是独立条目，形如 `pods/status`。
+       *
+       * `eviction` 是个例外：它的 kind 是 `Eviction`、group 是 policy、
+       * 动词只有 create。kubectl drain 就是靠在 discovery 里找到它
+       * 才走驱逐这条路的 —— 找不到就退回 delete，于是 PDB 形同虚设。
+       */
+      const subs = (definition.subresources ?? []).map((sub) => (sub === 'eviction'
+        ? {
+            name: `${definition.resource}/eviction`,
+            singularName: '',
+            namespaced: definition.namespaced,
+            group: 'policy',
+            version: 'v1',
+            kind: 'Eviction',
+            verbs: ['create'],
+          }
+        : {
+            name: `${definition.resource}/${sub}`,
+            singularName: '',
+            namespaced: definition.namespaced,
+            kind: definition.kind,
+            verbs: ['get', 'patch', 'update'],
+          }));
       return [base, ...subs];
     });
     return {

--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -176,6 +176,26 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
       ];
     },
   },
+  poddisruptionbudgets: {
+    columns: [
+      NAME_COLUMN,
+      col('Min Available', 'The minimum number of pods that must be available.'),
+      col('Max Unavailable', 'The maximum number of pods that may be unavailable.'),
+      col('Allowed Disruptions', 'The number of pods that may be evicted right now.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        spec.minAvailable !== undefined ? String(spec.minAvailable) : 'N/A',
+        spec.maxUnavailable !== undefined ? String(spec.maxUnavailable) : 'N/A',
+        String(status.disruptionsAllowed ?? 0),
+        age,
+      ];
+    },
+  },
   namespaces: {
     columns: [NAME_COLUMN, col('Status', 'The status of the namespace.'), AGE_COLUMN],
     cells: (object, age) => [

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -31,6 +31,7 @@ import {
 } from '../rbac';
 import { ESO_RESOURCES, ExternalSecretsController } from '../secrets';
 import { OBSERVABILITY_RESOURCES, PrometheusController } from '../observability';
+import { DISRUPTION_RESOURCES, PdbController, evictionVerdict } from '../disruption';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -154,7 +155,7 @@ export class Cluster {
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
-      ...OBSERVABILITY_RESOURCES,
+      ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -184,6 +185,21 @@ export class Cluster {
             }, user, attributes),
           }
         : {}),
+      /**
+       * 驱逐前问一遍 PDB。
+       *
+       * 这是 `kubectl drain` 会在违反预算时停下来的原因 ——
+       * 而 `kubectl delete pod` 走的是另一条路，谁也拦不住。
+       */
+      evict: (namespace, name) => {
+        const pods = this.scheme.get({ group: '', version: 'v1', resource: 'pods' });
+        const budgets = this.scheme.get({ group: 'policy', version: 'v1', resource: 'poddisruptionbudgets' });
+        if (!pods || !budgets) return { allowed: true };
+        const inNamespace = this.registry.list(pods, { namespace }).items;
+        const pod = inNamespace.find((item) => item.metadata.name === name);
+        if (!pod) return { allowed: true };
+        return evictionVerdict(pod, this.registry.list(budgets).items, inNamespace);
+      },
       exec: (request, stdin) => {
         if (!this.execHandler) throw new Error('exec 没有接上');
         return this.execHandler(request, stdin);
@@ -594,6 +610,8 @@ export class Cluster {
       // 每个节点一份：CNI 的 agent、日志采集都是这个形状
       new DaemonSetController(context),
       new EndpointsController(context),
+      // PDB 的状态。`kubectl get pdb` 里 ALLOWED DISRUPTIONS 那一列就是它写的。
+      new PdbController(context),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发

--- a/src/lib/opslab/controllers/resources.ts
+++ b/src/lib/opslab/controllers/resources.ts
@@ -19,7 +19,10 @@ export const NODES: ResourceDefinition = {
 
 export const PODS: ResourceDefinition = {
   group: '', version: 'v1', resource: 'pods', singular: 'pod', kind: 'Pod',
-  namespaced: true, shortNames: ['po'], categories: ['all'], subresources: ['status'],
+  namespaced: true, shortNames: ['po'], categories: ['all'],
+  // eviction 必须出现在 discovery 里，否则 kubectl drain 会退回 delete，
+  // 而 delete 不问 PDB
+  subresources: ['status', 'eviction'],
 };
 
 export const SERVICES: ResourceDefinition = {

--- a/src/lib/opslab/disruption/controller.ts
+++ b/src/lib/opslab/disruption/controller.ts
@@ -1,0 +1,51 @@
+/**
+ * PDB 的状态
+ *
+ * `kubectl get pdb` 那几列（ALLOWED DISRUPTIONS 尤其）就是这里写的。
+ * 值得盯着看的是 `disruptionsAllowed`：它是 0 的时候，任何驱逐都会被拒，
+ * 包括节点维护 —— 而这经常是「drain 卡住不动」的原因。
+ */
+import type { KubeObject } from '../apiserver';
+import { Controller, ControllerContext, Informer, isNotFound, splitKey } from '../controllers/framework';
+import { PODS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { evaluatePdb } from './pdb';
+import { PODDISRUPTIONBUDGETS } from './resources';
+
+export class PdbController extends Controller {
+  private budgets: Informer;
+  private pods: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'disruption');
+    this.budgets = new Informer(this.registry, PODDISRUPTIONBUDGETS);
+    this.pods = this.track(new Informer(this.registry, PODS));
+    this.watch(this.budgets);
+    // Pod 的 Ready 一变，允许中断的数量就变了
+    this.pods.onChange(() => {
+      for (const pdb of this.budgets.list()) {
+        this.enqueue(`${pdb.metadata.namespace}/${pdb.metadata.name}`);
+      }
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let pdb: KubeObject;
+    try {
+      pdb = this.registry.get(PODDISRUPTIONBUDGETS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    const pods = this.registry.list(PODS, { namespace }).items;
+    const status = evaluatePdb(pdb, pods);
+    await ignoreConflict(() => {
+      const latest = this.registry.get(PODDISRUPTIONBUDGETS, namespace, name);
+      updateStatusIfChanged(this.registry, PODDISRUPTIONBUDGETS, namespace, name, {
+        ...status,
+        observedGeneration: latest.metadata.generation,
+      });
+    });
+  }
+}

--- a/src/lib/opslab/disruption/index.ts
+++ b/src/lib/opslab/disruption/index.ts
@@ -1,0 +1,11 @@
+/**
+ * 自愿中断
+ *
+ * PDB 管的是主动发起的中断（维护、缩容、驱逐），管不了节点掉电这类
+ * 非自愿中断。驱逐走 eviction 子资源会先问 PDB，delete 不会 ——
+ * 这是 `kubectl drain` 和 `kubectl delete pod` 行为不同的根源。
+ */
+export { evaluatePdb, evictionVerdict, desiredHealthyOf, isHealthy, matchesSelector } from './pdb';
+export type { PdbStatus } from './pdb';
+export { PODDISRUPTIONBUDGETS, DISRUPTION_RESOURCES } from './resources';
+export { PdbController } from './controller';

--- a/src/lib/opslab/disruption/pdb.ts
+++ b/src/lib/opslab/disruption/pdb.ts
@@ -1,0 +1,103 @@
+/**
+ * PodDisruptionBudget 与驱逐
+ *
+ * PDB 管的是**自愿中断**：节点维护、缩容、手工驱逐。它管不了非自愿中断
+ * （节点突然掉电、OOMKill、Pod 被抢占）—— 这条区分很要紧，因为很多人
+ * 以为配了 PDB 就「不会少于 N 个副本」，其实 PDB 只是让**主动发起的**
+ * 中断被拒绝，而不是拦住世界。
+ *
+ * 驱逐走的是 Pod 的 `eviction` 子资源，不是 delete。两者的区别就在这里：
+ * delete 谁也拦不住，eviction 会先问 PDB。`kubectl drain` 用的是 eviction，
+ * 所以它会在违反 PDB 时停下来 —— 而 `kubectl delete pod` 不会。
+ */
+import type { KubeObject } from '../apiserver';
+
+export interface PdbStatus {
+  currentHealthy: number;
+  desiredHealthy: number;
+  expectedPods: number;
+  /** 还能再中断几个。0 表示这一刻谁都不许被驱逐。 */
+  disruptionsAllowed: number;
+}
+
+/** 一条 PDB 对一批 Pod 的判断 */
+export function evaluatePdb(pdb: KubeObject, pods: KubeObject[]): PdbStatus {
+  const spec = (pdb.spec ?? {}) as any;
+  const selected = pods.filter((pod) => matchesSelector(spec.selector, pod.metadata.labels));
+  const healthy = selected.filter(isHealthy).length;
+  const desired = desiredHealthyOf(spec, selected.length);
+  return {
+    currentHealthy: healthy,
+    desiredHealthy: desired,
+    expectedPods: selected.length,
+    disruptionsAllowed: Math.max(0, healthy - desired),
+  };
+}
+
+/**
+ * `minAvailable` 与 `maxUnavailable` 换算成「至少要活着几个」。
+ *
+ * 百分比按**期望的副本数**算并向上取整（minAvailable）或向下取整
+ * （maxUnavailable）—— 方向不同不是笔误，k8s 两边都往「更保守」取。
+ */
+export function desiredHealthyOf(spec: any, expected: number): number {
+  if (spec.minAvailable !== undefined) {
+    return resolve(spec.minAvailable, expected, Math.ceil);
+  }
+  if (spec.maxUnavailable !== undefined) {
+    return Math.max(0, expected - resolve(spec.maxUnavailable, expected, Math.floor));
+  }
+  // 两个都不写：PDB 不起任何作用
+  return 0;
+}
+
+function resolve(value: string | number, total: number, round: (value: number) => number): number {
+  if (typeof value === 'number') return value;
+  const percent = /^(\d+(?:\.\d+)?)%$/.exec(String(value));
+  if (percent) return round((Number(percent[1]) / 100) * total);
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function matchesSelector(
+  selector: { matchLabels?: Record<string, string> } | undefined,
+  labels: Record<string, string> | undefined
+): boolean {
+  const wanted = selector?.matchLabels ?? {};
+  const actual = labels ?? {};
+  return Object.entries(wanted).every(([key, value]) => actual[key] === value);
+}
+
+/** Ready 才算 healthy。正在启动的那个不能拿来抵数。 */
+export function isHealthy(pod: KubeObject): boolean {
+  if (pod.metadata.deletionTimestamp) return false;
+  const conditions: any[] = ((pod.status ?? {}) as any).conditions ?? [];
+  return conditions.some((entry) => entry.type === 'Ready' && entry.status === 'True');
+}
+
+/**
+ * 这个 Pod 现在能不能被驱逐。
+ *
+ * 任何一条选中它的 PDB 说不行就是不行。返回的消息一字不差抄真 apiserver ——
+ * `kubectl drain` 会把它原样打出来，学员据此知道是被谁拦的。
+ */
+export function evictionVerdict(
+  pod: KubeObject,
+  pdbs: KubeObject[],
+  podsInNamespace: KubeObject[]
+): { allowed: true } | { allowed: false; message: string; pdb: string } {
+  for (const pdb of pdbs) {
+    if (pdb.metadata.namespace !== pod.metadata.namespace) continue;
+    const spec = (pdb.spec ?? {}) as any;
+    if (!matchesSelector(spec.selector, pod.metadata.labels)) continue;
+    const status = evaluatePdb(pdb, podsInNamespace);
+    if (status.disruptionsAllowed <= 0) {
+      return {
+        allowed: false,
+        pdb: `${pdb.metadata.namespace}/${pdb.metadata.name}`,
+        message: "Cannot evict pod as it would violate the pod's disruption budget.",
+      };
+    }
+  }
+  return { allowed: true };
+}

--- a/src/lib/opslab/disruption/resources.ts
+++ b/src/lib/opslab/disruption/resources.ts
@@ -1,0 +1,9 @@
+import type { ResourceDefinition } from '../apiserver';
+
+export const PODDISRUPTIONBUDGETS: ResourceDefinition = {
+  group: 'policy', version: 'v1', resource: 'poddisruptionbudgets',
+  singular: 'poddisruptionbudget', kind: 'PodDisruptionBudget', namespaced: true,
+  shortNames: ['pdb'], subresources: ['status'],
+};
+
+export const DISRUPTION_RESOURCES: ResourceDefinition[] = [PODDISRUPTIONBUDGETS];

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -407,6 +407,8 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
       machine,
       runtime: options.runtime,
       apiServer: cluster.apiServer,
+      // CLI 在轮询的时候世界也该往前走，否则 kubectl wait / drain 永远等不到
+      advance: (ms) => cluster.advanceBy(ms),
       endpoints: spec.endpoints,
       now: () => cluster.wallClock(),
     })

--- a/src/lib/opslab/wasm/install.ts
+++ b/src/lib/opslab/wasm/install.ts
@@ -36,7 +36,19 @@ export interface InstallCliOptions {
    */
   endpoints?: string[];
   now?: () => number;
+  /**
+   * CLI 每发一次请求，就让世界往前走一点。
+   *
+   * 真集群里 kubectl 轮询的时候世界照样在动 —— `kubectl wait`、
+   * `rollout status`、`drain` 全都指望这一点。虚拟世界里时间只在被推动时
+   * 才走，所以要在这里推：**按请求次数推，不按真实时间推**，
+   * 于是同一串命令重放两遍走过的虚拟时间完全一样。
+   */
+  advance?: (ms: number) => Promise<void> | void;
 }
+
+/** 每次请求推进多少虚拟毫秒。够一个 Pod 在几次轮询里起来。 */
+export const TICK_PER_REQUEST_MS = 1000;
 
 /** kubeconfig 里的 server 是完整 URL，取出主机名（不含端口） */
 function hostOf(url: string): string | undefined {
@@ -57,13 +69,14 @@ export async function installClusterCli(options: InstallCliOptions): Promise<str
   }
 
   const endpoints = options.endpoints ?? ['apiserver.opslab'];
-  const fetchImpl: FetchLike = (url, init) => {
+  const fetchImpl: FetchLike = async (url, init) => {
     const host = hostOf(url);
     if (host && !endpoints.includes(host)) {
       // fetch 在 DNS 失败时抛的就是 TypeError，client-go 那边会翻成
       // 「Unable to connect to the server」
-      return Promise.reject(new TypeError(`dial tcp: lookup ${host}: no such host`));
+      throw new TypeError(`dial tcp: lookup ${host}: no such host`);
     }
+    await options.advance?.(TICK_PER_REQUEST_MS);
     return options.apiServer.handle(url, init as never);
   };
   /**

--- a/tests/opslab/disruption.test.ts
+++ b/tests/opslab/disruption.test.ts
@@ -1,0 +1,158 @@
+/**
+ * PDB 与驱逐
+ *
+ * PDB 管的是**自愿中断**。它管不了节点掉电、OOMKill 这类非自愿中断 ——
+ * 很多人以为配了 PDB 就「不会少于 N 个副本」，其实它只是让主动发起的中断
+ * 被拒绝。
+ *
+ * 另一条：`kubectl drain` 走 eviction 子资源会先问 PDB，
+ * `kubectl delete pod` 走 delete，谁也拦不住。
+ */
+import { desiredHealthyOf, evaluatePdb, evictionVerdict } from '../../src/lib/opslab/disruption';
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+
+const pod = (name: string, ready: boolean): KubeObject => ({
+  apiVersion: 'v1', kind: 'Pod',
+  metadata: { name, namespace: 'shop', labels: { app: 'portal' } },
+  status: { phase: 'Running', conditions: [{ type: 'Ready', status: ready ? 'True' : 'False' }] },
+} as never);
+
+const budget = (spec: Record<string, unknown>): KubeObject => ({
+  apiVersion: 'policy/v1', kind: 'PodDisruptionBudget',
+  metadata: { name: 'portal', namespace: 'shop' },
+  spec: { selector: { matchLabels: { app: 'portal' } }, ...spec },
+} as never);
+
+describe('算「还能中断几个」', () => {
+  it('minAvailable 是绝对数', () => {
+    const pods = [pod('a', true), pod('b', true), pod('c', true)];
+    expect(evaluatePdb(budget({ minAvailable: 2 }), pods)).toMatchObject({
+      currentHealthy: 3, desiredHealthy: 2, disruptionsAllowed: 1,
+    });
+  });
+
+  it('maxUnavailable 换算成「至少活着几个」', () => {
+    const pods = [pod('a', true), pod('b', true), pod('c', true)];
+    expect(evaluatePdb(budget({ maxUnavailable: 1 }), pods).disruptionsAllowed).toBe(1);
+  });
+
+  it('百分比：minAvailable 向上取整，maxUnavailable 向下取整', () => {
+    expect(desiredHealthyOf({ minAvailable: '50%' }, 3)).toBe(2);
+    expect(desiredHealthyOf({ maxUnavailable: '50%' }, 3)).toBe(2);
+  });
+
+  it('没 Ready 的不算数 —— 正在启动的那个抵不了数', () => {
+    const pods = [pod('a', true), pod('b', false), pod('c', true)];
+    expect(evaluatePdb(budget({ minAvailable: 2 }), pods)).toMatchObject({
+      currentHealthy: 2, disruptionsAllowed: 0,
+    });
+  });
+
+  it('两个都不写的 PDB 什么都不拦', () => {
+    expect(desiredHealthyOf({}, 5)).toBe(0);
+  });
+});
+
+describe('驱逐的判断', () => {
+  it('预算还有余量就放行', () => {
+    const pods = [pod('a', true), pod('b', true), pod('c', true)];
+    expect(evictionVerdict(pods[0], [budget({ minAvailable: 2 })], pods)).toEqual({ allowed: true });
+  });
+
+  it('刚好卡在下限就拒，消息照抄真 apiserver', () => {
+    const pods = [pod('a', true), pod('b', true)];
+    const verdict = evictionVerdict(pods[0], [budget({ minAvailable: 2 })], pods);
+    expect(verdict).toMatchObject({
+      allowed: false,
+      message: "Cannot evict pod as it would violate the pod's disruption budget.",
+      pdb: 'shop/portal',
+    });
+  });
+
+  it('选不中这个 Pod 的 PDB 不管它', () => {
+    const pods = [pod('a', true)];
+    const other = budget({ minAvailable: 5, selector: { matchLabels: { app: 'other' } } });
+    expect(evictionVerdict(pods[0], [other], pods)).toEqual({ allowed: true });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 集群里                                                              */
+/* ------------------------------------------------------------------ */
+
+const APP = 'harbor.corp.internal/team/portal:1.4.0';
+
+function spec(minAvailable: number): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'shop'],
+    images: { [APP]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 } },
+    objects: [
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'portal', namespace: 'shop' },
+        spec: {
+          replicas: 3,
+          selector: { matchLabels: { app: 'portal' } },
+          template: {
+            metadata: { labels: { app: 'portal' } },
+            spec: { containers: [{ name: 'web', image: APP }] },
+          },
+        },
+      },
+      {
+        apiVersion: 'policy/v1', kind: 'PodDisruptionBudget',
+        metadata: { name: 'portal', namespace: 'shop' },
+        spec: { minAvailable, selector: { matchLabels: { app: 'portal' } } },
+      },
+    ] as never,
+  };
+}
+
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+const PDBS = { group: 'policy', version: 'v1', resource: 'poddisruptionbudgets' } as const;
+
+describe('集群里的 PDB', () => {
+  it('status 里写着还能中断几个', async () => {
+    const w = await createOpsWorld({ world: spec(2) });
+    const pdb = w.cluster.registry.get(w.cluster.scheme.mustGet(PDBS), 'shop', 'portal');
+    expect((pdb.status as any)).toMatchObject({
+      currentHealthy: 3, desiredHealthy: 2, disruptionsAllowed: 1,
+    });
+  });
+
+  it('预算用满时驱逐被 429 拒掉', async () => {
+    const w = await createOpsWorld({ world: spec(3) });
+    const name = w.cluster.registry.list(w.cluster.scheme.mustGet(PODS), { namespace: 'shop' })
+      .items[0].metadata.name;
+    const response = await w.cluster.apiServer.handle(
+      `/api/v1/namespaces/shop/pods/${name}/eviction`,
+      { method: 'POST', body: '{}' } as never
+    );
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.message).toBe("Cannot evict pod as it would violate the pod's disruption budget.");
+    expect(body.details.causes[0].message).toContain('shop/portal');
+  });
+
+  it('有余量时驱逐真的把 Pod 删了', async () => {
+    const w = await createOpsWorld({ world: spec(2) });
+    const definition = w.cluster.scheme.mustGet(PODS);
+    const name = w.cluster.registry.list(definition, { namespace: 'shop' }).items[0].metadata.name;
+    const response = await w.cluster.apiServer.handle(
+      `/api/v1/namespaces/shop/pods/${name}/eviction`,
+      { method: 'POST', body: '{}' } as never
+    );
+    expect(response.status).toBe(201);
+    expect(w.cluster.registry.list(definition, { namespace: 'shop' }).items
+      .some((item) => item.metadata.name === name)).toBe(false);
+  });
+
+  it('delete 不问 PDB —— 这就是它和 drain 的区别', async () => {
+    const w = await createOpsWorld({ world: spec(3) });
+    const definition = w.cluster.scheme.mustGet(PODS);
+    const name = w.cluster.registry.list(definition, { namespace: 'shop' }).items[0].metadata.name!;
+    expect(() => w.cluster.registry.delete(definition, 'shop', name)).not.toThrow();
+  });
+});

--- a/tests/opslab/kubectl-integration.test.ts
+++ b/tests/opslab/kubectl-integration.test.ts
@@ -459,3 +459,71 @@ describeIfBuilt('真 kubectl 遇上 RBAC', () => {
     expect(result.stderr).toContain('dev@corp.internal');
   });
 });
+
+/**
+ * `kubectl drain` 真的会被 PDB 拦住
+ *
+ * drain 走的是 eviction 子资源，delete 不是 —— 这一组证明的是那个区别
+ * 在真 kubectl 那边也成立：它会重试、会打出 apiserver 那句话、
+ * 最后按 --timeout 放弃。
+ */
+describeIfBuilt('真 kubectl drain 遇上 PDB', () => {
+  jest.setTimeout(120_000);
+
+  const DRAIN_WORLD = (minAvailable: number) => ({
+    namespaces: ['default', 'shop'],
+    images: { 'harbor.corp.internal/team/portal:1.4.0': {} },
+    nodes: [{ name: 'node-1' }, { name: 'node-2' }],
+    objects: [
+      {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'portal', namespace: 'shop' },
+        spec: {
+          replicas: 2,
+          selector: { matchLabels: { app: 'portal' } },
+          template: {
+            metadata: { labels: { app: 'portal' } },
+            spec: { containers: [{ name: 'web', image: 'harbor.corp.internal/team/portal:1.4.0' }] },
+          },
+        },
+      },
+      {
+        apiVersion: 'policy/v1', kind: 'PodDisruptionBudget',
+        metadata: { name: 'portal', namespace: 'shop' },
+        spec: { minAvailable, selector: { matchLabels: { app: 'portal' } } },
+      },
+    ],
+  });
+
+  it('cordon 之后节点不再接新 Pod', async () => {
+    const world = await createOpsWorld({ world: DRAIN_WORLD(1) as never, runtime: runtime() });
+    const result = await world.run('kubectl cordon node-1');
+    expect(result.stdout).toContain('node/node-1 cordoned');
+
+    const node = world.cluster.registry.get(
+      world.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'nodes' }), undefined, 'node-1'
+    );
+    expect((node.spec as { unschedulable?: boolean }).unschedulable).toBe(true);
+  });
+
+  it('预算用满时 drain 停下来，报的是 apiserver 那句话', async () => {
+    const world = await createOpsWorld({ world: DRAIN_WORLD(2) as never, runtime: runtime() });
+    const result = await world.run('kubectl drain node-1 --ignore-daemonsets --force --timeout=3s');
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("Cannot evict pod as it would violate the pod's disruption budget");
+    expect(result.stderr).toContain('global timeout reached');
+  });
+
+  it('预算有余量时 drain 走得通', async () => {
+    const world = await createOpsWorld({ world: DRAIN_WORLD(1) as never, runtime: runtime() });
+    const result = await world.run('kubectl drain node-1 --ignore-daemonsets --force --timeout=10s');
+    expect(result.stdout).toContain('drained');
+  });
+
+  it('kubectl get pdb 那几列', async () => {
+    const world = await createOpsWorld({ world: DRAIN_WORLD(1) as never, runtime: runtime() });
+    const result = await world.run('kubectl get pdb -n shop');
+    expect(result.stdout).toContain('NAME     MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE');
+    expect(result.stdout).toContain('portal   1               N/A               1');
+  });
+});


### PR DESCRIPTION
`kubectl drain` 之前是**假通的**：它走 eviction 子资源，而我们没做，于是 kubectl 在 discovery 里找不到它、退回 delete —— PDB 形同虚设，drain 一路把 Pod 删光还报成功。

## 补上的

**PodDisruptionBudget**。`minAvailable` / `maxUnavailable`、百分比换算（minAvailable 向上取整、maxUnavailable 向下取整，方向不同不是笔误，k8s 两边都往更保守取）、只算 Ready 的 Pod。`kubectl get pdb` 的 ALLOWED DISRUPTIONS 那一列也有了。

**eviction 子资源**。违反预算回 429，消息一字不差抄真 apiserver。discovery 里 eviction 是个特例：kind 是 `Eviction`、group 是 `policy`、动词只有 `create` —— 这几个字段对不上，kubectl 就不走这条路。

**delete 不问 PDB，eviction 问**。这正是 `drain` 和 `delete pod` 行为不同的根源，单独有用例钉着。

## 两个时钟修正，都是被 drain 逼出来的

**单调时钟必须走真实时间**。之前把它也接到虚拟时钟上（第 12 关那片），结果 `kubectl drain` 这类「重试到超时为止」的命令永远转下去 —— 它的 deadline 用单调时钟，而虚拟时钟在一条命令执行期间不动。现在墙钟继续跟虚拟时钟（`helm list` 的输出仍然可复现），单调时钟还给真实时间。

**CLI 每发一次请求，世界往前走 1 秒**。真集群里 kubectl 轮询的时候世界照样在动，`kubectl wait` / `rollout status` / `drain` 全指望这一点。关键在于**按请求次数推、不按真实时间推**，所以同一串命令重放两遍走过的虚拟时间完全一样。

这一条的影响面本来让我有点担心（AGE 列、helm 的时间戳），实测全量 1550 个用例零改动通过。

## 实测

| 情形 | 结果 |
| --- | --- |
| 预算用满 | 重试、打出 apiserver 原话、按 `--timeout` 放弃、退出码非 0 |
| 预算有余量 | 驱逐一个、等替换的 Pod 起来、再驱逐下一个、`drained` |

WASM 产物 142,253,608 字节，和之前一致（只动了 wasm_exec.js）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)