### PR TITLE
feat(opslab): 第 20 关 渐进式发布与 PDB

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -40,6 +40,9 @@ const ESO_IMAGE = 'ghcr.io/external-secrets/external-secrets:v0.21.0';
 const PROMETHEUS_IMAGE = 'quay.io/prometheus/prometheus:v3.9.1';
 // 报表服务的一个坏版本：五分之一的请求 500
 const REPORTS_IMAGE_BAD = 'harbor.corp.internal/team/reports:2.3.0';
+const ROLLOUTS_IMAGE = 'quay.io/argoproj/argo-rollouts:v1.8.3';
+// 门户的一个坏版本：进程活着、探针照过，六成请求 500
+const PORTAL_IMAGE_BAD = 'harbor.corp.internal/team/portal:1.6.0';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -192,6 +195,23 @@ const WORLD = {
     [KYVERNO_IMAGE]: { pullMs: 500, startupMs: 700, readyAfterMs: 300, listens: [9443] },
     [ESO_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300, listens: [8080] },
     [PROMETHEUS_IMAGE]: { pullMs: 600, startupMs: 900, readyAfterMs: 400, listens: [9090] },
+    [ROLLOUTS_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300 },
+    // 门户的下一个版本，好的那个
+    [PORTAL_IMAGE_NEXT]: {
+      pullMs: 400, startupMs: 600, readyAfterMs: 300,
+      listens: [8080], routes: { '/': 200, '/healthz': 200, '/readyz': 200 },
+      memoryUsage: '180Mi', handlesSigterm: true, runAsUser: 10001,
+      requestsPerSecond: 40,
+    },
+    [PORTAL_IMAGE_BAD]: {
+      pullMs: 400, startupMs: 600, readyAfterMs: 300,
+      listens: [8080], routes: { '/': 200, '/healthz': 200, '/readyz': 200 },
+      memoryUsage: '180Mi', handlesSigterm: true, runAsUser: 10001,
+      // 坏在这里：探针全过，但六成请求 500。
+      // 注意分析看到的是**混进去之后**的整体错误率：金丝雀只占一小部分流量，
+      // 六成打到分母上摊完只剩不到一成 —— 这就是判据要写得比直觉严的原因。
+      requestsPerSecond: 40, errorRatio: 0.6,
+    },
     [REPORTS_IMAGE_BAD]: {
       pullMs: 500, startupMs: 800, readyAfterMs: 200,
       listens: [9090], routes: { '/healthz': 200, '/metrics': 200 },
@@ -6213,6 +6233,422 @@ const stage19 = {
   ),
 };
 
+
+/* ------------------------------------------------------------------ */
+/* 第 20 关                                                            */
+/* ------------------------------------------------------------------ */
+
+const ROLLOUTS_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'argo-rollouts', namespace: 'argocd',
+      labels: { 'app.kubernetes.io/name': 'argo-rollouts' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'argo-rollouts' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'argo-rollouts' } },
+        spec: { containers: [{ name: 'controller', image: ROLLOUTS_IMAGE }] },
+      },
+    },
+  },
+];
+
+/** 第 19 关配好的监控，这一关还要用 —— 金丝雀的判据就是它 */
+const MONITORING_CARRIED = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'prometheus', namespace: 'monitoring',
+      labels: { 'app.kubernetes.io/name': 'prometheus' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'prometheus' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'prometheus' } },
+        spec: { containers: [{ name: 'prometheus', image: PROMETHEUS_IMAGE, ports: [{ containerPort: 9090 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'monitoring.coreos.com/v1', kind: 'ServiceMonitor',
+    metadata: { name: 'portal', namespace: 'payments', labels: { release: 'kube-prom' } },
+    spec: { selector: { matchLabels: { app: 'portal' } }, endpoints: [{ port: 'http' }] },
+  },
+];
+
+/** 门户已经从 Deployment 换成 Rollout 了，跑的是好版本 */
+const PORTAL_ROLLOUT = [
+  {
+    apiVersion: 'argoproj.io/v1alpha1', kind: 'Rollout',
+    metadata: { name: 'portal', namespace: 'payments' },
+    spec: {
+      replicas: 4,
+      selector: { matchLabels: { app: 'portal' } },
+      strategy: { canary: { steps: [{ setWeight: 25 }, { setWeight: 100 }] } },
+      template: {
+        metadata: { labels: { app: 'portal' } },
+        spec: { containers: [{ name: 'web', image: PORTAL_IMAGE, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'portal', namespace: 'payments', labels: { app: 'portal' } },
+    spec: { clusterIP: '10.96.1.10', selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+  },
+];
+
+const CANARY_STARTER = code`
+  # 现在这个 Rollout 只会「分两步把新版本铺满」，不看任何指标。
+  # 换句话说：坏版本照样能一路铺到 100%。
+  #
+  # 要加的是：分析这一步，以及它依据的判据。
+  apiVersion: argoproj.io/v1alpha1
+  kind: Rollout
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    replicas: 4
+    selector:
+      matchLabels:
+        app: portal
+    strategy:
+      canary:
+        steps:
+        - setWeight: 25
+        - setWeight: 100
+    template:
+      metadata:
+        labels:
+          app: portal
+      spec:
+        containers:
+        - name: web
+          image: ${PORTAL_IMAGE}
+          ports:
+          - containerPort: 8080
+`;
+
+const CANARY_REFERENCE = code`
+  apiVersion: argoproj.io/v1alpha1
+  kind: AnalysisTemplate
+  metadata:
+    name: error-rate
+    namespace: payments
+  spec:
+    metrics:
+    - name: error-rate
+      # 先等两分钟再量：金丝雀刚起来时采样点还不够两个，算出来的是稳定版的错误率
+      initialDelay: 2m
+      successCondition: result < 0.05
+      provider:
+        prometheus:
+          address: http://prometheus.monitoring.svc:9090
+          query: |
+            sum(rate(http_requests_total{code=~"5.."}[5m]))
+            / sum(rate(http_requests_total[5m]))
+  ---
+  apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    minAvailable: 3
+    selector:
+      matchLabels:
+        app: portal
+  ---
+  apiVersion: argoproj.io/v1alpha1
+  kind: Rollout
+  metadata:
+    name: portal
+    namespace: payments
+  spec:
+    replicas: 4
+    selector:
+      matchLabels:
+        app: portal
+    strategy:
+      canary:
+        steps:
+        - setWeight: 25
+        - analysis:
+            templates:
+            - templateName: error-rate
+        - setWeight: 50
+        - analysis:
+            templates:
+            - templateName: error-rate
+        - setWeight: 100
+    template:
+      metadata:
+        labels:
+          app: portal
+      spec:
+        containers:
+        - name: web
+          image: ${PORTAL_IMAGE}
+          ports:
+          - containerPort: 8080
+`;
+
+const stage20 = {
+  id: 'progressive-delivery',
+  title: t('让坏版本自己退回去', 'Make a Bad Release Roll Itself Back'),
+  goal: t(
+    code`
+      上周那个坏版本是人肉发现的：先有人报「打不开」，再有人去看指标，
+      最后手工回滚 —— 中间隔了四十分钟。
+
+      门户已经从 Deployment 换成了 \`Rollout\`，但它现在的策略只是
+      「分两步把新版本铺满」，不看任何指标。也就是说坏版本照样能一路铺到 100%。
+
+      要做两件事：把**分析**加进发布流程，让坏版本自己退回去；
+      以及给门户配一个 \`PodDisruptionBudget\`，让节点维护不至于把服务打空。
+
+      ## 通关标准
+
+      1. 发一个好版本（\`${PORTAL_IMAGE_NEXT}\`）能走完全流程，最终 Healthy；
+      2. 发一个坏版本（\`${PORTAL_IMAGE_BAD}\`）会在分析那一步被拦下，
+         **自动回到稳定版**，而且稳定版的副本数是满的；
+      3. 判据用的是**错误率**（rate 相除），不是裸计数；
+      4. 有 PDB，且 \`kubectl drain\` 一个节点时不会把可用副本打到 3 以下。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl apply -f /root/infra/canary.yaml
+      kubectl get rollout portal -n payments
+      kubectl describe rollout portal -n payments
+      kubectl get analysisrun -n payments
+      kubectl get pdb -n payments
+      kubectl drain node-a1 --ignore-daemonsets --delete-emptydir-data --timeout=60s
+      \`\`\`
+    `,
+    code`
+      Last week's bad release was found by a human: someone reported "it will not
+      load", someone else looked at the metrics, and someone rolled it back by hand.
+      Forty minutes in total.
+
+      The portal is already a \`Rollout\` rather than a Deployment, but its current
+      strategy only spreads the new version in two steps without looking at any
+      metric. A bad version therefore reaches 100% just as happily as a good one.
+
+      Two things to do: add **analysis** to the release process so a bad version rolls
+      itself back, and give the portal a \`PodDisruptionBudget\` so node maintenance
+      cannot drain the service to nothing.
+
+      ## Done when
+
+      1. a good release (\`${PORTAL_IMAGE_NEXT}\`) completes and ends Healthy;
+      2. a bad release (\`${PORTAL_IMAGE_BAD}\`) is stopped at the analysis step and
+         **rolls back to the stable version** with a full replica count;
+      3. the criterion is an **error rate** (one rate divided by another), not a raw
+         counter;
+      4. a PDB exists, and draining a node cannot take available replicas below three.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl apply -f /root/infra/canary.yaml
+      kubectl get rollout portal -n payments
+      kubectl describe rollout portal -n payments
+      kubectl get analysisrun -n payments
+      kubectl get pdb -n payments
+      kubectl drain node-a1 --ignore-daemonsets --delete-emptydir-data --timeout=60s
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('好版本走得完', 'A good release completes'),
+    t('坏版本自己退回去', 'A bad release rolls itself back'),
+    t('节点维护打不空服务', 'Node maintenance cannot empty the service'),
+  ],
+  hints: [
+    t(
+      '金丝雀的判据和告警的判据应该是同一个表达式。不然会出现「发布时看着没事、上线后告警响」—— 那说明你在两个地方定义了两套「什么叫坏」。',
+      'The canary criterion and the alerting criterion should be the same expression. Otherwise you get "looked fine during rollout, paged after", which means you defined "bad" twice, differently.'
+    ),
+    t(
+      '\`initialDelay\` 不是可选的。金丝雀刚起来的那几秒，它的计数器还是 0、采样点还不够两个，这时候算出来的是**稳定版的**错误率 —— 看着很好，然后就把坏版本放行了。',
+      '`initialDelay` is not optional. In the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the **stable** version error rate. It looks great, and the bad version sails through.'
+    ),
+    t(
+      '中止不是「停在原地」，是回到稳定版：金丝雀缩到 0、稳定版拉回满副本。判定会检查回滚之后副本数是满的 —— 停在半路的服务只有一半容量。',
+      'Aborting does not mean stopping in place, it means returning to stable: the canary scales to zero and stable goes back to full. The grader checks the replica count after rollback, because a rollout stopped halfway leaves half the capacity.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '判据写成 \`sum(rate(http_requests_total{code=~"5.."}[5m])) > 0\`。任何一个 5xx 都会让发布失败 —— 而真实系统永远有零星的 5xx，于是没有任何版本发得出去，最后大家把分析这一步删了。判据要用**比例**。',
+      'Writing the criterion as `sum(rate(http_requests_total{code=~"5.."}[5m])) > 0`. Any single 5xx fails the release, real systems always have a few, so nothing ever ships and eventually somebody deletes the analysis step. Use a **ratio**.'
+    ),
+    t(
+      '配了 PDB 就以为副本数不会掉下来。PDB 只管**自愿中断**（维护、缩容、驱逐），管不了节点掉电、OOMKill、被抢占。它保证的是「不会被人为打空」，不是「永远有 N 个」。',
+      'Assuming a PDB keeps the replica count up. It governs **voluntary** disruptions (maintenance, scale-down, eviction) and does nothing about a node losing power, an OOMKill, or preemption. It guarantees nobody drains you to zero, not that N always exist.'
+    ),
+    t(
+      '\`minAvailable\` 写成和副本数一样大。这样任何驱逐都会被拒，节点永远维护不了 —— drain 会一直重试到超时。留出至少一个可中断的名额，否则 PDB 从「保护」变成「阻塞」。',
+      'Setting `minAvailable` equal to the replica count. Every eviction is then refused and the node can never be maintained: drain retries until it times out. Leave at least one disruptable slot, or the PDB stops protecting and starts blocking.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM,
+      ...ROLLOUTS_PLATFORM, ...MONITORING_CARRIED,
+      ...PORTAL_ROLLOUT, PORTAL_ROUTE,
+    ],
+    files: { '/root/infra/canary.yaml': CANARY_STARTER },
+    referenceFiles: { '/root/infra/canary.yaml': CANARY_REFERENCE },
+    referenceCommands: [
+      'kubectl apply -f /root/infra/canary.yaml',
+    ],
+  },
+  specs: [
+    spec('progressive-delivery.spec.ts', code`
+      import { advance, get, list, sh } from '@ops/lab';
+
+      const ROLLOUT = () => get('Rollout', 'portal', 'payments');
+
+      const release = async (image) => {
+        await sh(
+          "kubectl patch rollout portal -n payments --type=json -p "
+          + "'[{\\"op\\":\\"replace\\",\\"path\\":\\"/spec/template/spec/containers/0/image\\","
+          + "\\"value\\":\\"" + image + "\\"}]'"
+        );
+        await advance(1200000);
+      };
+
+      describe('渐进式发布', () => {
+        it('判据是错误率，不是裸计数', () => {
+          const templates = list('AnalysisTemplate', { namespace: 'payments' });
+          expect(templates.length).toBeGreaterThan(0);
+          const queries = templates.flatMap((template) => (template.spec.metrics || [])
+            .map((metric) => (metric.provider || {}).prometheus?.query || ''));
+          expect(queries.some((query) => /rate\\(/.test(query) && query.includes('/'))).toBe(true);
+        });
+
+        it('发布流程里有分析这一步', () => {
+          const steps = ROLLOUT().spec.strategy.canary.steps || [];
+          expect(steps.some((step) => step.analysis)).toBe(true);
+        });
+
+        it('好版本走得完', async () => {
+          await release('${PORTAL_IMAGE_NEXT}');
+          const status = ROLLOUT().status;
+          expect(status.phase).toBe('Healthy');
+          expect(status.currentPodHash).toBeTruthy();
+
+          const running = list('Pod', { namespace: 'payments' })
+            .filter((pod) => (pod.metadata.labels || {}).app === 'portal')
+            .filter((pod) => pod.status.phase === 'Running');
+          expect(running.length).toBe(4);
+          for (const pod of running) {
+            expect(pod.spec.containers[0].image).toBe('${PORTAL_IMAGE_NEXT}');
+          }
+        });
+
+        it('坏版本被拦下并自动回到稳定版', async () => {
+          await release('${PORTAL_IMAGE_BAD}');
+          const status = ROLLOUT().status;
+          expect(status.abort).toBe(true);
+          expect(status.phase).toBe('Degraded');
+
+          const running = list('Pod', { namespace: 'payments' })
+            .filter((pod) => (pod.metadata.labels || {}).app === 'portal')
+            .filter((pod) => pod.status.phase === 'Running');
+          // 回滚之后容量是满的，不是停在半路
+          expect(running.length).toBe(4);
+          for (const pod of running) {
+            expect(pod.spec.containers[0].image).not.toBe('${PORTAL_IMAGE_BAD}');
+          }
+        });
+
+        it('分析的结果查得到，看得出是哪条没过', () => {
+          const runs = list('AnalysisRun', { namespace: 'payments' });
+          const failed = runs.filter((run) => run.status.phase === 'Failed');
+          expect(failed.length).toBeGreaterThan(0);
+          expect(failed[0].status.metricResults[0].value).toBeGreaterThan(0.05);
+        });
+
+        it('PDB 留了可中断的名额，不至于把维护堵死', () => {
+          const pdbs = list('PodDisruptionBudget', { namespace: 'payments' });
+          expect(pdbs.length).toBeGreaterThan(0);
+          const pdb = pdbs[0];
+          expect(pdb.status.disruptionsAllowed).toBeGreaterThan(0);
+          expect(pdb.status.desiredHealthy).toBeGreaterThanOrEqual(3);
+        });
+
+        it('节点维护打不空服务', async () => {
+          const before = list('Pod', { namespace: 'payments' })
+            .filter((pod) => (pod.metadata.labels || {}).app === 'portal').length;
+          expect(before).toBe(4);
+
+          await sh('kubectl drain node-a1 --ignore-daemonsets --force --timeout=30s');
+          await advance(300000);
+
+          const healthy = list('Pod', { namespace: 'payments' })
+            .filter((pod) => (pod.metadata.labels || {}).app === 'portal')
+            .filter((pod) => pod.status.phase === 'Running').length;
+          expect(healthy).toBeGreaterThanOrEqual(3);
+        });
+      });
+    `),
+  ],
+  focus: ['resilience', 'observability'],
+  extension: t(
+    code`
+      渐进式发布真正改变的是**谁来发现问题**。滚动更新只回答「新的 Pod 起来了
+      没有」，而「起来了」和「好用」是两回事 —— 上周那个坏版本探针全过、
+      日志干净、Pod 全 Running，只是大半请求返回 500。把判据写进发布流程之后，
+      发现问题的是系统而不是用户，而且回滚是自动的。
+
+      有一条很容易被忽略：**金丝雀的判据应该和告警的判据是同一个表达式**。
+      两边写不一样的话，会出现「发布时看着没事、上线后告警响」，
+      或者反过来「发布一直失败但线上其实好好的」。同一个定义只写一遍，
+      放在 AnalysisTemplate 里、告警规则里引用同一段 PromQL。
+
+      PDB 那一半也值得多说一句。它管的是**自愿中断**，也就是有人主动发起的
+      那些：节点维护、缩容、驱逐。节点掉电、OOMKill、被抢占都不在它管辖之内。
+      所以 PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」——
+      后者要靠副本数、反亲和、跨可用区分布一起来做。而且 \`minAvailable\`
+      写得太紧会让节点永远维护不了：留不出可中断的名额，drain 就只能重试到
+      超时，最后有人一怒之下 \`--disable-eviction\`，PDB 白配。
+    `,
+    code`
+      What progressive delivery really changes is **who finds the problem**. A rolling
+      update only answers "did the new pods start", and starting is not the same as
+      working: last week's bad version passed every probe, logged nothing unusual, and
+      showed all pods Running while returning 500 to three requests in ten. Once the
+      criterion is part of the release process, the system finds the problem instead of
+      a user, and the rollback is automatic.
+
+      One thing that is easy to overlook: **the canary criterion and the alerting
+      criterion should be the same expression**. Write them differently and you get
+      either "looked fine during rollout, paged afterwards" or "releases keep failing
+      while production is perfectly healthy". Define "bad" once, and reference the same
+      PromQL from the AnalysisTemplate and the alerting rule.
+
+      The PDB half deserves a note too. It governs **voluntary** disruptions, the ones
+      somebody initiates: node maintenance, scale-down, eviction. A node losing power,
+      an OOMKill, or preemption are all outside its remit. So a PDB guarantees nobody
+      drains you to zero, not that N replicas always exist; that needs replica counts,
+      anti-affinity, and zone spread together. And a \`minAvailable\` set too tightly
+      makes nodes impossible to maintain: with no disruptable slot, drain retries until
+      it times out, and eventually somebody reaches for \`--disable-eviction\` and the
+      PDB may as well not exist.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -6258,6 +6694,6 @@ module.exports = {
   stages: [
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
-    stage13, stage14, stage15, stage16, stage17, stage18, stage19,
+    stage13, stage14, stage15, stage16, stage17, stage18, stage19, stage20,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5745,6 +5745,46 @@
               9090
             ]
           },
+          "quay.io/argoproj/argo-rollouts:v1.8.3": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300
+          },
+          "harbor.corp.internal/team/portal:1.5.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
+            ],
+            "routes": {
+              "/": 200,
+              "/healthz": 200,
+              "/readyz": 200
+            },
+            "memoryUsage": "180Mi",
+            "handlesSigterm": true,
+            "runAsUser": 10001,
+            "requestsPerSecond": 40
+          },
+          "harbor.corp.internal/team/portal:1.6.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
+            ],
+            "routes": {
+              "/": 200,
+              "/healthz": 200,
+              "/readyz": 200
+            },
+            "memoryUsage": "180Mi",
+            "handlesSigterm": true,
+            "runAsUser": 10001,
+            "requestsPerSecond": 40,
+            "errorRatio": 0.6
+          },
           "harbor.corp.internal/team/reports:2.3.0": {
             "pullMs": 500,
             "startupMs": 800,
@@ -12255,6 +12295,534 @@
         "primer": {
           "zh": "`Prometheus` 是**拉**模型：它按配置找到一批目标，每隔一段时间（默认 15 秒）去每个目标的 `/metrics` 上采一次。数据模型很小：一条`序列`由指标名加一组标签唯一确定，值按时间点存。这个模型带来两个直接后果：两次采样之间发生的事看不见（只活十秒的 Pod 可能一个点都没有），以及目标挂掉之后它此前的指标还会在图上停留一个回看窗口（默认五分钟）才消失。\n\n在 Kubernetes 里，采集配置写成 `ServiceMonitor`：按标签选中一批 Service，去它们后面的 Pod 上拉。这里有个**两层选择器**的坑：Prometheus 实例自己有一个 `serviceMonitorSelector`，先由它选中 ServiceMonitor，再由 ServiceMonitor 的 `selector` 选中 Service。少配任何一层的结果都是一条指标都采不到，而两个对象看起来都完全正常。`up` 这个指标是 Prometheus 自己合成的，不来自目标，它是判断「采不采得到」的第一手依据。\n\n`PromQL` 里最要紧的区分是 `counter` 与 `gauge`。counter 只增不减（请求总数、错误总数），直接看它的值没有意义，要用 `rate(x[5m])` 求每秒增量；gauge 可以上下浮动（内存、队列长度），直接看瞬时值。错误率是**两个 rate 相除**：`sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`。两侧必须聚合到同一组标签上，否则配不上，表达式返回空，而返回空的告警永远不会触发，也不会报错。另外比较运算符是`过滤`不是求布尔值：`up == 0` 返回的是那些确实为 0 的序列。\n\n告警规则写在 `PrometheusRule` 里，`expr` 加 `for`。`for` 的意思是「条件持续成立这么久才真的告警」，中间处于 `pending`；条件一旦不成立就整条清掉，所以抖动不会累积。两条实践值得记：一是 apiserver 收 PrometheusRule 时**不校验表达式**，写错了照样收下，所以上线前要 `promtool check rules` 加 `promtool query instant` 各跑一遍；二是`告症状不告原因`：「错误率超过 5%」用户感受得到，「某个 Pod 内存高」不一定有影响，按原因告警的系统很快就没人看了。",
           "en": "`Prometheus` is a **pull** model: it discovers a set of targets and scrapes `/metrics` on each at a fixed interval, 15 seconds by default. The data model is tiny: a `series` is identified by a metric name plus a set of labels, with values stored per timestamp. Two consequences follow directly. Anything happening between scrapes is invisible, so a pod that lived ten seconds may contribute no samples at all. And after a target dies, its earlier metrics linger for one lookback window (five minutes by default) before disappearing.\n\nIn Kubernetes the scrape config is a `ServiceMonitor`: select Services by label, scrape the pods behind them. There is a **two-selector** trap here: the Prometheus instance has its own `serviceMonitorSelector` which picks ServiceMonitors, and each ServiceMonitor has a `selector` which picks Services. Missing either layer collects nothing, while both objects look perfectly healthy. The `up` metric is synthesised by Prometheus rather than coming from the target, which makes it the first thing to check when nothing appears.\n\nThe distinction that matters most in `PromQL` is `counter` versus `gauge`. A counter only increases (requests served, errors returned) and its raw value means little; use `rate(x[5m])` for per-second increase. A gauge moves both ways (memory, queue depth) and is read directly. An error rate is **one rate divided by another**: `sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`. Both sides must be aggregated to the same label set or they will not match and the expression returns nothing, and an alert whose expression returns nothing never fires and never complains. Note also that comparison operators `filter` rather than produce booleans: `up == 0` returns the series that really are zero.\n\nAlerting rules live in a `PrometheusRule` as an `expr` plus a `for`. The `for` means the condition must hold that long before the alert really fires, staying `pending` meanwhile, and the whole thing clears the moment the condition stops holding, so blips do not accumulate. Two practices worth keeping: the apiserver does **not validate expressions** when accepting a PrometheusRule, so run `promtool check rules` and `promtool query instant` before shipping; and `alert on symptoms, not causes`, because users feel \"error rate above 5%\" while \"this pod uses a lot of memory\" may mean nothing, and cause-based alerting quickly stops being read."
+        }
+      },
+      {
+        "id": "progressive-delivery",
+        "title": {
+          "zh": "让坏版本自己退回去",
+          "en": "Make a Bad Release Roll Itself Back"
+        },
+        "goal": {
+          "zh": "上周那个坏版本是人肉发现的：先有人报「打不开」，再有人去看指标，\n最后手工回滚 —— 中间隔了四十分钟。\n\n门户已经从 Deployment 换成了 `Rollout`，但它现在的策略只是\n「分两步把新版本铺满」，不看任何指标。也就是说坏版本照样能一路铺到 100%。\n\n要做两件事：把**分析**加进发布流程，让坏版本自己退回去；\n以及给门户配一个 `PodDisruptionBudget`，让节点维护不至于把服务打空。\n\n## 通关标准\n\n1. 发一个好版本（`harbor.corp.internal/team/portal:1.5.0`）能走完全流程，最终 Healthy；\n2. 发一个坏版本（`harbor.corp.internal/team/portal:1.6.0`）会在分析那一步被拦下，\n   **自动回到稳定版**，而且稳定版的副本数是满的；\n3. 判据用的是**错误率**（rate 相除），不是裸计数；\n4. 有 PDB，且 `kubectl drain` 一个节点时不会把可用副本打到 3 以下。\n\n## 会用到的命令\n\n```bash\nkubectl apply -f /root/infra/canary.yaml\nkubectl get rollout portal -n payments\nkubectl describe rollout portal -n payments\nkubectl get analysisrun -n payments\nkubectl get pdb -n payments\nkubectl drain node-a1 --ignore-daemonsets --delete-emptydir-data --timeout=60s\n```\n",
+          "en": "Last week's bad release was found by a human: someone reported \"it will not\nload\", someone else looked at the metrics, and someone rolled it back by hand.\nForty minutes in total.\n\nThe portal is already a `Rollout` rather than a Deployment, but its current\nstrategy only spreads the new version in two steps without looking at any\nmetric. A bad version therefore reaches 100% just as happily as a good one.\n\nTwo things to do: add **analysis** to the release process so a bad version rolls\nitself back, and give the portal a `PodDisruptionBudget` so node maintenance\ncannot drain the service to nothing.\n\n## Done when\n\n1. a good release (`harbor.corp.internal/team/portal:1.5.0`) completes and ends Healthy;\n2. a bad release (`harbor.corp.internal/team/portal:1.6.0`) is stopped at the analysis step and\n   **rolls back to the stable version** with a full replica count;\n3. the criterion is an **error rate** (one rate divided by another), not a raw\n   counter;\n4. a PDB exists, and draining a node cannot take available replicas below three.\n\n## Commands you will need\n\n```bash\nkubectl apply -f /root/infra/canary.yaml\nkubectl get rollout portal -n payments\nkubectl describe rollout portal -n payments\nkubectl get analysisrun -n payments\nkubectl get pdb -n payments\nkubectl drain node-a1 --ignore-daemonsets --delete-emptydir-data --timeout=60s\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "好版本走得完",
+            "en": "A good release completes"
+          },
+          {
+            "zh": "坏版本自己退回去",
+            "en": "A bad release rolls itself back"
+          },
+          {
+            "zh": "节点维护打不空服务",
+            "en": "Node maintenance cannot empty the service"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "金丝雀的判据和告警的判据应该是同一个表达式。不然会出现「发布时看着没事、上线后告警响」—— 那说明你在两个地方定义了两套「什么叫坏」。",
+            "en": "The canary criterion and the alerting criterion should be the same expression. Otherwise you get \"looked fine during rollout, paged after\", which means you defined \"bad\" twice, differently."
+          },
+          {
+            "zh": "`initialDelay` 不是可选的。金丝雀刚起来的那几秒，它的计数器还是 0、采样点还不够两个，这时候算出来的是**稳定版的**错误率 —— 看着很好，然后就把坏版本放行了。",
+            "en": "`initialDelay` is not optional. In the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the **stable** version error rate. It looks great, and the bad version sails through."
+          },
+          {
+            "zh": "中止不是「停在原地」，是回到稳定版：金丝雀缩到 0、稳定版拉回满副本。判定会检查回滚之后副本数是满的 —— 停在半路的服务只有一半容量。",
+            "en": "Aborting does not mean stopping in place, it means returning to stable: the canary scales to zero and stable goes back to full. The grader checks the replica count after rollback, because a rollout stopped halfway leaves half the capacity."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "判据写成 `sum(rate(http_requests_total{code=~\"5..\"}[5m])) > 0`。任何一个 5xx 都会让发布失败 —— 而真实系统永远有零星的 5xx，于是没有任何版本发得出去，最后大家把分析这一步删了。判据要用**比例**。",
+            "en": "Writing the criterion as `sum(rate(http_requests_total{code=~\"5..\"}[5m])) > 0`. Any single 5xx fails the release, real systems always have a few, so nothing ever ships and eventually somebody deletes the analysis step. Use a **ratio**."
+          },
+          {
+            "zh": "配了 PDB 就以为副本数不会掉下来。PDB 只管**自愿中断**（维护、缩容、驱逐），管不了节点掉电、OOMKill、被抢占。它保证的是「不会被人为打空」，不是「永远有 N 个」。",
+            "en": "Assuming a PDB keeps the replica count up. It governs **voluntary** disruptions (maintenance, scale-down, eviction) and does nothing about a node losing power, an OOMKill, or preemption. It guarantees nobody drains you to zero, not that N always exist."
+          },
+          {
+            "zh": "`minAvailable` 写成和副本数一样大。这样任何驱逐都会被拒，节点永远维护不了 —— drain 会一直重试到超时。留出至少一个可中断的名额，否则 PDB 从「保护」变成「阻塞」。",
+            "en": "Setting `minAvailable` equal to the replica count. Every eviction is then refused and the node can never be maintained: drain retries until it times out. Leave at least one disruptable slot, or the PDB stops protecting and starts blocking."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/canary.yaml": "# 现在这个 Rollout 只会「分两步把新版本铺满」，不看任何指标。\n# 换句话说：坏版本照样能一路铺到 100%。\n#\n# 要加的是：分析这一步，以及它依据的判据。\napiVersion: argoproj.io/v1alpha1\nkind: Rollout\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  replicas: 4\n  selector:\n    matchLabels:\n      app: portal\n  strategy:\n    canary:\n      steps:\n      - setWeight: 25\n      - setWeight: 100\n  template:\n    metadata:\n      labels:\n        app: portal\n    spec:\n      containers:\n      - name: web\n        image: harbor.corp.internal/team/portal:1.4.0\n        ports:\n        - containerPort: 8080\n"
+          },
+          "referenceFiles": {
+            "/root/infra/canary.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: AnalysisTemplate\nmetadata:\n  name: error-rate\n  namespace: payments\nspec:\n  metrics:\n  - name: error-rate\n    # 先等两分钟再量：金丝雀刚起来时采样点还不够两个，算出来的是稳定版的错误率\n    initialDelay: 2m\n    successCondition: result < 0.05\n    provider:\n      prometheus:\n        address: http://prometheus.monitoring.svc:9090\n        query: |\n          sum(rate(http_requests_total{code=~\"5..\"}[5m]))\n          / sum(rate(http_requests_total[5m]))\n---\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  minAvailable: 3\n  selector:\n    matchLabels:\n      app: portal\n---\napiVersion: argoproj.io/v1alpha1\nkind: Rollout\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  replicas: 4\n  selector:\n    matchLabels:\n      app: portal\n  strategy:\n    canary:\n      steps:\n      - setWeight: 25\n      - analysis:\n          templates:\n          - templateName: error-rate\n      - setWeight: 50\n      - analysis:\n          templates:\n          - templateName: error-rate\n      - setWeight: 100\n  template:\n    metadata:\n      labels:\n        app: portal\n    spec:\n      containers:\n      - name: web\n        image: harbor.corp.internal/team/portal:1.4.0\n        ports:\n        - containerPort: 8080\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/canary.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "progressive-delivery.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst ROLLOUT = () => get('Rollout', 'portal', 'payments');\n\nconst release = async (image) => {\n  await sh(\n    \"kubectl patch rollout portal -n payments --type=json -p \"\n    + \"'[{\\\"op\\\":\\\"replace\\\",\\\"path\\\":\\\"/spec/template/spec/containers/0/image\\\",\"\n    + \"\\\"value\\\":\\\"\" + image + \"\\\"}]'\"\n  );\n  await advance(1200000);\n};\n\ndescribe('渐进式发布', () => {\n  it('判据是错误率，不是裸计数', () => {\n    const templates = list('AnalysisTemplate', { namespace: 'payments' });\n    expect(templates.length).toBeGreaterThan(0);\n    const queries = templates.flatMap((template) => (template.spec.metrics || [])\n      .map((metric) => (metric.provider || {}).prometheus?.query || ''));\n    expect(queries.some((query) => /rate\\(/.test(query) && query.includes('/'))).toBe(true);\n  });\n\n  it('发布流程里有分析这一步', () => {\n    const steps = ROLLOUT().spec.strategy.canary.steps || [];\n    expect(steps.some((step) => step.analysis)).toBe(true);\n  });\n\n  it('好版本走得完', async () => {\n    await release('harbor.corp.internal/team/portal:1.5.0');\n    const status = ROLLOUT().status;\n    expect(status.phase).toBe('Healthy');\n    expect(status.currentPodHash).toBeTruthy();\n\n    const running = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal')\n      .filter((pod) => pod.status.phase === 'Running');\n    expect(running.length).toBe(4);\n    for (const pod of running) {\n      expect(pod.spec.containers[0].image).toBe('harbor.corp.internal/team/portal:1.5.0');\n    }\n  });\n\n  it('坏版本被拦下并自动回到稳定版', async () => {\n    await release('harbor.corp.internal/team/portal:1.6.0');\n    const status = ROLLOUT().status;\n    expect(status.abort).toBe(true);\n    expect(status.phase).toBe('Degraded');\n\n    const running = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal')\n      .filter((pod) => pod.status.phase === 'Running');\n    // 回滚之后容量是满的，不是停在半路\n    expect(running.length).toBe(4);\n    for (const pod of running) {\n      expect(pod.spec.containers[0].image).not.toBe('harbor.corp.internal/team/portal:1.6.0');\n    }\n  });\n\n  it('分析的结果查得到，看得出是哪条没过', () => {\n    const runs = list('AnalysisRun', { namespace: 'payments' });\n    const failed = runs.filter((run) => run.status.phase === 'Failed');\n    expect(failed.length).toBeGreaterThan(0);\n    expect(failed[0].status.metricResults[0].value).toBeGreaterThan(0.05);\n  });\n\n  it('PDB 留了可中断的名额，不至于把维护堵死', () => {\n    const pdbs = list('PodDisruptionBudget', { namespace: 'payments' });\n    expect(pdbs.length).toBeGreaterThan(0);\n    const pdb = pdbs[0];\n    expect(pdb.status.disruptionsAllowed).toBeGreaterThan(0);\n    expect(pdb.status.desiredHealthy).toBeGreaterThanOrEqual(3);\n  });\n\n  it('节点维护打不空服务', async () => {\n    const before = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal').length;\n    expect(before).toBe(4);\n\n    await sh('kubectl drain node-a1 --ignore-daemonsets --force --timeout=30s');\n    await advance(300000);\n\n    const healthy = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal')\n      .filter((pod) => pod.status.phase === 'Running').length;\n    expect(healthy).toBeGreaterThanOrEqual(3);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "resilience",
+          "observability"
+        ],
+        "extension": {
+          "zh": "渐进式发布真正改变的是**谁来发现问题**。滚动更新只回答「新的 Pod 起来了\n没有」，而「起来了」和「好用」是两回事 —— 上周那个坏版本探针全过、\n日志干净、Pod 全 Running，只是大半请求返回 500。把判据写进发布流程之后，\n发现问题的是系统而不是用户，而且回滚是自动的。\n\n有一条很容易被忽略：**金丝雀的判据应该和告警的判据是同一个表达式**。\n两边写不一样的话，会出现「发布时看着没事、上线后告警响」，\n或者反过来「发布一直失败但线上其实好好的」。同一个定义只写一遍，\n放在 AnalysisTemplate 里、告警规则里引用同一段 PromQL。\n\nPDB 那一半也值得多说一句。它管的是**自愿中断**，也就是有人主动发起的\n那些：节点维护、缩容、驱逐。节点掉电、OOMKill、被抢占都不在它管辖之内。\n所以 PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」——\n后者要靠副本数、反亲和、跨可用区分布一起来做。而且 `minAvailable`\n写得太紧会让节点永远维护不了：留不出可中断的名额，drain 就只能重试到\n超时，最后有人一怒之下 `--disable-eviction`，PDB 白配。\n",
+          "en": "What progressive delivery really changes is **who finds the problem**. A rolling\nupdate only answers \"did the new pods start\", and starting is not the same as\nworking: last week's bad version passed every probe, logged nothing unusual, and\nshowed all pods Running while returning 500 to three requests in ten. Once the\ncriterion is part of the release process, the system finds the problem instead of\na user, and the rollback is automatic.\n\nOne thing that is easy to overlook: **the canary criterion and the alerting\ncriterion should be the same expression**. Write them differently and you get\neither \"looked fine during rollout, paged afterwards\" or \"releases keep failing\nwhile production is perfectly healthy\". Define \"bad\" once, and reference the same\nPromQL from the AnalysisTemplate and the alerting rule.\n\nThe PDB half deserves a note too. It governs **voluntary** disruptions, the ones\nsomebody initiates: node maintenance, scale-down, eviction. A node losing power,\nan OOMKill, or preemption are all outside its remit. So a PDB guarantees nobody\ndrains you to zero, not that N replicas always exist; that needs replica counts,\nanti-affinity, and zone spread together. And a `minAvailable` set too tightly\nmakes nodes impossible to maintain: with no disruptable slot, drain retries until\nit times out, and eventually somebody reaches for `--disable-eviction` and the\nPDB may as well not exist.\n"
+        },
+        "primer": {
+          "zh": "Deployment 的滚动更新只回答一个问题：新的 Pod 起来了没有。而「起来了」和「好用」是两回事：一个进程活着、探针全过、日志干净，但大半请求返回 500 的版本，滚动更新会毫不犹豫地把它铺到 100%。`渐进式发布`补的就是这一段：把「什么叫好」写进发布流程本身。\n\n`Argo Rollouts` 用 `Rollout` 替代 Deployment（是替代不是补充，一个工作负载只能由其中之一管）。它多出来的是 `strategy.canary.steps`：一串按顺序执行的步骤。`setWeight` 调整金丝雀占多少副本，`pause` 停一下（带 `duration` 就是等那么久，不带就是无限期等人来 `promote`），`analysis` 起一次分析。控制器用 `status.currentStepIndex` 记着走到第几步，每步做完才往前挪一格。\n\n`AnalysisTemplate` 描述判据：一条 PromQL 加一个 `successCondition`（形如 `result < 0.05`）。任何一条不满足，整个发布`中止`。要特别注意中止的含义，它不是「停在原地」，而是**回到稳定版本**：金丝雀缩到 0，稳定版拉回满副本。这也是自动回滚的实现，不需要人介入。另一个必写的字段是 `initialDelay`：金丝雀刚起来的那几秒计数器还是 0、采样点不够两个，这时候算出来的是稳定版的错误率，看着很好，然后就把坏版本放行了。\n\n判据本身要写成`比例`而不是计数。`sum(rate(errors[5m])) > 0` 会让任何一个 5xx 都毁掉发布，而真实系统永远有零星的 5xx，结果是没有版本发得出去，最后有人把分析这一步删掉。还有一条实践：**金丝雀的判据应该和告警的判据是同一个表达式**，否则会出现「发布时看着没事、上线后告警响」，那说明「什么叫坏」被定义了两遍。\n\n另一半是节点维护。`PodDisruptionBudget` 管的是`自愿中断`，也就是有人主动发起的那些：节点维护、缩容、驱逐。`kubectl drain` 走的是 Pod 的 `eviction` 子资源，会先问 PDB，违反就收到 429 并重试；而 `kubectl delete pod` 走的是普通删除，谁也拦不住。这是两条命令行为不同的根源。PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」：节点掉电、OOMKill、被抢占都不在它管辖内。还有一个反效果要避开：`minAvailable` 写成和副本数一样大，任何驱逐都会被拒，节点永远维护不了。",
+          "en": "A rolling update answers one question: did the new pods start. Starting is not the same as working, and a version whose process is alive, probes pass, and logs are clean while three requests in ten return 500 will be spread to 100% without hesitation. `Progressive delivery` fills that gap by writing \"what good looks like\" into the release process itself.\n\n`Argo Rollouts` replaces a Deployment with a `Rollout` (replaces, not supplements: a workload is managed by one or the other). What it adds is `strategy.canary.steps`, an ordered list. `setWeight` sets how many replicas are canary, `pause` stops (with a `duration` it waits that long, without one it waits indefinitely for a `promote`), and `analysis` runs an evaluation. The controller tracks progress in `status.currentStepIndex`, advancing only when a step completes.\n\nAn `AnalysisTemplate` describes the criterion: a PromQL query plus a `successCondition` such as `result < 0.05`. If any metric fails, the rollout `aborts`. Note what aborting means: not stopping in place but **returning to the stable version**, scaling the canary to zero and stable back to full. That is the automatic rollback, with nobody in the loop. The other field you must write is `initialDelay`: in the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the stable version error rate, which looks great and lets the bad version through.\n\nThe criterion must be a `ratio` rather than a count. `sum(rate(errors[5m])) > 0` fails a release on any single 5xx, real systems always have a few, nothing ever ships, and eventually somebody deletes the analysis step. One more practice: **the canary criterion and the alerting criterion should be the same expression**, or you get \"looked fine during rollout, paged afterwards\", which means \"bad\" was defined twice.\n\nThe other half is node maintenance. A `PodDisruptionBudget` governs `voluntary` disruptions, the ones somebody initiates: maintenance, scale-down, eviction. `kubectl drain` goes through the Pod `eviction` subresource, which consults the PDB and returns 429 with a retry when it would be violated, while `kubectl delete pod` is an ordinary delete that nothing stops. That is why the two commands behave differently. A PDB guarantees nobody drains you to zero, not that N replicas always exist: power loss, OOMKill, and preemption are all outside its remit. And avoid the counterproductive setting where `minAvailable` equals the replica count, because then every eviction is refused and the node can never be maintained."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1327,6 +1327,23 @@ const primers = {
       )
     ),
 
+    'progressive-delivery': t(
+      p(
+        'Deployment 的滚动更新只回答一个问题：新的 Pod 起来了没有。而「起来了」和「好用」是两回事：一个进程活着、探针全过、日志干净，但大半请求返回 500 的版本，滚动更新会毫不犹豫地把它铺到 100%。`渐进式发布`补的就是这一段：把「什么叫好」写进发布流程本身。',
+        '`Argo Rollouts` 用 `Rollout` 替代 Deployment（是替代不是补充，一个工作负载只能由其中之一管）。它多出来的是 `strategy.canary.steps`：一串按顺序执行的步骤。`setWeight` 调整金丝雀占多少副本，`pause` 停一下（带 `duration` 就是等那么久，不带就是无限期等人来 `promote`），`analysis` 起一次分析。控制器用 `status.currentStepIndex` 记着走到第几步，每步做完才往前挪一格。',
+        '`AnalysisTemplate` 描述判据：一条 PromQL 加一个 `successCondition`（形如 `result < 0.05`）。任何一条不满足，整个发布`中止`。要特别注意中止的含义，它不是「停在原地」，而是**回到稳定版本**：金丝雀缩到 0，稳定版拉回满副本。这也是自动回滚的实现，不需要人介入。另一个必写的字段是 `initialDelay`：金丝雀刚起来的那几秒计数器还是 0、采样点不够两个，这时候算出来的是稳定版的错误率，看着很好，然后就把坏版本放行了。',
+        '判据本身要写成`比例`而不是计数。`sum(rate(errors[5m])) > 0` 会让任何一个 5xx 都毁掉发布，而真实系统永远有零星的 5xx，结果是没有版本发得出去，最后有人把分析这一步删掉。还有一条实践：**金丝雀的判据应该和告警的判据是同一个表达式**，否则会出现「发布时看着没事、上线后告警响」，那说明「什么叫坏」被定义了两遍。',
+        '另一半是节点维护。`PodDisruptionBudget` 管的是`自愿中断`，也就是有人主动发起的那些：节点维护、缩容、驱逐。`kubectl drain` 走的是 Pod 的 `eviction` 子资源，会先问 PDB，违反就收到 429 并重试；而 `kubectl delete pod` 走的是普通删除，谁也拦不住。这是两条命令行为不同的根源。PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」：节点掉电、OOMKill、被抢占都不在它管辖内。还有一个反效果要避开：`minAvailable` 写成和副本数一样大，任何驱逐都会被拒，节点永远维护不了。'
+      ),
+      p(
+        'A rolling update answers one question: did the new pods start. Starting is not the same as working, and a version whose process is alive, probes pass, and logs are clean while three requests in ten return 500 will be spread to 100% without hesitation. `Progressive delivery` fills that gap by writing "what good looks like" into the release process itself.',
+        '`Argo Rollouts` replaces a Deployment with a `Rollout` (replaces, not supplements: a workload is managed by one or the other). What it adds is `strategy.canary.steps`, an ordered list. `setWeight` sets how many replicas are canary, `pause` stops (with a `duration` it waits that long, without one it waits indefinitely for a `promote`), and `analysis` runs an evaluation. The controller tracks progress in `status.currentStepIndex`, advancing only when a step completes.',
+        'An `AnalysisTemplate` describes the criterion: a PromQL query plus a `successCondition` such as `result < 0.05`. If any metric fails, the rollout `aborts`. Note what aborting means: not stopping in place but **returning to the stable version**, scaling the canary to zero and stable back to full. That is the automatic rollback, with nobody in the loop. The other field you must write is `initialDelay`: in the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the stable version error rate, which looks great and lets the bad version through.',
+        'The criterion must be a `ratio` rather than a count. `sum(rate(errors[5m])) > 0` fails a release on any single 5xx, real systems always have a few, nothing ever ships, and eventually somebody deletes the analysis step. One more practice: **the canary criterion and the alerting criterion should be the same expression**, or you get "looked fine during rollout, paged afterwards", which means "bad" was defined twice.',
+        'The other half is node maintenance. A `PodDisruptionBudget` governs `voluntary` disruptions, the ones somebody initiates: maintenance, scale-down, eviction. `kubectl drain` goes through the Pod `eviction` subresource, which consults the PDB and returns 429 with a retry when it would be violated, while `kubectl delete pod` is an ordinary delete that nothing stops. That is why the two commands behave differently. A PDB guarantees nobody drains you to zero, not that N replicas always exist: power loss, OOMKill, and preemption are all outside its remit. And avoid the counterproductive setting where `minAvailable` equals the replica count, because then every eviction is refused and the node can never be maintained.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5745,6 +5745,46 @@
               9090
             ]
           },
+          "quay.io/argoproj/argo-rollouts:v1.8.3": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300
+          },
+          "harbor.corp.internal/team/portal:1.5.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
+            ],
+            "routes": {
+              "/": 200,
+              "/healthz": 200,
+              "/readyz": 200
+            },
+            "memoryUsage": "180Mi",
+            "handlesSigterm": true,
+            "runAsUser": 10001,
+            "requestsPerSecond": 40
+          },
+          "harbor.corp.internal/team/portal:1.6.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300,
+            "listens": [
+              8080
+            ],
+            "routes": {
+              "/": 200,
+              "/healthz": 200,
+              "/readyz": 200
+            },
+            "memoryUsage": "180Mi",
+            "handlesSigterm": true,
+            "runAsUser": 10001,
+            "requestsPerSecond": 40,
+            "errorRatio": 0.6
+          },
           "harbor.corp.internal/team/reports:2.3.0": {
             "pullMs": 500,
             "startupMs": 800,
@@ -12255,6 +12295,534 @@
         "primer": {
           "zh": "`Prometheus` 是**拉**模型：它按配置找到一批目标，每隔一段时间（默认 15 秒）去每个目标的 `/metrics` 上采一次。数据模型很小：一条`序列`由指标名加一组标签唯一确定，值按时间点存。这个模型带来两个直接后果：两次采样之间发生的事看不见（只活十秒的 Pod 可能一个点都没有），以及目标挂掉之后它此前的指标还会在图上停留一个回看窗口（默认五分钟）才消失。\n\n在 Kubernetes 里，采集配置写成 `ServiceMonitor`：按标签选中一批 Service，去它们后面的 Pod 上拉。这里有个**两层选择器**的坑：Prometheus 实例自己有一个 `serviceMonitorSelector`，先由它选中 ServiceMonitor，再由 ServiceMonitor 的 `selector` 选中 Service。少配任何一层的结果都是一条指标都采不到，而两个对象看起来都完全正常。`up` 这个指标是 Prometheus 自己合成的，不来自目标，它是判断「采不采得到」的第一手依据。\n\n`PromQL` 里最要紧的区分是 `counter` 与 `gauge`。counter 只增不减（请求总数、错误总数），直接看它的值没有意义，要用 `rate(x[5m])` 求每秒增量；gauge 可以上下浮动（内存、队列长度），直接看瞬时值。错误率是**两个 rate 相除**：`sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`。两侧必须聚合到同一组标签上，否则配不上，表达式返回空，而返回空的告警永远不会触发，也不会报错。另外比较运算符是`过滤`不是求布尔值：`up == 0` 返回的是那些确实为 0 的序列。\n\n告警规则写在 `PrometheusRule` 里，`expr` 加 `for`。`for` 的意思是「条件持续成立这么久才真的告警」，中间处于 `pending`；条件一旦不成立就整条清掉，所以抖动不会累积。两条实践值得记：一是 apiserver 收 PrometheusRule 时**不校验表达式**，写错了照样收下，所以上线前要 `promtool check rules` 加 `promtool query instant` 各跑一遍；二是`告症状不告原因`：「错误率超过 5%」用户感受得到，「某个 Pod 内存高」不一定有影响，按原因告警的系统很快就没人看了。",
           "en": "`Prometheus` is a **pull** model: it discovers a set of targets and scrapes `/metrics` on each at a fixed interval, 15 seconds by default. The data model is tiny: a `series` is identified by a metric name plus a set of labels, with values stored per timestamp. Two consequences follow directly. Anything happening between scrapes is invisible, so a pod that lived ten seconds may contribute no samples at all. And after a target dies, its earlier metrics linger for one lookback window (five minutes by default) before disappearing.\n\nIn Kubernetes the scrape config is a `ServiceMonitor`: select Services by label, scrape the pods behind them. There is a **two-selector** trap here: the Prometheus instance has its own `serviceMonitorSelector` which picks ServiceMonitors, and each ServiceMonitor has a `selector` which picks Services. Missing either layer collects nothing, while both objects look perfectly healthy. The `up` metric is synthesised by Prometheus rather than coming from the target, which makes it the first thing to check when nothing appears.\n\nThe distinction that matters most in `PromQL` is `counter` versus `gauge`. A counter only increases (requests served, errors returned) and its raw value means little; use `rate(x[5m])` for per-second increase. A gauge moves both ways (memory, queue depth) and is read directly. An error rate is **one rate divided by another**: `sum(rate(errors[5m])) by (job) / sum(rate(total[5m])) by (job)`. Both sides must be aggregated to the same label set or they will not match and the expression returns nothing, and an alert whose expression returns nothing never fires and never complains. Note also that comparison operators `filter` rather than produce booleans: `up == 0` returns the series that really are zero.\n\nAlerting rules live in a `PrometheusRule` as an `expr` plus a `for`. The `for` means the condition must hold that long before the alert really fires, staying `pending` meanwhile, and the whole thing clears the moment the condition stops holding, so blips do not accumulate. Two practices worth keeping: the apiserver does **not validate expressions** when accepting a PrometheusRule, so run `promtool check rules` and `promtool query instant` before shipping; and `alert on symptoms, not causes`, because users feel \"error rate above 5%\" while \"this pod uses a lot of memory\" may mean nothing, and cause-based alerting quickly stops being read."
+        }
+      },
+      {
+        "id": "progressive-delivery",
+        "title": {
+          "zh": "让坏版本自己退回去",
+          "en": "Make a Bad Release Roll Itself Back"
+        },
+        "goal": {
+          "zh": "上周那个坏版本是人肉发现的：先有人报「打不开」，再有人去看指标，\n最后手工回滚 —— 中间隔了四十分钟。\n\n门户已经从 Deployment 换成了 `Rollout`，但它现在的策略只是\n「分两步把新版本铺满」，不看任何指标。也就是说坏版本照样能一路铺到 100%。\n\n要做两件事：把**分析**加进发布流程，让坏版本自己退回去；\n以及给门户配一个 `PodDisruptionBudget`，让节点维护不至于把服务打空。\n\n## 通关标准\n\n1. 发一个好版本（`harbor.corp.internal/team/portal:1.5.0`）能走完全流程，最终 Healthy；\n2. 发一个坏版本（`harbor.corp.internal/team/portal:1.6.0`）会在分析那一步被拦下，\n   **自动回到稳定版**，而且稳定版的副本数是满的；\n3. 判据用的是**错误率**（rate 相除），不是裸计数；\n4. 有 PDB，且 `kubectl drain` 一个节点时不会把可用副本打到 3 以下。\n\n## 会用到的命令\n\n```bash\nkubectl apply -f /root/infra/canary.yaml\nkubectl get rollout portal -n payments\nkubectl describe rollout portal -n payments\nkubectl get analysisrun -n payments\nkubectl get pdb -n payments\nkubectl drain node-a1 --ignore-daemonsets --delete-emptydir-data --timeout=60s\n```\n",
+          "en": "Last week's bad release was found by a human: someone reported \"it will not\nload\", someone else looked at the metrics, and someone rolled it back by hand.\nForty minutes in total.\n\nThe portal is already a `Rollout` rather than a Deployment, but its current\nstrategy only spreads the new version in two steps without looking at any\nmetric. A bad version therefore reaches 100% just as happily as a good one.\n\nTwo things to do: add **analysis** to the release process so a bad version rolls\nitself back, and give the portal a `PodDisruptionBudget` so node maintenance\ncannot drain the service to nothing.\n\n## Done when\n\n1. a good release (`harbor.corp.internal/team/portal:1.5.0`) completes and ends Healthy;\n2. a bad release (`harbor.corp.internal/team/portal:1.6.0`) is stopped at the analysis step and\n   **rolls back to the stable version** with a full replica count;\n3. the criterion is an **error rate** (one rate divided by another), not a raw\n   counter;\n4. a PDB exists, and draining a node cannot take available replicas below three.\n\n## Commands you will need\n\n```bash\nkubectl apply -f /root/infra/canary.yaml\nkubectl get rollout portal -n payments\nkubectl describe rollout portal -n payments\nkubectl get analysisrun -n payments\nkubectl get pdb -n payments\nkubectl drain node-a1 --ignore-daemonsets --delete-emptydir-data --timeout=60s\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "好版本走得完",
+            "en": "A good release completes"
+          },
+          {
+            "zh": "坏版本自己退回去",
+            "en": "A bad release rolls itself back"
+          },
+          {
+            "zh": "节点维护打不空服务",
+            "en": "Node maintenance cannot empty the service"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "金丝雀的判据和告警的判据应该是同一个表达式。不然会出现「发布时看着没事、上线后告警响」—— 那说明你在两个地方定义了两套「什么叫坏」。",
+            "en": "The canary criterion and the alerting criterion should be the same expression. Otherwise you get \"looked fine during rollout, paged after\", which means you defined \"bad\" twice, differently."
+          },
+          {
+            "zh": "`initialDelay` 不是可选的。金丝雀刚起来的那几秒，它的计数器还是 0、采样点还不够两个，这时候算出来的是**稳定版的**错误率 —— 看着很好，然后就把坏版本放行了。",
+            "en": "`initialDelay` is not optional. In the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the **stable** version error rate. It looks great, and the bad version sails through."
+          },
+          {
+            "zh": "中止不是「停在原地」，是回到稳定版：金丝雀缩到 0、稳定版拉回满副本。判定会检查回滚之后副本数是满的 —— 停在半路的服务只有一半容量。",
+            "en": "Aborting does not mean stopping in place, it means returning to stable: the canary scales to zero and stable goes back to full. The grader checks the replica count after rollback, because a rollout stopped halfway leaves half the capacity."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "判据写成 `sum(rate(http_requests_total{code=~\"5..\"}[5m])) > 0`。任何一个 5xx 都会让发布失败 —— 而真实系统永远有零星的 5xx，于是没有任何版本发得出去，最后大家把分析这一步删了。判据要用**比例**。",
+            "en": "Writing the criterion as `sum(rate(http_requests_total{code=~\"5..\"}[5m])) > 0`. Any single 5xx fails the release, real systems always have a few, so nothing ever ships and eventually somebody deletes the analysis step. Use a **ratio**."
+          },
+          {
+            "zh": "配了 PDB 就以为副本数不会掉下来。PDB 只管**自愿中断**（维护、缩容、驱逐），管不了节点掉电、OOMKill、被抢占。它保证的是「不会被人为打空」，不是「永远有 N 个」。",
+            "en": "Assuming a PDB keeps the replica count up. It governs **voluntary** disruptions (maintenance, scale-down, eviction) and does nothing about a node losing power, an OOMKill, or preemption. It guarantees nobody drains you to zero, not that N always exist."
+          },
+          {
+            "zh": "`minAvailable` 写成和副本数一样大。这样任何驱逐都会被拒，节点永远维护不了 —— drain 会一直重试到超时。留出至少一个可中断的名额，否则 PDB 从「保护」变成「阻塞」。",
+            "en": "Setting `minAvailable` equal to the replica count. Every eviction is then refused and the node can never be maintained: drain retries until it times out. Leave at least one disruptable slot, or the PDB stops protecting and starts blocking."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "files": {
+            "/root/infra/canary.yaml": "# 现在这个 Rollout 只会「分两步把新版本铺满」，不看任何指标。\n# 换句话说：坏版本照样能一路铺到 100%。\n#\n# 要加的是：分析这一步，以及它依据的判据。\napiVersion: argoproj.io/v1alpha1\nkind: Rollout\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  replicas: 4\n  selector:\n    matchLabels:\n      app: portal\n  strategy:\n    canary:\n      steps:\n      - setWeight: 25\n      - setWeight: 100\n  template:\n    metadata:\n      labels:\n        app: portal\n    spec:\n      containers:\n      - name: web\n        image: harbor.corp.internal/team/portal:1.4.0\n        ports:\n        - containerPort: 8080\n"
+          },
+          "referenceFiles": {
+            "/root/infra/canary.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: AnalysisTemplate\nmetadata:\n  name: error-rate\n  namespace: payments\nspec:\n  metrics:\n  - name: error-rate\n    # 先等两分钟再量：金丝雀刚起来时采样点还不够两个，算出来的是稳定版的错误率\n    initialDelay: 2m\n    successCondition: result < 0.05\n    provider:\n      prometheus:\n        address: http://prometheus.monitoring.svc:9090\n        query: |\n          sum(rate(http_requests_total{code=~\"5..\"}[5m]))\n          / sum(rate(http_requests_total[5m]))\n---\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  minAvailable: 3\n  selector:\n    matchLabels:\n      app: portal\n---\napiVersion: argoproj.io/v1alpha1\nkind: Rollout\nmetadata:\n  name: portal\n  namespace: payments\nspec:\n  replicas: 4\n  selector:\n    matchLabels:\n      app: portal\n  strategy:\n    canary:\n      steps:\n      - setWeight: 25\n      - analysis:\n          templates:\n          - templateName: error-rate\n      - setWeight: 50\n      - analysis:\n          templates:\n          - templateName: error-rate\n      - setWeight: 100\n  template:\n    metadata:\n      labels:\n        app: portal\n    spec:\n      containers:\n      - name: web\n        image: harbor.corp.internal/team/portal:1.4.0\n        ports:\n        - containerPort: 8080\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/infra/canary.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "progressive-delivery.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst ROLLOUT = () => get('Rollout', 'portal', 'payments');\n\nconst release = async (image) => {\n  await sh(\n    \"kubectl patch rollout portal -n payments --type=json -p \"\n    + \"'[{\\\"op\\\":\\\"replace\\\",\\\"path\\\":\\\"/spec/template/spec/containers/0/image\\\",\"\n    + \"\\\"value\\\":\\\"\" + image + \"\\\"}]'\"\n  );\n  await advance(1200000);\n};\n\ndescribe('渐进式发布', () => {\n  it('判据是错误率，不是裸计数', () => {\n    const templates = list('AnalysisTemplate', { namespace: 'payments' });\n    expect(templates.length).toBeGreaterThan(0);\n    const queries = templates.flatMap((template) => (template.spec.metrics || [])\n      .map((metric) => (metric.provider || {}).prometheus?.query || ''));\n    expect(queries.some((query) => /rate\\(/.test(query) && query.includes('/'))).toBe(true);\n  });\n\n  it('发布流程里有分析这一步', () => {\n    const steps = ROLLOUT().spec.strategy.canary.steps || [];\n    expect(steps.some((step) => step.analysis)).toBe(true);\n  });\n\n  it('好版本走得完', async () => {\n    await release('harbor.corp.internal/team/portal:1.5.0');\n    const status = ROLLOUT().status;\n    expect(status.phase).toBe('Healthy');\n    expect(status.currentPodHash).toBeTruthy();\n\n    const running = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal')\n      .filter((pod) => pod.status.phase === 'Running');\n    expect(running.length).toBe(4);\n    for (const pod of running) {\n      expect(pod.spec.containers[0].image).toBe('harbor.corp.internal/team/portal:1.5.0');\n    }\n  });\n\n  it('坏版本被拦下并自动回到稳定版', async () => {\n    await release('harbor.corp.internal/team/portal:1.6.0');\n    const status = ROLLOUT().status;\n    expect(status.abort).toBe(true);\n    expect(status.phase).toBe('Degraded');\n\n    const running = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal')\n      .filter((pod) => pod.status.phase === 'Running');\n    // 回滚之后容量是满的，不是停在半路\n    expect(running.length).toBe(4);\n    for (const pod of running) {\n      expect(pod.spec.containers[0].image).not.toBe('harbor.corp.internal/team/portal:1.6.0');\n    }\n  });\n\n  it('分析的结果查得到，看得出是哪条没过', () => {\n    const runs = list('AnalysisRun', { namespace: 'payments' });\n    const failed = runs.filter((run) => run.status.phase === 'Failed');\n    expect(failed.length).toBeGreaterThan(0);\n    expect(failed[0].status.metricResults[0].value).toBeGreaterThan(0.05);\n  });\n\n  it('PDB 留了可中断的名额，不至于把维护堵死', () => {\n    const pdbs = list('PodDisruptionBudget', { namespace: 'payments' });\n    expect(pdbs.length).toBeGreaterThan(0);\n    const pdb = pdbs[0];\n    expect(pdb.status.disruptionsAllowed).toBeGreaterThan(0);\n    expect(pdb.status.desiredHealthy).toBeGreaterThanOrEqual(3);\n  });\n\n  it('节点维护打不空服务', async () => {\n    const before = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal').length;\n    expect(before).toBe(4);\n\n    await sh('kubectl drain node-a1 --ignore-daemonsets --force --timeout=30s');\n    await advance(300000);\n\n    const healthy = list('Pod', { namespace: 'payments' })\n      .filter((pod) => (pod.metadata.labels || {}).app === 'portal')\n      .filter((pod) => pod.status.phase === 'Running').length;\n    expect(healthy).toBeGreaterThanOrEqual(3);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "resilience",
+          "observability"
+        ],
+        "extension": {
+          "zh": "渐进式发布真正改变的是**谁来发现问题**。滚动更新只回答「新的 Pod 起来了\n没有」，而「起来了」和「好用」是两回事 —— 上周那个坏版本探针全过、\n日志干净、Pod 全 Running，只是大半请求返回 500。把判据写进发布流程之后，\n发现问题的是系统而不是用户，而且回滚是自动的。\n\n有一条很容易被忽略：**金丝雀的判据应该和告警的判据是同一个表达式**。\n两边写不一样的话，会出现「发布时看着没事、上线后告警响」，\n或者反过来「发布一直失败但线上其实好好的」。同一个定义只写一遍，\n放在 AnalysisTemplate 里、告警规则里引用同一段 PromQL。\n\nPDB 那一半也值得多说一句。它管的是**自愿中断**，也就是有人主动发起的\n那些：节点维护、缩容、驱逐。节点掉电、OOMKill、被抢占都不在它管辖之内。\n所以 PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」——\n后者要靠副本数、反亲和、跨可用区分布一起来做。而且 `minAvailable`\n写得太紧会让节点永远维护不了：留不出可中断的名额，drain 就只能重试到\n超时，最后有人一怒之下 `--disable-eviction`，PDB 白配。\n",
+          "en": "What progressive delivery really changes is **who finds the problem**. A rolling\nupdate only answers \"did the new pods start\", and starting is not the same as\nworking: last week's bad version passed every probe, logged nothing unusual, and\nshowed all pods Running while returning 500 to three requests in ten. Once the\ncriterion is part of the release process, the system finds the problem instead of\na user, and the rollback is automatic.\n\nOne thing that is easy to overlook: **the canary criterion and the alerting\ncriterion should be the same expression**. Write them differently and you get\neither \"looked fine during rollout, paged afterwards\" or \"releases keep failing\nwhile production is perfectly healthy\". Define \"bad\" once, and reference the same\nPromQL from the AnalysisTemplate and the alerting rule.\n\nThe PDB half deserves a note too. It governs **voluntary** disruptions, the ones\nsomebody initiates: node maintenance, scale-down, eviction. A node losing power,\nan OOMKill, or preemption are all outside its remit. So a PDB guarantees nobody\ndrains you to zero, not that N replicas always exist; that needs replica counts,\nanti-affinity, and zone spread together. And a `minAvailable` set too tightly\nmakes nodes impossible to maintain: with no disruptable slot, drain retries until\nit times out, and eventually somebody reaches for `--disable-eviction` and the\nPDB may as well not exist.\n"
+        },
+        "primer": {
+          "zh": "Deployment 的滚动更新只回答一个问题：新的 Pod 起来了没有。而「起来了」和「好用」是两回事：一个进程活着、探针全过、日志干净，但大半请求返回 500 的版本，滚动更新会毫不犹豫地把它铺到 100%。`渐进式发布`补的就是这一段：把「什么叫好」写进发布流程本身。\n\n`Argo Rollouts` 用 `Rollout` 替代 Deployment（是替代不是补充，一个工作负载只能由其中之一管）。它多出来的是 `strategy.canary.steps`：一串按顺序执行的步骤。`setWeight` 调整金丝雀占多少副本，`pause` 停一下（带 `duration` 就是等那么久，不带就是无限期等人来 `promote`），`analysis` 起一次分析。控制器用 `status.currentStepIndex` 记着走到第几步，每步做完才往前挪一格。\n\n`AnalysisTemplate` 描述判据：一条 PromQL 加一个 `successCondition`（形如 `result < 0.05`）。任何一条不满足，整个发布`中止`。要特别注意中止的含义，它不是「停在原地」，而是**回到稳定版本**：金丝雀缩到 0，稳定版拉回满副本。这也是自动回滚的实现，不需要人介入。另一个必写的字段是 `initialDelay`：金丝雀刚起来的那几秒计数器还是 0、采样点不够两个，这时候算出来的是稳定版的错误率，看着很好，然后就把坏版本放行了。\n\n判据本身要写成`比例`而不是计数。`sum(rate(errors[5m])) > 0` 会让任何一个 5xx 都毁掉发布，而真实系统永远有零星的 5xx，结果是没有版本发得出去，最后有人把分析这一步删掉。还有一条实践：**金丝雀的判据应该和告警的判据是同一个表达式**，否则会出现「发布时看着没事、上线后告警响」，那说明「什么叫坏」被定义了两遍。\n\n另一半是节点维护。`PodDisruptionBudget` 管的是`自愿中断`，也就是有人主动发起的那些：节点维护、缩容、驱逐。`kubectl drain` 走的是 Pod 的 `eviction` 子资源，会先问 PDB，违反就收到 429 并重试；而 `kubectl delete pod` 走的是普通删除，谁也拦不住。这是两条命令行为不同的根源。PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」：节点掉电、OOMKill、被抢占都不在它管辖内。还有一个反效果要避开：`minAvailable` 写成和副本数一样大，任何驱逐都会被拒，节点永远维护不了。",
+          "en": "A rolling update answers one question: did the new pods start. Starting is not the same as working, and a version whose process is alive, probes pass, and logs are clean while three requests in ten return 500 will be spread to 100% without hesitation. `Progressive delivery` fills that gap by writing \"what good looks like\" into the release process itself.\n\n`Argo Rollouts` replaces a Deployment with a `Rollout` (replaces, not supplements: a workload is managed by one or the other). What it adds is `strategy.canary.steps`, an ordered list. `setWeight` sets how many replicas are canary, `pause` stops (with a `duration` it waits that long, without one it waits indefinitely for a `promote`), and `analysis` runs an evaluation. The controller tracks progress in `status.currentStepIndex`, advancing only when a step completes.\n\nAn `AnalysisTemplate` describes the criterion: a PromQL query plus a `successCondition` such as `result < 0.05`. If any metric fails, the rollout `aborts`. Note what aborting means: not stopping in place but **returning to the stable version**, scaling the canary to zero and stable back to full. That is the automatic rollback, with nobody in the loop. The other field you must write is `initialDelay`: in the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the stable version error rate, which looks great and lets the bad version through.\n\nThe criterion must be a `ratio` rather than a count. `sum(rate(errors[5m])) > 0` fails a release on any single 5xx, real systems always have a few, nothing ever ships, and eventually somebody deletes the analysis step. One more practice: **the canary criterion and the alerting criterion should be the same expression**, or you get \"looked fine during rollout, paged afterwards\", which means \"bad\" was defined twice.\n\nThe other half is node maintenance. A `PodDisruptionBudget` governs `voluntary` disruptions, the ones somebody initiates: maintenance, scale-down, eviction. `kubectl drain` goes through the Pod `eviction` subresource, which consults the PDB and returns 429 with a retry when it would be violated, while `kubectl delete pod` is an ordinary delete that nothing stops. That is why the two commands behave differently. A PDB guarantees nobody drains you to zero, not that N replicas always exist: power loss, OOMKill, and preemption are all outside its remit. And avoid the counterproductive setting where `minAvailable` equals the replica count, because then every eviction is refused and the node can never be maintained."
         }
       }
     ]

--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -176,6 +176,30 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
       ];
     },
   },
+  rollouts: {
+    columns: [
+      NAME_COLUMN,
+      col('Desired', 'The desired number of replicas.'),
+      col('Current', 'The current number of replicas.'),
+      col('Up-to-date', 'The number of replicas on the latest revision.'),
+      col('Available', 'The number of available replicas.'),
+      AGE_COLUMN,
+    ],
+    // 和 Argo Rollouts 的 CRD 一样：这五列里没有状态。
+    // 想知道走到哪一步、为什么停了，得 describe，或者看 AnalysisRun。
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        String(spec.replicas ?? 1),
+        String(status.replicas ?? 0),
+        String(status.updatedReplicas ?? 0),
+        String(status.availableReplicas ?? 0),
+        age,
+      ];
+    },
+  },
   poddisruptionbudgets: {
     columns: [
       NAME_COLUMN,

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -30,7 +30,10 @@ import {
   CLUSTERROLEBINDINGS, CLUSTERROLES, RBAC_RESOURCES, ROLEBINDINGS, ROLES, authorize,
 } from '../rbac';
 import { ESO_RESOURCES, ExternalSecretsController } from '../secrets';
-import { OBSERVABILITY_RESOURCES, PrometheusController } from '../observability';
+import {
+  OBSERVABILITY_RESOURCES, PrometheusController, evaluate as promqlEvaluate,
+} from '../observability';
+import { ROLLOUT_RESOURCES, RolloutController } from '../rollouts';
 import { DISRUPTION_RESOURCES, PdbController, evictionVerdict } from '../disruption';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
@@ -155,7 +158,7 @@ export class Cluster {
     this.scheme = createScheme([
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
-      ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES,
+      ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES, ...ROLLOUT_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -619,6 +622,26 @@ export class Cluster {
       // 监控：采集是定时拉的，所以采样之间发生的事看不见
       ...(this.options.metrics
         ? [(this.prometheus = new PrometheusController(context, this.options.metrics))]
+        : []),
+      /**
+       * 渐进式发布。
+       *
+       * 分析用的是同一套 PromQL 求值器 —— 金丝雀的判据和告警的判据本来
+       * 就该是同一个东西，不然「发布时看着没事、上线后告警响」。
+       */
+      ...(this.options.metrics
+        ? [new RolloutController(context, {
+            evaluate: (query) => {
+              const prometheus = this.prometheus;
+              if (!prometheus) return undefined;
+              try {
+                const results = promqlEvaluate(prometheus.tsdb, query, this.wallClock());
+                return results[0]?.value;
+              } catch {
+                return undefined;
+              }
+            },
+          })]
         : []),
       // 密钥：真值住在集群外面，这里只维护一份投影
       ...(this.options.fetchSecret

--- a/src/lib/opslab/kernel/clock.ts
+++ b/src/lib/opslab/kernel/clock.ts
@@ -157,11 +157,22 @@ export class VirtualClock {
 
   /** 把时钟推进 ms，沿途所有定时器都会触发 */
   advanceBy(ms: number): void {
+    if (!Number.isFinite(ms)) {
+      throw new TypeError(`advanceBy 收到的不是一个有限的毫秒数：${ms}`);
+    }
     this.advanceTo(this.time + Math.max(0, Math.floor(ms)));
   }
 
-  /** 把时钟推到某个绝对时刻 */
+  /**
+   * 把时钟推到某个绝对时刻。
+   *
+   * target 必须是有限值：NaN 的话 `next > target` 永远为假，这个循环会
+   * 一直烧下去，而且不报错 —— 表现是整个进程静悄悄地卡住。
+   */
   advanceTo(target: number): void {
+    if (!Number.isFinite(target)) {
+      throw new TypeError(`advanceTo 收到的不是一个有限的时刻：${target}`);
+    }
     let batchesAtSameInstant = 0;
     let lastInstant = this.time;
 

--- a/src/lib/opslab/kernel/clock.ts
+++ b/src/lib/opslab/kernel/clock.ts
@@ -139,12 +139,19 @@ export class VirtualClock {
 
   /**
    * 把时钟推到下一个到期时刻，触发该时刻的**全部**定时器。
+   *
+   * `includeBackground: false` 只影响**推到哪儿**，不影响沿途触发谁：
+   * 后台定时器不能决定世界要不要往前走，但世界走过去的时候它们必须响。
+   * 早先这里是 fireUpTo(target)，于是时钟从 30s 一步跨到 150s（一个前台
+   * 的暂停定时器），把中间十次 15s 的采集全跳了 —— 金丝雀分析拿不到两个
+   * 采样点，错误率算出来是稳定版的 0。
+   *
    * @returns 是否真的推进了
    */
   advanceToNext(options: { includeBackground?: boolean } = {}): boolean {
     const target = this.peekNextTime(options);
     if (target === null) return false;
-    this.fireUpTo(target);
+    this.advanceTo(target);
     return true;
   }
 

--- a/src/lib/opslab/lab/view.ts
+++ b/src/lib/opslab/lab/view.ts
@@ -61,7 +61,10 @@ const LANE_PADDING = 28;
 /** 泳道从上到下：流量怎么进来 → 谁在提供服务 → 实例 → 落在哪台机器 */
 const LANES: Array<{ id: string; title: string; kinds: string[] }> = [
   { id: 'ingress', title: '入口', kinds: ['Gateway', 'HTTPRoute', 'Ingress', 'Service'] },
-  { id: 'workload', title: '工作负载', kinds: ['Deployment', 'StatefulSet', 'DaemonSet', 'Job', 'CronJob', 'ReplicaSet'] },
+  {
+    id: 'workload', title: '工作负载',
+    kinds: ['Deployment', 'StatefulSet', 'DaemonSet', 'Job', 'CronJob', 'Rollout', 'ReplicaSet'],
+  },
   { id: 'pod', title: '实例', kinds: ['Pod'] },
   { id: 'node', title: '节点', kinds: ['Node'] },
 ];
@@ -165,6 +168,22 @@ function describe(object: KubeObject): { detail: string; status: TopologyStatus 
       return {
         detail: `${ready}/${desired}`,
         status: desired === 0 ? 'pending' : ready === desired ? 'ok' : ready === 0 ? 'error' : 'warn',
+      };
+    }
+    /**
+     * Rollout 比 Deployment 多一样东西：它停在哪一步。
+     * 只打 `可用/期望` 的话，「暂停等人确认」和「分析失败已经退回去」
+     * 在图上长得一模一样，而这两件事要采取的动作完全相反。
+     */
+    case 'Rollout': {
+      const available = Number(status.availableReplicas ?? 0);
+      const desired = Number(spec.replicas ?? 0);
+      const phase = String(status.phase ?? 'Progressing');
+      return {
+        detail: `${available}/${desired} ${phase}`,
+        status: phase === 'Degraded' ? 'error'
+          : phase === 'Healthy' ? 'ok'
+            : phase === 'Paused' ? 'pending' : 'warn',
       };
     }
     case 'ReplicaSet': {

--- a/src/lib/opslab/rollouts/controller.ts
+++ b/src/lib/opslab/rollouts/controller.ts
@@ -1,0 +1,460 @@
+/**
+ * Argo Rollouts 的控制器
+ *
+ * 金丝雀的核心是一个**状态机**：`status.currentStepIndex` 指向 steps 里的
+ * 第几步，每一步做完才往前挪一格。四种步骤：
+ *
+ *   setWeight  调整金丝雀的副本占比
+ *   pause      停住（带 duration 就是等那么久，不带就是等人来 promote）
+ *   analysis   起一个 AnalysisRun，按 PromQL 求值决定继续还是中止
+ *
+ * 中止（abort）不是「停在原地」，是**回到稳定版本**：金丝雀缩到 0，
+ * 稳定版拉回满副本。这一点常被误解 —— 自动回滚是分析失败时的默认行为，
+ * 不需要人介入。
+ */
+import type { KubeObject } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isConflict, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS, POD_TEMPLATE_HASH, REPLICASETS, templateHash } from '../controllers/resources';
+import { ignoreConflict, isPodReady, updateStatusIfChanged } from '../controllers/workloads';
+import { PODS } from '../controllers/resources';
+import { ANALYSISRUNS, ANALYSISTEMPLATES, ROLLOUTS, ROLLOUTS_LABEL } from './resources';
+import { parseDuration } from '../observability';
+
+/** 分析用什么求值。由集群注入 —— 控制器自己不认识 Prometheus。 */
+export type AnalysisEvaluator = (query: string) => number | undefined;
+
+/** 查不到数最多等这么久，之后按失败算 */
+export const NO_DATA_GRACE_MS = 5 * 60_000;
+
+export interface RolloutsOptions {
+  evaluate: AnalysisEvaluator;
+}
+
+export class RolloutController extends Controller {
+  private rollouts: Informer;
+  private replicaSets: Informer;
+  private pods: Informer;
+  private deployments: Informer;
+  private templates: Informer;
+  private runs: Informer;
+
+  constructor(context: ControllerContext, private readonly options: RolloutsOptions) {
+    super(context, 'argo-rollouts');
+    this.rollouts = new Informer(this.registry, ROLLOUTS);
+    this.replicaSets = this.track(new Informer(this.registry, REPLICASETS));
+    this.pods = this.track(new Informer(this.registry, PODS));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.templates = this.track(new Informer(this.registry, ANALYSISTEMPLATES));
+    this.runs = this.track(new Informer(this.registry, ANALYSISRUNS));
+    this.watch(this.rollouts);
+    for (const informer of [this.replicaSets, this.pods, this.deployments, this.runs]) {
+      informer.onChange(() => {
+        for (const rollout of this.rollouts.list()) this.enqueue(objectKey(rollout));
+      });
+    }
+  }
+
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[ROLLOUTS_LABEL.key] !== ROLLOUTS_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let rollout: KubeObject;
+    try {
+      rollout = this.registry.get(ROLLOUTS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (rollout.metadata.deletionTimestamp) return;
+
+    const spec = (rollout.spec ?? {}) as any;
+    const status = (rollout.status ?? {}) as any;
+    const desired = spec.replicas ?? 1;
+    const steps: any[] = spec.strategy?.canary?.steps ?? [];
+    const hash = templateHash(spec.template);
+
+    const owned = this.ownedReplicaSets(rollout);
+    const canary = owned.find((rs) => rs.metadata.labels?.[POD_TEMPLATE_HASH] === hash)
+      ?? this.createReplicaSet(rollout, hash);
+    const stable = owned.find(
+      (rs) => rs.metadata.labels?.[POD_TEMPLATE_HASH] === status.stableRS && rs.metadata.uid !== canary.metadata.uid
+    );
+
+    /**
+     * 副本计数是**跨所有 ReplicaSet** 的总数。
+     *
+     * 金丝雀期间四个副本分在两个 ReplicaSet 上（比如 1 新 3 旧），
+     * `kubectl get rollout` 的 CURRENT 要把两边都算上，只数一边看起来像
+     * 掉了一半副本。UP-TO-DATE 才是只数新模板那一边的那一列 ——
+     * 「已经换过去多少」和「一共有多少」是两个问题。
+     */
+    const all = owned.some((rs) => rs.metadata.uid === canary.metadata.uid) ? owned : [...owned, canary];
+    const counts = () => ({
+      replicas: all.reduce((sum, rs) => sum + this.podsOf(rs).length, 0),
+      readyReplicas: all.reduce((sum, rs) => sum + this.readyOf(rs), 0),
+      availableReplicas: all.reduce((sum, rs) => sum + this.readyOf(rs), 0),
+      updatedReplicas: this.readyOf(canary),
+    });
+
+    // 第一次见到这个 Rollout：直接把它当稳定版拉满，不走金丝雀
+    if (!status.stableRS) {
+      this.scale(canary, desired);
+      await this.writeStatus(rollout, {
+        stableRS: hash, currentPodHash: hash, currentStepIndex: steps.length,
+        phase: 'Healthy', ...counts(),
+      });
+      return;
+    }
+
+    // 模板变了：从第 0 步重新开始
+    if (status.currentPodHash !== hash) {
+      await this.writeStatus(rollout, {
+        ...status, currentPodHash: hash, currentStepIndex: 0,
+        phase: 'Progressing', abort: false, message: undefined, ...counts(),
+      });
+      return;
+    }
+
+    if (status.abort) {
+      // 中止 = 回到稳定版，不是停在原地
+      this.scale(canary, 0);
+      if (stable) this.scale(stable, desired);
+      await this.writeStatus(rollout, {
+        ...status, phase: 'Degraded',
+        message: status.message ?? 'Rollout aborted',
+        ...counts(),
+      });
+      return;
+    }
+
+    const stepIndex: number = status.currentStepIndex ?? 0;
+    if (stepIndex >= steps.length) {
+      // 走完了：金丝雀转正
+      this.scale(canary, desired);
+      if (stable && stable.metadata.uid !== canary.metadata.uid) this.scale(stable, 0);
+      await this.writeStatus(rollout, {
+        ...status, stableRS: hash, phase: 'Healthy', message: undefined, ...counts(),
+      });
+      return;
+    }
+
+    const step = steps[stepIndex];
+    const at = this.context.now();
+
+    if (step.setWeight !== undefined) {
+      const weight = Number(step.setWeight);
+      const canaryReplicas = Math.max(1, Math.round((desired * weight) / 100));
+      this.scale(canary, canaryReplicas);
+      if (stable) this.scale(stable, Math.max(0, desired - canaryReplicas));
+      // 等这一步的副本都 Ready 了才往下走
+      if (this.readyOf(canary) < canaryReplicas) {
+        await this.writeStatus(rollout, {
+          ...status, phase: 'Progressing', canaryWeight: weight, ...counts(),
+        });
+        return;
+      }
+      await this.writeStatus(rollout, {
+        ...status, phase: 'Progressing', canaryWeight: weight,
+        currentStepIndex: stepIndex + 1, ...counts(),
+      });
+      return;
+    }
+
+    if (step.pause !== undefined) {
+      /**
+       * 不带 duration 的 pause 是**无限期**的，等人来 `promote`。
+       * 很多人以为它会自己继续 —— 不会，这正是「手动确认」这一步的实现。
+       */
+      if (!step.pause?.duration) {
+        await this.writeStatus(rollout, {
+          ...status, phase: 'Paused', message: 'CanaryPauseStep',
+          pauseStartedAt: status.pauseStartedAt ?? new Date(at).toISOString(),
+          ...counts(),
+        });
+        return;
+      }
+      const startedAt = status.pauseStartedAt ? Date.parse(status.pauseStartedAt) : at;
+      if (!status.pauseStartedAt) {
+        await this.writeStatus(rollout, {
+          ...status, phase: 'Paused', pauseStartedAt: new Date(at).toISOString(), ...counts(),
+        });
+        return;
+      }
+      const remaining = parseDuration(String(step.pause.duration)) - (at - startedAt);
+      if (remaining > 0) {
+        /**
+         * 到点了得有人来叫醒它。
+         *
+         * 控制器是事件驱动的，而「暂停结束」不是任何对象的变化 ——
+         * 不排这个定时器的话，Rollout 会一直停在 Paused，
+         * 哪怕 duration 早就过了。
+         */
+        this.kernel.setTimeout(
+          () => this.enqueue(`${rollout.metadata.namespace}/${rollout.metadata.name}`),
+          remaining,
+          { label: `rollout:pause:${rollout.metadata.name}` }
+        );
+        return;
+      }
+      await this.writeStatus(rollout, {
+        ...status, phase: 'Progressing', currentStepIndex: stepIndex + 1,
+        pauseStartedAt: undefined, ...counts(),
+      });
+      return;
+    }
+
+    if (step.analysis) {
+      const outcome = this.runAnalysis(rollout, step.analysis, stepIndex);
+      if (outcome === 'Running') return;
+      if (outcome === 'Failed') {
+        await this.writeStatus(rollout, {
+          ...status, abort: true, phase: 'Degraded',
+          message: `Rollout aborted: analysis at step ${stepIndex} failed`,
+          ...counts(),
+        });
+        return;
+      }
+      await this.writeStatus(rollout, { ...status, currentStepIndex: stepIndex + 1, ...counts() });
+      return;
+    }
+
+    // 不认识的步骤：跳过，但留个痕迹
+    this.context.recordEvent({
+      object: rollout, type: 'Warning', reason: 'UnknownStep',
+      message: `step ${stepIndex} has no recognised action, skipping`,
+    });
+    await this.writeStatus(rollout, { ...status, currentStepIndex: stepIndex + 1, ...counts() });
+  }
+
+  /**
+   * 跑一次分析。
+   *
+   * 每个 metric 一条 PromQL，配一个 `successCondition`（形如 `result < 0.05`）。
+   * 任何一条不满足就是失败，整个发布中止 —— 这就是自动回滚。
+   */
+  private runAnalysis(rollout: KubeObject, analysis: any, stepIndex: number): 'Successful' | 'Failed' | 'Running' {
+    /**
+     * 名字里必须带模板哈希。
+     *
+     * 只用 `<rollout>-<step>` 的话，第二次发布走到同一步时会撞上上一次留下的
+     * AnalysisRun —— 那条已经是 Successful 了，于是这一次**一次都不量**就放行。
+     * 坏版本就是这么溜过去的。真 Argo 的运行名同样带 podhash 和 revision。
+     */
+    const hash = ((rollout.status ?? {}) as { currentPodHash?: string }).currentPodHash ?? 'unknown';
+    const name = `${rollout.metadata.name}-${hash}-${stepIndex}`;
+    const templateName = analysis.templates?.[0]?.templateName;
+    const template = this.templates.list().find(
+      (item) => item.metadata.namespace === rollout.metadata.namespace && item.metadata.name === templateName
+    );
+    if (!template) {
+      this.context.recordEvent({
+        object: rollout, type: 'Warning', reason: 'AnalysisTemplateNotFound',
+        message: `AnalysisTemplate "${templateName}" not found`,
+      });
+      return 'Failed';
+    }
+
+    const metrics: any[] = ((template.spec ?? {}) as any).metrics ?? [];
+
+    /**
+     * `initialDelay`：先别急着量。
+     *
+     * 金丝雀刚起来的那几秒，它的计数器还是 0、采样点还不够两个，
+     * 这时候算出来的错误率是**稳定版的**错误率 —— 看着很好，
+     * 然后就把坏版本放行了。真 Argo Rollouts 的 initialDelay 就是干这个的，
+     * 不写它是金丝雀分析最常见的失效方式。
+     */
+    const existingRun = this.runs.list().find(
+      (item) => item.metadata.namespace === rollout.metadata.namespace && item.metadata.name === name
+    );
+    const runStartedAt = ((existingRun?.status ?? {}) as any)?.startedAt;
+    const startedAt = runStartedAt ?? new Date(this.context.now()).toISOString();
+    const delay = metrics
+      .map((metric) => (metric.initialDelay ? parseDuration(String(metric.initialDelay)) : 0))
+      .reduce((a, b) => Math.max(a, b), 0);
+    const waited = this.context.now() - Date.parse(startedAt);
+    if (delay > 0 && waited < delay) {
+      this.upsertRun(rollout, name, 'Running', metrics.map((metric) => ({
+        name: metric.name, value: null, phase: 'Pending', condition: metric.successCondition,
+      })), startedAt);
+      this.kernel.setTimeout(
+        () => this.enqueue(`${rollout.metadata.namespace}/${rollout.metadata.name}`),
+        delay - waited,
+        { label: `rollout:analysis:${rollout.metadata.name}` }
+      );
+      return 'Running';
+    }
+
+    const measurements: any[] = [];
+    let phase: 'Successful' | 'Failed' | 'Running' = 'Successful';
+    let missing = false;
+    for (const metric of metrics) {
+      const query = metric.provider?.prometheus?.query;
+      const value = query ? this.options.evaluate(String(query)) : undefined;
+      if (value === undefined || Number.isNaN(value)) {
+        /**
+         * 查不到数不等于通过。
+         *
+         * 金丝雀刚起来的时候指标还没攒够两个采样点，rate 算不出来 ——
+         * 这时候正确的做法是**再等等**，而不是当成「没问题」放行。
+         * 等太久还是没有数据，就明确判失败：一条永远查不到数的判据
+         * 等于没有判据，静默放行比失败危险得多。
+         */
+        missing = true;
+        measurements.push({ name: metric.name, value: null, phase: 'Pending', condition: metric.successCondition });
+        continue;
+      }
+      const ok = checkCondition(metric.successCondition, value);
+      measurements.push({
+        name: metric.name,
+        value,
+        phase: ok ? 'Successful' : 'Failed',
+        condition: metric.successCondition,
+      });
+      if (!ok) phase = 'Failed';
+    }
+
+    if (missing && phase !== 'Failed') {
+      const first = Date.parse(startedAt);
+      if (this.context.now() - first < NO_DATA_GRACE_MS) {
+        this.upsertRun(rollout, name, 'Running', measurements, new Date(first).toISOString());
+        return 'Running';
+      }
+      this.upsertRun(rollout, name, 'Failed', measurements, new Date(first).toISOString());
+      return 'Failed';
+    }
+
+    this.upsertRun(rollout, name, phase, measurements, startedAt);
+    return phase as 'Successful' | 'Failed';
+  }
+
+  private upsertRun(
+    rollout: KubeObject,
+    name: string,
+    phase: string,
+    measurements: unknown[],
+    startedAt = new Date(this.context.now()).toISOString()
+  ): void {
+    const namespace = rollout.metadata.namespace;
+    const body: KubeObject = {
+      apiVersion: 'argoproj.io/v1alpha1', kind: 'AnalysisRun',
+      metadata: {
+        name, namespace,
+        ownerReferences: [{
+          apiVersion: 'argoproj.io/v1alpha1', kind: 'Rollout',
+          name: rollout.metadata.name!, uid: rollout.metadata.uid!,
+          controller: true, blockOwnerDeletion: true,
+        }],
+      },
+      status: { phase, metricResults: measurements, startedAt },
+    } as KubeObject;
+    try {
+      this.registry.get(ANALYSISRUNS, namespace, name);
+      updateStatusIfChanged(this.registry, ANALYSISRUNS, namespace, name, {
+        phase, metricResults: measurements, startedAt,
+      });
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      try {
+        this.registry.create(ANALYSISRUNS, namespace, body);
+      } catch (created) {
+        if (!isConflict(created)) throw created;
+      }
+    }
+  }
+
+  private ownedReplicaSets(rollout: KubeObject): KubeObject[] {
+    return this.registry.list(REPLICASETS, { namespace: rollout.metadata.namespace }).items
+      .filter((rs) => (rs.metadata.ownerReferences ?? []).some((ref) => ref.uid === rollout.metadata.uid));
+  }
+
+  private podsOf(replicaSet: KubeObject): KubeObject[] {
+    return this.registry.list(PODS, { namespace: replicaSet.metadata.namespace }).items
+      .filter((pod) => (pod.metadata.ownerReferences ?? []).some((ref) => ref.uid === replicaSet.metadata.uid))
+      .filter((pod) => !pod.metadata.deletionTimestamp);
+  }
+
+  private readyOf(replicaSet: KubeObject): number {
+    return this.podsOf(replicaSet).filter((pod) => isPodReady(pod)).length;
+  }
+
+  private scale(replicaSet: KubeObject, replicas: number): void {
+    if (((replicaSet.spec as any)?.replicas ?? 0) === replicas) return;
+    void ignoreConflict(() => {
+      const latest = this.registry.get(REPLICASETS, replicaSet.metadata.namespace, replicaSet.metadata.name);
+      this.registry.update(REPLICASETS, latest.metadata.namespace, latest.metadata.name, {
+        ...latest, spec: { ...(latest.spec as any), replicas },
+      });
+    });
+  }
+
+  private createReplicaSet(rollout: KubeObject, hash: string): KubeObject {
+    const spec = (rollout.spec ?? {}) as any;
+    const template = spec.template ?? {};
+    const replicaSet: KubeObject = {
+      apiVersion: 'apps/v1', kind: 'ReplicaSet',
+      metadata: {
+        name: `${rollout.metadata.name}-${hash}`,
+        namespace: rollout.metadata.namespace,
+        labels: { ...(template.metadata?.labels ?? {}), [POD_TEMPLATE_HASH]: hash },
+        ownerReferences: [{
+          apiVersion: 'argoproj.io/v1alpha1', kind: 'Rollout',
+          name: rollout.metadata.name!, uid: rollout.metadata.uid!,
+          controller: true, blockOwnerDeletion: true,
+        }],
+      },
+      spec: {
+        replicas: 0,
+        selector: { matchLabels: { ...(spec.selector?.matchLabels ?? {}), [POD_TEMPLATE_HASH]: hash } },
+        template: {
+          ...template,
+          metadata: {
+            ...(template.metadata ?? {}),
+            labels: { ...(template.metadata?.labels ?? {}), [POD_TEMPLATE_HASH]: hash },
+          },
+        },
+      },
+      status: {},
+    } as KubeObject;
+    return this.registry.create(REPLICASETS, rollout.metadata.namespace, replicaSet);
+  }
+
+  private async writeStatus(rollout: KubeObject, status: Record<string, unknown>): Promise<void> {
+    await ignoreConflict(() => {
+      updateStatusIfChanged(
+        this.registry, ROLLOUTS, rollout.metadata.namespace, rollout.metadata.name!, status
+      );
+    });
+  }
+}
+
+/**
+ * `successCondition` 的求值。
+ *
+ * Argo Rollouts 用的是 expr 语法，实际写出来的几乎都是
+ * `result < 0.05` 这种一元比较。这里只做这一种，写别的会被当成失败 ——
+ * 静默通过比明确失败危险得多。
+ */
+export function checkCondition(condition: string | undefined, value: number): boolean {
+  if (!condition) return true;
+  const match = /^\s*result\s*(<=|>=|<|>|==|!=)\s*(-?\d+(?:\.\d+)?)\s*$/.exec(condition);
+  if (!match) return false;
+  const bound = Number(match[2]);
+  switch (match[1]) {
+    case '<': return value < bound;
+    case '<=': return value <= bound;
+    case '>': return value > bound;
+    case '>=': return value >= bound;
+    case '==': return value === bound;
+    case '!=': return value !== bound;
+    default: return false;
+  }
+}

--- a/src/lib/opslab/rollouts/controller.ts
+++ b/src/lib/opslab/rollouts/controller.ts
@@ -2,7 +2,7 @@
  * Argo Rollouts 的控制器
  *
  * 金丝雀的核心是一个**状态机**：`status.currentStepIndex` 指向 steps 里的
- * 第几步，每一步做完才往前挪一格。四种步骤：
+ * 第几步，每一步做完才往前挪一格。三种步骤：
  *
  *   setWeight  调整金丝雀的副本占比
  *   pause      停住（带 duration 就是等那么久，不带就是等人来 promote）
@@ -16,9 +16,10 @@ import type { KubeObject } from '../apiserver';
 import {
   Controller, ControllerContext, Informer, isConflict, isNotFound, objectKey, splitKey,
 } from '../controllers/framework';
-import { DEPLOYMENTS, POD_TEMPLATE_HASH, REPLICASETS, templateHash } from '../controllers/resources';
+import {
+  DEPLOYMENTS, POD_TEMPLATE_HASH, PODS, REPLICASETS, templateHash,
+} from '../controllers/resources';
 import { ignoreConflict, isPodReady, updateStatusIfChanged } from '../controllers/workloads';
-import { PODS } from '../controllers/resources';
 import { ANALYSISRUNS, ANALYSISTEMPLATES, ROLLOUTS, ROLLOUTS_LABEL } from './resources';
 import { parseDuration } from '../observability';
 
@@ -27,6 +28,15 @@ export type AnalysisEvaluator = (query: string) => number | undefined;
 
 /** 查不到数最多等这么久，之后按失败算 */
 export const NO_DATA_GRACE_MS = 5 * 60_000;
+
+/**
+ * 查不到数时隔多久再量一次。
+ *
+ * 控制器是事件驱动的，而「Prometheus 又采了一轮」不是任何一个它盯着的对象
+ * 的变化。不排这个定时器的话，分析会停在 Running 上等一个永远不来的事件。
+ * 比采集间隔更快地重试没有意义 —— 那边还没有新的点。
+ */
+const NO_DATA_RETRY_MS = 15_000;
 
 export interface RolloutsOptions {
   evaluate: AnalysisEvaluator;
@@ -39,6 +49,16 @@ export class RolloutController extends Controller {
   private deployments: Informer;
   private templates: Informer;
   private runs: Informer;
+
+  /**
+   * 每个 Rollout 最多挂一条唤醒定时器。
+   *
+   * 不去重的话每次 reconcile 都排一条：而 reconcile 是事件驱动的，
+   * 一条 AnalysisRun 写回去就会再触发一轮 —— 定时器成指数增长，
+   * 到点一起炸开，世界当场卡死。真控制器的 workqueue 也是这个道理，
+   * 同一个 key 排队里只留一份。
+   */
+  private wakeups = new Map<string, number>();
 
   constructor(context: ControllerContext, private readonly options: RolloutsOptions) {
     super(context, 'argo-rollouts');
@@ -54,6 +74,23 @@ export class RolloutController extends Controller {
         for (const rollout of this.rollouts.list()) this.enqueue(objectKey(rollout));
       });
     }
+  }
+
+  /** 排一条「过 ms 之后再看一眼」，同一个 Rollout 只留最新的那条 */
+  private wakeAfter(rollout: KubeObject, ms: number, background: boolean): void {
+    const key = `${rollout.metadata.namespace}/${rollout.metadata.name}`;
+    const pending = this.wakeups.get(key);
+    if (pending !== undefined) this.kernel.clearTimer(pending);
+    this.wakeups.set(key, this.kernel.setTimeout(() => {
+      this.wakeups.delete(key);
+      this.enqueue(key);
+    }, ms, { background, label: `rollout:wake:${rollout.metadata.name}` }));
+  }
+
+  stop(): void {
+    for (const id of this.wakeups.values()) this.kernel.clearTimer(id);
+    this.wakeups.clear();
+    super.stop();
   }
 
   private installed(): boolean {
@@ -197,11 +234,7 @@ export class RolloutController extends Controller {
          * 不排这个定时器的话，Rollout 会一直停在 Paused，
          * 哪怕 duration 早就过了。
          */
-        this.kernel.setTimeout(
-          () => this.enqueue(`${rollout.metadata.namespace}/${rollout.metadata.name}`),
-          remaining,
-          { label: `rollout:pause:${rollout.metadata.name}` }
-        );
+        this.wakeAfter(rollout, remaining, false);
         return;
       }
       await this.writeStatus(rollout, {
@@ -285,11 +318,7 @@ export class RolloutController extends Controller {
       this.upsertRun(rollout, name, 'Running', metrics.map((metric) => ({
         name: metric.name, value: null, phase: 'Pending', condition: metric.successCondition,
       })), startedAt);
-      this.kernel.setTimeout(
-        () => this.enqueue(`${rollout.metadata.namespace}/${rollout.metadata.name}`),
-        delay - waited,
-        { label: `rollout:analysis:${rollout.metadata.name}` }
-      );
+      this.wakeAfter(rollout, delay - waited, false);
       return 'Running';
     }
 
@@ -326,6 +355,8 @@ export class RolloutController extends Controller {
       const first = Date.parse(startedAt);
       if (this.context.now() - first < NO_DATA_GRACE_MS) {
         this.upsertRun(rollout, name, 'Running', measurements, new Date(first).toISOString());
+        // 后台：这条会一直重排下去，算进前台的话世界永远静不下来
+        this.wakeAfter(rollout, NO_DATA_RETRY_MS, true);
         return 'Running';
       }
       this.upsertRun(rollout, name, 'Failed', measurements, new Date(first).toISOString());

--- a/src/lib/opslab/rollouts/index.ts
+++ b/src/lib/opslab/rollouts/index.ts
@@ -1,0 +1,10 @@
+/**
+ * 渐进式发布
+ *
+ * Deployment 的滚动更新只关心「新的起来了没有」，不关心「新的好不好」。
+ * Rollout 把发布过程本身写成 steps：放多少流量、停多久、看哪条指标。
+ * 分析失败时**自动回到稳定版本**，不需要人介入。
+ */
+export { ROLLOUTS, ANALYSISTEMPLATES, ANALYSISRUNS, ROLLOUT_RESOURCES, ROLLOUTS_LABEL } from './resources';
+export { RolloutController, checkCondition } from './controller';
+export type { AnalysisEvaluator, RolloutsOptions } from './controller';

--- a/src/lib/opslab/rollouts/index.ts
+++ b/src/lib/opslab/rollouts/index.ts
@@ -6,5 +6,5 @@
  * 分析失败时**自动回到稳定版本**，不需要人介入。
  */
 export { ROLLOUTS, ANALYSISTEMPLATES, ANALYSISRUNS, ROLLOUT_RESOURCES, ROLLOUTS_LABEL } from './resources';
-export { RolloutController, checkCondition } from './controller';
+export { NO_DATA_GRACE_MS, RolloutController, checkCondition } from './controller';
 export type { AnalysisEvaluator, RolloutsOptions } from './controller';

--- a/src/lib/opslab/rollouts/resources.ts
+++ b/src/lib/opslab/rollouts/resources.ts
@@ -1,0 +1,30 @@
+/**
+ * Argo Rollouts 的 CRD
+ *
+ * `Rollout` 是 Deployment 的替代品，不是补充 —— 一个工作负载要么由
+ * Deployment 管，要么由 Rollout 管。它多出来的是**发布过程本身可以被描述**：
+ * 分几步、每步放多少流量、每步停多久、停的时候看什么指标。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const ROLLOUTS: ResourceDefinition = {
+  group: 'argoproj.io', version: 'v1alpha1', resource: 'rollouts',
+  singular: 'rollout', kind: 'Rollout', namespaced: true,
+  shortNames: ['ro'], categories: ['all'], subresources: ['status', 'scale'],
+};
+
+export const ANALYSISTEMPLATES: ResourceDefinition = {
+  group: 'argoproj.io', version: 'v1alpha1', resource: 'analysistemplates',
+  singular: 'analysistemplate', kind: 'AnalysisTemplate', namespaced: true, shortNames: ['at'],
+};
+
+export const ANALYSISRUNS: ResourceDefinition = {
+  group: 'argoproj.io', version: 'v1alpha1', resource: 'analysisruns',
+  singular: 'analysisrun', kind: 'AnalysisRun', namespaced: true,
+  shortNames: ['ar'], subresources: ['status'],
+};
+
+export const ROLLOUT_RESOURCES: ResourceDefinition[] = [ROLLOUTS, ANALYSISTEMPLATES, ANALYSISRUNS];
+
+/** 控制器自己。没有它，Rollout 就只是一个对象。 */
+export const ROLLOUTS_LABEL = { key: 'app.kubernetes.io/name', value: 'argo-rollouts' };

--- a/tests/opslab/kernel.test.ts
+++ b/tests/opslab/kernel.test.ts
@@ -77,6 +77,35 @@ describe('虚拟时钟', () => {
     expect(Date.now() - wallStart).toBeLessThan(2000);
   });
 
+  /**
+   * 后台定时器不决定世界要不要往前走，但世界走过去的时候它们必须响。
+   *
+   * 原来 settle 里是 fireUpTo(前台定时器的时刻)，于是时钟从 0 一步跨到
+   * 120 秒，中间八次 15 秒的采集一次都没发生 —— 表现是「Prometheus 在
+   * 暂停期间不采样」，金丝雀分析拿不到两个采样点，判据永远算不出来。
+   */
+  it('推进到前台定时器时，沿途的后台定时器一个都不能少', async () => {
+    const kernel = createKernel();
+    const ticks: number[] = [];
+    kernel.setInterval(() => ticks.push(kernel.now()), 15_000, {
+      background: true,
+      label: 'scrape',
+    });
+
+    let woke = 0;
+    kernel.setTimeout(() => { woke = kernel.now(); }, 120_000, { label: 'pause' });
+
+    await kernel.settle();
+    expect(woke).toBe(120_000);
+    expect(ticks).toEqual([15_000, 30_000, 45_000, 60_000, 75_000, 90_000, 105_000, 120_000]);
+  });
+
+  it('推进的毫秒数必须是有限值，NaN 要当场报错而不是空转', async () => {
+    const kernel = createKernel();
+    expect(() => kernel.clock.advanceBy(Number.NaN)).toThrow(TypeError);
+    expect(() => kernel.clock.advanceTo(Number.POSITIVE_INFINITY)).toThrow(TypeError);
+  });
+
   it('后台定时器不会让世界永远静不下来', async () => {
     const kernel = createKernel();
     let resyncs = 0;

--- a/tests/opslab/rollouts.test.ts
+++ b/tests/opslab/rollouts.test.ts
@@ -7,7 +7,7 @@
  * 这一组要钉住的：状态机一步一步走、不带 duration 的 pause 会一直停、
  * 分析失败会中止并回滚、以及中止不是「停在原地」。
  */
-import { checkCondition } from '../../src/lib/opslab/rollouts';
+import { NO_DATA_GRACE_MS, checkCondition } from '../../src/lib/opslab/rollouts';
 import { buildTopology, createOpsWorld } from '../../src/lib/opslab/lab';
 import { SCRAPE_INTERVAL_MS } from '../../src/lib/opslab/observability';
 import type { OpsWorldSpec } from '../../src/lib/engineering/types';
@@ -83,6 +83,19 @@ const TEMPLATE = {
   },
 };
 
+/** 判据引用一个根本不存在的指标：这条查询永远查不到数 */
+const TEMPLATE_NO_DATA = {
+  apiVersion: 'argoproj.io/v1alpha1', kind: 'AnalysisTemplate',
+  metadata: { name: 'no-data', namespace: 'shop' },
+  spec: {
+    metrics: [{
+      name: 'error-rate',
+      successCondition: 'result < 0.05',
+      provider: { prometheus: { query: 'sum(rate(nothing_here_total[5m]))' } },
+    }],
+  },
+};
+
 const MONITOR = {
   apiVersion: 'monitoring.coreos.com/v1', kind: 'ServiceMonitor',
   metadata: { name: 'portal', namespace: 'shop' },
@@ -124,7 +137,7 @@ function spec(objects: unknown[]): OpsWorldSpec {
       [GOOD]: { pullMs: 10, startupMs: 10, readyAfterMs: 10, requestsPerSecond: 20, errorRatio: 0 },
       // 好版本的几个后续 tag。不声明的话拉不到镜像，Pod 起不来，
       // 会被误读成「金丝雀卡住了」
-      ...Object.fromEntries(['1.4.1', '1.4.2', '1.4.3', '1.4.4', '1.4.5'].map((tag) => [
+      ...Object.fromEntries(['1.4.1', '1.4.2', '1.4.3', '1.4.4', '1.4.5', '1.4.6'].map((tag) => [
         `harbor.corp.internal/team/portal:${tag}`,
         { pullMs: 10, startupMs: 10, readyAfterMs: 10, requestsPerSecond: 20, errorRatio: 0 },
       ])),
@@ -276,6 +289,30 @@ describe('金丝雀', () => {
     expect(node!.detail).toContain('Paused');
     // 属主链要接得上：Rollout -> ReplicaSet -> Pod
     expect(graph.edges.some((edge) => edge.from === node!.id && edge.kind === 'owns')).toBe(true);
+  });
+
+  /**
+   * 查不到数不等于通过。
+   *
+   * 一条永远查不到数的判据等于没有判据。先等（指标可能只是还没攒够点），
+   * 等够宽限期还是没有，就明确判失败 —— 静默放行比失败危险得多。
+   */
+  it('查不到数先等，等够宽限期还是没有就判失败', async () => {
+    const steps = [
+      { setWeight: 25 },
+      { analysis: { templates: [{ templateName: 'no-data' }] } },
+      { setWeight: 100 },
+    ];
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE_NO_DATA, rollout(GOOD, steps)]);
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.6', 60_000);
+    // 还在宽限期内：既没放行，也没判死
+    expect(statusOf(w).abort).toBeFalsy();
+    expect(statusOf(w).currentStepIndex).toBe(1);
+
+    await w.cluster.advanceBy(NO_DATA_GRACE_MS + 60_000);
+    expect(statusOf(w).abort).toBe(true);
+    const runs = w.cluster.registry.list(w.cluster.scheme.mustGet(RUNS), { namespace: 'shop' }).items;
+    expect(runs.some((run) => (run.status as any)?.phase === 'Failed')).toBe(true);
   });
 
   it('AnalysisTemplate 找不到时按失败处理，不静默放行', async () => {

--- a/tests/opslab/rollouts.test.ts
+++ b/tests/opslab/rollouts.test.ts
@@ -1,0 +1,287 @@
+/**
+ * 渐进式发布
+ *
+ * Deployment 的滚动更新只关心「新的起来了没有」，不关心「新的好不好」。
+ * Rollout 把发布过程写成 steps，并在分析失败时**自动回到稳定版本**。
+ *
+ * 这一组要钉住的：状态机一步一步走、不带 duration 的 pause 会一直停、
+ * 分析失败会中止并回滚、以及中止不是「停在原地」。
+ */
+import { checkCondition } from '../../src/lib/opslab/rollouts';
+import { buildTopology, createOpsWorld } from '../../src/lib/opslab/lab';
+import { SCRAPE_INTERVAL_MS } from '../../src/lib/opslab/observability';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import { printerFor, type KubeObject } from '../../src/lib/opslab/apiserver';
+
+describe('successCondition', () => {
+  it('一元比较', () => {
+    expect(checkCondition('result < 0.05', 0.01)).toBe(true);
+    expect(checkCondition('result < 0.05', 0.2)).toBe(false);
+    expect(checkCondition('result >= 0.99', 0.99)).toBe(true);
+  });
+
+  it('不写就是通过', () => {
+    expect(checkCondition(undefined, 42)).toBe(true);
+  });
+
+  it('看不懂的条件按失败算 —— 静默通过比明确失败危险', () => {
+    expect(checkCondition('result matches /ok/', 1)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+
+const GOOD = 'harbor.corp.internal/team/portal:1.4.0';
+const BAD = 'harbor.corp.internal/team/portal:1.5.0-bad';
+const PROM_IMAGE = 'quay.io/prometheus/prometheus:v3.9.1';
+const ROLLOUTS_IMAGE = 'quay.io/argoproj/argo-rollouts:v1.8.3';
+
+const PLATFORM = [
+  { apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'monitoring' }, status: { phase: 'Active' } },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'prometheus', namespace: 'monitoring', labels: { 'app.kubernetes.io/name': 'prometheus' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'prometheus' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'prometheus' } },
+        spec: { containers: [{ name: 'prometheus', image: PROM_IMAGE }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'argo-rollouts', namespace: 'monitoring', labels: { 'app.kubernetes.io/name': 'argo-rollouts' } },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'argo-rollouts' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'argo-rollouts' } },
+        spec: { containers: [{ name: 'controller', image: ROLLOUTS_IMAGE }] },
+      },
+    },
+  },
+];
+
+const TEMPLATE = {
+  apiVersion: 'argoproj.io/v1alpha1', kind: 'AnalysisTemplate',
+  metadata: { name: 'error-rate', namespace: 'shop' },
+  spec: {
+    metrics: [{
+      name: 'error-rate',
+      // 先等一分钟再量：金丝雀刚起来的时候算出来的是稳定版的错误率
+      initialDelay: '1m',
+      successCondition: 'result < 0.05',
+      provider: {
+        prometheus: {
+          query: 'sum(rate(http_requests_total{code=~"5.."}[5m]))'
+            + ' / sum(rate(http_requests_total[5m]))',
+        },
+      },
+    }],
+  },
+};
+
+const MONITOR = {
+  apiVersion: 'monitoring.coreos.com/v1', kind: 'ServiceMonitor',
+  metadata: { name: 'portal', namespace: 'shop' },
+  spec: { selector: { matchLabels: { app: 'portal' } } },
+};
+
+const SERVICE = {
+  apiVersion: 'v1', kind: 'Service',
+  metadata: { name: 'portal', namespace: 'shop', labels: { app: 'portal' } },
+  spec: { selector: { app: 'portal' }, ports: [{ port: 80, targetPort: 8080 }] },
+};
+
+function rollout(image: string, steps: unknown[]) {
+  return {
+    apiVersion: 'argoproj.io/v1alpha1', kind: 'Rollout',
+    metadata: { name: 'portal', namespace: 'shop' },
+    spec: {
+      replicas: 4,
+      selector: { matchLabels: { app: 'portal' } },
+      strategy: { canary: { steps } },
+      template: {
+        metadata: { labels: { app: 'portal' } },
+        spec: { containers: [{ name: 'web', image, ports: [{ containerPort: 8080 }] }] },
+      },
+    },
+  };
+}
+
+const STEPS = [
+  { setWeight: 25 },
+  { analysis: { templates: [{ templateName: 'error-rate' }] } },
+  { setWeight: 50 },
+];
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'shop'],
+    images: {
+      [GOOD]: { pullMs: 10, startupMs: 10, readyAfterMs: 10, requestsPerSecond: 20, errorRatio: 0 },
+      // 好版本的几个后续 tag。不声明的话拉不到镜像，Pod 起不来，
+      // 会被误读成「金丝雀卡住了」
+      ...Object.fromEntries(['1.4.1', '1.4.2', '1.4.3', '1.4.4', '1.4.5'].map((tag) => [
+        `harbor.corp.internal/team/portal:${tag}`,
+        { pullMs: 10, startupMs: 10, readyAfterMs: 10, requestsPerSecond: 20, errorRatio: 0 },
+      ])),
+      [BAD]: { pullMs: 10, startupMs: 10, readyAfterMs: 10, requestsPerSecond: 20, errorRatio: 0.4 },
+      [PROM_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [ROLLOUTS_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+const ROLLOUTS = { group: 'argoproj.io', version: 'v1alpha1', resource: 'rollouts' } as const;
+const REPLICASETS = { group: 'apps', version: 'v1', resource: 'replicasets' } as const;
+const RUNS = { group: 'argoproj.io', version: 'v1alpha1', resource: 'analysisruns' } as const;
+
+async function build(objects: unknown[]) {
+  const world = await createOpsWorld({ world: spec(objects) });
+  await world.cluster.advanceBy(SCRAPE_INTERVAL_MS * 40);
+  return world;
+}
+
+const statusOf = (w: Awaited<ReturnType<typeof build>>) =>
+  (w.cluster.registry.get(w.cluster.scheme.mustGet(ROLLOUTS), 'shop', 'portal').status ?? {}) as any;
+
+const replicasOf = (w: Awaited<ReturnType<typeof build>>) =>
+  w.cluster.registry.list(w.cluster.scheme.mustGet(REPLICASETS), { namespace: 'shop' }).items
+    .map((rs) => [(rs.spec as any).template.spec.containers[0].image, (rs.spec as any).replicas] as const);
+
+async function updateImage(
+  w: Awaited<ReturnType<typeof build>>,
+  image: string,
+  advanceMs = SCRAPE_INTERVAL_MS * 60
+) {
+  const definition = w.cluster.scheme.mustGet(ROLLOUTS);
+  const live = w.cluster.registry.get(definition, 'shop', 'portal');
+  const spec = JSON.parse(JSON.stringify(live.spec)) as any;
+  spec.template.spec.containers[0].image = image;
+  w.cluster.registry.update(definition, 'shop', 'portal', { ...live, spec } as KubeObject);
+  await w.cluster.advanceBy(advanceMs);
+}
+
+describe('金丝雀', () => {
+  it('第一次创建直接拉满，不走金丝雀', async () => {
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, STEPS)]);
+    const status = statusOf(w);
+    expect(status.phase).toBe('Healthy');
+    expect(replicasOf(w)).toEqual([[GOOD, 4]]);
+  });
+
+  it('控制器不在时 Rollout 就只是一个对象', async () => {
+    const w = await build([SERVICE, MONITOR, TEMPLATE, rollout(GOOD, STEPS)]);
+    expect(statusOf(w).phase).toBeUndefined();
+    expect(replicasOf(w)).toEqual([]);
+  });
+
+  it('好版本走完所有步骤，金丝雀转正、旧的缩到 0', async () => {
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, STEPS)]);
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.1');
+
+    const status = statusOf(w);
+    expect(status.phase).toBe('Healthy');
+    const replicas = Object.fromEntries(replicasOf(w));
+    expect(replicas['harbor.corp.internal/team/portal:1.4.1']).toBe(4);
+    expect(replicas[GOOD]).toBe(0);
+  });
+
+  it('坏版本在分析那一步被拦下，自动回到稳定版', async () => {
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, STEPS)]);
+    await updateImage(w, BAD);
+
+    const status = statusOf(w);
+    expect(status.phase).toBe('Degraded');
+    expect(status.abort).toBe(true);
+    expect(status.message).toContain('analysis at step 1 failed');
+
+    // 中止 = 回到稳定版，不是停在原地
+    const replicas = Object.fromEntries(replicasOf(w));
+    expect(replicas[BAD]).toBe(0);
+    expect(replicas[GOOD]).toBe(4);
+  });
+
+  it('分析的结果留在 AnalysisRun 里，能看出是哪条指标没过', async () => {
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, STEPS)]);
+    await updateImage(w, BAD);
+    const runs = w.cluster.registry.list(w.cluster.scheme.mustGet(RUNS), { namespace: 'shop' }).items;
+    expect(runs.length).toBeGreaterThan(0);
+    const status = (runs[0].status ?? {}) as any;
+    expect(status.phase).toBe('Failed');
+    expect(status.metricResults[0]).toMatchObject({ name: 'error-rate', phase: 'Failed' });
+    expect(status.metricResults[0].value).toBeGreaterThan(0.05);
+  });
+
+  it('不带 duration 的 pause 会一直停着，等人 promote', async () => {
+    const steps = [{ setWeight: 25 }, { pause: {} }, { setWeight: 100 }];
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, steps)]);
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.2', 60_000);
+
+    expect(statusOf(w).phase).toBe('Paused');
+    // 再等多久都不会自己往下走
+    await w.cluster.advanceBy(60 * 60_000);
+    expect(statusOf(w).phase).toBe('Paused');
+    expect(statusOf(w).currentStepIndex).toBe(1);
+  });
+
+  it('带 duration 的 pause 到点自己继续', async () => {
+    const steps = [{ setWeight: 25 }, { pause: { duration: '5m' } }, { setWeight: 100 }];
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, steps)]);
+    // 只推一分钟：pause 是 5m，这时候应该还停着
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.3', 60_000);
+    expect(statusOf(w).phase).toBe('Paused');
+
+    await w.cluster.advanceBy(6 * 60_000);
+    expect(statusOf(w).phase).toBe('Healthy');
+  });
+
+  /**
+   * 计数跨两个 ReplicaSet。
+   *
+   * 金丝雀期间副本分在新旧两边，只数一边的话 `kubectl get rollout` 的
+   * CURRENT 会突然掉一截，看着像丢了副本。UP-TO-DATE 才是只数新那边的列。
+   */
+  it('金丝雀期间 CURRENT 数两边，UP-TO-DATE 只数新的', async () => {
+    const steps = [{ setWeight: 25 }, { pause: {} }, { setWeight: 100 }];
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, steps)]);
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.5');
+
+    const status = statusOf(w);
+    expect(status.phase).toBe('Paused');
+    expect(status.replicas).toBe(4);
+    expect(status.availableReplicas).toBe(4);
+    expect(status.updatedReplicas).toBe(1);
+
+    // `kubectl get rollout` 打出来的就是这五列，和 Argo 的 CRD 一致
+    const printer = printerFor('rollouts');
+    const live = w.cluster.registry.get(w.cluster.scheme.mustGet(ROLLOUTS), 'shop', 'portal');
+    expect(printer.columns.map((column) => column.name))
+      .toEqual(['Name', 'Desired', 'Current', 'Up-to-date', 'Available', 'Age']);
+    expect(printer.cells(live, '10m')).toEqual(['portal', '4', '4', '1', '4', '10m']);
+  });
+
+  it('拓扑图上 Rollout 站在工作负载那一排，并且说得出停在哪一步', async () => {
+    const steps = [{ setWeight: 25 }, { pause: {} }, { setWeight: 100 }];
+    const w = await build([...PLATFORM, SERVICE, MONITOR, TEMPLATE, rollout(GOOD, steps)]);
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.5');
+
+    const graph = buildTopology(w.cluster, { namespace: 'shop' });
+    const node = graph.nodes.find((item) => item.kind === 'Rollout');
+    expect(node).toBeDefined();
+    expect(node!.detail).toContain('Paused');
+    // 属主链要接得上：Rollout -> ReplicaSet -> Pod
+    expect(graph.edges.some((edge) => edge.from === node!.id && edge.kind === 'owns')).toBe(true);
+  });
+
+  it('AnalysisTemplate 找不到时按失败处理，不静默放行', async () => {
+    const steps = [{ analysis: { templates: [{ templateName: 'nope' }] } }];
+    const w = await build([...PLATFORM, SERVICE, MONITOR, rollout(GOOD, steps)]);
+    await updateImage(w, 'harbor.corp.internal/team/portal:1.4.4');
+    expect(statusOf(w).abort).toBe(true);
+  });
+});


### PR DESCRIPTION
第 20 关 `progressive-delivery`：把「什么叫好」写进发布流程本身。

## 这一关教什么

Deployment 的滚动更新只回答「新的 Pod 起来了没有」。探针全过、日志干净、
大半请求返回 500 的版本，它会毫不犹豫地铺到 100%。这一关补上两件事：

- **金丝雀 + 分析**：`Rollout` 的 steps 一步步走，`AnalysisTemplate` 写判据
  （一条 PromQL 加一个 `successCondition`）。任何一条不满足就中止，
  而中止的含义是**回到稳定版本**，不是停在原地 —— 这就是自动回滚。
- **PDB**：`kubectl drain` 走的是 `eviction` 子资源，会先问 PDB；
  `kubectl delete pod` 走普通删除，谁也拦不住。两条命令行为不同的根源。

## 实现

新增 `src/lib/opslab/rollouts/`：Rollout / AnalysisTemplate / AnalysisRun 三个
CRD 加一个控制器。分析复用 observability 里那套 PromQL 求值器 —— 金丝雀的
判据和线上告警的判据本来就该是同一个东西。控制器照例是**工作负载**：
`argo-rollouts` Deployment 停掉，CRD 就变成一堆惰性对象，`kubectl get` 照样
看得见，宿主不特判。

## 顺带修掉的两个真 bug

**1. 虚拟时钟会跳过后台定时器**

`VirtualClock.advanceToNext({ includeBackground: false })` 原来是 `fireUpTo`，
于是时钟从 30s 一步跨到 150s（一个前台的暂停定时器），把中间十次 15 秒的
采集整个跳过去。后果是金丝雀分析拿不到两个采样点，`rate()` 算不出来，
错误率读成稳定版的 0，坏版本一路放行。`includeBackground` 只该决定
「推到哪儿」，不该决定「沿途谁响」。

**2. AnalysisRun 重名，第二次发布不量就放行**

名字原来是 `<rollout>-<step>`，第二次发布走到同一步会撞上上一次留下的、
已经 Successful 的那条。名字里补上模板哈希，和真 Argo 一致。

## 其它

- 副本计数改成跨所有 ReplicaSet 统计，补上 `updatedReplicas`：金丝雀期间
  四个副本分在两边，只数一边的话 CURRENT 看起来像掉了一半。
- `kubectl get rollout` 的列对齐 Argo 的 CRD（DESIRED / CURRENT / UP-TO-DATE
  / AVAILABLE / AGE，没有 STATUS 那一列 —— 想知道停在哪一步得 describe
  或者看 AnalysisRun）。
- 拓扑图上 Rollout 站进工作负载那一排，节点上打得出停在哪一步。

## 验证

- `npx jest`：46 个 suite、1566 条全绿（含 stage 20 的参考解全绿 / 什么都不做要挂）
- `npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)