### PR TITLE
feat(opslab): CSI 卷快照

### DIFF
--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -285,6 +285,76 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
       ];
     },
   },
+  volumesnapshots: {
+    columns: [
+      NAME_COLUMN,
+      col('Readytouse', 'Whether the snapshot is ready to be used to restore a volume.'),
+      col('Sourcepvc', 'The PVC this snapshot was taken from.'),
+      col('Sourcesnapshotcontent', 'The pre-provisioned content this snapshot binds to.'),
+      col('Restoresize', 'The size of a volume restored from this snapshot.'),
+      col('Snapshotclass', 'The VolumeSnapshotClass used.'),
+      col('Snapshotcontent', 'The bound VolumeSnapshotContent.'),
+      col('Creationtime', 'The time the snapshot was taken on the storage system.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        String(Boolean(status.readyToUse)),
+        spec.source?.persistentVolumeClaimName ?? '',
+        spec.source?.volumeSnapshotContentName ?? '',
+        status.restoreSize ?? '',
+        spec.volumeSnapshotClassName ?? '',
+        status.boundVolumeSnapshotContentName ?? '',
+        status.creationTime ?? '',
+        age,
+      ];
+    },
+  },
+  volumesnapshotcontents: {
+    columns: [
+      NAME_COLUMN,
+      col('Readytouse', 'Whether the snapshot is ready to be used.'),
+      col('Restoresize', 'The size of a volume restored from this snapshot.'),
+      col('Deletionpolicy', 'What happens to the snapshot when its VolumeSnapshot goes away.'),
+      col('Driver', 'The CSI driver that took the snapshot.'),
+      col('Volumesnapshotclass', 'The VolumeSnapshotClass used.'),
+      col('Volumesnapshot', 'The VolumeSnapshot this content is bound to.'),
+      col('Volumesnapshotnamespace', 'The namespace of the bound VolumeSnapshot.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        String(Boolean(status.readyToUse)),
+        status.restoreSize ?? '',
+        spec.deletionPolicy ?? 'Delete',
+        spec.driver ?? '',
+        spec.volumeSnapshotClassName ?? '',
+        spec.volumeSnapshotRef?.name ?? '',
+        spec.volumeSnapshotRef?.namespace ?? '',
+        age,
+      ];
+    },
+  },
+  volumesnapshotclasses: {
+    columns: [
+      NAME_COLUMN,
+      col('Driver', 'The CSI driver that takes snapshots for this class.'),
+      col('Deletionpolicy', 'What happens to snapshots of this class when released.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => [
+      object.metadata.name,
+      (object as any).driver ?? '',
+      (object as any).deletionPolicy ?? 'Delete',
+      age,
+    ],
+  },
   poddisruptionbudgets: {
     columns: [
       NAME_COLUMN,

--- a/src/lib/opslab/backup/index.ts
+++ b/src/lib/opslab/backup/index.ts
@@ -1,0 +1,15 @@
+/**
+ * 备份与恢复
+ *
+ * 这一层只回答一个问题：**东西没了之后，能不能拿回来**。
+ *
+ * 拿回来要两样都在：对象图（PVC 的 YAML）和字节（盘上的数据）。
+ * 只备份对象图的话，恢复出来是一个一模一样的空盘 —— 而 `kubectl get pvc`
+ * 看不出空盘和满盘的区别，所以这个错误往往在最不能出错的那天才被发现。
+ */
+export {
+  VOLUMESNAPSHOTS, VOLUMESNAPSHOTCONTENTS, VOLUMESNAPSHOTCLASSES,
+  SNAPSHOT_RESOURCES, SNAPSHOT_CONTROLLER_LABEL,
+} from './resources';
+export { SnapshotController } from './snapshots';
+export type { SnapshotOptions } from './snapshots';

--- a/src/lib/opslab/backup/resources.ts
+++ b/src/lib/opslab/backup/resources.ts
@@ -1,0 +1,47 @@
+/**
+ * CSI 卷快照
+ *
+ * 三个对象对应三件事：`VolumeSnapshotClass` 说的是「谁来拍、拍完怎么处置」，
+ * `VolumeSnapshot` 是应用侧提出的一次请求，`VolumeSnapshotContent` 是存储侧
+ * 真正那张快照。中间这层间接和 PVC/PV 一模一样，原因也一样：请求的人和
+ * 拥有数据的人不是同一个，生命周期也不该绑在一起。
+ *
+ * 快照是**时间点**。拍完之后往卷里再写什么，都跟这张快照无关了 ——
+ * 这句话听起来是废话，但「备份跑完之后又写进去的数据也一并恢复了吧」
+ * 是真实发生过的误解。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const VOLUMESNAPSHOTCLASSES: ResourceDefinition = {
+  group: 'snapshot.storage.k8s.io', version: 'v1', resource: 'volumesnapshotclasses',
+  singular: 'volumesnapshotclass', kind: 'VolumeSnapshotClass', namespaced: false,
+  shortNames: ['vsclass', 'vsclasses'],
+};
+
+export const VOLUMESNAPSHOTS: ResourceDefinition = {
+  group: 'snapshot.storage.k8s.io', version: 'v1', resource: 'volumesnapshots',
+  singular: 'volumesnapshot', kind: 'VolumeSnapshot', namespaced: true,
+  shortNames: ['vs'], subresources: ['status'],
+};
+
+export const VOLUMESNAPSHOTCONTENTS: ResourceDefinition = {
+  group: 'snapshot.storage.k8s.io', version: 'v1', resource: 'volumesnapshotcontents',
+  singular: 'volumesnapshotcontent', kind: 'VolumeSnapshotContent', namespaced: false,
+  shortNames: ['vsc', 'vscs'], subresources: ['status'],
+};
+
+export const SNAPSHOT_RESOURCES: ResourceDefinition[] = [
+  VOLUMESNAPSHOTCLASSES, VOLUMESNAPSHOTS, VOLUMESNAPSHOTCONTENTS,
+];
+
+/**
+ * 快照控制器。
+ *
+ * 它和 CSI 驱动是**两个**工作负载：驱动负责造盘，snapshot-controller 负责
+ * 把 VolumeSnapshot 变成 VolumeSnapshotContent。装了驱动没装它，
+ * `kubectl apply` 一个 VolumeSnapshot 会成功 —— 对象建出来了，
+ * 然后永远 readyToUse: false，一个事件都没有。
+ */
+export const SNAPSHOT_CONTROLLER_LABEL = {
+  key: 'app.kubernetes.io/name', value: 'snapshot-controller',
+};

--- a/src/lib/opslab/backup/snapshots.ts
+++ b/src/lib/opslab/backup/snapshots.ts
@@ -1,0 +1,190 @@
+/**
+ * 快照控制器
+ *
+ * 一次快照分两步，两步分属两个对象：VolumeSnapshot 是「我要一张」，
+ * VolumeSnapshotContent 是「存储上真有这张」。控制器负责把前者变成后者，
+ * 并且把那一刻的字节拷进快照里。
+ *
+ * 这里的字节和 PV 的字节放在同一个 VolumeStore 上，按名字区分
+ * （`pvc-xxx` 是盘，`snapcontent-xxx` 是快照）—— 它们本来就是同一种东西：
+ * 一堆存储后端上的字节，跟 apiserver 无关。
+ */
+import type { KubeObject } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { PERSISTENTVOLUMECLAIMS, PERSISTENTVOLUMES } from '../storage';
+import type { VolumeStore } from '../storage';
+import {
+  SNAPSHOT_CONTROLLER_LABEL, VOLUMESNAPSHOTCLASSES, VOLUMESNAPSHOTCONTENTS, VOLUMESNAPSHOTS,
+} from './resources';
+
+export interface SnapshotOptions {
+  volumes: VolumeStore;
+}
+
+export class SnapshotController extends Controller {
+  private snapshots: Informer;
+  private contents: Informer;
+  private classes: Informer;
+  private claims: Informer;
+  private volumes: Informer;
+  private deployments: Informer;
+
+  constructor(context: ControllerContext, private readonly options: SnapshotOptions) {
+    super(context, 'snapshot-controller');
+    this.snapshots = new Informer(this.registry, VOLUMESNAPSHOTS);
+    this.contents = this.track(new Informer(this.registry, VOLUMESNAPSHOTCONTENTS));
+    this.classes = this.track(new Informer(this.registry, VOLUMESNAPSHOTCLASSES));
+    this.claims = this.track(new Informer(this.registry, PERSISTENTVOLUMECLAIMS));
+    this.volumes = this.track(new Informer(this.registry, PERSISTENTVOLUMES));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.watch(this.snapshots);
+    for (const informer of [this.claims, this.volumes, this.deployments]) {
+      informer.onChange(() => {
+        for (const snapshot of this.snapshots.list()) this.enqueue(objectKey(snapshot));
+      });
+    }
+  }
+
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[SNAPSHOT_CONTROLLER_LABEL.key] !== SNAPSHOT_CONTROLLER_LABEL.value) {
+        return false;
+      }
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let snapshot: KubeObject;
+    try {
+      snapshot = this.registry.get(VOLUMESNAPSHOTS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return this.releaseFor(namespace, name);
+      throw error;
+    }
+    if (snapshot.metadata.deletionTimestamp) return;
+
+    const status = (snapshot.status ?? {}) as any;
+    if (status.readyToUse) return;
+
+    const spec = (snapshot.spec ?? {}) as any;
+    const claimName = spec.source?.persistentVolumeClaimName;
+    if (!claimName) {
+      return this.fail(snapshot, 'Snapshot source must be a PersistentVolumeClaim');
+    }
+
+    let claim: KubeObject;
+    try {
+      claim = this.registry.get(PERSISTENTVOLUMECLAIMS, namespace, claimName);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      return this.fail(snapshot, `Failed to get PVC ${namespace}/${claimName}: not found`);
+    }
+
+    /**
+     * 源盘没绑上就拍不了。
+     *
+     * 这条看着显然，但它解释了一个真实的坑：备份脚本先建 PVC 再立刻拍快照，
+     * 供给还没完成，快照直接失败 —— 而失败信息在 VolumeSnapshot 的
+     * status.error 里，不在事件里，`kubectl get` 也看不见。
+     */
+    const volumeName = ((claim.spec ?? {}) as any).volumeName;
+    if (((claim.status ?? {}) as any).phase !== 'Bound' || !volumeName) {
+      return this.fail(snapshot, `PVC ${namespace}/${claimName} is not bound`);
+    }
+
+    const className = spec.volumeSnapshotClassName;
+    const snapshotClass = className
+      ? this.classes.list().find((item) => item.metadata.name === className)
+      : this.classes.list().find(
+        (item) => item.metadata.annotations?.['snapshot.storage.kubernetes.io/is-default-class'] === 'true'
+      );
+    if (!snapshotClass) {
+      return this.fail(snapshot, className
+        ? `Failed to get snapshot class with error volumesnapshotclass.snapshot.storage.k8s.io "${className}" not found`
+        : 'Failed to get default snapshot class with error cannot find default snapshot class');
+    }
+
+    const contentName = `snapcontent-${snapshot.metadata.uid}`;
+    const volume = this.volumes.list().find((item) => item.metadata.name === volumeName);
+    const now = new Date(this.context.now()).toISOString();
+
+    // 拍下来的是**这一刻**的字节。之后往盘里写什么都跟它无关了。
+    this.options.volumes.copy(volumeName, contentName);
+
+    try {
+      this.registry.get(VOLUMESNAPSHOTCONTENTS, undefined, contentName);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      this.registry.create(VOLUMESNAPSHOTCONTENTS, undefined, {
+        apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshotContent',
+        metadata: { name: contentName },
+        spec: {
+          deletionPolicy: (snapshotClass as any).deletionPolicy ?? 'Delete',
+          driver: (snapshotClass as any).driver ?? 'csi',
+          source: { volumeHandle: volumeName },
+          volumeSnapshotClassName: snapshotClass.metadata.name,
+          volumeSnapshotRef: {
+            apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshot',
+            name, namespace, uid: snapshot.metadata.uid,
+          },
+        },
+      } as KubeObject);
+    }
+
+    const restoreSize = ((volume?.spec ?? {}) as any)?.capacity?.storage
+      ?? ((claim.status ?? {}) as any)?.capacity?.storage;
+
+    await ignoreConflict(() => {
+      updateStatusIfChanged(this.registry, VOLUMESNAPSHOTCONTENTS, undefined, contentName, {
+        readyToUse: true, creationTime: now, restoreSize, snapshotHandle: contentName,
+      });
+      updateStatusIfChanged(this.registry, VOLUMESNAPSHOTS, namespace, name, {
+        readyToUse: true,
+        boundVolumeSnapshotContentName: contentName,
+        creationTime: now,
+        restoreSize,
+      });
+    });
+  }
+
+  private async fail(snapshot: KubeObject, message: string): Promise<void> {
+    await ignoreConflict(() => {
+      updateStatusIfChanged(
+        this.registry, VOLUMESNAPSHOTS, snapshot.metadata.namespace, snapshot.metadata.name!,
+        {
+          readyToUse: false,
+          error: { message, time: new Date(this.context.now()).toISOString() },
+        }
+      );
+    });
+  }
+
+  /**
+   * VolumeSnapshot 没了，那张快照怎么办。
+   *
+   * `Delete` 连字节一起删，`Retain` 把 content 留下 —— 留下之后它是一张
+   * **没有主人**的快照，`kubectl get volumesnapshot` 里再也看不到它，
+   * 只有 `volumesnapshotcontent` 里还在。存储账单上也还在。
+   */
+  private releaseFor(namespace: string | undefined, name: string): void {
+    for (const content of this.contents.list()) {
+      const spec = (content.spec ?? {}) as any;
+      const ref = spec.volumeSnapshotRef;
+      if (!ref || ref.namespace !== namespace || ref.name !== name) continue;
+      if ((spec.deletionPolicy ?? 'Delete') !== 'Delete') continue;
+      this.options.volumes.drop(content.metadata.name!);
+      try {
+        this.registry.delete(VOLUMESNAPSHOTCONTENTS, undefined, content.metadata.name!);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+  }
+}

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -38,6 +38,7 @@ import { DISRUPTION_RESOURCES, PdbController, evictionVerdict } from '../disrupt
 import {
   STORAGE_RESOURCES, StorageController, VolumeStore, createDefaultStorageClassDefaulter,
 } from '../storage';
+import { SNAPSHOT_RESOURCES, SnapshotController } from '../backup';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -170,7 +171,7 @@ export class Cluster {
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
       ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES, ...ROLLOUT_RESOURCES,
-      ...STORAGE_RESOURCES,
+      ...STORAGE_RESOURCES, ...SNAPSHOT_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -637,6 +638,8 @@ export class Cluster {
        * **动态供给**要看 CSI 驱动这个工作负载在不在（见 StorageController）。
        */
       new StorageController(context, { volumes: this.volumes }),
+      // 快照：又一个工作负载。装了 CSI 驱动不等于装了它。
+      new SnapshotController(context, { volumes: this.volumes }),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发

--- a/src/lib/opslab/storage/controller.ts
+++ b/src/lib/opslab/storage/controller.ts
@@ -26,6 +26,8 @@ import {
   PERSISTENTVOLUMECLAIMS, PERSISTENTVOLUMES, STORAGECLASSES,
 } from './resources';
 import type { VolumeStore } from './volumes';
+// 只引资源定义，不引控制器 —— 从快照恢复是存储这一侧的事
+import { VOLUMESNAPSHOTS } from '../backup/resources';
 
 export interface StorageOptions {
   volumes: VolumeStore;
@@ -200,6 +202,30 @@ export class StorageController extends Controller {
   private async provision(claim: KubeObject, storageClass: KubeObject): Promise<void> {
     const spec = (claim.spec ?? {}) as any;
     const name = `pvc-${claim.metadata.uid}`;
+
+    /**
+     * 从快照恢复。
+     *
+     * `dataSource` 指到一张 VolumeSnapshot 上，供给出来的盘带着那一刻的字节。
+     * 快照还没就绪就先不造 —— 造了就是一块空盘，而空盘和「恢复成功」
+     * 在 `kubectl get pvc` 里长得一模一样。
+     */
+    let seed: Record<string, string> | undefined;
+    const source = spec.dataSource ?? spec.dataSourceRef;
+    if (source?.kind === 'VolumeSnapshot') {
+      let snapshot: KubeObject;
+      try {
+        snapshot = this.registry.get(VOLUMESNAPSHOTS, claim.metadata.namespace, source.name);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+        return this.pending(claim, `failed to get snapshot ${source.name}: not found`);
+      }
+      const snapshotStatus = (snapshot.status ?? {}) as any;
+      if (!snapshotStatus.readyToUse || !snapshotStatus.boundVolumeSnapshotContentName) {
+        return this.pending(claim, `snapshot ${source.name} is not yet ready to use`);
+      }
+      seed = this.options.volumes.read(snapshotStatus.boundVolumeSnapshotContentName);
+    }
     const body: KubeObject = {
       apiVersion: 'v1', kind: 'PersistentVolume',
       metadata: {
@@ -222,8 +248,10 @@ export class StorageController extends Controller {
     } catch {
       created = this.registry.get(PERSISTENTVOLUMES, undefined, name);
     }
-    // 新盘是空的。这一句在这里，是为了让「盘存在」和「盘上有数据」分成两件事。
-    if (!this.options.volumes.has(name)) this.options.volumes.write(name, {});
+    // 新盘是空的，除非它是从快照恢复出来的。
+    // 「盘存在」和「盘上有数据」是两件事，这一句是那条缝。
+    if (seed) this.options.volumes.write(name, seed);
+    else if (!this.options.volumes.has(name)) this.options.volumes.write(name, {});
     this.context.recordEvent({
       object: claim, type: 'Normal', reason: 'ProvisioningSucceeded',
       message: `Successfully provisioned volume ${name}`,

--- a/tests/opslab/snapshots.test.ts
+++ b/tests/opslab/snapshots.test.ts
@@ -1,0 +1,283 @@
+/**
+ * CSI 卷快照
+ *
+ * 要钉住的四件：
+ *   1. 快照控制器是**另一个**工作负载，装了 CSI 驱动不等于装了它
+ *   2. 快照是时间点，拍完再写的东西不在里面
+ *   3. 从快照恢复出来的盘带着那一刻的字节
+ *   4. deletionPolicy 决定 VolumeSnapshot 没了之后字节还在不在
+ */
+import { createExecHandler, createOpsWorld } from '../../src/lib/opslab/lab';
+import { printerFor } from '../../src/lib/opslab/apiserver';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const APP_IMAGE = 'registry.corp.internal/ledger:3.2';
+const CSI_IMAGE = 'registry.k8s.io/sig-storage/csi-provisioner:v5.1.0';
+const SNAP_IMAGE = 'registry.k8s.io/sig-storage/snapshot-controller:v8.2.0';
+
+const PVCS = { group: '', version: 'v1', resource: 'persistentvolumeclaims' } as const;
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+const SNAPSHOTS = { group: 'snapshot.storage.k8s.io', version: 'v1', resource: 'volumesnapshots' } as const;
+const CONTENTS = { group: 'snapshot.storage.k8s.io', version: 'v1', resource: 'volumesnapshotcontents' } as const;
+
+const deployment = (name: string, image: string) => ({
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name, namespace: 'kube-system', labels: { 'app.kubernetes.io/name': name } },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': name } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': name } },
+      spec: { containers: [{ name: 'main', image }] },
+    },
+  },
+});
+
+const CSI_DRIVER = deployment('csi-driver', CSI_IMAGE);
+const SNAP_CONTROLLER = deployment('snapshot-controller', SNAP_IMAGE);
+
+const CLASS = {
+  apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass',
+  metadata: { name: 'standard', annotations: { 'storageclass.kubernetes.io/is-default-class': 'true' } },
+  provisioner: 'csi.corp.internal', reclaimPolicy: 'Delete', volumeBindingMode: 'Immediate',
+};
+
+const SNAP_CLASS = {
+  apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshotClass',
+  metadata: { name: 'csi-standard' },
+  driver: 'csi.corp.internal', deletionPolicy: 'Delete',
+};
+
+const CLAIM = {
+  apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+  metadata: { name: 'data', namespace: 'shop' },
+  spec: { accessModes: ['ReadWriteOnce'], resources: { requests: { storage: '5Gi' } } },
+};
+
+const POD = {
+  apiVersion: 'v1', kind: 'Pod',
+  metadata: { name: 'ledger', namespace: 'shop' },
+  spec: {
+    containers: [{ name: 'app', image: APP_IMAGE, volumeMounts: [{ name: 'data', mountPath: '/data' }] }],
+    volumes: [{ name: 'data', persistentVolumeClaim: { claimName: 'data' } }],
+  },
+};
+
+const snapshot = (name: string, overrides: Record<string, unknown> = {}) => ({
+  apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshot',
+  metadata: { name, namespace: 'shop' },
+  spec: {
+    volumeSnapshotClassName: 'csi-standard',
+    source: { persistentVolumeClaimName: 'data' },
+    ...overrides,
+  },
+});
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'shop', 'kube-system'],
+    images: {
+      [APP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [CSI_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [SNAP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(objects: unknown[]) {
+  const world = await createOpsWorld({ world: spec(objects) });
+  await world.cluster.advanceBy(60_000);
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+async function writeData(w: World, text: string) {
+  return createExecHandler(w.cluster)(
+    { namespace: 'shop', pod: 'ledger', command: ['sh', '-c', `echo ${text} > /data/ledger.txt`], stdin: false, tty: false },
+    ''
+  );
+}
+
+const snapOf = (w: World, name: string) =>
+  w.cluster.registry.get(w.cluster.scheme.mustGet(SNAPSHOTS), 'shop', name);
+const contentsOf = (w: World) =>
+  w.cluster.registry.list(w.cluster.scheme.mustGet(CONTENTS), {}).items;
+const create = (w: World, definition: any, namespace: string | undefined, object: unknown) =>
+  w.cluster.registry.create(w.cluster.scheme.mustGet(definition), namespace, object as KubeObject);
+
+const PLATFORM = [CSI_DRIVER, SNAP_CONTROLLER, CLASS, SNAP_CLASS];
+
+describe('拍快照', () => {
+  it('拍下来的是那一刻的字节，之后再写跟它无关', async () => {
+    const w = await build([...PLATFORM, CLAIM, POD]);
+    await writeData(w, 'before');
+
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(30_000);
+
+    await writeData(w, 'after');
+
+    const status = (snapOf(w, 'snap-1').status ?? {}) as any;
+    expect(status.readyToUse).toBe(true);
+    expect(status.boundVolumeSnapshotContentName).toMatch(/^snapcontent-/);
+    expect(status.restoreSize).toBe('5Gi');
+    expect(w.cluster.volumes.read(status.boundVolumeSnapshotContentName))
+      .toEqual({ 'ledger.txt': 'before\n' });
+  });
+
+  /**
+   * 快照控制器和 CSI 驱动是两个工作负载。
+   * 只装驱动的话，VolumeSnapshot 建得出来，然后就没有然后了 ——
+   * 没有 content、没有事件、status 是空的。这个「安静的失败」要能复现。
+   */
+  it('没有 snapshot-controller：对象建得出来，但永远不就绪', async () => {
+    const w = await build([CSI_DRIVER, CLASS, SNAP_CLASS, CLAIM, POD]);
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(120_000);
+
+    expect((snapOf(w, 'snap-1').status ?? {})).toEqual({});
+    expect(contentsOf(w)).toHaveLength(0);
+  });
+
+  it('快照类名写错：失败信息落在 status.error 上', async () => {
+    const w = await build([...PLATFORM, CLAIM, POD]);
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1', { volumeSnapshotClassName: 'nope' }));
+    await w.cluster.advanceBy(30_000);
+
+    const status = (snapOf(w, 'snap-1').status ?? {}) as any;
+    expect(status.readyToUse).toBe(false);
+    expect(status.error.message).toContain('"nope" not found');
+  });
+
+  it('源 PVC 没绑上就拍不了', async () => {
+    const w = await build([SNAP_CONTROLLER, CLASS, SNAP_CLASS, CLAIM]);
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(30_000);
+
+    const status = (snapOf(w, 'snap-1').status ?? {}) as any;
+    expect(status.error.message).toContain('is not bound');
+  });
+});
+
+describe('从快照恢复', () => {
+  async function snapped() {
+    const w = await build([...PLATFORM, CLAIM, POD]);
+    await writeData(w, 'before');
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(30_000);
+    return w;
+  }
+
+  it('dataSource 指到快照上，供给出来的盘带着数据', async () => {
+    const w = await snapped();
+    create(w, PVCS, 'shop', {
+      apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+      metadata: { name: 'restored', namespace: 'shop' },
+      spec: {
+        accessModes: ['ReadWriteOnce'],
+        resources: { requests: { storage: '5Gi' } },
+        dataSource: { apiGroup: 'snapshot.storage.k8s.io', kind: 'VolumeSnapshot', name: 'snap-1' },
+      },
+    });
+    await w.cluster.advanceBy(30_000);
+
+    const restored = w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'shop', 'restored');
+    expect((restored.status as any).phase).toBe('Bound');
+    expect(w.cluster.volumes.read((restored.spec as any).volumeName))
+      .toEqual({ 'ledger.txt': 'before\n' });
+
+    // 挂上去真读得到
+    create(w, PODS, 'shop', {
+      apiVersion: 'v1', kind: 'Pod',
+      metadata: { name: 'check', namespace: 'shop' },
+      spec: {
+        containers: [{ name: 'app', image: APP_IMAGE, volumeMounts: [{ name: 'd', mountPath: '/data' }] }],
+        volumes: [{ name: 'd', persistentVolumeClaim: { claimName: 'restored' } }],
+      },
+    });
+    await w.cluster.advanceBy(60_000);
+    const read = await createExecHandler(w.cluster)(
+      { namespace: 'shop', pod: 'check', command: ['cat', '/data/ledger.txt'], stdin: false, tty: false },
+      ''
+    );
+    expect(read.stdout).toBe('before\n');
+  });
+
+  it('快照还没就绪就先不供给，而不是给一块空盘', async () => {
+    // 没有 snapshot-controller：快照永远不就绪
+    const w = await build([CSI_DRIVER, CLASS, SNAP_CLASS, CLAIM, POD]);
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(30_000);
+    create(w, PVCS, 'shop', {
+      apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+      metadata: { name: 'restored', namespace: 'shop' },
+      spec: {
+        accessModes: ['ReadWriteOnce'],
+        resources: { requests: { storage: '5Gi' } },
+        dataSource: { apiGroup: 'snapshot.storage.k8s.io', kind: 'VolumeSnapshot', name: 'snap-1' },
+      },
+    });
+    await w.cluster.advanceBy(60_000);
+
+    const restored = w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'shop', 'restored');
+    expect((restored.status as any).phase).toBe('Pending');
+    expect((restored.spec as any).volumeName).toBeUndefined();
+  });
+});
+
+describe('快照的生命周期', () => {
+  it('deletionPolicy Delete：VolumeSnapshot 没了，字节也没了', async () => {
+    const w = await build([...PLATFORM, CLAIM, POD]);
+    await writeData(w, 'before');
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(30_000);
+    const contentName = (snapOf(w, 'snap-1').status as any).boundVolumeSnapshotContentName;
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(SNAPSHOTS), 'shop', 'snap-1');
+    await w.cluster.advanceBy(30_000);
+
+    expect(contentsOf(w)).toHaveLength(0);
+    expect(w.cluster.volumes.read(contentName)).toEqual({});
+  });
+
+  /**
+   * Retain 留下的是一张**没有主人**的快照：
+   * `kubectl get volumesnapshot` 里看不见它，`volumesnapshotcontent` 里还在，
+   * 存储账单上也还在。
+   */
+  it('deletionPolicy Retain：content 留下来，只是没人认领了', async () => {
+    const keep = { ...SNAP_CLASS, metadata: { name: 'keep' }, deletionPolicy: 'Retain' };
+    const w = await build([CSI_DRIVER, SNAP_CONTROLLER, CLASS, keep, CLAIM, POD]);
+    await writeData(w, 'before');
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1', { volumeSnapshotClassName: 'keep' }));
+    await w.cluster.advanceBy(30_000);
+    const contentName = (snapOf(w, 'snap-1').status as any).boundVolumeSnapshotContentName;
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(SNAPSHOTS), 'shop', 'snap-1');
+    await w.cluster.advanceBy(30_000);
+
+    expect(contentsOf(w)).toHaveLength(1);
+    expect(w.cluster.volumes.read(contentName)).toEqual({ 'ledger.txt': 'before\n' });
+  });
+});
+
+describe('表格', () => {
+  it('volumesnapshot 的列跟 kubectl 一致', async () => {
+    const w = await build([...PLATFORM, CLAIM, POD]);
+    create(w, SNAPSHOTS, 'shop', snapshot('snap-1'));
+    await w.cluster.advanceBy(30_000);
+
+    const printer = printerFor('volumesnapshots');
+    expect(printer.columns.map((column) => column.name)).toEqual([
+      'Name', 'Readytouse', 'Sourcepvc', 'Sourcesnapshotcontent', 'Restoresize',
+      'Snapshotclass', 'Snapshotcontent', 'Creationtime', 'Age',
+    ]);
+    const cells = printer.cells(snapOf(w, 'snap-1'), '30s');
+    expect(cells[1]).toBe('true');
+    expect(cells[2]).toBe('data');
+    expect(cells[5]).toBe('csi-standard');
+  });
+});


### PR DESCRIPTION
第 21 关（灾难恢复）的第二块地基。上一片有了卷，这一片能给卷拍照。

## 做了什么

`VolumeSnapshot` / `VolumeSnapshotContent` / `VolumeSnapshotClass` 三个对象，
一个快照控制器，以及 PVC 通过 `spec.dataSource` 从快照恢复。

快照的字节和 PV 的字节放在同一个 `VolumeStore` 上，按名字区分
（`pvc-xxx` 是盘，`snapcontent-xxx` 是快照）—— 它们本来就是同一种东西：
存储后端上的一堆字节，跟 apiserver 无关。

## 要立住的一句话

**快照是时间点。** 拍完之后往盘里写什么，都跟这张快照无关。听起来是废话，
但"备份跑完之后又写进去的那些也一并恢复了吧"是真发生过的误解。

## 三处安静的失败

真集群里这三种情况都不报错，所以都要能复现：

- **snapshot-controller 和 CSI 驱动是两个工作负载**。只装驱动的话，
  `kubectl apply` 一个 VolumeSnapshot 会成功，然后就没有然后了：
  没有 content、没有事件、status 是空的。
- **快照类名写错 / 源 PVC 还没绑上**：失败信息落在 `status.error` 里，
  不在事件里，`kubectl get volumesnapshot` 那一行也看不出来。
- **快照还没就绪时，带 dataSource 的 PVC 先不供给**。造出来就是一块空盘，
  而空盘和"恢复成功"在 `kubectl get pvc` 里长得一模一样。

`deletionPolicy: Retain` 留下的是一张**没有主人**的 content：
`kubectl get volumesnapshot` 里看不见它，`volumesnapshotcontent` 里还在，
存储账单上也还在。

## 验证

- 新增 `tests/opslab/snapshots.test.ts` 9 条
- `npx jest`：48 个 suite、1592 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)