### PR TITLE
feat(opslab): 持久卷

### DIFF
--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -200,6 +200,91 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
       ];
     },
   },
+  /**
+   * 访问模式在表里是缩写。
+   *
+   * `ReadWriteOnce` 打成 `RWO` —— 这不是省字，是 kubectl 的既定输出，
+   * 学员在真集群里看到的就是这三个字母。
+   */
+  persistentvolumeclaims: {
+    columns: [
+      NAME_COLUMN,
+      col('Status', 'The status of the claim.'),
+      col('Volume', 'The bound volume.'),
+      col('Capacity', 'The capacity of the bound volume.'),
+      col('Access Modes', 'The access modes of the bound volume.'),
+      col('Storageclass', 'The StorageClass of the claim.'),
+      col('VolumeAttributesClass', 'The VolumeAttributesClass of the claim.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        status.phase ?? 'Pending',
+        spec.volumeName ?? '',
+        status.capacity?.storage ?? '',
+        shortAccessModes(status.accessModes ?? spec.accessModes),
+        spec.storageClassName ?? '',
+        '<unset>',
+        age,
+      ];
+    },
+  },
+  persistentvolumes: {
+    columns: [
+      NAME_COLUMN,
+      col('Capacity', 'The capacity of the volume.'),
+      col('Access Modes', 'The access modes of the volume.'),
+      col('Reclaim Policy', 'What happens to the volume when its claim goes away.'),
+      col('Status', 'The status of the volume.'),
+      col('Claim', 'The claim bound to this volume.'),
+      col('Storageclass', 'The StorageClass of the volume.'),
+      col('VolumeAttributesClass', 'The VolumeAttributesClass of the volume.'),
+      col('Reason', 'The reason for the current status.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      const ref = spec.claimRef;
+      return [
+        object.metadata.name,
+        spec.capacity?.storage ?? '',
+        shortAccessModes(spec.accessModes),
+        spec.persistentVolumeReclaimPolicy ?? 'Retain',
+        status.phase ?? 'Pending',
+        ref ? `${ref.namespace}/${ref.name}` : '',
+        spec.storageClassName ?? '',
+        '<unset>',
+        status.reason ?? '',
+        age,
+      ];
+    },
+  },
+  storageclasses: {
+    columns: [
+      NAME_COLUMN,
+      col('Provisioner', 'The provisioner that creates volumes for this class.'),
+      col('Reclaimpolicy', 'What happens to volumes of this class when released.'),
+      col('Volumebindingmode', 'When volumes of this class are bound.'),
+      col('Allowvolumeexpansion', 'Whether volumes of this class can be expanded.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const item = object as any;
+      const isDefault = object.metadata.annotations?.['storageclass.kubernetes.io/is-default-class'] === 'true';
+      return [
+        `${object.metadata.name}${isDefault ? ' (default)' : ''}`,
+        item.provisioner ?? '',
+        item.reclaimPolicy ?? 'Delete',
+        item.volumeBindingMode ?? 'Immediate',
+        String(item.allowVolumeExpansion ?? false),
+        age,
+      ];
+    },
+  },
   poddisruptionbudgets: {
     columns: [
       NAME_COLUMN,
@@ -362,6 +447,14 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
  * 规则有点特别：大于 10 个单位就只显示一个单位（`13d` 而不是 `13d4h`），
  * 小于 10 才显示两个（`4h12m`）。照抄是因为学员对着真集群的输出会对不上。
  */
+/** ReadWriteOnce -> RWO，ReadWriteOncePod -> RWOP */
+function shortAccessModes(modes: string[] | undefined): string {
+  const short: Record<string, string> = {
+    ReadWriteOnce: 'RWO', ReadOnlyMany: 'ROX', ReadWriteMany: 'RWX', ReadWriteOncePod: 'RWOP',
+  };
+  return [...new Set((modes ?? []).map((mode) => short[mode] ?? mode))].join(',');
+}
+
 export function humanDuration(fromEpochMs: number, nowEpochMs: number): string {
   const ms = nowEpochMs - fromEpochMs;
   if (!Number.isFinite(ms)) return '<unknown>';

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -35,6 +35,9 @@ import {
 } from '../observability';
 import { ROLLOUT_RESOURCES, RolloutController } from '../rollouts';
 import { DISRUPTION_RESOURCES, PdbController, evictionVerdict } from '../disruption';
+import {
+  STORAGE_RESOURCES, StorageController, VolumeStore, createDefaultStorageClassDefaulter,
+} from '../storage';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -138,6 +141,14 @@ export class Cluster {
   /** 网络：DNS、Service 转发、NetworkPolicy 判定，全都读 apiserver 里的对象 */
   readonly network: Network;
 
+  /**
+   * 卷上的字节。
+   *
+   * 不放在 apiserver 里，因为它本来就不在那儿 —— PV 只是一条元数据记录，
+   * 数据在存储后端上。这个区别是「备份了对象图，恢复出来是空盘」的根。
+   */
+  readonly volumes = new VolumeStore();
+
   /** 监控。世界没配 metrics 就是 undefined。 */
   prometheus?: PrometheusController;
   /** 由外面装上（createOpsWorld 会接一个 Pod 里的 shell 进来） */
@@ -159,6 +170,7 @@ export class Cluster {
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
       ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES, ...ROLLOUT_RESOURCES,
+      ...STORAGE_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -227,6 +239,11 @@ export class Cluster {
     // 这样 `kubectl expose` 之后紧跟 `kubectl get svc`，IP 已经在那儿了
     this.registry.addDefaulter(createServiceIpDefaulter({
       registry: this.registry, scheme: this.scheme, cidr: options.serviceCidr,
+    }));
+
+    // 同理：PVC 的 storageClassName 由 apiserver 补默认值，不是控制器事后写的
+    this.registry.addDefaulter(createDefaultStorageClassDefaulter({
+      registry: this.registry, scheme: this.scheme,
     }));
 
     /**
@@ -615,6 +632,11 @@ export class Cluster {
       new EndpointsController(context),
       // PDB 的状态。`kubectl get pdb` 里 ALLOWED DISRUPTIONS 那一列就是它写的。
       new PdbController(context),
+      /**
+       * 绑定与回收。静态绑定是控制面自带的，所以这个控制器无条件跑；
+       * **动态供给**要看 CSI 驱动这个工作负载在不在（见 StorageController）。
+       */
+      new StorageController(context, { volumes: this.volumes }),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -16,6 +16,7 @@ import {
   objectKey,
   splitKey,
 } from './framework';
+import { PERSISTENTVOLUMECLAIMS } from '../storage/resources';
 import {
   CONFIGMAPS,
   DEPLOYMENTS,
@@ -91,18 +92,23 @@ export function updateStatusIfChanged(
 export class SchedulerController extends Controller {
   private pods: Informer;
   private nodes: Informer;
+  private claims: Informer;
 
   constructor(context: ControllerContext) {
     super(context, 'scheduler');
     this.pods = new Informer(this.registry, PODS);
     this.nodes = this.track(new Informer(this.registry, NODES));
     this.watch(this.pods);
-    // 节点变了，所有待调度的 Pod 都值得再看一眼
-    this.nodes.onChange(() => {
-      for (const pod of this.pods.list()) {
-        if (!(pod.spec as any)?.nodeName) this.queue.add(objectKey(pod));
-      }
-    });
+    this.claims = this.track(new Informer(this.registry, PERSISTENTVOLUMECLAIMS));
+    // 节点变了，所有待调度的 Pod 都值得再看一眼。
+    // PVC 也一样：一块盘绑上，等着它的 Pod 才有得调度。
+    for (const informer of [this.nodes, this.claims]) {
+      informer.onChange(() => {
+        for (const pod of this.pods.list()) {
+          if (!(pod.spec as any)?.nodeName) this.queue.add(objectKey(pod));
+        }
+      });
+    }
   }
 
   protected async reconcile(key: string): Promise<void> {
@@ -119,8 +125,22 @@ export class SchedulerController extends Controller {
     if (spec.nodeName) return;                       // 已经调度过了
     if (pod.metadata.deletionTimestamp) return;
 
-    const candidates = this.nodes.list().filter((node) => this.fits(node, pod));
+    /**
+     * 卷没绑上就别调度。
+     *
+     * 真调度器把「PVC 绑好了没有」当成一个 predicate：盘还没有，Pod 落到
+     * 哪台机器上都没意义。学员看到的现象是 Pod 一直 Pending 而节点明明有富余，
+     * describe 里那一行 `pod has unbound immediate PersistentVolumeClaims`
+     * 才是真正的原因。
+     */
+    const unbound = this.unboundClaims(pod);
+    const candidates = unbound.length > 0
+      ? []
+      : this.nodes.list().filter((node) => this.fits(node, pod));
     if (candidates.length === 0) {
+      const reason = unbound.length > 0
+        ? `0/${this.nodes.list().length} nodes are available: pod has unbound immediate PersistentVolumeClaims.`
+        : `0/${this.nodes.list().length} nodes are available: insufficient resources or no matching node.`;
       let changed = false;
       await ignoreConflict(() => {
         const before = JSON.stringify(this.registry.get(PODS, namespace, name).status ?? null);
@@ -128,8 +148,7 @@ export class SchedulerController extends Controller {
           ...(pod.status as any),
           phase: 'Pending',
           conditions: [{
-            type: 'PodScheduled', status: 'False', reason: 'Unschedulable',
-            message: '0/' + this.nodes.list().length + ' nodes are available: insufficient resources or no matching node.',
+            type: 'PodScheduled', status: 'False', reason: 'Unschedulable', message: reason,
           }],
         });
         changed = before !== JSON.stringify(this.registry.get(PODS, namespace, name).status ?? null);
@@ -137,8 +156,7 @@ export class SchedulerController extends Controller {
       // 状态没变就别再刷一条一样的事件出来
       if (!changed) return;
       this.context.recordEvent({
-        object: pod, type: 'Warning', reason: 'FailedScheduling',
-        message: `0/${this.nodes.list().length} nodes are available.`,
+        object: pod, type: 'Warning', reason: 'FailedScheduling', message: reason,
       });
       return;
     }
@@ -155,6 +173,26 @@ export class SchedulerController extends Controller {
       object: pod, type: 'Normal', reason: 'Scheduled',
       message: `Successfully assigned ${namespace}/${name} to ${chosen.metadata.name}`,
     });
+  }
+
+  /** Pod 引用了但还没 Bound 的 PVC */
+  private unboundClaims(pod: KubeObject): string[] {
+    const volumes = ((pod.spec as any)?.volumes ?? []) as any[];
+    const out: string[] = [];
+    for (const volume of volumes) {
+      const claimName = volume.persistentVolumeClaim?.claimName;
+      if (!claimName) continue;
+      try {
+        const claim = this.registry.get(
+          PERSISTENTVOLUMECLAIMS, pod.metadata.namespace, claimName
+        );
+        if (((claim.status ?? {}) as any).phase !== 'Bound') out.push(claimName);
+      } catch {
+        // PVC 还不存在也算没绑上 —— Pod 和 PVC 同时 apply 时会短暂经过这个状态
+        out.push(claimName);
+      }
+    }
+    return out;
   }
 
   private fits(node: KubeObject, pod: KubeObject): boolean {

--- a/src/lib/opslab/lab/podshell.ts
+++ b/src/lib/opslab/lab/podshell.ts
@@ -77,6 +77,19 @@ export function createExecHandler(cluster: Cluster) {
     vfs.populate(rootfsFor(pod, cluster));
     for (const directory of ['/bin', '/usr/bin', '/tmp', '/app']) vfs.mkdirp(directory);
 
+    /**
+     * 把卷挂进来。
+     *
+     * 容器的根文件系统每次 exec 都是新的（真容器里写在 rootfs 上的东西
+     * 一重建也就没了），**挂载点下面**的内容却来自卷 —— 这正是持久化的含义。
+     * emptyDir 故意不接：它和 Pod 同生共死，写进去的东西下一次 exec 就不在了。
+     */
+    const mounts = mountsOf(pod, container.name, cluster);
+    for (const mount of mounts) {
+      vfs.mkdirp(mount.path);
+      vfs.populate(prefixed(cluster.volumes.read(mount.volume), mount.path));
+    }
+
     const source = {
       zone: 'cluster' as const,
       namespace: request.namespace,
@@ -109,8 +122,74 @@ export function createExecHandler(cluster: Cluster) {
     // `kubectl exec pod -- sh -c '...'` 与 `kubectl exec pod -- curl x` 都要能跑
     const command = normalizeCommand(request.command);
     const result = await shell.run(command, stdin);
+
+    // 写回。挂载点下面的都是卷上的字节，其余的随容器一起消失。
+    for (const mount of mounts) {
+      cluster.volumes.write(mount.volume, stripped(vfs.toFileMap(mount.path), mount.path));
+    }
     return { stdout: result.stdout, stderr: result.stderr, code: result.code };
   };
+}
+
+/**
+ * 这个容器挂了哪些卷。
+ *
+ * 一条挂载要经过两跳：容器的 volumeMounts 指到 Pod 的 volumes 上，
+ * volumes 里那一项再指到 PVC，PVC 再指到 PV。任何一跳断了都是「挂上去了，
+ * 但里面是空的」—— 而这三跳分别由三个人写（开发、平台、存储），
+ * 所以现实里断得很频繁。
+ */
+function mountsOf(
+  pod: KubeObject,
+  containerName: string,
+  cluster: Cluster
+): Array<{ path: string; volume: string }> {
+  const spec = (pod.spec ?? {}) as any;
+  const container = (spec.containers ?? []).find((item: any) => item.name === containerName);
+  const volumes: any[] = spec.volumes ?? [];
+  const out: Array<{ path: string; volume: string }> = [];
+
+  for (const mount of container?.volumeMounts ?? []) {
+    const volume = volumes.find((item) => item.name === mount.name);
+    const claimName = volume?.persistentVolumeClaim?.claimName;
+    if (!claimName) continue;
+    const claims = cluster.scheme.get({ group: '', version: 'v1', resource: 'persistentvolumeclaims' });
+    if (!claims) continue;
+    try {
+      const claim = cluster.registry.get(claims, pod.metadata.namespace, claimName);
+      const volumeName = ((claim.spec ?? {}) as any).volumeName;
+      if (volumeName) out.push({ path: normalizeMountPath(mount.mountPath), volume: volumeName });
+    } catch {
+      // PVC 不在了：挂载点还在，只是下面什么都没有
+    }
+  }
+  return out;
+}
+
+/** `/data/` → `/data`，根目录保持 `/` */
+function normalizeMountPath(path: string): string {
+  const trimmed = (path ?? '/').replace(/\/+$/, '');
+  return trimmed === '' ? '/' : trimmed;
+}
+
+/** 卷上的相对路径 → 容器里的绝对路径 */
+function prefixed(content: Record<string, string>, mountPath: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [path, value] of Object.entries(content)) {
+    out[`${mountPath === '/' ? '' : mountPath}/${path.replace(/^\/+/, '')}`] = value;
+  }
+  return out;
+}
+
+/** 容器里的绝对路径 → 卷上的相对路径 */
+function stripped(files: Record<string, string>, mountPath: string): Record<string, string> {
+  const prefix = mountPath === '/' ? '/' : `${mountPath}/`;
+  const out: Record<string, string> = {};
+  for (const [path, value] of Object.entries(files)) {
+    if (!path.startsWith(prefix)) continue;
+    out[path.slice(prefix.length)] = value;
+  }
+  return out;
 }
 
 /**

--- a/src/lib/opslab/storage/controller.ts
+++ b/src/lib/opslab/storage/controller.ts
@@ -1,0 +1,318 @@
+/**
+ * 绑定与供给
+ *
+ * PVC 提交上来只是一句「我要 5Gi、要能读写」。把它变成一块真盘有两条路：
+ *
+ *   静态：管理员先建好 PV，控制器按容量和访问模式挑一块配上去。
+ *         这条路是 kube-controller-manager 做的，控制面自带。
+ *   动态：StorageClass 指定一个 provisioner，由**外部 CSI 驱动**现造一块。
+ *         这条路是集群里的一个工作负载做的。驱动不在，PVC 就一直 Pending。
+ *
+ * 回收策略决定「PVC 没了之后那块盘怎么办」：`Delete` 连盘带数据一起删，
+ * `Retain` 留着但转成 Released —— 而 Released 的 PV **不会**被下一个 PVC
+ * 自动接手，得有人先把 claimRef 清掉。这是「我明明设了 Retain，
+ * 为什么新的 PVC 还是 Pending」的答案。
+ */
+import type { Defaulter, KubeObject, Registry, Scheme } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS, PODS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+// 容量和 CPU/内存用的是同一套单位写法，解析也用同一份，免得两处对不上
+import { parseQuantity } from '../controllers/runtime';
+import {
+  CSI_DRIVER_LABEL, DEFAULT_CLASS_ANNOTATION,
+  PERSISTENTVOLUMECLAIMS, PERSISTENTVOLUMES, STORAGECLASSES,
+} from './resources';
+import type { VolumeStore } from './volumes';
+
+export interface StorageOptions {
+  volumes: VolumeStore;
+}
+
+/**
+ * 默认 StorageClass 的准入。
+ *
+ * 真 apiserver 有一个内置插件叫 DefaultStorageClass：PVC 没写
+ * `storageClassName` 时，它在**写进去之前**把默认类的名字补上。
+ * 所以 `kubectl get pvc` 里那一列一开始就有值，不是控制器事后补的。
+ * 注意它只在字段**缺失**时动手，写成空串是明确要求静态绑定，不补。
+ */
+export function createDefaultStorageClassDefaulter(options: {
+  registry: Registry;
+  scheme: Scheme;
+}): Defaulter {
+  return {
+    matches: (definition) => definition.resource === 'persistentvolumeclaims',
+    apply: (object) => {
+      const spec = (object.spec ?? {}) as any;
+      if (spec.storageClassName !== undefined) return;
+      const definition = options.scheme.get({
+        group: 'storage.k8s.io', version: 'v1', resource: 'storageclasses',
+      });
+      if (!definition) return;
+      const fallback = options.registry.list(definition).items.find(
+        (item) => item.metadata.annotations?.[DEFAULT_CLASS_ANNOTATION] === 'true'
+      );
+      if (!fallback) return;
+      object.spec = { ...spec, storageClassName: fallback.metadata.name };
+    },
+  };
+}
+
+export class StorageController extends Controller {
+  private claims: Informer;
+  private volumes: Informer;
+  private classes: Informer;
+  private pods: Informer;
+  private deployments: Informer;
+
+  constructor(context: ControllerContext, private readonly options: StorageOptions) {
+    super(context, 'persistentvolume');
+    this.claims = new Informer(this.registry, PERSISTENTVOLUMECLAIMS);
+    this.volumes = this.track(new Informer(this.registry, PERSISTENTVOLUMES));
+    this.classes = this.track(new Informer(this.registry, STORAGECLASSES));
+    this.pods = this.track(new Informer(this.registry, PODS));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.watch(this.claims);
+    // PV、StorageClass、Pod 任何一样变了，等着的 PVC 都值得再看一眼
+    for (const informer of [this.volumes, this.classes, this.pods, this.deployments]) {
+      informer.onChange(() => {
+        for (const claim of this.claims.list()) this.enqueue(objectKey(claim));
+      });
+    }
+  }
+
+  /** 动态供给要有人干活。静态绑定不需要 —— 那是控制面自带的。 */
+  private provisionerReady(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[CSI_DRIVER_LABEL.key] !== CSI_DRIVER_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { namespace, name } = splitKey(key);
+    let claim: KubeObject;
+    try {
+      claim = this.registry.get(PERSISTENTVOLUMECLAIMS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return this.reclaimFor(namespace, name);
+      throw error;
+    }
+    if (claim.metadata.deletionTimestamp) return;
+
+    const spec = (claim.spec ?? {}) as any;
+    const status = (claim.status ?? {}) as any;
+    if (status.phase === 'Bound' && spec.volumeName) return;
+
+    const bound = spec.volumeName
+      ? this.volumes.list().find((pv) => pv.metadata.name === spec.volumeName)
+      : this.findMatch(claim);
+
+    if (bound) return this.bind(claim, bound);
+
+    const className = this.classNameOf(claim);
+    const storageClass = className
+      ? this.classes.list().find((item) => item.metadata.name === className)
+      : undefined;
+
+    /**
+     * `storageClassName: ""` 是**明确要求静态绑定**，不是「用默认的」。
+     * 这两者写法只差一对引号，行为完全相反。
+     */
+    if (spec.storageClassName === '') return this.pending(claim, 'no PersistentVolume matches this claim');
+    if (!storageClass) {
+      return this.pending(claim, className
+        ? `storageclass.storage.k8s.io "${className}" not found`
+        : 'no default StorageClass and no matching PersistentVolume');
+    }
+
+    /**
+     * WaitForFirstConsumer：没有 Pod 用它就先不造。
+     *
+     * 云上的默认 StorageClass 基本都是这个模式 —— 盘要造在 Pod 落的那个
+     * 可用区里，所以得先知道 Pod 去哪儿。「PVC 一直 Pending，但什么都没配错」
+     * 十有八九就是它。
+     */
+    const mode = (storageClass.spec as any)?.volumeBindingMode
+      ?? (storageClass as any).volumeBindingMode
+      ?? 'Immediate';
+    if (mode === 'WaitForFirstConsumer' && !this.claimed(claim)) {
+      return this.pending(claim, 'waiting for first consumer to be created before binding');
+    }
+
+    if (!this.provisionerReady()) {
+      const provisioner = (storageClass as any).provisioner ?? 'unknown';
+      return this.pending(
+        claim,
+        `waiting for a volume to be created, either by external provisioner "${provisioner}"`
+          + ' or manually by system administrator'
+      );
+    }
+
+    await this.provision(claim, storageClass);
+  }
+
+  /** 有没有 Pod 引用了这个 PVC */
+  private claimed(claim: KubeObject): boolean {
+    return this.pods.list().some((pod) => {
+      if (pod.metadata.namespace !== claim.metadata.namespace) return false;
+      return ((pod.spec as any)?.volumes ?? []).some(
+        (volume: any) => volume.persistentVolumeClaim?.claimName === claim.metadata.name
+      );
+    });
+  }
+
+  private classNameOf(claim: KubeObject): string | undefined {
+    const requested = (claim.spec as any)?.storageClassName;
+    if (typeof requested === 'string') return requested || undefined;
+    const fallback = this.classes.list().find(
+      (item) => item.metadata.annotations?.[DEFAULT_CLASS_ANNOTATION] === 'true'
+    );
+    return fallback?.metadata.name;
+  }
+
+  /**
+   * 静态匹配。
+   *
+   * 真调度里还看节点亲和，这里只看三样：类、容量、访问模式。
+   * 注意**已经 Released 的 PV 不参与匹配** —— 上一个 PVC 的 claimRef 还在
+   * 上面，谁也接不走。
+   */
+  private findMatch(claim: KubeObject): KubeObject | undefined {
+    const spec = (claim.spec ?? {}) as any;
+    const wanted = parseQuantity(spec.resources?.requests?.storage);
+    const modes: string[] = spec.accessModes ?? [];
+    const className = this.classNameOf(claim);
+    return this.volumes.list().find((pv) => {
+      const pvSpec = (pv.spec ?? {}) as any;
+      const phase = ((pv.status ?? {}) as any).phase;
+      if (phase && phase !== 'Available') return false;
+      if (pvSpec.claimRef) return false;
+      if ((pvSpec.storageClassName || undefined) !== className) return false;
+      if (parseQuantity(pvSpec.capacity?.storage) < wanted) return false;
+      return modes.every((mode) => (pvSpec.accessModes ?? []).includes(mode));
+    });
+  }
+
+  private async provision(claim: KubeObject, storageClass: KubeObject): Promise<void> {
+    const spec = (claim.spec ?? {}) as any;
+    const name = `pvc-${claim.metadata.uid}`;
+    const body: KubeObject = {
+      apiVersion: 'v1', kind: 'PersistentVolume',
+      metadata: {
+        name,
+        annotations: { 'pv.kubernetes.io/provisioned-by': (storageClass as any).provisioner ?? 'csi' },
+      },
+      spec: {
+        capacity: { storage: spec.resources?.requests?.storage ?? '1Gi' },
+        accessModes: spec.accessModes ?? ['ReadWriteOnce'],
+        persistentVolumeReclaimPolicy: (storageClass as any).reclaimPolicy ?? 'Delete',
+        storageClassName: storageClass.metadata.name,
+        csi: { driver: (storageClass as any).provisioner ?? 'csi', volumeHandle: name },
+      },
+      status: { phase: 'Available' },
+    } as KubeObject;
+
+    let created: KubeObject;
+    try {
+      created = this.registry.create(PERSISTENTVOLUMES, undefined, body);
+    } catch {
+      created = this.registry.get(PERSISTENTVOLUMES, undefined, name);
+    }
+    // 新盘是空的。这一句在这里，是为了让「盘存在」和「盘上有数据」分成两件事。
+    if (!this.options.volumes.has(name)) this.options.volumes.write(name, {});
+    this.context.recordEvent({
+      object: claim, type: 'Normal', reason: 'ProvisioningSucceeded',
+      message: `Successfully provisioned volume ${name}`,
+    });
+    await this.bind(claim, created);
+  }
+
+  private async bind(claim: KubeObject, volume: KubeObject): Promise<void> {
+    const namespace = claim.metadata.namespace;
+    const name = claim.metadata.name!;
+    await ignoreConflict(() => {
+      const latest = this.registry.get(PERSISTENTVOLUMES, undefined, volume.metadata.name!);
+      const spec = (latest.spec ?? {}) as any;
+      if (!spec.claimRef) {
+        this.registry.update(PERSISTENTVOLUMES, undefined, latest.metadata.name!, {
+          ...latest,
+          spec: {
+            ...spec,
+            claimRef: {
+              apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+              name, namespace, uid: claim.metadata.uid,
+            },
+          },
+        });
+      }
+      updateStatusIfChanged(this.registry, PERSISTENTVOLUMES, undefined, latest.metadata.name!, {
+        phase: 'Bound',
+      });
+    });
+
+    await ignoreConflict(() => {
+      const latest = this.registry.get(PERSISTENTVOLUMECLAIMS, namespace, name);
+      const spec = (latest.spec ?? {}) as any;
+      if (spec.volumeName !== volume.metadata.name) {
+        this.registry.update(PERSISTENTVOLUMECLAIMS, namespace, name, {
+          ...latest, spec: { ...spec, volumeName: volume.metadata.name },
+        });
+      }
+      const pvSpec = (this.registry.get(PERSISTENTVOLUMES, undefined, volume.metadata.name!).spec ?? {}) as any;
+      updateStatusIfChanged(this.registry, PERSISTENTVOLUMECLAIMS, namespace, name, {
+        phase: 'Bound',
+        accessModes: pvSpec.accessModes ?? spec.accessModes,
+        capacity: pvSpec.capacity,
+      });
+    });
+  }
+
+  private async pending(claim: KubeObject, message: string): Promise<void> {
+    const namespace = claim.metadata.namespace;
+    const name = claim.metadata.name!;
+    let changed = false;
+    await ignoreConflict(() => {
+      const before = JSON.stringify(this.registry.get(PERSISTENTVOLUMECLAIMS, namespace, name).status ?? null);
+      updateStatusIfChanged(this.registry, PERSISTENTVOLUMECLAIMS, namespace, name, { phase: 'Pending' });
+      changed = before !== JSON.stringify(
+        this.registry.get(PERSISTENTVOLUMECLAIMS, namespace, name).status ?? null
+      );
+    });
+    if (!changed) return;
+    this.context.recordEvent({
+      object: claim, type: 'Normal', reason: 'WaitForFirstConsumer', message,
+    });
+  }
+
+  /**
+   * PVC 没了：按回收策略处置那块盘。
+   *
+   * `Delete` 是**连数据一起**删。生产上这条最疼 —— 删一个 Helm release
+   * 顺手带走 PVC，盘就跟着没了，而 apiserver 里再也查不到它存在过。
+   */
+  private reclaimFor(namespace: string | undefined, name: string): void {
+    for (const volume of this.volumes.list()) {
+      const spec = (volume.spec ?? {}) as any;
+      const ref = spec.claimRef;
+      if (!ref || ref.namespace !== namespace || ref.name !== name) continue;
+      const policy = spec.persistentVolumeReclaimPolicy ?? 'Retain';
+      if (policy === 'Delete') {
+        this.options.volumes.drop(volume.metadata.name!);
+        try {
+          this.registry.delete(PERSISTENTVOLUMES, undefined, volume.metadata.name!);
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+        }
+        continue;
+      }
+      // Retain：盘和数据都留着，但 claimRef 还挂着，下一个 PVC 接不走
+      updateStatusIfChanged(this.registry, PERSISTENTVOLUMES, undefined, volume.metadata.name!, {
+        phase: 'Released',
+      });
+    }
+  }
+}

--- a/src/lib/opslab/storage/index.ts
+++ b/src/lib/opslab/storage/index.ts
@@ -1,0 +1,14 @@
+/**
+ * 持久化存储
+ *
+ * 这一层要立住的是一件事：**数据不属于 Pod**。Pod 是可以随时被杀掉重建的，
+ * 数据不是。中间隔着 PVC 和 PV 两层，正是为了让这两件事的生命周期分开。
+ */
+export {
+  PERSISTENTVOLUMES, PERSISTENTVOLUMECLAIMS, STORAGECLASSES, STORAGE_RESOURCES,
+  CSI_DRIVER_LABEL, DEFAULT_CLASS_ANNOTATION,
+} from './resources';
+export { StorageController, createDefaultStorageClassDefaulter } from './controller';
+export type { StorageOptions } from './controller';
+export { VolumeStore } from './volumes';
+export type { VolumeContent } from './volumes';

--- a/src/lib/opslab/storage/resources.ts
+++ b/src/lib/opslab/storage/resources.ts
@@ -1,0 +1,47 @@
+/**
+ * 存储的三个对象
+ *
+ * `StorageClass` 说的是「怎么造」，`PersistentVolume` 是造出来的那块盘，
+ * `PersistentVolumeClaim` 是应用提出的要求。应用只写 PVC，绑定由控制器做 ——
+ * 这一层间接正是「Pod 不知道自己的数据落在哪台机器上」的来源。
+ *
+ * PV 和 PVC 都是核心组（v1），StorageClass 在 storage.k8s.io 里。
+ * 这个区别有实际后果：`kubectl api-resources` 里它们分在不同的组，
+ * RBAC 规则也要分开写。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const PERSISTENTVOLUMES: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'persistentvolumes',
+  singular: 'persistentvolume', kind: 'PersistentVolume', namespaced: false,
+  shortNames: ['pv'], subresources: ['status'],
+};
+
+export const PERSISTENTVOLUMECLAIMS: ResourceDefinition = {
+  group: '', version: 'v1', resource: 'persistentvolumeclaims',
+  singular: 'persistentvolumeclaim', kind: 'PersistentVolumeClaim', namespaced: true,
+  shortNames: ['pvc'], categories: ['all'], subresources: ['status'],
+};
+
+export const STORAGECLASSES: ResourceDefinition = {
+  group: 'storage.k8s.io', version: 'v1', resource: 'storageclasses',
+  singular: 'storageclass', kind: 'StorageClass', namespaced: false,
+  shortNames: ['sc'],
+};
+
+export const STORAGE_RESOURCES: ResourceDefinition[] = [
+  PERSISTENTVOLUMES, PERSISTENTVOLUMECLAIMS, STORAGECLASSES,
+];
+
+/**
+ * 动态供给的那个组件。
+ *
+ * 静态绑定（管理员先建好 PV）是 kube-controller-manager 干的，控制面自带；
+ * **动态供给**是外部 CSI 驱动干的，它是一个跑在集群里的工作负载。
+ * 把它停掉，StorageClass 还在、PVC 还能提交，但永远停在 Pending ——
+ * 真集群里这条最难查，因为所有对象看起来都正常。
+ */
+export const CSI_DRIVER_LABEL = { key: 'app.kubernetes.io/name', value: 'csi-driver' };
+
+/** 默认 StorageClass 的标记 */
+export const DEFAULT_CLASS_ANNOTATION = 'storageclass.kubernetes.io/is-default-class';

--- a/src/lib/opslab/storage/volumes.ts
+++ b/src/lib/opslab/storage/volumes.ts
@@ -1,0 +1,53 @@
+/**
+ * 卷里的数据
+ *
+ * apiserver 里存的是**对象**，不是数据。PV 只是一条元数据记录，
+ * 真正的字节在存储后端上 —— 这里就是那个后端。
+ *
+ * 分开存有两个直接后果，两个都是这一层要教的：
+ *
+ *   1. 删掉 Pod 数据还在（数据不属于 Pod），删掉 PV 数据才没
+ *   2. 备份对象图不等于备份数据 —— Velero 把 PVC 的 YAML 存下来了，
+ *      恢复出来是一个**空盘**，除非它同时做了卷快照
+ */
+
+/** 一块盘上的内容：绝对路径到内容 */
+export type VolumeContent = Record<string, string>;
+
+export class VolumeStore {
+  private data = new Map<string, VolumeContent>();
+
+  /** 读一块盘。没有就是空盘，不是错误 —— 新建的盘本来就是空的。 */
+  read(name: string): VolumeContent {
+    return { ...(this.data.get(name) ?? {}) };
+  }
+
+  write(name: string, content: VolumeContent): void {
+    this.data.set(name, { ...content });
+  }
+
+  has(name: string): boolean {
+    return this.data.has(name);
+  }
+
+  /** 盘没了，数据也就没了 */
+  drop(name: string): void {
+    this.data.delete(name);
+  }
+
+  /** 快照/恢复用：整块拷过去 */
+  copy(from: string, to: string): void {
+    this.data.set(to, { ...(this.data.get(from) ?? {}) });
+  }
+
+  /** 世界快照。排序是为了让同样的世界序列化出同样的字节。 */
+  snapshot(): Record<string, VolumeContent> {
+    const out: Record<string, VolumeContent> = {};
+    for (const name of [...this.data.keys()].sort()) out[name] = { ...this.data.get(name)! };
+    return out;
+  }
+
+  restore(state: Record<string, VolumeContent>): void {
+    this.data = new Map(Object.entries(state).map(([name, content]) => [name, { ...content }]));
+  }
+}

--- a/tests/opslab/storage.test.ts
+++ b/tests/opslab/storage.test.ts
@@ -1,0 +1,316 @@
+/**
+ * 持久化存储
+ *
+ * 要钉住的核心只有一句：**数据不属于 Pod**。
+ *
+ * 围着它的是四件容易搞错的事：动态供给要有人干活（CSI 驱动是工作负载，
+ * 不是控制面自带）、PVC 没绑上 Pod 就不该被调度、回收策略决定删了 PVC
+ * 之后数据还在不在、以及 Retain 留下的 PV **不会**被下一个 PVC 自动接手。
+ */
+import { createExecHandler, createOpsWorld } from '../../src/lib/opslab/lab';
+import { printerFor } from '../../src/lib/opslab/apiserver';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const APP_IMAGE = 'registry.corp.internal/ledger:3.2';
+const CSI_IMAGE = 'registry.k8s.io/sig-storage/csi-provisioner:v5.1.0';
+
+const PVCS = { group: '', version: 'v1', resource: 'persistentvolumeclaims' } as const;
+const PVS = { group: '', version: 'v1', resource: 'persistentvolumes' } as const;
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+
+/** CSI 驱动：和别的平台组件一样，是集群里的一个工作负载 */
+const CSI_DRIVER = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: {
+    name: 'csi-provisioner', namespace: 'kube-system',
+    labels: { 'app.kubernetes.io/name': 'csi-driver' },
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'csi-driver' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'csi-driver' } },
+      spec: { containers: [{ name: 'provisioner', image: CSI_IMAGE }] },
+    },
+  },
+};
+
+const CLASS = {
+  apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass',
+  metadata: {
+    name: 'standard',
+    annotations: { 'storageclass.kubernetes.io/is-default-class': 'true' },
+  },
+  provisioner: 'csi.corp.internal',
+  reclaimPolicy: 'Delete',
+  volumeBindingMode: 'Immediate',
+};
+
+const claim = (overrides: Record<string, unknown> = {}) => ({
+  apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+  metadata: { name: 'data', namespace: 'shop' },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '5Gi' } },
+    ...overrides,
+  },
+});
+
+const pod = (claimName = 'data') => ({
+  apiVersion: 'v1', kind: 'Pod',
+  metadata: { name: 'ledger', namespace: 'shop' },
+  spec: {
+    containers: [{
+      name: 'app', image: APP_IMAGE,
+      volumeMounts: [{ name: 'data', mountPath: '/data' }],
+    }],
+    volumes: [{ name: 'data', persistentVolumeClaim: { claimName } }],
+  },
+});
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'shop', 'kube-system'],
+    images: {
+      [APP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [CSI_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(objects: unknown[]) {
+  const world = await createOpsWorld({ world: spec(objects) });
+  await world.cluster.advanceBy(60_000);
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+const pvcOf = (w: World, name = 'data') =>
+  w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'shop', name);
+const pvsOf = (w: World) =>
+  w.cluster.registry.list(w.cluster.scheme.mustGet(PVS), {}).items;
+const eventsOn = (w: World, name: string) =>
+  w.cluster.registry.list(w.cluster.scheme.mustGet(
+    { group: '', version: 'v1', resource: 'events' }
+  ), { namespace: 'shop' }).items
+    .filter((event) => (event as any).involvedObject?.name === name)
+    .map((event) => String((event as any).message));
+
+describe('绑定与供给', () => {
+  it('有 StorageClass 又有驱动：盘自己造出来并绑上', async () => {
+    const w = await build([CSI_DRIVER, CLASS, claim()]);
+    const pvc = pvcOf(w);
+    expect((pvc.status as any).phase).toBe('Bound');
+    expect((pvc.spec as any).volumeName).toMatch(/^pvc-/);
+
+    const pv = pvsOf(w)[0];
+    expect((pv.status as any).phase).toBe('Bound');
+    expect((pv.spec as any).claimRef).toMatchObject({ namespace: 'shop', name: 'data' });
+    expect((pv.spec as any).persistentVolumeReclaimPolicy).toBe('Delete');
+  });
+
+  /**
+   * 动态供给是工作负载干的活，不是控制面自带的。
+   * 把驱动停掉，所有对象看起来都正常，PVC 就是一直 Pending —— 真集群里
+   * 这条最难查，所以事件里必须说得出「在等谁」。
+   */
+  it('驱动不在：PVC 一直 Pending，而且说得出在等谁', async () => {
+    const w = await build([CLASS, claim()]);
+    expect((pvcOf(w).status as any).phase).toBe('Pending');
+    expect(pvsOf(w)).toHaveLength(0);
+    expect(eventsOn(w, 'data').join('\n')).toContain('external provisioner "csi.corp.internal"');
+  });
+
+  it('静态绑定不需要驱动：管理员建好的盘照样绑得上', async () => {
+    const w = await build([
+      CLASS,
+      {
+        apiVersion: 'v1', kind: 'PersistentVolume',
+        metadata: { name: 'nfs-01' },
+        spec: {
+          capacity: { storage: '10Gi' }, accessModes: ['ReadWriteOnce'],
+          persistentVolumeReclaimPolicy: 'Retain', storageClassName: 'standard',
+        },
+      },
+      claim(),
+    ]);
+    expect((pvcOf(w).spec as any).volumeName).toBe('nfs-01');
+    expect((pvcOf(w).status as any).capacity).toEqual({ storage: '10Gi' });
+  });
+
+  it('盘太小或者访问模式不对就不绑，而不是勉强绑上', async () => {
+    const w = await build([
+      CLASS,
+      {
+        apiVersion: 'v1', kind: 'PersistentVolume',
+        metadata: { name: 'tiny' },
+        spec: {
+          capacity: { storage: '1Gi' }, accessModes: ['ReadWriteOnce'],
+          storageClassName: 'standard',
+        },
+      },
+      {
+        apiVersion: 'v1', kind: 'PersistentVolume',
+        metadata: { name: 'readonly' },
+        spec: {
+          capacity: { storage: '50Gi' }, accessModes: ['ReadOnlyMany'],
+          storageClassName: 'standard',
+        },
+      },
+      claim(),
+    ]);
+    expect((pvcOf(w).status as any).phase).toBe('Pending');
+  });
+
+  /**
+   * `storageClassName: ""` 和不写这个字段，差一对引号，行为完全相反：
+   * 空串是**明确要求静态绑定**，不写才是用默认类。
+   */
+  it('storageClassName 写空串就是不要动态供给', async () => {
+    const w = await build([CSI_DRIVER, CLASS, claim({ storageClassName: '' })]);
+    expect((pvcOf(w).status as any).phase).toBe('Pending');
+    expect(pvsOf(w)).toHaveLength(0);
+  });
+
+  it('WaitForFirstConsumer：没有 Pod 用它就先不造', async () => {
+    const late = { ...CLASS, metadata: { ...CLASS.metadata, name: 'late' }, volumeBindingMode: 'WaitForFirstConsumer' };
+    const w = await build([CSI_DRIVER, late, claim({ storageClassName: 'late' })]);
+    expect((pvcOf(w).status as any).phase).toBe('Pending');
+    expect(eventsOn(w, 'data').join('\n')).toContain('waiting for first consumer');
+
+    w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', pod() as KubeObject);
+    await w.cluster.advanceBy(60_000);
+    expect((pvcOf(w).status as any).phase).toBe('Bound');
+  });
+});
+
+describe('数据的生命周期', () => {
+  async function withData() {
+    const w = await build([CSI_DRIVER, CLASS, claim(), pod()]);
+    const exec = createExecHandler(w.cluster);
+    await exec(
+      { namespace: 'shop', pod: 'ledger', command: ['sh', '-c', 'echo balance=42 > /data/ledger.txt'], stdin: false, tty: false },
+      ''
+    );
+    return { w, exec };
+  }
+
+  it('写进挂载点的东西留在卷上，Pod 重建照样读得到', async () => {
+    const { w } = await withData();
+    const volumeName = (pvcOf(w).spec as any).volumeName;
+    expect(w.cluster.volumes.read(volumeName)).toEqual({ 'ledger.txt': 'balance=42\n' });
+
+    // 把 Pod 删掉重建：数据不属于 Pod
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(PODS), 'shop', 'ledger');
+    await w.cluster.advanceBy(30_000);
+    w.cluster.registry.create(w.cluster.scheme.mustGet(PODS), 'shop', pod() as KubeObject);
+    await w.cluster.advanceBy(60_000);
+
+    const again = await createExecHandler(w.cluster)(
+      { namespace: 'shop', pod: 'ledger', command: ['cat', '/data/ledger.txt'], stdin: false, tty: false },
+      ''
+    );
+    expect(again.stdout).toBe('balance=42\n');
+  });
+
+  it('容器根文件系统上的东西不留', async () => {
+    const { w, exec } = await withData();
+    await exec(
+      { namespace: 'shop', pod: 'ledger', command: ['sh', '-c', 'echo scratch > /tmp/note'], stdin: false, tty: false },
+      ''
+    );
+    const again = await exec(
+      { namespace: 'shop', pod: 'ledger', command: ['cat', '/tmp/note'], stdin: false, tty: false },
+      ''
+    );
+    expect(again.code).not.toBe(0);
+  });
+
+  /**
+   * `Delete` 是连数据一起删。
+   * 生产上这条最疼：删一个 release 顺手带走 PVC，盘就没了，
+   * 而 apiserver 里再也查不到它存在过。
+   */
+  it('回收策略 Delete：PVC 一没，盘和数据一起没', async () => {
+    const { w } = await withData();
+    const volumeName = (pvcOf(w).spec as any).volumeName;
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(PODS), 'shop', 'ledger');
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(PVCS), 'shop', 'data');
+    await w.cluster.advanceBy(30_000);
+
+    expect(pvsOf(w)).toHaveLength(0);
+    expect(w.cluster.volumes.read(volumeName)).toEqual({});
+  });
+
+  it('回收策略 Retain：盘和数据都留着，但下一个 PVC 接不走', async () => {
+    const retain = { ...CLASS, metadata: { ...CLASS.metadata, name: 'keep' }, reclaimPolicy: 'Retain' };
+    const w = await build([CSI_DRIVER, retain, claim({ storageClassName: 'keep' }), pod()]);
+    await createExecHandler(w.cluster)(
+      { namespace: 'shop', pod: 'ledger', command: ['sh', '-c', 'echo keep-me > /data/x'], stdin: false, tty: false },
+      ''
+    );
+    const volumeName = (pvcOf(w).spec as any).volumeName;
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(PODS), 'shop', 'ledger');
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(PVCS), 'shop', 'data');
+    await w.cluster.advanceBy(30_000);
+
+    expect((pvsOf(w)[0].status as any).phase).toBe('Released');
+    expect(w.cluster.volumes.read(volumeName)).toEqual({ x: 'keep-me\n' });
+
+    // 新 PVC 接不走：claimRef 还挂在上面
+    w.cluster.registry.create(
+      w.cluster.scheme.mustGet(PVCS), 'shop',
+      claim({ storageClassName: 'keep' }) as KubeObject
+    );
+    await w.cluster.advanceBy(30_000);
+    expect((pvcOf(w).spec as any).volumeName).not.toBe(volumeName);
+  });
+});
+
+describe('调度', () => {
+  it('PVC 没绑上，Pod 就不调度，而且说得出原因', async () => {
+    const w = await build([CLASS, claim(), pod()]);
+    const running = w.cluster.registry.get(w.cluster.scheme.mustGet(PODS), 'shop', 'ledger');
+    expect((running.spec as any).nodeName).toBeUndefined();
+    expect((running.status as any).phase).toBe('Pending');
+    expect(JSON.stringify((running.status as any).conditions))
+      .toContain('unbound immediate PersistentVolumeClaims');
+  });
+
+  it('绑上之后就调度得动了', async () => {
+    const w = await build([CSI_DRIVER, CLASS, claim(), pod()]);
+    const running = w.cluster.registry.get(w.cluster.scheme.mustGet(PODS), 'shop', 'ledger');
+    expect((running.spec as any).nodeName).toBeTruthy();
+  });
+});
+
+describe('表格', () => {
+  it('pvc 和 pv 的列跟 kubectl 一致，访问模式打的是缩写', async () => {
+    const w = await build([CSI_DRIVER, CLASS, claim()]);
+    const pvcPrinter = printerFor('persistentvolumeclaims');
+    expect(pvcPrinter.columns.map((column) => column.name)).toEqual([
+      'Name', 'Status', 'Volume', 'Capacity', 'Access Modes',
+      'Storageclass', 'VolumeAttributesClass', 'Age',
+    ]);
+    const cells = pvcPrinter.cells(pvcOf(w), '3m');
+    expect(cells[1]).toBe('Bound');
+    expect(cells[4]).toBe('RWO');
+    expect(cells[5]).toBe('standard');
+
+    const pvCells = printerFor('persistentvolumes').cells(pvsOf(w)[0], '3m');
+    expect(pvCells[3]).toBe('Delete');
+    expect(pvCells[5]).toBe('shop/data');
+  });
+
+  it('默认 StorageClass 名字后面跟 (default)', async () => {
+    const w = await build([CLASS]);
+    const classes = w.cluster.registry.list(
+      w.cluster.scheme.mustGet({ group: 'storage.k8s.io', version: 'v1', resource: 'storageclasses' }), {}
+    ).items;
+    expect(printerFor('storageclasses').cells(classes[0], '1h')[0]).toBe('standard (default)');
+  });
+});


### PR DESCRIPTION
第 21 关（灾难恢复）的地基。备份要有东西可备，先得有卷。

## 做了什么

`PersistentVolume` / `PersistentVolumeClaim` / `StorageClass` 三个对象，
加上绑定、动态供给、回收三件事，以及 exec 进容器时的挂载与写回。

卷上的**字节**单独存（`VolumeStore`），不放在 apiserver 里 —— 因为它本来
就不在那儿：PV 只是一条元数据记录，数据在存储后端上。这个区别下一片直接要用：
备份对象图不等于备份数据，Velero 把 PVC 的 YAML 存下来了，恢复出来是一个空盘。

## 照着真集群行为做的几处

- **动态供给是工作负载干的活**（外部 CSI 驱动），静态绑定才是控制面自带。
  把驱动停掉，StorageClass 还在、PVC 还能提交，就是永远 Pending。所有对象
  看起来都正常，所以事件里必须说得出「在等哪个 provisioner」。
- `storageClassName: ""` 和不写这个字段差一对引号，行为完全相反：空串是
  **明确要求静态绑定**。默认类由 apiserver 的 DefaultStorageClass 准入补上，
  不是控制器事后写的 —— 所以 `kubectl get pvc` 里那一列一开始就有值。
- **WaitForFirstConsumer**：没有 Pod 用它就先不造。云上默认类基本都是这个模式，
  「PVC 一直 Pending 但什么都没配错」十有八九就是它。
- **Retain 留下的 PV 转成 Released**，claimRef 还挂在上面，下一个 PVC 接不走。
  这是「我明明设了 Retain，为什么新的 PVC 还是 Pending」的答案。
- **PVC 没绑上，调度器就不选节点**。学员看到的是 Pod 一直 Pending 而节点明明
  有富余，describe 里那句 `pod has unbound immediate PersistentVolumeClaims`
  才是真原因。

## 数据的生命周期

exec 进容器时把卷挂到 mountPath 上，退出时写回。写在挂载点下面的东西 Pod
重建之后还在（数据不属于 Pod），写在容器根文件系统上的下一次 exec 就没了。
回收策略 `Delete` 是**连数据一起**删 —— 生产上这条最疼。

## 验证

- 新增 `tests/opslab/storage.test.ts` 14 条
- `npx jest`：47 个 suite、1583 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)