### PR TITLE
feat(opslab): 第 21 关 灾难恢复

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -43,6 +43,11 @@ const REPORTS_IMAGE_BAD = 'harbor.corp.internal/team/reports:2.3.0';
 const ROLLOUTS_IMAGE = 'quay.io/argoproj/argo-rollouts:v1.8.3';
 // 门户的一个坏版本：进程活着、探针照过，六成请求 500
 const PORTAL_IMAGE_BAD = 'harbor.corp.internal/team/portal:1.6.0';
+const CSI_IMAGE = 'registry.k8s.io/sig-storage/csi-provisioner:v5.1.0';
+const SNAPSHOT_IMAGE = 'registry.k8s.io/sig-storage/snapshot-controller:v8.2.0';
+const VELERO_IMAGE = 'velero/velero:v1.16.1';
+// 对账库。数据在盘上，不在镜像里 —— 这一关整关都建立在这个区别上。
+const LEDGERDB_IMAGE = 'harbor.corp.internal/team/ledgerdb:14.2';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -149,7 +154,7 @@ const WORLD = {
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
     'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
-    'kyverno', 'external-secrets', 'monitoring',
+    'kyverno', 'external-secrets', 'monitoring', 'velero',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -196,6 +201,13 @@ const WORLD = {
     [ESO_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300, listens: [8080] },
     [PROMETHEUS_IMAGE]: { pullMs: 600, startupMs: 900, readyAfterMs: 400, listens: [9090] },
     [ROLLOUTS_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300 },
+    [CSI_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200 },
+    [SNAPSHOT_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200 },
+    [VELERO_IMAGE]: { pullMs: 700, startupMs: 900, readyAfterMs: 400 },
+    [LEDGERDB_IMAGE]: {
+      pullMs: 800, startupMs: 1200, readyAfterMs: 600,
+      listens: [5432], memoryUsage: '512Mi', handlesSigterm: true,
+    },
     // 门户的下一个版本，好的那个
     [PORTAL_IMAGE_NEXT]: {
       pullMs: 400, startupMs: 600, readyAfterMs: 300,
@@ -6649,6 +6661,410 @@ const stage20 = {
   ),
 };
 
+/* ------------------------------------------------------------------ */
+/* 第 21 关：灾难恢复                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 存储那一套。
+ *
+ * 三个东西分属三个组件：CSI 驱动造盘、snapshot-controller 拍快照、
+ * StorageClass 说怎么造。快照类是有的 —— 只是没打让 Velero 认得的标签，
+ * 这一关的核心失效就藏在这一行里。
+ */
+const STORAGE_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'csi-provisioner', namespace: 'kube-system',
+      labels: { 'app.kubernetes.io/name': 'csi-driver' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'csi-driver' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'csi-driver' } },
+        spec: { containers: [{ name: 'provisioner', image: CSI_IMAGE }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'snapshot-controller', namespace: 'kube-system',
+      labels: { 'app.kubernetes.io/name': 'snapshot-controller' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'snapshot-controller' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'snapshot-controller' } },
+        spec: { containers: [{ name: 'controller', image: SNAPSHOT_IMAGE }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass',
+    metadata: {
+      name: 'standard',
+      annotations: { 'storageclass.kubernetes.io/is-default-class': 'true' },
+    },
+    provisioner: 'csi.corp.internal',
+    reclaimPolicy: 'Delete',
+    volumeBindingMode: 'Immediate',
+  },
+  {
+    apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshotClass',
+    metadata: { name: 'csi-standard' },
+    driver: 'csi.corp.internal',
+    deletionPolicy: 'Delete',
+  },
+];
+
+/** Velero 和它的桶。装是装上了，没人配过备份。 */
+const VELERO_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'velero', namespace: 'velero',
+      labels: { 'app.kubernetes.io/name': 'velero' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'velero' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'velero' } },
+        spec: { containers: [{ name: 'velero', image: VELERO_IMAGE }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'velero.io/v1', kind: 'BackupStorageLocation',
+    metadata: { name: 'default', namespace: 'velero' },
+    spec: {
+      provider: 'aws',
+      default: true,
+      objectStorage: { bucket: 'corp-backups' },
+      config: { region: 'internal', s3Url: 'http://minio.storage.svc:9000' },
+    },
+  },
+];
+
+/** 对账库。它的数据在盘上，不在镜像里。 */
+const LEDGERDB_WORKLOAD = [
+  {
+    apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+    metadata: { name: 'ledger-data', namespace: 'payments' },
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      resources: { requests: { storage: '20Gi' } },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'ledgerdb', namespace: 'payments' },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'ledgerdb' } },
+      template: {
+        metadata: { labels: { app: 'ledgerdb' } },
+        spec: {
+          containers: [{
+            name: 'db', image: LEDGERDB_IMAGE,
+            ports: [{ containerPort: 5432 }],
+            volumeMounts: [{ name: 'data', mountPath: '/var/lib/ledger' }],
+          }],
+          volumes: [{ name: 'data', persistentVolumeClaim: { claimName: 'ledger-data' } }],
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'v1', kind: 'Service',
+    metadata: { name: 'ledgerdb', namespace: 'payments' },
+    spec: { selector: { app: 'ledgerdb' }, ports: [{ port: 5432, targetPort: 5432 }] },
+  },
+];
+
+/** 库里已经有的数据。恢复出来必须一字不差。 */
+const LEDGER_ROWS = [
+  'date,id,amount',
+  '2026-08-01,pay-100317,42.00',
+  '2026-08-02,pay-100318,128.50',
+  '2026-08-03,pay-100319,7.25',
+  '',
+].join('\n');
+
+const BACKUP_STARTER = code`
+  # 备份还没配过。
+  #
+  # 这里需要一个 Backup 对象，把 payments 整个命名空间备下来。
+  # 光把对象备下来是不够的 —— 想清楚盘上的字节靠什么进备份。
+`;
+
+const BACKUP_REFERENCE = code`
+  apiVersion: velero.io/v1
+  kind: Backup
+  metadata:
+    name: payments-daily
+    namespace: velero
+  spec:
+    includedNamespaces:
+    - payments
+    storageLocation: default
+    # 不写 snapshotVolumes 就是「要拍快照」。但拍不拍得成，取决于有没有一个
+    # 打了 velero.io/csi-volumesnapshot-class 标签的 VolumeSnapshotClass。
+    ttl: 720h
+`;
+
+const stage21 = {
+  id: 'disaster-recovery',
+  title: t('把删掉的东西连数据一起找回来', 'Get It Back, Data and All'),
+  goal: t(
+    code`
+      对账库 \`ledgerdb\` 的数据在一块 20Gi 的盘上。集群装了 Velero，
+      也配好了桶 —— 但从来没有人跑过一次备份，更没有人恢复过。
+
+      「我们有备份」和「我们能恢复」是两句话。这一关要把后一句变成真的。
+
+      要做三件事：
+
+      1. 让 Velero 备份**连卷数据一起**备走；
+      2. 把 payments 整个命名空间备下来；
+      3. 做一次恢复演练，恢复到**另一个命名空间**，证明这份备份真的能用。
+
+      做完之后判定会真的删掉 payments 命名空间，再从你的备份把它恢复回来。
+
+      ## 通关标准
+
+      1. 备份是 \`Completed\`，而且 \`volumeSnapshotsCompleted\` 大于 0；
+      2. 有一次恢复演练，落在别的命名空间里，且演练出来的数据是对的；
+      3. \`kubectl delete namespace payments\` 之后，从这份备份能把库和数据
+         一起恢复回来，一行不差。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl get volumesnapshotclass
+      kubectl label volumesnapshotclass <name> <key>=<value>
+      kubectl apply -f /root/infra/backup.yaml
+      velero backup get
+      velero backup describe <name>
+      velero restore create <name> --from-backup <backup> --namespace-mappings a:b
+      velero restore get
+      kubectl get pvc,volumesnapshot -n payments
+      \`\`\`
+    `,
+    code`
+      The ledger database \`ledgerdb\` keeps its data on a 20Gi volume. The cluster has
+      Velero installed and a bucket configured, but nobody has ever run a backup, let
+      alone restored one.
+
+      "We have backups" and "we can restore" are two different sentences. This stage is
+      about making the second one true.
+
+      Three things to do:
+
+      1. make Velero back up the **volume data**, not just the objects;
+      2. back up the whole payments namespace;
+      3. run a restore drill into **another namespace** to prove the backup works.
+
+      When you are done, the grader really does delete the payments namespace and
+      restores it from your backup.
+
+      ## Done when
+
+      1. the backup is \`Completed\` and \`volumeSnapshotsCompleted\` is above zero;
+      2. a restore drill exists, landing in a different namespace, with correct data;
+      3. after \`kubectl delete namespace payments\`, your backup brings the database
+         and every row back.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl get volumesnapshotclass
+      kubectl label volumesnapshotclass <name> <key>=<value>
+      kubectl apply -f /root/infra/backup.yaml
+      velero backup get
+      velero backup describe <name>
+      velero restore create <name> --from-backup <backup> --namespace-mappings a:b
+      velero restore get
+      kubectl get pvc,volumesnapshot -n payments
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('备份里有卷数据', 'The backup contains volume data'),
+    t('恢复演练做过', 'A restore drill has been run'),
+    t('删了也回得来', 'Deleted and brought back'),
+  ],
+  hints: [
+    t(
+      'Velero 挑卷快照类靠的是一个标签：\`velero.io/csi-volumesnapshot-class: "true"\`。没有任何一个快照类打这个标签时，备份**不报错** —— 它照样 Completed，只是 warnings 加一，卷数据一个字节都没进去。\`velero backup describe\` 里那两行 Attempted / Completed 就是拿来看这个的。',
+      'Velero picks a snapshot class by a label: `velero.io/csi-volumesnapshot-class: "true"`. When no class carries it the backup does **not** fail. It still says Completed, just with one more warning, and not a byte of volume data goes in. Those Attempted / Completed lines in `velero backup describe` are exactly what to read.'
+    ),
+    t(
+      '恢复演练不要在生产命名空间上做。Velero 默认**跳过**已经存在的对象，所以往原地恢复多半是「跑完了，什么都没变」—— 而你会以为验证过了。用 \`--namespace-mappings\` 恢复到一个新命名空间。',
+      'Do not drill in the production namespace. Velero **skips** resources that already exist, so restoring in place usually means "it ran and nothing changed", and you walk away thinking you verified something. Restore into a fresh namespace with `--namespace-mappings`.'
+    ),
+    t(
+      '恢复出来的 PVC 是不是有数据，看不出来 —— Bound 就是 Bound。要证明，只能进去读一行：\`kubectl exec\` 进 Pod \`cat\` 一下。',
+      'You cannot tell whether a restored PVC has data by looking at it: Bound is Bound. The only proof is reading a row, so `kubectl exec` into the pod and `cat` the file.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '把「备份任务是绿的」当成「数据备下来了」。没有可用的卷快照类时，Velero 照样报 Completed。这类失效只会在恢复那天暴露，而那天恰好是最不能出错的一天。判据要看 \`volumeSnapshotsCompleted\`，不是 \`phase\`。',
+      'Treating "the backup job is green" as "the data is backed up". With no usable volume snapshot class Velero still reports Completed. This failure only surfaces on the day you restore, which is exactly the day it must not. Check `volumeSnapshotsCompleted`, not `phase`.'
+    ),
+    t(
+      '原地恢复。Velero 默认跳过已经存在的对象，恢复完 phase 是 PartiallyFailed，而集群一点没变 —— 很容易读成「恢复成功，只是有点小问题」。',
+      'Restoring in place. Velero skips resources that already exist, the restore ends PartiallyFailed, and nothing in the cluster changed. That reads a lot like "restored, with minor issues".'
+    ),
+    t(
+      '以为删掉命名空间只是删掉一堆对象。它会一起带走 PVC，而回收策略是 \`Delete\` 的话，盘和盘上的字节跟着一起消失，apiserver 里再也查不到它存在过。',
+      'Assuming deleting a namespace only deletes some objects. It takes the PVCs with it, and with a `Delete` reclaim policy the volume and every byte on it go too, with no record left in the apiserver that they ever existed.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM,
+      ...ROLLOUTS_PLATFORM, ...MONITORING_CARRIED,
+      ...PORTAL_ROLLOUT, PORTAL_ROUTE,
+      ...STORAGE_PLATFORM, ...VELERO_PLATFORM, ...LEDGERDB_WORKLOAD,
+    ],
+    volumes: { 'payments/ledger-data': { 'ledger.csv': LEDGER_ROWS } },
+    files: { '/root/infra/backup.yaml': BACKUP_STARTER },
+    referenceFiles: { '/root/infra/backup.yaml': BACKUP_REFERENCE },
+    referenceCommands: [
+      'kubectl label volumesnapshotclass csi-standard velero.io/csi-volumesnapshot-class=true',
+      'kubectl apply -f /root/infra/backup.yaml',
+      'velero backup get',
+      'velero restore create drill --from-backup payments-daily --namespace-mappings payments:payments-drill',
+    ],
+  },
+  specs: [
+    spec('disaster-recovery.spec.ts', code`
+      import { advance, get, list, sh } from '@ops/lab';
+
+      const COMPLETED = () => list('Backup', { namespace: 'velero' })
+        .filter((backup) => (backup.status || {}).phase === 'Completed');
+
+      const rowsIn = async (namespace) => {
+        const pod = list('Pod', { namespace })
+          .filter((item) => (item.metadata.labels || {}).app === 'ledgerdb')
+          .filter((item) => item.status.phase === 'Running')[0];
+        if (!pod) return '';
+        const result = await sh(
+          'kubectl exec ' + pod.metadata.name + ' -n ' + namespace
+          + ' -- cat /var/lib/ledger/ledger.csv'
+        );
+        return result.stdout;
+      };
+
+      describe('灾难恢复', () => {
+        it('卷快照类是 Velero 认得的', () => {
+          const classes = list('VolumeSnapshotClass');
+          expect(classes.length).toBeGreaterThan(0);
+          const usable = classes.filter(
+            (item) => (item.metadata.labels || {})['velero.io/csi-volumesnapshot-class'] === 'true'
+          );
+          expect(usable.length).toBeGreaterThan(0);
+        });
+
+        it('备份完成了，而且卷数据在里面', () => {
+          const backups = COMPLETED();
+          expect(backups.length).toBeGreaterThan(0);
+          const backup = backups[0];
+          // Completed 只说明任务跑完了。数据在不在，看这一行。
+          expect(backup.status.volumeSnapshotsCompleted).toBeGreaterThan(0);
+          expect(backup.status.warnings || 0).toBe(0);
+          expect((backup.spec.includedNamespaces || []).includes('payments')).toBe(true);
+        });
+
+        it('恢复演练做过，而且不是在生产上做的', async () => {
+          const drills = list('Restore', { namespace: 'velero' }).filter((restore) => {
+            const mapping = (restore.spec || {}).namespaceMapping || {};
+            return Object.keys(mapping).length > 0 && mapping.payments !== 'payments';
+          });
+          expect(drills.length).toBeGreaterThan(0);
+
+          const target = drills[0].spec.namespaceMapping.payments;
+          expect(drills[0].status.phase).toBe('Completed');
+
+          await advance(120000);
+          const rows = await rowsIn(target);
+          expect(rows).toContain('pay-100317');
+          expect(rows).toContain('pay-100319');
+        });
+
+        it('真出事了也回得来：整个命名空间删掉，数据照样一行不差', async () => {
+          const name = COMPLETED()[0].metadata.name;
+
+          await sh('kubectl delete namespace payments');
+          await advance(60000);
+          expect(list('PersistentVolumeClaim', { namespace: 'payments' }).length).toBe(0);
+          expect(list('Deployment', { namespace: 'payments' }).length).toBe(0);
+
+          await sh('velero restore create rescue --from-backup ' + name);
+          await advance(600000);
+
+          const claim = get('PersistentVolumeClaim', 'ledger-data', 'payments');
+          expect(claim.status.phase).toBe('Bound');
+          expect(get('Deployment', 'ledgerdb', 'payments')).toBeTruthy();
+
+          const rows = await rowsIn('payments');
+          expect(rows).toContain('pay-100317');
+          expect(rows).toContain('pay-100318');
+          expect(rows).toContain('pay-100319');
+        });
+      });
+    `),
+  ],
+  focus: ['resilience'],
+  extension: t(
+    code`
+      备份这件事上，绝大多数团队真正缺的不是备份，是**恢复**。备份任务天天绿，
+      没有人试过从它恢复；等到需要的那天才发现里面只有对象图没有数据，
+      或者恢复流程要三个人商量两小时。所以「多久备份一次」远不如
+      「多久演练一次恢复」重要，后者才是真正被验证过的那个数字。
+
+      演练一定要恢复到一个新的地方。Velero 默认跳过已经存在的对象，
+      往原地恢复的结果往往是「跑完了，什么都没变」—— 你验证了个寂寞，
+      还得到一份虚假的信心。用 \`--namespace-mappings\` 恢复到一个临时命名空间，
+      读一行数据出来对一下，然后把临时命名空间删掉。
+
+      还有一层是**备份的边界**。这一关备的是一个命名空间，
+      但恢复一个真实系统往往还需要命名空间之外的东西：CRD、集群角色、
+      StorageClass、Secret 里那把只存在于集群里的密钥。
+      备份策略里最该问的一句话是：如果整个集群没了，
+      光靠这个桶里的东西，能不能从零把服务拉起来。
+    `,
+    code`
+      What most teams are missing is not backups, it is **restores**. The backup job is
+      green every day and nobody has ever restored from it, so the day it matters is the
+      day you learn it holds objects but no data, or that the procedure takes three
+      people and two hours to agree on. How often you back up matters far less than how
+      often you rehearse a restore, because only the second number has been verified.
+
+      Always drill into a new place. Velero skips resources that already exist, so an
+      in-place restore usually means "it ran and nothing changed": you verified nothing
+      and walked away with false confidence. Restore into a temporary namespace with
+      \`--namespace-mappings\`, read a row of real data out of it, then delete the
+      temporary namespace.
+
+      There is also the question of **what the backup's edge is**. This stage backs up a
+      namespace, but restoring a real system usually needs things outside it: CRDs,
+      cluster roles, StorageClasses, the key that only ever existed inside a Secret in
+      that cluster. The question worth asking of any backup strategy is whether, with
+      the whole cluster gone, the contents of that bucket alone are enough to bring the
+      service back from nothing.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -6695,5 +7111,6 @@ module.exports = {
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
     stage13, stage14, stage15, stage16, stage17, stage18, stage19, stage20,
+    stage21,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5621,7 +5621,8 @@
           "istio-system",
           "kyverno",
           "external-secrets",
-          "monitoring"
+          "monitoring",
+          "velero"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5749,6 +5750,31 @@
             "pullMs": 400,
             "startupMs": 600,
             "readyAfterMs": 300
+          },
+          "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200
+          },
+          "registry.k8s.io/sig-storage/snapshot-controller:v8.2.0": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200
+          },
+          "velero/velero:v1.16.1": {
+            "pullMs": 700,
+            "startupMs": 900,
+            "readyAfterMs": 400
+          },
+          "harbor.corp.internal/team/ledgerdb:14.2": {
+            "pullMs": 800,
+            "startupMs": 1200,
+            "readyAfterMs": 600,
+            "listens": [
+              5432
+            ],
+            "memoryUsage": "512Mi",
+            "handlesSigterm": true
           },
           "harbor.corp.internal/team/portal:1.5.0": {
             "pullMs": 400,
@@ -12823,6 +12849,771 @@
         "primer": {
           "zh": "Deployment 的滚动更新只回答一个问题：新的 Pod 起来了没有。而「起来了」和「好用」是两回事：一个进程活着、探针全过、日志干净，但大半请求返回 500 的版本，滚动更新会毫不犹豫地把它铺到 100%。`渐进式发布`补的就是这一段：把「什么叫好」写进发布流程本身。\n\n`Argo Rollouts` 用 `Rollout` 替代 Deployment（是替代不是补充，一个工作负载只能由其中之一管）。它多出来的是 `strategy.canary.steps`：一串按顺序执行的步骤。`setWeight` 调整金丝雀占多少副本，`pause` 停一下（带 `duration` 就是等那么久，不带就是无限期等人来 `promote`），`analysis` 起一次分析。控制器用 `status.currentStepIndex` 记着走到第几步，每步做完才往前挪一格。\n\n`AnalysisTemplate` 描述判据：一条 PromQL 加一个 `successCondition`（形如 `result < 0.05`）。任何一条不满足，整个发布`中止`。要特别注意中止的含义，它不是「停在原地」，而是**回到稳定版本**：金丝雀缩到 0，稳定版拉回满副本。这也是自动回滚的实现，不需要人介入。另一个必写的字段是 `initialDelay`：金丝雀刚起来的那几秒计数器还是 0、采样点不够两个，这时候算出来的是稳定版的错误率，看着很好，然后就把坏版本放行了。\n\n判据本身要写成`比例`而不是计数。`sum(rate(errors[5m])) > 0` 会让任何一个 5xx 都毁掉发布，而真实系统永远有零星的 5xx，结果是没有版本发得出去，最后有人把分析这一步删掉。还有一条实践：**金丝雀的判据应该和告警的判据是同一个表达式**，否则会出现「发布时看着没事、上线后告警响」，那说明「什么叫坏」被定义了两遍。\n\n另一半是节点维护。`PodDisruptionBudget` 管的是`自愿中断`，也就是有人主动发起的那些：节点维护、缩容、驱逐。`kubectl drain` 走的是 Pod 的 `eviction` 子资源，会先问 PDB，违反就收到 429 并重试；而 `kubectl delete pod` 走的是普通删除，谁也拦不住。这是两条命令行为不同的根源。PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」：节点掉电、OOMKill、被抢占都不在它管辖内。还有一个反效果要避开：`minAvailable` 写成和副本数一样大，任何驱逐都会被拒，节点永远维护不了。",
           "en": "A rolling update answers one question: did the new pods start. Starting is not the same as working, and a version whose process is alive, probes pass, and logs are clean while three requests in ten return 500 will be spread to 100% without hesitation. `Progressive delivery` fills that gap by writing \"what good looks like\" into the release process itself.\n\n`Argo Rollouts` replaces a Deployment with a `Rollout` (replaces, not supplements: a workload is managed by one or the other). What it adds is `strategy.canary.steps`, an ordered list. `setWeight` sets how many replicas are canary, `pause` stops (with a `duration` it waits that long, without one it waits indefinitely for a `promote`), and `analysis` runs an evaluation. The controller tracks progress in `status.currentStepIndex`, advancing only when a step completes.\n\nAn `AnalysisTemplate` describes the criterion: a PromQL query plus a `successCondition` such as `result < 0.05`. If any metric fails, the rollout `aborts`. Note what aborting means: not stopping in place but **returning to the stable version**, scaling the canary to zero and stable back to full. That is the automatic rollback, with nobody in the loop. The other field you must write is `initialDelay`: in the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the stable version error rate, which looks great and lets the bad version through.\n\nThe criterion must be a `ratio` rather than a count. `sum(rate(errors[5m])) > 0` fails a release on any single 5xx, real systems always have a few, nothing ever ships, and eventually somebody deletes the analysis step. One more practice: **the canary criterion and the alerting criterion should be the same expression**, or you get \"looked fine during rollout, paged afterwards\", which means \"bad\" was defined twice.\n\nThe other half is node maintenance. A `PodDisruptionBudget` governs `voluntary` disruptions, the ones somebody initiates: maintenance, scale-down, eviction. `kubectl drain` goes through the Pod `eviction` subresource, which consults the PDB and returns 429 with a retry when it would be violated, while `kubectl delete pod` is an ordinary delete that nothing stops. That is why the two commands behave differently. A PDB guarantees nobody drains you to zero, not that N replicas always exist: power loss, OOMKill, and preemption are all outside its remit. And avoid the counterproductive setting where `minAvailable` equals the replica count, because then every eviction is refused and the node can never be maintained."
+        }
+      },
+      {
+        "id": "disaster-recovery",
+        "title": {
+          "zh": "把删掉的东西连数据一起找回来",
+          "en": "Get It Back, Data and All"
+        },
+        "goal": {
+          "zh": "对账库 `ledgerdb` 的数据在一块 20Gi 的盘上。集群装了 Velero，\n也配好了桶 —— 但从来没有人跑过一次备份，更没有人恢复过。\n\n「我们有备份」和「我们能恢复」是两句话。这一关要把后一句变成真的。\n\n要做三件事：\n\n1. 让 Velero 备份**连卷数据一起**备走；\n2. 把 payments 整个命名空间备下来；\n3. 做一次恢复演练，恢复到**另一个命名空间**，证明这份备份真的能用。\n\n做完之后判定会真的删掉 payments 命名空间，再从你的备份把它恢复回来。\n\n## 通关标准\n\n1. 备份是 `Completed`，而且 `volumeSnapshotsCompleted` 大于 0；\n2. 有一次恢复演练，落在别的命名空间里，且演练出来的数据是对的；\n3. `kubectl delete namespace payments` 之后，从这份备份能把库和数据\n   一起恢复回来，一行不差。\n\n## 会用到的命令\n\n```bash\nkubectl get volumesnapshotclass\nkubectl label volumesnapshotclass <name> <key>=<value>\nkubectl apply -f /root/infra/backup.yaml\nvelero backup get\nvelero backup describe <name>\nvelero restore create <name> --from-backup <backup> --namespace-mappings a:b\nvelero restore get\nkubectl get pvc,volumesnapshot -n payments\n```\n",
+          "en": "The ledger database `ledgerdb` keeps its data on a 20Gi volume. The cluster has\nVelero installed and a bucket configured, but nobody has ever run a backup, let\nalone restored one.\n\n\"We have backups\" and \"we can restore\" are two different sentences. This stage is\nabout making the second one true.\n\nThree things to do:\n\n1. make Velero back up the **volume data**, not just the objects;\n2. back up the whole payments namespace;\n3. run a restore drill into **another namespace** to prove the backup works.\n\nWhen you are done, the grader really does delete the payments namespace and\nrestores it from your backup.\n\n## Done when\n\n1. the backup is `Completed` and `volumeSnapshotsCompleted` is above zero;\n2. a restore drill exists, landing in a different namespace, with correct data;\n3. after `kubectl delete namespace payments`, your backup brings the database\n   and every row back.\n\n## Commands you will need\n\n```bash\nkubectl get volumesnapshotclass\nkubectl label volumesnapshotclass <name> <key>=<value>\nkubectl apply -f /root/infra/backup.yaml\nvelero backup get\nvelero backup describe <name>\nvelero restore create <name> --from-backup <backup> --namespace-mappings a:b\nvelero restore get\nkubectl get pvc,volumesnapshot -n payments\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "备份里有卷数据",
+            "en": "The backup contains volume data"
+          },
+          {
+            "zh": "恢复演练做过",
+            "en": "A restore drill has been run"
+          },
+          {
+            "zh": "删了也回得来",
+            "en": "Deleted and brought back"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "Velero 挑卷快照类靠的是一个标签：`velero.io/csi-volumesnapshot-class: \"true\"`。没有任何一个快照类打这个标签时，备份**不报错** —— 它照样 Completed，只是 warnings 加一，卷数据一个字节都没进去。`velero backup describe` 里那两行 Attempted / Completed 就是拿来看这个的。",
+            "en": "Velero picks a snapshot class by a label: `velero.io/csi-volumesnapshot-class: \"true\"`. When no class carries it the backup does **not** fail. It still says Completed, just with one more warning, and not a byte of volume data goes in. Those Attempted / Completed lines in `velero backup describe` are exactly what to read."
+          },
+          {
+            "zh": "恢复演练不要在生产命名空间上做。Velero 默认**跳过**已经存在的对象，所以往原地恢复多半是「跑完了，什么都没变」—— 而你会以为验证过了。用 `--namespace-mappings` 恢复到一个新命名空间。",
+            "en": "Do not drill in the production namespace. Velero **skips** resources that already exist, so restoring in place usually means \"it ran and nothing changed\", and you walk away thinking you verified something. Restore into a fresh namespace with `--namespace-mappings`."
+          },
+          {
+            "zh": "恢复出来的 PVC 是不是有数据，看不出来 —— Bound 就是 Bound。要证明，只能进去读一行：`kubectl exec` 进 Pod `cat` 一下。",
+            "en": "You cannot tell whether a restored PVC has data by looking at it: Bound is Bound. The only proof is reading a row, so `kubectl exec` into the pod and `cat` the file."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "把「备份任务是绿的」当成「数据备下来了」。没有可用的卷快照类时，Velero 照样报 Completed。这类失效只会在恢复那天暴露，而那天恰好是最不能出错的一天。判据要看 `volumeSnapshotsCompleted`，不是 `phase`。",
+            "en": "Treating \"the backup job is green\" as \"the data is backed up\". With no usable volume snapshot class Velero still reports Completed. This failure only surfaces on the day you restore, which is exactly the day it must not. Check `volumeSnapshotsCompleted`, not `phase`."
+          },
+          {
+            "zh": "原地恢复。Velero 默认跳过已经存在的对象，恢复完 phase 是 PartiallyFailed，而集群一点没变 —— 很容易读成「恢复成功，只是有点小问题」。",
+            "en": "Restoring in place. Velero skips resources that already exist, the restore ends PartiallyFailed, and nothing in the cluster changed. That reads a lot like \"restored, with minor issues\"."
+          },
+          {
+            "zh": "以为删掉命名空间只是删掉一堆对象。它会一起带走 PVC，而回收策略是 `Delete` 的话，盘和盘上的字节跟着一起消失，apiserver 里再也查不到它存在过。",
+            "en": "Assuming deleting a namespace only deletes some objects. It takes the PVCs with it, and with a `Delete` reclaim policy the volume and every byte on it go too, with no record left in the apiserver that they ever existed."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "csi-provisioner",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "csi-driver"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "csi-driver"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "csi-driver"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "provisioner",
+                        "image": "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "snapshot-controller",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "snapshot-controller"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "snapshot-controller"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "snapshot-controller"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/sig-storage/snapshot-controller:v8.2.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "storage.k8s.io/v1",
+              "kind": "StorageClass",
+              "metadata": {
+                "name": "standard",
+                "annotations": {
+                  "storageclass.kubernetes.io/is-default-class": "true"
+                }
+              },
+              "provisioner": "csi.corp.internal",
+              "reclaimPolicy": "Delete",
+              "volumeBindingMode": "Immediate"
+            },
+            {
+              "apiVersion": "snapshot.storage.k8s.io/v1",
+              "kind": "VolumeSnapshotClass",
+              "metadata": {
+                "name": "csi-standard"
+              },
+              "driver": "csi.corp.internal",
+              "deletionPolicy": "Delete"
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "velero",
+                "namespace": "velero",
+                "labels": {
+                  "app.kubernetes.io/name": "velero"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "velero"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "velero"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "velero",
+                        "image": "velero/velero:v1.16.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "velero.io/v1",
+              "kind": "BackupStorageLocation",
+              "metadata": {
+                "name": "default",
+                "namespace": "velero"
+              },
+              "spec": {
+                "provider": "aws",
+                "default": true,
+                "objectStorage": {
+                  "bucket": "corp-backups"
+                },
+                "config": {
+                  "region": "internal",
+                  "s3Url": "http://minio.storage.svc:9000"
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "PersistentVolumeClaim",
+              "metadata": {
+                "name": "ledger-data",
+                "namespace": "payments"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "20Gi"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ledgerdb",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "ledgerdb"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ledgerdb"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "db",
+                        "image": "harbor.corp.internal/team/ledgerdb:14.2",
+                        "ports": [
+                          {
+                            "containerPort": 5432
+                          }
+                        ],
+                        "volumeMounts": [
+                          {
+                            "name": "data",
+                            "mountPath": "/var/lib/ledger"
+                          }
+                        ]
+                      }
+                    ],
+                    "volumes": [
+                      {
+                        "name": "data",
+                        "persistentVolumeClaim": {
+                          "claimName": "ledger-data"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "ledgerdb",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "ledgerdb"
+                },
+                "ports": [
+                  {
+                    "port": 5432,
+                    "targetPort": 5432
+                  }
+                ]
+              }
+            }
+          ],
+          "volumes": {
+            "payments/ledger-data": {
+              "ledger.csv": "date,id,amount\n2026-08-01,pay-100317,42.00\n2026-08-02,pay-100318,128.50\n2026-08-03,pay-100319,7.25\n"
+            }
+          },
+          "files": {
+            "/root/infra/backup.yaml": "# 备份还没配过。\n#\n# 这里需要一个 Backup 对象，把 payments 整个命名空间备下来。\n# 光把对象备下来是不够的 —— 想清楚盘上的字节靠什么进备份。\n"
+          },
+          "referenceFiles": {
+            "/root/infra/backup.yaml": "apiVersion: velero.io/v1\nkind: Backup\nmetadata:\n  name: payments-daily\n  namespace: velero\nspec:\n  includedNamespaces:\n  - payments\n  storageLocation: default\n  # 不写 snapshotVolumes 就是「要拍快照」。但拍不拍得成，取决于有没有一个\n  # 打了 velero.io/csi-volumesnapshot-class 标签的 VolumeSnapshotClass。\n  ttl: 720h\n"
+          },
+          "referenceCommands": [
+            "kubectl label volumesnapshotclass csi-standard velero.io/csi-volumesnapshot-class=true",
+            "kubectl apply -f /root/infra/backup.yaml",
+            "velero backup get",
+            "velero restore create drill --from-backup payments-daily --namespace-mappings payments:payments-drill"
+          ]
+        },
+        "specs": [
+          {
+            "path": "disaster-recovery.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst COMPLETED = () => list('Backup', { namespace: 'velero' })\n  .filter((backup) => (backup.status || {}).phase === 'Completed');\n\nconst rowsIn = async (namespace) => {\n  const pod = list('Pod', { namespace })\n    .filter((item) => (item.metadata.labels || {}).app === 'ledgerdb')\n    .filter((item) => item.status.phase === 'Running')[0];\n  if (!pod) return '';\n  const result = await sh(\n    'kubectl exec ' + pod.metadata.name + ' -n ' + namespace\n    + ' -- cat /var/lib/ledger/ledger.csv'\n  );\n  return result.stdout;\n};\n\ndescribe('灾难恢复', () => {\n  it('卷快照类是 Velero 认得的', () => {\n    const classes = list('VolumeSnapshotClass');\n    expect(classes.length).toBeGreaterThan(0);\n    const usable = classes.filter(\n      (item) => (item.metadata.labels || {})['velero.io/csi-volumesnapshot-class'] === 'true'\n    );\n    expect(usable.length).toBeGreaterThan(0);\n  });\n\n  it('备份完成了，而且卷数据在里面', () => {\n    const backups = COMPLETED();\n    expect(backups.length).toBeGreaterThan(0);\n    const backup = backups[0];\n    // Completed 只说明任务跑完了。数据在不在，看这一行。\n    expect(backup.status.volumeSnapshotsCompleted).toBeGreaterThan(0);\n    expect(backup.status.warnings || 0).toBe(0);\n    expect((backup.spec.includedNamespaces || []).includes('payments')).toBe(true);\n  });\n\n  it('恢复演练做过，而且不是在生产上做的', async () => {\n    const drills = list('Restore', { namespace: 'velero' }).filter((restore) => {\n      const mapping = (restore.spec || {}).namespaceMapping || {};\n      return Object.keys(mapping).length > 0 && mapping.payments !== 'payments';\n    });\n    expect(drills.length).toBeGreaterThan(0);\n\n    const target = drills[0].spec.namespaceMapping.payments;\n    expect(drills[0].status.phase).toBe('Completed');\n\n    await advance(120000);\n    const rows = await rowsIn(target);\n    expect(rows).toContain('pay-100317');\n    expect(rows).toContain('pay-100319');\n  });\n\n  it('真出事了也回得来：整个命名空间删掉，数据照样一行不差', async () => {\n    const name = COMPLETED()[0].metadata.name;\n\n    await sh('kubectl delete namespace payments');\n    await advance(60000);\n    expect(list('PersistentVolumeClaim', { namespace: 'payments' }).length).toBe(0);\n    expect(list('Deployment', { namespace: 'payments' }).length).toBe(0);\n\n    await sh('velero restore create rescue --from-backup ' + name);\n    await advance(600000);\n\n    const claim = get('PersistentVolumeClaim', 'ledger-data', 'payments');\n    expect(claim.status.phase).toBe('Bound');\n    expect(get('Deployment', 'ledgerdb', 'payments')).toBeTruthy();\n\n    const rows = await rowsIn('payments');\n    expect(rows).toContain('pay-100317');\n    expect(rows).toContain('pay-100318');\n    expect(rows).toContain('pay-100319');\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "resilience"
+        ],
+        "extension": {
+          "zh": "备份这件事上，绝大多数团队真正缺的不是备份，是**恢复**。备份任务天天绿，\n没有人试过从它恢复；等到需要的那天才发现里面只有对象图没有数据，\n或者恢复流程要三个人商量两小时。所以「多久备份一次」远不如\n「多久演练一次恢复」重要，后者才是真正被验证过的那个数字。\n\n演练一定要恢复到一个新的地方。Velero 默认跳过已经存在的对象，\n往原地恢复的结果往往是「跑完了，什么都没变」—— 你验证了个寂寞，\n还得到一份虚假的信心。用 `--namespace-mappings` 恢复到一个临时命名空间，\n读一行数据出来对一下，然后把临时命名空间删掉。\n\n还有一层是**备份的边界**。这一关备的是一个命名空间，\n但恢复一个真实系统往往还需要命名空间之外的东西：CRD、集群角色、\nStorageClass、Secret 里那把只存在于集群里的密钥。\n备份策略里最该问的一句话是：如果整个集群没了，\n光靠这个桶里的东西，能不能从零把服务拉起来。\n",
+          "en": "What most teams are missing is not backups, it is **restores**. The backup job is\ngreen every day and nobody has ever restored from it, so the day it matters is the\nday you learn it holds objects but no data, or that the procedure takes three\npeople and two hours to agree on. How often you back up matters far less than how\noften you rehearse a restore, because only the second number has been verified.\n\nAlways drill into a new place. Velero skips resources that already exist, so an\nin-place restore usually means \"it ran and nothing changed\": you verified nothing\nand walked away with false confidence. Restore into a temporary namespace with\n`--namespace-mappings`, read a row of real data out of it, then delete the\ntemporary namespace.\n\nThere is also the question of **what the backup's edge is**. This stage backs up a\nnamespace, but restoring a real system usually needs things outside it: CRDs,\ncluster roles, StorageClasses, the key that only ever existed inside a Secret in\nthat cluster. The question worth asking of any backup strategy is whether, with\nthe whole cluster gone, the contents of that bucket alone are enough to bring the\nservice back from nothing.\n"
+        },
+        "primer": {
+          "zh": "接手一个系统之后最该问的一句话不是「有没有备份」，是「上次从备份恢复是什么时候」。这两句差得很远：备份任务天天绿，不代表那个桶里的东西能把服务拉起来。这一关要做的就是把第二句变成真的。\n\nKubernetes 里的数据分两层，这一层的所有困惑都从这儿来。`PersistentVolumeClaim` 是一个**对象**，住在 apiserver 里；盘上的字节不在 apiserver 里，它们在存储后端上。所以把 apiserver 里的对象全导出来，得到的是一份完整的 YAML 和**零字节数据**。恢复出来是一个一模一样的空盘，而 `kubectl get pvc` 看不出空盘和满盘的区别。\n\n要把字节也带上，得靠 `CSI 卷快照`。三个对象：`VolumeSnapshotClass` 说谁来拍、拍完怎么处置，`VolumeSnapshot` 是应用侧的一次请求，`VolumeSnapshotContent` 是存储上真正那张。快照是`时间点`：拍完之后往盘里再写什么都跟它无关。另外要留意拍快照的是 `snapshot-controller` 这个工作负载，它和 CSI 驱动是两个东西，只装驱动的话 VolumeSnapshot 建得出来然后永远不就绪。\n\n`Velero` 把这两件事缝起来：它自己导出对象图放进桶里，卷数据则委托给 CSI 快照。缝的地方有一个标签：`velero.io/csi-volumesnapshot-class: \"true\"`。没有任何快照类打这个标签时，Velero **不报错**，备份照样 `Completed`，只是 warnings 加一，卷数据一个字节都没进去。所以判断一次备份好不好，要看的是 `volumeSnapshotsCompleted` 而不是 `phase`。\n\n恢复这一侧有一条默认行为要记住：Velero **跳过**已经存在的对象。所以往原地恢复的结果通常是「跑完了，phase 是 PartiallyFailed，集群一点没变」，很容易被读成「恢复成功，只是有点小问题」。演练要用 `--namespace-mappings` 恢复到一个新命名空间，进去读一行真数据出来对一下，再把它删掉。\n\n最后是灾难本身。`kubectl delete namespace` 不只是删掉一堆对象，它会一起带走 PVC；回收策略是 `Delete` 的话，盘和盘上的字节跟着消失，apiserver 里再也查不到它存在过。一条命令、一个词的差别，带走的是整个环境，这也正是备份存在的理由。",
+          "en": "The first question to ask about a system you have just inherited is not whether it has backups, it is when somebody last restored from one. Those are far apart: a backup job going green every day says nothing about whether the contents of that bucket can bring the service back. This stage is about making the second sentence true.\n\nData in Kubernetes lives on two levels, and every confusion here comes from that split. A `PersistentVolumeClaim` is an **object** in the apiserver; the bytes on the volume are not, they live on the storage backend. So exporting every object from the apiserver gives you a complete set of YAML and **zero bytes of data**. What comes back is an identical empty disk, and `kubectl get pvc` shows no difference between an empty one and a full one.\n\nCarrying the bytes as well takes `CSI volume snapshots`. Three objects: a `VolumeSnapshotClass` says who takes them and what happens afterwards, a `VolumeSnapshot` is the request from the application side, and a `VolumeSnapshotContent` is the real snapshot on the storage system. A snapshot is a `point in time`: whatever is written to the volume afterwards is not in it. Note also that snapshots are taken by the `snapshot-controller` workload, which is separate from the CSI driver: install only the driver and a VolumeSnapshot will be created and then never become ready.\n\n`Velero` stitches the two together: it exports the object graph into the bucket itself and delegates volume data to CSI snapshots. The seam is a label, `velero.io/csi-volumesnapshot-class: \"true\"`. When no snapshot class carries it, Velero does **not** fail. The backup still reports `Completed`, just with one more warning, and not a byte of volume data goes in. So the health of a backup is read from `volumeSnapshotsCompleted`, not from `phase`.\n\nOn the restore side there is one default worth memorising: Velero **skips** resources that already exist. Restoring in place therefore usually means \"it ran, phase is PartiallyFailed, and nothing in the cluster changed\", which reads a lot like \"restored, with minor issues\". Drill with `--namespace-mappings` into a fresh namespace, read a row of real data out of it, and delete it afterwards.\n\nFinally the disaster itself. `kubectl delete namespace` does not just remove a pile of objects, it takes the PVCs with it; with a `Delete` reclaim policy the volume and every byte on it go too, leaving no record in the apiserver that they ever existed. One command, one word of difference, and an entire environment is gone, which is the whole reason backups exist."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1344,6 +1344,25 @@ const primers = {
       )
     ),
 
+    'disaster-recovery': t(
+      p(
+        '接手一个系统之后最该问的一句话不是「有没有备份」，是「上次从备份恢复是什么时候」。这两句差得很远：备份任务天天绿，不代表那个桶里的东西能把服务拉起来。这一关要做的就是把第二句变成真的。',
+        'Kubernetes 里的数据分两层，这一层的所有困惑都从这儿来。`PersistentVolumeClaim` 是一个**对象**，住在 apiserver 里；盘上的字节不在 apiserver 里，它们在存储后端上。所以把 apiserver 里的对象全导出来，得到的是一份完整的 YAML 和**零字节数据**。恢复出来是一个一模一样的空盘，而 `kubectl get pvc` 看不出空盘和满盘的区别。',
+        '要把字节也带上，得靠 `CSI 卷快照`。三个对象：`VolumeSnapshotClass` 说谁来拍、拍完怎么处置，`VolumeSnapshot` 是应用侧的一次请求，`VolumeSnapshotContent` 是存储上真正那张。快照是`时间点`：拍完之后往盘里再写什么都跟它无关。另外要留意拍快照的是 `snapshot-controller` 这个工作负载，它和 CSI 驱动是两个东西，只装驱动的话 VolumeSnapshot 建得出来然后永远不就绪。',
+        '`Velero` 把这两件事缝起来：它自己导出对象图放进桶里，卷数据则委托给 CSI 快照。缝的地方有一个标签：`velero.io/csi-volumesnapshot-class: "true"`。没有任何快照类打这个标签时，Velero **不报错**，备份照样 `Completed`，只是 warnings 加一，卷数据一个字节都没进去。所以判断一次备份好不好，要看的是 `volumeSnapshotsCompleted` 而不是 `phase`。',
+        '恢复这一侧有一条默认行为要记住：Velero **跳过**已经存在的对象。所以往原地恢复的结果通常是「跑完了，phase 是 PartiallyFailed，集群一点没变」，很容易被读成「恢复成功，只是有点小问题」。演练要用 `--namespace-mappings` 恢复到一个新命名空间，进去读一行真数据出来对一下，再把它删掉。',
+        '最后是灾难本身。`kubectl delete namespace` 不只是删掉一堆对象，它会一起带走 PVC；回收策略是 `Delete` 的话，盘和盘上的字节跟着消失，apiserver 里再也查不到它存在过。一条命令、一个词的差别，带走的是整个环境，这也正是备份存在的理由。'
+      ),
+      p(
+        'The first question to ask about a system you have just inherited is not whether it has backups, it is when somebody last restored from one. Those are far apart: a backup job going green every day says nothing about whether the contents of that bucket can bring the service back. This stage is about making the second sentence true.',
+        'Data in Kubernetes lives on two levels, and every confusion here comes from that split. A `PersistentVolumeClaim` is an **object** in the apiserver; the bytes on the volume are not, they live on the storage backend. So exporting every object from the apiserver gives you a complete set of YAML and **zero bytes of data**. What comes back is an identical empty disk, and `kubectl get pvc` shows no difference between an empty one and a full one.',
+        'Carrying the bytes as well takes `CSI volume snapshots`. Three objects: a `VolumeSnapshotClass` says who takes them and what happens afterwards, a `VolumeSnapshot` is the request from the application side, and a `VolumeSnapshotContent` is the real snapshot on the storage system. A snapshot is a `point in time`: whatever is written to the volume afterwards is not in it. Note also that snapshots are taken by the `snapshot-controller` workload, which is separate from the CSI driver: install only the driver and a VolumeSnapshot will be created and then never become ready.',
+        '`Velero` stitches the two together: it exports the object graph into the bucket itself and delegates volume data to CSI snapshots. The seam is a label, `velero.io/csi-volumesnapshot-class: "true"`. When no snapshot class carries it, Velero does **not** fail. The backup still reports `Completed`, just with one more warning, and not a byte of volume data goes in. So the health of a backup is read from `volumeSnapshotsCompleted`, not from `phase`.',
+        'On the restore side there is one default worth memorising: Velero **skips** resources that already exist. Restoring in place therefore usually means "it ran, phase is PartiallyFailed, and nothing in the cluster changed", which reads a lot like "restored, with minor issues". Drill with `--namespace-mappings` into a fresh namespace, read a row of real data out of it, and delete it afterwards.',
+        'Finally the disaster itself. `kubectl delete namespace` does not just remove a pile of objects, it takes the PVCs with it; with a `Delete` reclaim policy the volume and every byte on it go too, leaving no record in the apiserver that they ever existed. One command, one word of difference, and an entire environment is gone, which is the whole reason backups exist.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5621,7 +5621,8 @@
           "istio-system",
           "kyverno",
           "external-secrets",
-          "monitoring"
+          "monitoring",
+          "velero"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5749,6 +5750,31 @@
             "pullMs": 400,
             "startupMs": 600,
             "readyAfterMs": 300
+          },
+          "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200
+          },
+          "registry.k8s.io/sig-storage/snapshot-controller:v8.2.0": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200
+          },
+          "velero/velero:v1.16.1": {
+            "pullMs": 700,
+            "startupMs": 900,
+            "readyAfterMs": 400
+          },
+          "harbor.corp.internal/team/ledgerdb:14.2": {
+            "pullMs": 800,
+            "startupMs": 1200,
+            "readyAfterMs": 600,
+            "listens": [
+              5432
+            ],
+            "memoryUsage": "512Mi",
+            "handlesSigterm": true
           },
           "harbor.corp.internal/team/portal:1.5.0": {
             "pullMs": 400,
@@ -12823,6 +12849,771 @@
         "primer": {
           "zh": "Deployment 的滚动更新只回答一个问题：新的 Pod 起来了没有。而「起来了」和「好用」是两回事：一个进程活着、探针全过、日志干净，但大半请求返回 500 的版本，滚动更新会毫不犹豫地把它铺到 100%。`渐进式发布`补的就是这一段：把「什么叫好」写进发布流程本身。\n\n`Argo Rollouts` 用 `Rollout` 替代 Deployment（是替代不是补充，一个工作负载只能由其中之一管）。它多出来的是 `strategy.canary.steps`：一串按顺序执行的步骤。`setWeight` 调整金丝雀占多少副本，`pause` 停一下（带 `duration` 就是等那么久，不带就是无限期等人来 `promote`），`analysis` 起一次分析。控制器用 `status.currentStepIndex` 记着走到第几步，每步做完才往前挪一格。\n\n`AnalysisTemplate` 描述判据：一条 PromQL 加一个 `successCondition`（形如 `result < 0.05`）。任何一条不满足，整个发布`中止`。要特别注意中止的含义，它不是「停在原地」，而是**回到稳定版本**：金丝雀缩到 0，稳定版拉回满副本。这也是自动回滚的实现，不需要人介入。另一个必写的字段是 `initialDelay`：金丝雀刚起来的那几秒计数器还是 0、采样点不够两个，这时候算出来的是稳定版的错误率，看着很好，然后就把坏版本放行了。\n\n判据本身要写成`比例`而不是计数。`sum(rate(errors[5m])) > 0` 会让任何一个 5xx 都毁掉发布，而真实系统永远有零星的 5xx，结果是没有版本发得出去，最后有人把分析这一步删掉。还有一条实践：**金丝雀的判据应该和告警的判据是同一个表达式**，否则会出现「发布时看着没事、上线后告警响」，那说明「什么叫坏」被定义了两遍。\n\n另一半是节点维护。`PodDisruptionBudget` 管的是`自愿中断`，也就是有人主动发起的那些：节点维护、缩容、驱逐。`kubectl drain` 走的是 Pod 的 `eviction` 子资源，会先问 PDB，违反就收到 429 并重试；而 `kubectl delete pod` 走的是普通删除，谁也拦不住。这是两条命令行为不同的根源。PDB 保证的是「不会被人为打空」，不是「永远有 N 个副本」：节点掉电、OOMKill、被抢占都不在它管辖内。还有一个反效果要避开：`minAvailable` 写成和副本数一样大，任何驱逐都会被拒，节点永远维护不了。",
           "en": "A rolling update answers one question: did the new pods start. Starting is not the same as working, and a version whose process is alive, probes pass, and logs are clean while three requests in ten return 500 will be spread to 100% without hesitation. `Progressive delivery` fills that gap by writing \"what good looks like\" into the release process itself.\n\n`Argo Rollouts` replaces a Deployment with a `Rollout` (replaces, not supplements: a workload is managed by one or the other). What it adds is `strategy.canary.steps`, an ordered list. `setWeight` sets how many replicas are canary, `pause` stops (with a `duration` it waits that long, without one it waits indefinitely for a `promote`), and `analysis` runs an evaluation. The controller tracks progress in `status.currentStepIndex`, advancing only when a step completes.\n\nAn `AnalysisTemplate` describes the criterion: a PromQL query plus a `successCondition` such as `result < 0.05`. If any metric fails, the rollout `aborts`. Note what aborting means: not stopping in place but **returning to the stable version**, scaling the canary to zero and stable back to full. That is the automatic rollback, with nobody in the loop. The other field you must write is `initialDelay`: in the first seconds a canary counter is still zero with fewer than two samples, so what you compute is the stable version error rate, which looks great and lets the bad version through.\n\nThe criterion must be a `ratio` rather than a count. `sum(rate(errors[5m])) > 0` fails a release on any single 5xx, real systems always have a few, nothing ever ships, and eventually somebody deletes the analysis step. One more practice: **the canary criterion and the alerting criterion should be the same expression**, or you get \"looked fine during rollout, paged afterwards\", which means \"bad\" was defined twice.\n\nThe other half is node maintenance. A `PodDisruptionBudget` governs `voluntary` disruptions, the ones somebody initiates: maintenance, scale-down, eviction. `kubectl drain` goes through the Pod `eviction` subresource, which consults the PDB and returns 429 with a retry when it would be violated, while `kubectl delete pod` is an ordinary delete that nothing stops. That is why the two commands behave differently. A PDB guarantees nobody drains you to zero, not that N replicas always exist: power loss, OOMKill, and preemption are all outside its remit. And avoid the counterproductive setting where `minAvailable` equals the replica count, because then every eviction is refused and the node can never be maintained."
+        }
+      },
+      {
+        "id": "disaster-recovery",
+        "title": {
+          "zh": "把删掉的东西连数据一起找回来",
+          "en": "Get It Back, Data and All"
+        },
+        "goal": {
+          "zh": "对账库 `ledgerdb` 的数据在一块 20Gi 的盘上。集群装了 Velero，\n也配好了桶 —— 但从来没有人跑过一次备份，更没有人恢复过。\n\n「我们有备份」和「我们能恢复」是两句话。这一关要把后一句变成真的。\n\n要做三件事：\n\n1. 让 Velero 备份**连卷数据一起**备走；\n2. 把 payments 整个命名空间备下来；\n3. 做一次恢复演练，恢复到**另一个命名空间**，证明这份备份真的能用。\n\n做完之后判定会真的删掉 payments 命名空间，再从你的备份把它恢复回来。\n\n## 通关标准\n\n1. 备份是 `Completed`，而且 `volumeSnapshotsCompleted` 大于 0；\n2. 有一次恢复演练，落在别的命名空间里，且演练出来的数据是对的；\n3. `kubectl delete namespace payments` 之后，从这份备份能把库和数据\n   一起恢复回来，一行不差。\n\n## 会用到的命令\n\n```bash\nkubectl get volumesnapshotclass\nkubectl label volumesnapshotclass <name> <key>=<value>\nkubectl apply -f /root/infra/backup.yaml\nvelero backup get\nvelero backup describe <name>\nvelero restore create <name> --from-backup <backup> --namespace-mappings a:b\nvelero restore get\nkubectl get pvc,volumesnapshot -n payments\n```\n",
+          "en": "The ledger database `ledgerdb` keeps its data on a 20Gi volume. The cluster has\nVelero installed and a bucket configured, but nobody has ever run a backup, let\nalone restored one.\n\n\"We have backups\" and \"we can restore\" are two different sentences. This stage is\nabout making the second one true.\n\nThree things to do:\n\n1. make Velero back up the **volume data**, not just the objects;\n2. back up the whole payments namespace;\n3. run a restore drill into **another namespace** to prove the backup works.\n\nWhen you are done, the grader really does delete the payments namespace and\nrestores it from your backup.\n\n## Done when\n\n1. the backup is `Completed` and `volumeSnapshotsCompleted` is above zero;\n2. a restore drill exists, landing in a different namespace, with correct data;\n3. after `kubectl delete namespace payments`, your backup brings the database\n   and every row back.\n\n## Commands you will need\n\n```bash\nkubectl get volumesnapshotclass\nkubectl label volumesnapshotclass <name> <key>=<value>\nkubectl apply -f /root/infra/backup.yaml\nvelero backup get\nvelero backup describe <name>\nvelero restore create <name> --from-backup <backup> --namespace-mappings a:b\nvelero restore get\nkubectl get pvc,volumesnapshot -n payments\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "备份里有卷数据",
+            "en": "The backup contains volume data"
+          },
+          {
+            "zh": "恢复演练做过",
+            "en": "A restore drill has been run"
+          },
+          {
+            "zh": "删了也回得来",
+            "en": "Deleted and brought back"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "Velero 挑卷快照类靠的是一个标签：`velero.io/csi-volumesnapshot-class: \"true\"`。没有任何一个快照类打这个标签时，备份**不报错** —— 它照样 Completed，只是 warnings 加一，卷数据一个字节都没进去。`velero backup describe` 里那两行 Attempted / Completed 就是拿来看这个的。",
+            "en": "Velero picks a snapshot class by a label: `velero.io/csi-volumesnapshot-class: \"true\"`. When no class carries it the backup does **not** fail. It still says Completed, just with one more warning, and not a byte of volume data goes in. Those Attempted / Completed lines in `velero backup describe` are exactly what to read."
+          },
+          {
+            "zh": "恢复演练不要在生产命名空间上做。Velero 默认**跳过**已经存在的对象，所以往原地恢复多半是「跑完了，什么都没变」—— 而你会以为验证过了。用 `--namespace-mappings` 恢复到一个新命名空间。",
+            "en": "Do not drill in the production namespace. Velero **skips** resources that already exist, so restoring in place usually means \"it ran and nothing changed\", and you walk away thinking you verified something. Restore into a fresh namespace with `--namespace-mappings`."
+          },
+          {
+            "zh": "恢复出来的 PVC 是不是有数据，看不出来 —— Bound 就是 Bound。要证明，只能进去读一行：`kubectl exec` 进 Pod `cat` 一下。",
+            "en": "You cannot tell whether a restored PVC has data by looking at it: Bound is Bound. The only proof is reading a row, so `kubectl exec` into the pod and `cat` the file."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "把「备份任务是绿的」当成「数据备下来了」。没有可用的卷快照类时，Velero 照样报 Completed。这类失效只会在恢复那天暴露，而那天恰好是最不能出错的一天。判据要看 `volumeSnapshotsCompleted`，不是 `phase`。",
+            "en": "Treating \"the backup job is green\" as \"the data is backed up\". With no usable volume snapshot class Velero still reports Completed. This failure only surfaces on the day you restore, which is exactly the day it must not. Check `volumeSnapshotsCompleted`, not `phase`."
+          },
+          {
+            "zh": "原地恢复。Velero 默认跳过已经存在的对象，恢复完 phase 是 PartiallyFailed，而集群一点没变 —— 很容易读成「恢复成功，只是有点小问题」。",
+            "en": "Restoring in place. Velero skips resources that already exist, the restore ends PartiallyFailed, and nothing in the cluster changed. That reads a lot like \"restored, with minor issues\"."
+          },
+          {
+            "zh": "以为删掉命名空间只是删掉一堆对象。它会一起带走 PVC，而回收策略是 `Delete` 的话，盘和盘上的字节跟着一起消失，apiserver 里再也查不到它存在过。",
+            "en": "Assuming deleting a namespace only deletes some objects. It takes the PVCs with it, and with a `Delete` reclaim policy the volume and every byte on it go too, with no record left in the apiserver that they ever existed."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "csi-provisioner",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "csi-driver"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "csi-driver"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "csi-driver"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "provisioner",
+                        "image": "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "snapshot-controller",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "snapshot-controller"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "snapshot-controller"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "snapshot-controller"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/sig-storage/snapshot-controller:v8.2.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "storage.k8s.io/v1",
+              "kind": "StorageClass",
+              "metadata": {
+                "name": "standard",
+                "annotations": {
+                  "storageclass.kubernetes.io/is-default-class": "true"
+                }
+              },
+              "provisioner": "csi.corp.internal",
+              "reclaimPolicy": "Delete",
+              "volumeBindingMode": "Immediate"
+            },
+            {
+              "apiVersion": "snapshot.storage.k8s.io/v1",
+              "kind": "VolumeSnapshotClass",
+              "metadata": {
+                "name": "csi-standard"
+              },
+              "driver": "csi.corp.internal",
+              "deletionPolicy": "Delete"
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "velero",
+                "namespace": "velero",
+                "labels": {
+                  "app.kubernetes.io/name": "velero"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "velero"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "velero"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "velero",
+                        "image": "velero/velero:v1.16.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "velero.io/v1",
+              "kind": "BackupStorageLocation",
+              "metadata": {
+                "name": "default",
+                "namespace": "velero"
+              },
+              "spec": {
+                "provider": "aws",
+                "default": true,
+                "objectStorage": {
+                  "bucket": "corp-backups"
+                },
+                "config": {
+                  "region": "internal",
+                  "s3Url": "http://minio.storage.svc:9000"
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "PersistentVolumeClaim",
+              "metadata": {
+                "name": "ledger-data",
+                "namespace": "payments"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "20Gi"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "ledgerdb",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "ledgerdb"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "ledgerdb"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "db",
+                        "image": "harbor.corp.internal/team/ledgerdb:14.2",
+                        "ports": [
+                          {
+                            "containerPort": 5432
+                          }
+                        ],
+                        "volumeMounts": [
+                          {
+                            "name": "data",
+                            "mountPath": "/var/lib/ledger"
+                          }
+                        ]
+                      }
+                    ],
+                    "volumes": [
+                      {
+                        "name": "data",
+                        "persistentVolumeClaim": {
+                          "claimName": "ledger-data"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "ledgerdb",
+                "namespace": "payments"
+              },
+              "spec": {
+                "selector": {
+                  "app": "ledgerdb"
+                },
+                "ports": [
+                  {
+                    "port": 5432,
+                    "targetPort": 5432
+                  }
+                ]
+              }
+            }
+          ],
+          "volumes": {
+            "payments/ledger-data": {
+              "ledger.csv": "date,id,amount\n2026-08-01,pay-100317,42.00\n2026-08-02,pay-100318,128.50\n2026-08-03,pay-100319,7.25\n"
+            }
+          },
+          "files": {
+            "/root/infra/backup.yaml": "# 备份还没配过。\n#\n# 这里需要一个 Backup 对象，把 payments 整个命名空间备下来。\n# 光把对象备下来是不够的 —— 想清楚盘上的字节靠什么进备份。\n"
+          },
+          "referenceFiles": {
+            "/root/infra/backup.yaml": "apiVersion: velero.io/v1\nkind: Backup\nmetadata:\n  name: payments-daily\n  namespace: velero\nspec:\n  includedNamespaces:\n  - payments\n  storageLocation: default\n  # 不写 snapshotVolumes 就是「要拍快照」。但拍不拍得成，取决于有没有一个\n  # 打了 velero.io/csi-volumesnapshot-class 标签的 VolumeSnapshotClass。\n  ttl: 720h\n"
+          },
+          "referenceCommands": [
+            "kubectl label volumesnapshotclass csi-standard velero.io/csi-volumesnapshot-class=true",
+            "kubectl apply -f /root/infra/backup.yaml",
+            "velero backup get",
+            "velero restore create drill --from-backup payments-daily --namespace-mappings payments:payments-drill"
+          ]
+        },
+        "specs": [
+          {
+            "path": "disaster-recovery.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst COMPLETED = () => list('Backup', { namespace: 'velero' })\n  .filter((backup) => (backup.status || {}).phase === 'Completed');\n\nconst rowsIn = async (namespace) => {\n  const pod = list('Pod', { namespace })\n    .filter((item) => (item.metadata.labels || {}).app === 'ledgerdb')\n    .filter((item) => item.status.phase === 'Running')[0];\n  if (!pod) return '';\n  const result = await sh(\n    'kubectl exec ' + pod.metadata.name + ' -n ' + namespace\n    + ' -- cat /var/lib/ledger/ledger.csv'\n  );\n  return result.stdout;\n};\n\ndescribe('灾难恢复', () => {\n  it('卷快照类是 Velero 认得的', () => {\n    const classes = list('VolumeSnapshotClass');\n    expect(classes.length).toBeGreaterThan(0);\n    const usable = classes.filter(\n      (item) => (item.metadata.labels || {})['velero.io/csi-volumesnapshot-class'] === 'true'\n    );\n    expect(usable.length).toBeGreaterThan(0);\n  });\n\n  it('备份完成了，而且卷数据在里面', () => {\n    const backups = COMPLETED();\n    expect(backups.length).toBeGreaterThan(0);\n    const backup = backups[0];\n    // Completed 只说明任务跑完了。数据在不在，看这一行。\n    expect(backup.status.volumeSnapshotsCompleted).toBeGreaterThan(0);\n    expect(backup.status.warnings || 0).toBe(0);\n    expect((backup.spec.includedNamespaces || []).includes('payments')).toBe(true);\n  });\n\n  it('恢复演练做过，而且不是在生产上做的', async () => {\n    const drills = list('Restore', { namespace: 'velero' }).filter((restore) => {\n      const mapping = (restore.spec || {}).namespaceMapping || {};\n      return Object.keys(mapping).length > 0 && mapping.payments !== 'payments';\n    });\n    expect(drills.length).toBeGreaterThan(0);\n\n    const target = drills[0].spec.namespaceMapping.payments;\n    expect(drills[0].status.phase).toBe('Completed');\n\n    await advance(120000);\n    const rows = await rowsIn(target);\n    expect(rows).toContain('pay-100317');\n    expect(rows).toContain('pay-100319');\n  });\n\n  it('真出事了也回得来：整个命名空间删掉，数据照样一行不差', async () => {\n    const name = COMPLETED()[0].metadata.name;\n\n    await sh('kubectl delete namespace payments');\n    await advance(60000);\n    expect(list('PersistentVolumeClaim', { namespace: 'payments' }).length).toBe(0);\n    expect(list('Deployment', { namespace: 'payments' }).length).toBe(0);\n\n    await sh('velero restore create rescue --from-backup ' + name);\n    await advance(600000);\n\n    const claim = get('PersistentVolumeClaim', 'ledger-data', 'payments');\n    expect(claim.status.phase).toBe('Bound');\n    expect(get('Deployment', 'ledgerdb', 'payments')).toBeTruthy();\n\n    const rows = await rowsIn('payments');\n    expect(rows).toContain('pay-100317');\n    expect(rows).toContain('pay-100318');\n    expect(rows).toContain('pay-100319');\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "resilience"
+        ],
+        "extension": {
+          "zh": "备份这件事上，绝大多数团队真正缺的不是备份，是**恢复**。备份任务天天绿，\n没有人试过从它恢复；等到需要的那天才发现里面只有对象图没有数据，\n或者恢复流程要三个人商量两小时。所以「多久备份一次」远不如\n「多久演练一次恢复」重要，后者才是真正被验证过的那个数字。\n\n演练一定要恢复到一个新的地方。Velero 默认跳过已经存在的对象，\n往原地恢复的结果往往是「跑完了，什么都没变」—— 你验证了个寂寞，\n还得到一份虚假的信心。用 `--namespace-mappings` 恢复到一个临时命名空间，\n读一行数据出来对一下，然后把临时命名空间删掉。\n\n还有一层是**备份的边界**。这一关备的是一个命名空间，\n但恢复一个真实系统往往还需要命名空间之外的东西：CRD、集群角色、\nStorageClass、Secret 里那把只存在于集群里的密钥。\n备份策略里最该问的一句话是：如果整个集群没了，\n光靠这个桶里的东西，能不能从零把服务拉起来。\n",
+          "en": "What most teams are missing is not backups, it is **restores**. The backup job is\ngreen every day and nobody has ever restored from it, so the day it matters is the\nday you learn it holds objects but no data, or that the procedure takes three\npeople and two hours to agree on. How often you back up matters far less than how\noften you rehearse a restore, because only the second number has been verified.\n\nAlways drill into a new place. Velero skips resources that already exist, so an\nin-place restore usually means \"it ran and nothing changed\": you verified nothing\nand walked away with false confidence. Restore into a temporary namespace with\n`--namespace-mappings`, read a row of real data out of it, then delete the\ntemporary namespace.\n\nThere is also the question of **what the backup's edge is**. This stage backs up a\nnamespace, but restoring a real system usually needs things outside it: CRDs,\ncluster roles, StorageClasses, the key that only ever existed inside a Secret in\nthat cluster. The question worth asking of any backup strategy is whether, with\nthe whole cluster gone, the contents of that bucket alone are enough to bring the\nservice back from nothing.\n"
+        },
+        "primer": {
+          "zh": "接手一个系统之后最该问的一句话不是「有没有备份」，是「上次从备份恢复是什么时候」。这两句差得很远：备份任务天天绿，不代表那个桶里的东西能把服务拉起来。这一关要做的就是把第二句变成真的。\n\nKubernetes 里的数据分两层，这一层的所有困惑都从这儿来。`PersistentVolumeClaim` 是一个**对象**，住在 apiserver 里；盘上的字节不在 apiserver 里，它们在存储后端上。所以把 apiserver 里的对象全导出来，得到的是一份完整的 YAML 和**零字节数据**。恢复出来是一个一模一样的空盘，而 `kubectl get pvc` 看不出空盘和满盘的区别。\n\n要把字节也带上，得靠 `CSI 卷快照`。三个对象：`VolumeSnapshotClass` 说谁来拍、拍完怎么处置，`VolumeSnapshot` 是应用侧的一次请求，`VolumeSnapshotContent` 是存储上真正那张。快照是`时间点`：拍完之后往盘里再写什么都跟它无关。另外要留意拍快照的是 `snapshot-controller` 这个工作负载，它和 CSI 驱动是两个东西，只装驱动的话 VolumeSnapshot 建得出来然后永远不就绪。\n\n`Velero` 把这两件事缝起来：它自己导出对象图放进桶里，卷数据则委托给 CSI 快照。缝的地方有一个标签：`velero.io/csi-volumesnapshot-class: \"true\"`。没有任何快照类打这个标签时，Velero **不报错**，备份照样 `Completed`，只是 warnings 加一，卷数据一个字节都没进去。所以判断一次备份好不好，要看的是 `volumeSnapshotsCompleted` 而不是 `phase`。\n\n恢复这一侧有一条默认行为要记住：Velero **跳过**已经存在的对象。所以往原地恢复的结果通常是「跑完了，phase 是 PartiallyFailed，集群一点没变」，很容易被读成「恢复成功，只是有点小问题」。演练要用 `--namespace-mappings` 恢复到一个新命名空间，进去读一行真数据出来对一下，再把它删掉。\n\n最后是灾难本身。`kubectl delete namespace` 不只是删掉一堆对象，它会一起带走 PVC；回收策略是 `Delete` 的话，盘和盘上的字节跟着消失，apiserver 里再也查不到它存在过。一条命令、一个词的差别，带走的是整个环境，这也正是备份存在的理由。",
+          "en": "The first question to ask about a system you have just inherited is not whether it has backups, it is when somebody last restored from one. Those are far apart: a backup job going green every day says nothing about whether the contents of that bucket can bring the service back. This stage is about making the second sentence true.\n\nData in Kubernetes lives on two levels, and every confusion here comes from that split. A `PersistentVolumeClaim` is an **object** in the apiserver; the bytes on the volume are not, they live on the storage backend. So exporting every object from the apiserver gives you a complete set of YAML and **zero bytes of data**. What comes back is an identical empty disk, and `kubectl get pvc` shows no difference between an empty one and a full one.\n\nCarrying the bytes as well takes `CSI volume snapshots`. Three objects: a `VolumeSnapshotClass` says who takes them and what happens afterwards, a `VolumeSnapshot` is the request from the application side, and a `VolumeSnapshotContent` is the real snapshot on the storage system. A snapshot is a `point in time`: whatever is written to the volume afterwards is not in it. Note also that snapshots are taken by the `snapshot-controller` workload, which is separate from the CSI driver: install only the driver and a VolumeSnapshot will be created and then never become ready.\n\n`Velero` stitches the two together: it exports the object graph into the bucket itself and delegates volume data to CSI snapshots. The seam is a label, `velero.io/csi-volumesnapshot-class: \"true\"`. When no snapshot class carries it, Velero does **not** fail. The backup still reports `Completed`, just with one more warning, and not a byte of volume data goes in. So the health of a backup is read from `volumeSnapshotsCompleted`, not from `phase`.\n\nOn the restore side there is one default worth memorising: Velero **skips** resources that already exist. Restoring in place therefore usually means \"it ran, phase is PartiallyFailed, and nothing in the cluster changed\", which reads a lot like \"restored, with minor issues\". Drill with `--namespace-mappings` into a fresh namespace, read a row of real data out of it, and delete it afterwards.\n\nFinally the disaster itself. `kubectl delete namespace` does not just remove a pile of objects, it takes the PVCs with it; with a `Delete` reclaim policy the volume and every byte on it go too, leaving no record in the apiserver that they ever existed. One command, one word of difference, and an entire environment is gone, which is the whole reason backups exist."
         }
       }
     ]

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -341,6 +341,15 @@ export interface OpsWorldSpec {
   endpoints?: string[];
   /** 开局就存在的集群对象 */
   objects?: Record<string, unknown>[];
+  /**
+   * 盘上开局就有的数据。
+   *
+   * key 是 PVC 的 `命名空间/名字`，value 是**卷内的相对路径**到内容。
+   * 之所以不能写在 objects 里：这些字节根本不在 apiserver 上，它们在存储
+   * 后端。而「已经在跑的库里有数据」是备份这类题目的前提 —— 没有数据，
+   * 「恢复成功」和「恢复出一块空盘」看起来一模一样。
+   */
+  volumes?: Record<string, Record<string, string>>;
 }
 
 /** 内网 PKI 的初态 */
@@ -398,6 +407,13 @@ export interface OpsStageSpec {
   referenceCommands?: string[];
   /** 参考解顺带写下的文件（比如学员要自己写的 manifest） */
   referenceFiles?: Record<string, string>;
+  /**
+   * 盘上开局就有的数据。
+   *
+   * 和 `OpsWorldSpec.volumes` 同一个形状，只是作用在这一关：
+   * key 是 PVC 的 `命名空间/名字`，value 是卷内相对路径到内容。
+   */
+  volumes?: Record<string, Record<string, string>>;
 }
 
 export type WorkspaceSpec = CodeWorkspaceSpec | OpsWorkspaceSpec;

--- a/src/lib/opslab/backup/index.ts
+++ b/src/lib/opslab/backup/index.ts
@@ -13,3 +13,10 @@ export {
 } from './resources';
 export { SnapshotController } from './snapshots';
 export type { SnapshotOptions } from './snapshots';
+export {
+  BACKUPS, RESTORES, BACKUPSTORAGELOCATIONS, VELERO_RESOURCES, VELERO_LABEL,
+  CSI_CLASS_LABEL, EXCLUDE_LABEL, BackupStore, VeleroController,
+} from './velero';
+export type { StoredBackup, VeleroOptions } from './velero';
+export { createVeleroCommand } from './velerocli';
+export type { VeleroCliOptions } from './velerocli';

--- a/src/lib/opslab/backup/snapshots.ts
+++ b/src/lib/opslab/backup/snapshots.ts
@@ -74,6 +74,17 @@ export class SnapshotController extends Controller {
     if (status.readyToUse) return;
 
     const spec = (snapshot.spec ?? {}) as any;
+
+    /**
+     * 预置快照（pre-provisioned）。
+     *
+     * 另一条路：content 已经在存储上了，VolumeSnapshot 只是把它认领回来。
+     * 恢复走的就是这条 —— 备份留下的那张 content 还在，但它的主人
+     * （原来那个命名空间里的 VolumeSnapshot）早就跟着命名空间一起没了。
+     */
+    const preprovisioned = spec.source?.volumeSnapshotContentName;
+    if (preprovisioned) return this.adopt(snapshot, preprovisioned);
+
     const claimName = spec.source?.persistentVolumeClaimName;
     if (!claimName) {
       return this.fail(snapshot, 'Snapshot source must be a PersistentVolumeClaim');
@@ -150,6 +161,42 @@ export class SnapshotController extends Controller {
         boundVolumeSnapshotContentName: contentName,
         creationTime: now,
         restoreSize,
+      });
+    });
+  }
+
+  /** 认领一张已经在存储上的 content */
+  private async adopt(snapshot: KubeObject, contentName: string): Promise<void> {
+    const namespace = snapshot.metadata.namespace;
+    const name = snapshot.metadata.name!;
+    let content: KubeObject;
+    try {
+      content = this.registry.get(VOLUMESNAPSHOTCONTENTS, undefined, contentName);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      return this.fail(snapshot, `VolumeSnapshotContent "${contentName}" not found`);
+    }
+
+    await ignoreConflict(() => {
+      const latest = this.registry.get(VOLUMESNAPSHOTCONTENTS, undefined, contentName);
+      const spec = (latest.spec ?? {}) as any;
+      // content 上的 ref 指回新的这张快照，否则两边对不上，谁也不认谁
+      this.registry.update(VOLUMESNAPSHOTCONTENTS, undefined, contentName, {
+        ...latest,
+        spec: {
+          ...spec,
+          volumeSnapshotRef: {
+            apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshot',
+            name, namespace, uid: snapshot.metadata.uid,
+          },
+        },
+      });
+      updateStatusIfChanged(this.registry, VOLUMESNAPSHOTS, namespace, name, {
+        readyToUse: true,
+        boundVolumeSnapshotContentName: contentName,
+        creationTime: ((content.status ?? {}) as any).creationTime
+          ?? new Date(this.context.now()).toISOString(),
+        restoreSize: ((content.status ?? {}) as any).restoreSize,
       });
     });
   }

--- a/src/lib/opslab/backup/velero.ts
+++ b/src/lib/opslab/backup/velero.ts
@@ -1,0 +1,511 @@
+/**
+ * Velero
+ *
+ * 备份要备两样：**对象图**和**字节**。Velero 自己只管前者 —— 把选中的对象
+ * 序列化进对象存储；后者要靠卷快照，而快照要靠 CSI。两件事之间的接缝，
+ * 就是「备份显示 Completed，恢复出来是一个空盘」的所在。
+ *
+ * 这里刻意保留了真 Velero 最难受的那个行为：**没有可用的卷快照类时，
+ * 备份照样 Completed**，只是多一条 warning。备份系统报绿，数据不在里面。
+ */
+import type { KubeObject, ResourceDefinition } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS, EVENTS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { PERSISTENTVOLUMECLAIMS } from '../storage';
+import { parseDuration } from '../observability';
+import { VOLUMESNAPSHOTCLASSES, VOLUMESNAPSHOTCONTENTS, VOLUMESNAPSHOTS } from './resources';
+
+export const BACKUPS: ResourceDefinition = {
+  group: 'velero.io', version: 'v1', resource: 'backups',
+  singular: 'backup', kind: 'Backup', namespaced: true, subresources: ['status'],
+};
+
+export const RESTORES: ResourceDefinition = {
+  group: 'velero.io', version: 'v1', resource: 'restores',
+  singular: 'restore', kind: 'Restore', namespaced: true, subresources: ['status'],
+};
+
+export const BACKUPSTORAGELOCATIONS: ResourceDefinition = {
+  group: 'velero.io', version: 'v1', resource: 'backupstoragelocations',
+  singular: 'backupstoragelocation', kind: 'BackupStorageLocation', namespaced: true,
+  shortNames: ['bsl'], subresources: ['status'],
+};
+
+export const VELERO_RESOURCES: ResourceDefinition[] = [BACKUPS, RESTORES, BACKUPSTORAGELOCATIONS];
+
+/** Velero 自己。它也只是集群里的一个 Deployment。 */
+export const VELERO_LABEL = { key: 'app.kubernetes.io/name', value: 'velero' };
+
+/**
+ * 让 Velero 认得的卷快照类。
+ *
+ * 真 Velero 靠这个标签挑快照类。少打这个标签，备份里就没有卷数据 ——
+ * 而它**不报错**，只在 warnings 里加一。
+ */
+export const CSI_CLASS_LABEL = { key: 'velero.io/csi-volumesnapshot-class', value: 'true' };
+
+/** 打了这个标签的对象不进备份 */
+export const EXCLUDE_LABEL = 'velero.io/exclude-from-backup';
+
+/** 默认保留期。真 Velero 也是 720h。 */
+const DEFAULT_TTL = '720h';
+
+/**
+ * 备份仓库。
+ *
+ * 备份**不在集群里**。集群里只有一个 Backup 对象（一条记录），
+ * 内容在对象存储的桶里。这个区别有实际后果：集群整个没了，备份还在；
+ * 反过来，桶没了而 Backup 对象还在，`kubectl get backup` 照样显示 Completed。
+ */
+export interface StoredBackup {
+  items: KubeObject[];
+  /** `namespace/pvc` -> VolumeSnapshotContent 的名字 */
+  snapshots: Record<string, string>;
+  namespaces: string[];
+}
+
+export class BackupStore {
+  private data = new Map<string, StoredBackup>();
+
+  put(name: string, backup: StoredBackup): void {
+    this.data.set(name, JSON.parse(JSON.stringify(backup)));
+  }
+
+  get(name: string): StoredBackup | undefined {
+    const found = this.data.get(name);
+    return found ? (JSON.parse(JSON.stringify(found)) as StoredBackup) : undefined;
+  }
+
+  drop(name: string): void {
+    this.data.delete(name);
+  }
+
+  names(): string[] {
+    return [...this.data.keys()].sort();
+  }
+}
+
+export interface VeleroOptions {
+  store: BackupStore;
+}
+
+export class VeleroController extends Controller {
+  private backups: Informer;
+  private restores: Informer;
+  private locations: Informer;
+  private snapshots: Informer;
+  private contents: Informer;
+  private snapshotClasses: Informer;
+  private deployments: Informer;
+
+  constructor(context: ControllerContext, private readonly options: VeleroOptions) {
+    super(context, 'velero');
+    this.backups = new Informer(this.registry, BACKUPS);
+    this.restores = new Informer(this.registry, RESTORES);
+    this.locations = this.track(new Informer(this.registry, BACKUPSTORAGELOCATIONS));
+    this.snapshots = this.track(new Informer(this.registry, VOLUMESNAPSHOTS));
+    this.contents = this.track(new Informer(this.registry, VOLUMESNAPSHOTCONTENTS));
+    this.snapshotClasses = this.track(new Informer(this.registry, VOLUMESNAPSHOTCLASSES));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+
+    this.watch(this.backups, (_, key) => `backup/${key}`);
+    this.watch(this.restores, (_, key) => `restore/${key}`);
+    // 快照就绪、位置可用，都可能让一个卡住的备份继续
+    for (const informer of [this.snapshots, this.deployments, this.locations]) {
+      informer.onChange(() => {
+        for (const backup of this.backups.list()) this.enqueue(`backup/${objectKey(backup)}`);
+        for (const restore of this.restores.list()) this.enqueue(`restore/${objectKey(restore)}`);
+      });
+    }
+  }
+
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.[VELERO_LABEL.key] !== VELERO_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    await this.validateLocations();
+
+    const slash = key.indexOf('/');
+    const kind = key.slice(0, slash);
+    const { namespace, name } = splitKey(key.slice(slash + 1));
+    if (kind === 'backup') return this.reconcileBackup(namespace, name);
+    if (kind === 'restore') return this.reconcileRestore(namespace, name);
+  }
+
+  /**
+   * 位置可用性。
+   *
+   * 真 Velero 每隔一分钟去桶里放一个探测文件。这里简化成「Velero 在跑
+   * 而且配了桶就是可用」—— 要教的不是探测机制，是「位置不可用时备份直接失败，
+   * 而失败信息在 BackupStorageLocation 上，不在 Backup 上」。
+   */
+  private async validateLocations(): Promise<void> {
+    for (const location of this.locations.list()) {
+      const bucket = ((location.spec ?? {}) as any)?.objectStorage?.bucket;
+      await ignoreConflict(() => {
+        updateStatusIfChanged(
+          this.registry, BACKUPSTORAGELOCATIONS, location.metadata.namespace, location.metadata.name!,
+          {
+            phase: bucket ? 'Available' : 'Unavailable',
+            lastValidationTime: new Date(this.context.now()).toISOString(),
+            ...(bucket ? {} : { message: 'no bucket configured' }),
+          }
+        );
+      });
+    }
+  }
+
+  /* ---------------- 备份 ---------------- */
+
+  private async reconcileBackup(namespace: string | undefined, name: string): Promise<void> {
+    let backup: KubeObject;
+    try {
+      backup = this.registry.get(BACKUPS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.options.store.drop(name);
+        return;
+      }
+      throw error;
+    }
+    const status = (backup.status ?? {}) as any;
+    if (status.phase && status.phase !== 'New' && status.phase !== 'InProgress') return;
+
+    const spec = (backup.spec ?? {}) as any;
+    const now = this.context.now();
+    const startedAt = status.startTimestamp ?? new Date(now).toISOString();
+
+    const locationName = spec.storageLocation ?? 'default';
+    const location = this.locations.list().find(
+      (item) => item.metadata.namespace === namespace && item.metadata.name === locationName
+    );
+    if (!location || ((location.status ?? {}) as any).phase !== 'Available') {
+      return this.finishBackup(backup, {
+        phase: 'Failed', startTimestamp: startedAt,
+        completionTimestamp: new Date(now).toISOString(),
+        failureReason: `backup storage location "${locationName}" is unavailable`,
+      });
+    }
+
+    const namespaces = this.namespacesFor(spec);
+    const items = this.collect(spec, namespaces);
+
+    /**
+     * 卷数据。
+     *
+     * `snapshotVolumes: false` 是明确说「只要对象图」。不写它就是要拍快照，
+     * 但**拍不拍得成**取决于有没有一个打了 velero 标签的 VolumeSnapshotClass。
+     * 没有的话这里加一条 warning 然后照样 Completed —— 真 Velero 就是这样。
+     */
+    const claims = items.filter((item) => item.kind === 'PersistentVolumeClaim');
+    const snapshots: Record<string, string> = {};
+    let warnings = 0;
+    let attempted = 0;
+    let pending = false;
+
+    if (spec.snapshotVolumes !== false) {
+      for (const claim of claims) {
+        attempted += 1;
+        const snapshotClass = this.snapshotClasses.list().find(
+          (item) => item.metadata.labels?.[CSI_CLASS_LABEL.key] === CSI_CLASS_LABEL.value
+        );
+        if (!snapshotClass) {
+          warnings += 1;
+          continue;
+        }
+        const outcome = this.snapshotFor(backup, claim, snapshotClass);
+        if (outcome === 'pending') { pending = true; continue; }
+        if (outcome === 'failed') { warnings += 1; continue; }
+        snapshots[`${claim.metadata.namespace}/${claim.metadata.name}`] = outcome;
+      }
+    }
+
+    // 还有快照没拍完就先停在 InProgress，别急着说 Completed
+    if (pending) {
+      return this.finishBackup(backup, {
+        phase: 'InProgress', startTimestamp: startedAt,
+        progress: { totalItems: items.length, itemsBackedUp: items.length },
+      });
+    }
+
+    this.options.store.put(name, { items, snapshots, namespaces });
+    const ttl = spec.ttl ?? DEFAULT_TTL;
+    await this.finishBackup(backup, {
+      phase: 'Completed',
+      startTimestamp: startedAt,
+      completionTimestamp: new Date(now).toISOString(),
+      expiration: new Date(now + parseDuration(String(ttl))).toISOString(),
+      progress: { totalItems: items.length, itemsBackedUp: items.length },
+      volumeSnapshotsAttempted: attempted,
+      volumeSnapshotsCompleted: Object.keys(snapshots).length,
+      warnings,
+      errors: 0,
+      formatVersion: '1.1.0',
+    });
+  }
+
+  /**
+   * 给一个 PVC 拍快照，返回 content 的名字。
+   *
+   * 拍完之后要把 content 的回收策略改成 `Retain` —— 否则命名空间一删，
+   * VolumeSnapshot 跟着没，content 和字节也跟着没，备份就成了一张白纸。
+   * 真 Velero 的 CSI 插件做的就是这一手。
+   */
+  private snapshotFor(
+    backup: KubeObject,
+    claim: KubeObject,
+    snapshotClass: KubeObject
+  ): string | 'pending' | 'failed' {
+    const namespace = claim.metadata.namespace;
+    const name = `velero-${claim.metadata.name}-${backup.metadata.name}`;
+    let snapshot: KubeObject;
+    try {
+      snapshot = this.registry.get(VOLUMESNAPSHOTS, namespace, name);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      this.registry.create(VOLUMESNAPSHOTS, namespace, {
+        apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshot',
+        metadata: {
+          name, namespace,
+          labels: { 'velero.io/backup-name': backup.metadata.name! },
+        },
+        spec: {
+          volumeSnapshotClassName: snapshotClass.metadata.name,
+          source: { persistentVolumeClaimName: claim.metadata.name },
+        },
+      } as KubeObject);
+      return 'pending';
+    }
+
+    const status = (snapshot.status ?? {}) as any;
+    if (status.error) return 'failed';
+    if (!status.readyToUse || !status.boundVolumeSnapshotContentName) return 'pending';
+
+    const contentName = status.boundVolumeSnapshotContentName as string;
+    const content = this.registry.get(VOLUMESNAPSHOTCONTENTS, undefined, contentName);
+    const contentSpec = (content.spec ?? {}) as any;
+    if (contentSpec.deletionPolicy !== 'Retain') {
+      this.registry.update(VOLUMESNAPSHOTCONTENTS, undefined, contentName, {
+        ...content, spec: { ...contentSpec, deletionPolicy: 'Retain' },
+      });
+    }
+    return contentName;
+  }
+
+  private async finishBackup(backup: KubeObject, status: Record<string, unknown>): Promise<void> {
+    await ignoreConflict(() => {
+      updateStatusIfChanged(
+        this.registry, BACKUPS, backup.metadata.namespace, backup.metadata.name!, status
+      );
+    });
+  }
+
+  private namespacesFor(spec: any): string[] {
+    const included: string[] = spec.includedNamespaces ?? ['*'];
+    const excluded: string[] = spec.excludedNamespaces ?? [];
+    const all = this.registry
+      .list(this.namespaceDefinition()).items
+      .map((item) => item.metadata.name!)
+      .filter((item) => !excluded.includes(item));
+    if (included.includes('*')) return all.sort();
+    return all.filter((item) => included.includes(item)).sort();
+  }
+
+  private namespaceDefinition(): ResourceDefinition {
+    return this.context.scheme.mustGet({ group: '', version: 'v1', resource: 'namespaces' });
+  }
+
+  /**
+   * 收集要备份的对象。
+   *
+   * 三条过滤，和真 Velero 一致：命名空间、资源类型、标签选择器。
+   * 另外两类永远不进：事件（备份出来毫无意义），
+   * 以及打了 `velero.io/exclude-from-backup` 的对象。
+   */
+  private collect(spec: any, namespaces: string[]): KubeObject[] {
+    const included: string[] | undefined = spec.includedResources;
+    const excluded: string[] = spec.excludedResources ?? [];
+    const selector: Record<string, string> | undefined = spec.labelSelector?.matchLabels;
+    const out: KubeObject[] = [];
+
+    for (const definition of this.context.scheme.list()) {
+      if (!definition.namespaced) continue;
+      if (definition.resource === EVENTS.resource) continue;
+      if (excluded.includes(definition.resource)) continue;
+      if (included && !included.includes(definition.resource)) continue;
+
+      for (const namespace of namespaces) {
+        for (const object of this.registry.list(definition, { namespace }).items) {
+          if (object.metadata.labels?.[EXCLUDE_LABEL] === 'true') continue;
+          if (selector && !Object.entries(selector).every(
+            ([k, v]) => object.metadata.labels?.[k] === v
+          )) continue;
+          out.push(JSON.parse(JSON.stringify(object)) as KubeObject);
+        }
+      }
+    }
+    return out;
+  }
+
+  /* ---------------- 恢复 ---------------- */
+
+  private async reconcileRestore(namespace: string | undefined, name: string): Promise<void> {
+    let restore: KubeObject;
+    try {
+      restore = this.registry.get(RESTORES, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    const status = (restore.status ?? {}) as any;
+    if (status.phase && status.phase !== 'New') return;
+
+    const spec = (restore.spec ?? {}) as any;
+    const now = new Date(this.context.now()).toISOString();
+    const stored = spec.backupName ? this.options.store.get(spec.backupName) : undefined;
+    if (!stored) {
+      return this.finishRestore(restore, {
+        phase: 'Failed', startTimestamp: now, completionTimestamp: now,
+        failureReason: `backup ${spec.backupName} not found`,
+      });
+    }
+
+    const mapping: Record<string, string> = spec.namespaceMapping ?? {};
+    const included: string[] | undefined = spec.includedNamespaces;
+    let restored = 0;
+    let warnings = 0;
+
+    // 命名空间本身要先在
+    for (const source of stored.namespaces) {
+      if (included && !included.includes(source)) continue;
+      const target = mapping[source] ?? source;
+      this.ensureNamespace(target);
+    }
+
+    for (const item of stored.items) {
+      const source = item.metadata.namespace!;
+      if (included && !included.includes(source)) continue;
+      const target = mapping[source] ?? source;
+      const definition = this.context.scheme.list().find(
+        (entry) => entry.kind === item.kind
+          && entry.version === item.apiVersion.split('/').pop()
+      );
+      if (!definition) { warnings += 1; continue; }
+
+      /**
+       * Pod 不恢复。
+       *
+       * 真 Velero 会恢复 Pod，但由 Deployment 管的 Pod 恢复出来是多余的 ——
+       * 控制器自己会造。这里索性不恢复，免得教出「恢复完有一堆孤儿 Pod」
+       * 这种错觉。ReplicaSet 同理。
+       */
+      if (item.kind === 'Pod' || item.kind === 'ReplicaSet' || item.kind === 'Endpoints') continue;
+
+      const body = this.sanitize(item, target, stored);
+      try {
+        this.registry.get(definition, target, item.metadata.name!);
+        // 已经在了就跳过。这是 Velero 的默认策略，也是「恢复了但什么都没变」的原因。
+        warnings += 1;
+        continue;
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+      try {
+        this.registry.create(definition, target, body);
+        restored += 1;
+      } catch {
+        warnings += 1;
+      }
+    }
+
+    await this.finishRestore(restore, {
+      phase: warnings > 0 ? 'PartiallyFailed' : 'Completed',
+      startTimestamp: now,
+      completionTimestamp: now,
+      progress: { totalItems: stored.items.length, itemsRestored: restored },
+      warnings,
+      errors: 0,
+    });
+  }
+
+  private ensureNamespace(name: string): void {
+    const definition = this.namespaceDefinition();
+    try {
+      this.registry.get(definition, undefined, name);
+    } catch {
+      this.registry.create(definition, undefined, {
+        apiVersion: 'v1', kind: 'Namespace', metadata: { name },
+        status: { phase: 'Active' },
+      } as KubeObject);
+    }
+  }
+
+  /**
+   * 把对象洗干净再放回去。
+   *
+   * 备份下来的是**运行时**的样子：uid、resourceVersion、status，还有
+   * PVC 上已经绑定的 volumeName 和 PV 上的 claimRef。原样放回去的话
+   * 不是被 apiserver 拒绝，就是绑到一块根本不存在的盘上。
+   *
+   * PVC 还要多做一件事：把 dataSource 指到那张快照上，否则恢复出来是空盘。
+   */
+  private sanitize(item: KubeObject, targetNamespace: string, stored: StoredBackup): KubeObject {
+    const body = JSON.parse(JSON.stringify(item)) as KubeObject;
+    body.metadata = {
+      name: body.metadata.name,
+      namespace: targetNamespace,
+      labels: body.metadata.labels,
+      annotations: body.metadata.annotations,
+    } as any;
+    delete (body as any).status;
+
+    if (body.kind === 'PersistentVolumeClaim') {
+      const spec = (body.spec ?? {}) as any;
+      delete spec.volumeName;
+      const contentName = stored.snapshots[`${item.metadata.namespace}/${item.metadata.name}`];
+      if (contentName) {
+        const snapshotName = `${item.metadata.name}-restore`;
+        this.adoptContent(contentName, targetNamespace, snapshotName);
+        spec.dataSource = {
+          apiGroup: 'snapshot.storage.k8s.io', kind: 'VolumeSnapshot', name: snapshotName,
+        };
+      }
+      body.spec = spec;
+    }
+    return body;
+  }
+
+  /**
+   * 备份留下的那张 content 还在存储上，但没有主人。
+   * 建一张**预置**的 VolumeSnapshot 去认领它，PVC 才有得引用。
+   */
+  private adoptContent(contentName: string, namespace: string, snapshotName: string): void {
+    try {
+      this.registry.get(VOLUMESNAPSHOTS, namespace, snapshotName);
+      return;
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+    this.registry.create(VOLUMESNAPSHOTS, namespace, {
+      apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshot',
+      metadata: { name: snapshotName, namespace },
+      spec: { source: { volumeSnapshotContentName: contentName } },
+    } as KubeObject);
+  }
+
+  private async finishRestore(restore: KubeObject, status: Record<string, unknown>): Promise<void> {
+    await ignoreConflict(() => {
+      updateStatusIfChanged(
+        this.registry, RESTORES, restore.metadata.namespace, restore.metadata.name!, status
+      );
+    });
+  }
+}

--- a/src/lib/opslab/backup/velero.ts
+++ b/src/lib/opslab/backup/velero.ts
@@ -150,11 +150,20 @@ export class VeleroController extends Controller {
   private async validateLocations(): Promise<void> {
     for (const location of this.locations.list()) {
       const bucket = ((location.spec ?? {}) as any)?.objectStorage?.bucket;
+      const phase = bucket ? 'Available' : 'Unavailable';
+      const status = (location.status ?? {}) as any;
+      /**
+       * 只在结论变了的时候才写回。
+       *
+       * 每次 reconcile 都刷一个新的 lastValidationTime 的话，写回本身会
+       * 触发下一轮 reconcile —— 世界自己把自己吵醒，永远静不下来。
+       */
+      if (status.phase === phase) continue;
       await ignoreConflict(() => {
         updateStatusIfChanged(
           this.registry, BACKUPSTORAGELOCATIONS, location.metadata.namespace, location.metadata.name!,
           {
-            phase: bucket ? 'Available' : 'Unavailable',
+            phase,
             lastValidationTime: new Date(this.context.now()).toISOString(),
             ...(bucket ? {} : { message: 'no bucket configured' }),
           }
@@ -466,6 +475,20 @@ export class VeleroController extends Controller {
       annotations: body.metadata.annotations,
     } as any;
     delete (body as any).status;
+
+    /**
+     * Service 上那个 clusterIP 不能原样带回去。
+     *
+     * 它是集群分配的，不是用户写的。恢复到另一个命名空间时原样放回去，
+     * 就是两个 Service 抢同一个 IP；恢复到原地也未必还空着。
+     * 真 Velero 也是把它清掉让集群重新分配。
+     */
+    if (body.kind === 'Service') {
+      const spec = (body.spec ?? {}) as any;
+      delete spec.clusterIP;
+      delete spec.clusterIPs;
+      body.spec = spec;
+    }
 
     if (body.kind === 'PersistentVolumeClaim') {
       const spec = (body.spec ?? {}) as any;

--- a/src/lib/opslab/backup/velerocli.ts
+++ b/src/lib/opslab/backup/velerocli.ts
@@ -1,0 +1,278 @@
+/**
+ * `velero`
+ *
+ * 这个 CLI 本质上是 `kubectl apply` 的壳：`velero backup create` 就是建一个
+ * Backup 对象，`velero restore create` 就是建一个 Restore。做出来是因为
+ * 真人在真集群里用的就是它，而且 `velero backup describe` 打出来的那几行
+ * （尤其是 warnings 和 volume snapshots 的计数）正是这一关要学员看懂的东西。
+ */
+import type { CommandHandler, CommandResult } from '../machine/shell/shell';
+import type { KubeObject, Registry, Scheme } from '../apiserver';
+import { BACKUPS, BACKUPSTORAGELOCATIONS, RESTORES } from './velero';
+
+export interface VeleroCliOptions {
+  registry: Registry;
+  scheme: Scheme;
+  /** 建完对象之后让世界往前走一会儿，不然 create 完立刻 get 什么都没有 */
+  settle: () => void;
+  namespace?: string;
+}
+
+const USAGE = [
+  'Velero is a tool for managing disaster recovery, specifically for Kubernetes',
+  'cluster resources.',
+  '',
+  'Usage:',
+  '  velero backup create NAME [flags]',
+  '  velero backup get',
+  '  velero backup describe NAME',
+  '  velero restore create NAME --from-backup BACKUP [flags]',
+  '  velero restore get',
+  '  velero restore describe NAME',
+  '  velero backup-location get',
+  '',
+].join('\n');
+
+export function createVeleroCommand(options: VeleroCliOptions): CommandHandler {
+  return ({ argv }) => {
+    const [group, ...rest] = argv;
+    if (!group || group === 'help' || group === '--help') return { stdout: USAGE };
+    if (group === 'version' || group === '--version') {
+      return { stdout: 'Client:\n\tVersion: v1.16.1\n' };
+    }
+    if (group === 'backup') return backup(rest, options);
+    if (group === 'restore') return restore(rest, options);
+    if (group === 'backup-location') return locations(rest, options);
+    return { stderr: `Error: unknown command "${group}" for "velero"\n`, code: 1 };
+  };
+}
+
+/** `--flag value` 和 `--flag=value` 都要认 */
+function parseFlags(argv: string[]): { positional: string[]; flags: Record<string, string> } {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const entry = argv[index];
+    if (!entry.startsWith('--')) { positional.push(entry); continue; }
+    const equals = entry.indexOf('=');
+    if (equals >= 0) {
+      flags[entry.slice(2, equals)] = entry.slice(equals + 1);
+      continue;
+    }
+    const next = argv[index + 1];
+    if (next !== undefined && !next.startsWith('--')) {
+      flags[entry.slice(2)] = next;
+      index += 1;
+    } else {
+      flags[entry.slice(2)] = 'true';
+    }
+  }
+  return { positional, flags };
+}
+
+const list = (value: string | undefined): string[] | undefined =>
+  value === undefined ? undefined : value.split(',').map((entry) => entry.trim()).filter(Boolean);
+
+function backup(argv: string[], options: VeleroCliOptions): CommandResult {
+  const [action, ...rest] = argv;
+  const { positional, flags } = parseFlags(rest);
+  const namespace = options.namespace ?? 'velero';
+
+  if (action === 'create') {
+    const name = positional[0];
+    if (!name) return { stderr: 'Error: accepts 1 arg(s), received 0\n', code: 1 };
+    const spec: Record<string, unknown> = {
+      storageLocation: flags['storage-location'] ?? 'default',
+      includedNamespaces: list(flags['include-namespaces']) ?? ['*'],
+      ttl: flags.ttl,
+    };
+    if (flags['exclude-namespaces']) spec.excludedNamespaces = list(flags['exclude-namespaces']);
+    if (flags['include-resources']) spec.includedResources = list(flags['include-resources']);
+    if (flags['exclude-resources']) spec.excludedResources = list(flags['exclude-resources']);
+    if (flags['snapshot-volumes'] === 'false') spec.snapshotVolumes = false;
+    if (flags['snapshot-volumes'] === 'true') spec.snapshotVolumes = true;
+    if (flags.selector) {
+      spec.labelSelector = {
+        matchLabels: Object.fromEntries(
+          flags.selector.split(',').map((pair) => pair.split('=').map((part) => part.trim()) as [string, string])
+        ),
+      };
+    }
+    if (spec.ttl === undefined) delete spec.ttl;
+
+    try {
+      options.registry.create(BACKUPS, namespace, {
+        apiVersion: 'velero.io/v1', kind: 'Backup',
+        metadata: { name, namespace }, spec,
+      } as KubeObject);
+    } catch (error) {
+      return { stderr: `Error: ${(error as Error).message}\n`, code: 1 };
+    }
+    options.settle();
+    return {
+      stdout: `Backup request "${name}" submitted successfully.\n`
+        + 'Run `velero backup describe ' + name + '` or `velero backup logs ' + name + '` for more details.\n',
+    };
+  }
+
+  if (action === 'get') {
+    const items = options.registry.list(BACKUPS, { namespace }).items;
+    if (items.length === 0) return { stdout: 'No backups found.\n' };
+    const rows = items.map((item) => {
+      const status = (item.status ?? {}) as any;
+      return [
+        item.metadata.name!, status.phase ?? 'New',
+        String(status.errors ?? 0), String(status.warnings ?? 0),
+        status.expiration ?? '<none>',
+        ((item.spec ?? {}) as any).storageLocation ?? 'default',
+      ];
+    });
+    return { stdout: table(['NAME', 'STATUS', 'ERRORS', 'WARNINGS', 'EXPIRES', 'STORAGE LOCATION'], rows) };
+  }
+
+  if (action === 'describe') {
+    const name = positional[0];
+    if (!name) return { stderr: 'Error: accepts 1 arg(s), received 0\n', code: 1 };
+    let item: KubeObject;
+    try {
+      item = options.registry.get(BACKUPS, namespace, name);
+    } catch {
+      return { stderr: `Error: backups.velero.io "${name}" not found\n`, code: 1 };
+    }
+    const spec = (item.spec ?? {}) as any;
+    const status = (item.status ?? {}) as any;
+    const lines = [
+      `Name:         ${name}`,
+      `Namespace:    ${namespace}`,
+      '',
+      `Phase:  ${status.phase ?? 'New'}`,
+      ...(status.failureReason ? [`Failure:  ${status.failureReason}`] : []),
+      '',
+      ...(status.warnings ? [`Warnings:  ${status.warnings}`, ''] : []),
+      'Namespaces:',
+      `  Included:  ${(spec.includedNamespaces ?? ['*']).join(', ')}`,
+      `  Excluded:  ${(spec.excludedNamespaces ?? ['<none>']).join(', ')}`,
+      '',
+      `Storage Location:  ${spec.storageLocation ?? 'default'}`,
+      '',
+      `Velero-Native Snapshot PVs:  ${spec.snapshotVolumes === false ? 'false' : 'auto'}`,
+      '',
+      'CSI Snapshots:',
+      `  Attempted:  ${status.volumeSnapshotsAttempted ?? 0}`,
+      `  Completed:  ${status.volumeSnapshotsCompleted ?? 0}`,
+      '',
+      `TTL:  ${spec.ttl ?? '720h0m0s'}`,
+      '',
+    ];
+    return { stdout: `${lines.join('\n')}\n` };
+  }
+
+  return { stdout: USAGE, code: 1 };
+}
+
+function restore(argv: string[], options: VeleroCliOptions): CommandResult {
+  const [action, ...rest] = argv;
+  const { positional, flags } = parseFlags(rest);
+  const namespace = options.namespace ?? 'velero';
+
+  if (action === 'create') {
+    const backupName = flags['from-backup'];
+    if (!backupName) {
+      return { stderr: 'Error: either a backup or schedule must be specified, but not both\n', code: 1 };
+    }
+    const name = positional[0] ?? `${backupName}-restore`;
+    const spec: Record<string, unknown> = { backupName };
+    if (flags['include-namespaces']) spec.includedNamespaces = list(flags['include-namespaces']);
+    if (flags['namespace-mappings']) {
+      spec.namespaceMapping = Object.fromEntries(
+        flags['namespace-mappings'].split(',')
+          .map((pair) => pair.split(':').map((part) => part.trim()) as [string, string])
+      );
+    }
+    try {
+      options.registry.create(RESTORES, namespace, {
+        apiVersion: 'velero.io/v1', kind: 'Restore',
+        metadata: { name, namespace }, spec,
+      } as KubeObject);
+    } catch (error) {
+      return { stderr: `Error: ${(error as Error).message}\n`, code: 1 };
+    }
+    options.settle();
+    return {
+      stdout: `Restore request "${name}" submitted successfully.\n`
+        + 'Run `velero restore describe ' + name + '` for more details.\n',
+    };
+  }
+
+  if (action === 'get') {
+    const items = options.registry.list(RESTORES, { namespace }).items;
+    if (items.length === 0) return { stdout: 'No restores found.\n' };
+    const rows = items.map((item) => {
+      const status = (item.status ?? {}) as any;
+      return [
+        item.metadata.name!,
+        ((item.spec ?? {}) as any).backupName ?? '',
+        status.phase ?? 'New',
+        String(status.errors ?? 0), String(status.warnings ?? 0),
+      ];
+    });
+    return { stdout: table(['NAME', 'BACKUP', 'STATUS', 'ERRORS', 'WARNINGS'], rows) };
+  }
+
+  if (action === 'describe') {
+    const name = positional[0];
+    let item: KubeObject;
+    try {
+      item = options.registry.get(RESTORES, namespace, name ?? '');
+    } catch {
+      return { stderr: `Error: restores.velero.io "${name}" not found\n`, code: 1 };
+    }
+    const spec = (item.spec ?? {}) as any;
+    const status = (item.status ?? {}) as any;
+    return {
+      stdout: [
+        `Name:         ${name}`,
+        `Namespace:    ${namespace}`,
+        '',
+        `Phase:  ${status.phase ?? 'New'}`,
+        ...(status.failureReason ? [`Failure:  ${status.failureReason}`] : []),
+        `Backup:  ${spec.backupName}`,
+        '',
+        `Warnings:  ${status.warnings ?? 0}`,
+        `Errors:    ${status.errors ?? 0}`,
+        '',
+      ].join('\n') + '\n',
+    };
+  }
+
+  return { stdout: USAGE, code: 1 };
+}
+
+function locations(argv: string[], options: VeleroCliOptions): CommandResult {
+  if (argv[0] !== 'get') return { stdout: USAGE, code: 1 };
+  const namespace = options.namespace ?? 'velero';
+  const items = options.registry.list(BACKUPSTORAGELOCATIONS, { namespace }).items;
+  if (items.length === 0) return { stdout: 'No backup storage locations found.\n' };
+  const rows = items.map((item) => {
+    const spec = (item.spec ?? {}) as any;
+    const status = (item.status ?? {}) as any;
+    return [
+      item.metadata.name!, spec.provider ?? '',
+      spec.objectStorage?.bucket ?? '', status.phase ?? 'Unknown',
+      status.lastValidationTime ?? '', String(spec.default === true),
+    ];
+  });
+  return { stdout: table(['NAME', 'PROVIDER', 'BUCKET/PREFIX', 'PHASE', 'LAST VALIDATED', 'DEFAULT'], rows) };
+}
+
+/** 列宽对齐。velero 自己也是这么打的，两个空格分隔。 */
+function table(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, index) => Math.max(
+    header.length, ...rows.map((row) => (row[index] ?? '').length)
+  ));
+  const line = (cells: string[]) => cells
+    .map((cell, index) => (index === cells.length - 1 ? cell : cell.padEnd(widths[index])))
+    .join('   ')
+    .replace(/\s+$/, '');
+  return [line(headers), ...rows.map(line)].join('\n') + '\n';
+}

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -38,11 +38,14 @@ import { DISRUPTION_RESOURCES, PdbController, evictionVerdict } from '../disrupt
 import {
   STORAGE_RESOURCES, StorageController, VolumeStore, createDefaultStorageClassDefaulter,
 } from '../storage';
-import { SNAPSHOT_RESOURCES, SnapshotController } from '../backup';
+import {
+  BackupStore, SNAPSHOT_RESOURCES, SnapshotController, VELERO_RESOURCES, VeleroController,
+} from '../backup';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
   EndpointsController,
+  NamespaceController,
   ImageSpec,
   KubeletController,
   NodePressureController,
@@ -150,6 +153,14 @@ export class Cluster {
    */
   readonly volumes = new VolumeStore();
 
+  /**
+   * 备份桶。
+   *
+   * 同理，也不在 apiserver 里：集群整个没了，桶还在；反过来桶没了而
+   * Backup 对象还在，`kubectl get backup` 照样显示 Completed。
+   */
+  readonly backups = new BackupStore();
+
   /** 监控。世界没配 metrics 就是 undefined。 */
   prometheus?: PrometheusController;
   /** 由外面装上（createOpsWorld 会接一个 Pod 里的 shell 进来） */
@@ -171,7 +182,7 @@ export class Cluster {
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
       ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES, ...ROLLOUT_RESOURCES,
-      ...STORAGE_RESOURCES, ...SNAPSHOT_RESOURCES,
+      ...STORAGE_RESOURCES, ...SNAPSHOT_RESOURCES, ...VELERO_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -631,6 +642,8 @@ export class Cluster {
       // 每个节点一份：CNI 的 agent、日志采集都是这个形状
       new DaemonSetController(context),
       new EndpointsController(context),
+      // 删掉一个命名空间，里面的东西全部跟着没 —— 包括 PVC，也就包括数据
+      new NamespaceController(context),
       // PDB 的状态。`kubectl get pdb` 里 ALLOWED DISRUPTIONS 那一列就是它写的。
       new PdbController(context),
       /**
@@ -640,6 +653,8 @@ export class Cluster {
       new StorageController(context, { volumes: this.volumes }),
       // 快照：又一个工作负载。装了 CSI 驱动不等于装了它。
       new SnapshotController(context, { volumes: this.volumes }),
+      // 备份。Backup 对象在集群里，备份内容在桶里 —— 所以 store 不在 registry 上。
+      new VeleroController(context, { store: this.backups }),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发

--- a/src/lib/opslab/controllers/index.ts
+++ b/src/lib/opslab/controllers/index.ts
@@ -13,7 +13,8 @@ export {
   matchesSelector, templateHash,
 } from './resources';
 export {
-  DeploymentController, EndpointsController, KubeletController, NodePressureController,
+  DeploymentController, EndpointsController, KubeletController, NamespaceController,
+  NodePressureController,
   ReplicaSetController, SchedulerController, isPodReady, parseCpu, resolveCount,
 } from './workloads';
 export type { ImageSpec, KubeletOptions } from './workloads';

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -20,6 +20,7 @@ import { PERSISTENTVOLUMECLAIMS } from '../storage/resources';
 import {
   CONFIGMAPS,
   DEPLOYMENTS,
+  NAMESPACES,
   ENDPOINTS,
   matchesSelector,
   NODES,
@@ -1281,4 +1282,58 @@ function describeProbe(probe: Probe | undefined): string {
     return `dial tcp: connect: connection refused (port ${probe.tcpSocket.port})`;
   }
   return 'command failed';
+}
+
+/* ------------------------------------------------------------------ */
+/* 命名空间回收                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 删掉一个命名空间，里面的东西**全部**跟着没。
+ *
+ * 这是 `kubectl delete namespace` 最需要被亲身经历一次的性质：一条命令、
+ * 一个词的差别，带走的是整个环境 —— 包括 PVC，也就包括数据（回收策略
+ * 是 Delete 的话）。所以第 21 关的灾难就是这一条命令。
+ *
+ * 真集群里这个过程有中间态：命名空间先进 `Terminating`，控制器逐个删完
+ * 内容再摘掉 finalizer。这里简化成一步 —— 卡在 Terminating 的命名空间
+ * 是另一个话题（某个 APIService 挂了导致 discovery 失败），不在这一关。
+ */
+export class NamespaceController extends Controller {
+  private namespaces: Informer;
+  private known = new Set<string>();
+
+  constructor(context: ControllerContext) {
+    super(context, 'namespace');
+    this.namespaces = this.track(new Informer(this.registry, NAMESPACES));
+    this.namespaces.onChange((key) => this.queue.add(key));
+  }
+
+  protected reconcile(key: string): void {
+    const { name } = splitKey(key);
+    try {
+      this.registry.get(NAMESPACES, undefined, name);
+      this.known.add(name);
+      return;
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+    // 没了：把里面的东西清干净
+    if (!this.known.delete(name)) return;
+    this.purge(name);
+  }
+
+  private purge(namespace: string): void {
+    for (const definition of this.context.scheme.list()) {
+      if (!definition.namespaced) continue;
+      for (const object of this.registry.list(definition, { namespace }).items) {
+        try {
+          this.registry.delete(definition, namespace, object.metadata.name!);
+        } catch (error) {
+          // 属主先被删掉时，级联已经把它带走了
+          if (!isNotFound(error)) throw error;
+        }
+      }
+    }
+  }
 }

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -22,6 +22,7 @@ import { createOpensslCommand } from './openssl';
 import { materializePki } from './pki';
 import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } from '../git';
 import { createIstioctlCommand } from '../mesh';
+import { createVeleroCommand } from '../backup';
 import { SignatureStore, createCosignCommand } from '../admission';
 import { OpenBao, createBaoCommand } from '../secrets';
 import { createPromtoolCommand } from '../observability';
@@ -355,6 +356,13 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     },
   }));
 
+  machine.install('velero', createVeleroCommand({
+    registry: cluster.registry,
+    scheme: cluster.scheme,
+    // 建完对象立刻 get 是常见用法，让世界先跑一小会儿
+    settle: () => { void cluster.advanceBy(5_000); },
+  }));
+
   machine.install('istioctl', createIstioctlCommand({
     view: () => cluster.istioView(),
     namespace: () => (machine.vfs.exists(DEFAULT_KUBECONFIG_PATH)
@@ -436,6 +444,23 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
     }
   });
   await cluster.settle();
+
+  /**
+   * 盘上开局就有的数据。
+   *
+   * 要等 settle 之后才能写：PVC 得先绑到一块 PV 上，我们才知道字节该往哪儿放。
+   * 找不到对应的盘就直接报错 —— 悄悄不写的话，题目会变成「恢复出空盘也算对」。
+   */
+  for (const [key, content] of Object.entries({ ...(spec.volumes ?? {}), ...(stage.volumes ?? {}) })) {
+    const [namespace, name] = key.split('/');
+    const claims = cluster.scheme.get({ group: '', version: 'v1', resource: 'persistentvolumeclaims' });
+    const claim = claims && cluster.registry.get(claims, namespace, name);
+    const volumeName = claim && ((claim.spec ?? {}) as { volumeName?: string }).volumeName;
+    if (!volumeName) {
+      throw new Error(`世界里的 PVC ${key} 没有绑上盘，写不进初始数据`);
+    }
+    cluster.volumes.write(volumeName, content);
+  }
 
   const world: OpsWorld = {
     cluster,

--- a/tests/opslab/storage.test.ts
+++ b/tests/opslab/storage.test.ts
@@ -271,6 +271,34 @@ describe('数据的生命周期', () => {
   });
 });
 
+describe('删命名空间', () => {
+  /**
+   * 一条命令带走整个环境。
+   *
+   * `kubectl delete namespace` 会把里面的东西全部删掉，包括 PVC ——
+   * 而回收策略是 Delete 的话，盘和数据也跟着走。第 21 关的灾难就是这一条。
+   */
+  it('命名空间没了，里面的 PVC 和盘上的数据一起没', async () => {
+    const w = await build([CSI_DRIVER, CLASS, claim(), pod()]);
+    await createExecHandler(w.cluster)(
+      { namespace: 'shop', pod: 'ledger', command: ['sh', '-c', 'echo gone > /data/x'], stdin: false, tty: false },
+      ''
+    );
+    const volumeName = (pvcOf(w).spec as any).volumeName;
+    expect(w.cluster.volumes.read(volumeName)).toEqual({ x: 'gone\n' });
+
+    w.cluster.registry.delete(
+      w.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'namespaces' }), undefined, 'shop'
+    );
+    await w.cluster.advanceBy(30_000);
+
+    expect(w.cluster.registry.list(w.cluster.scheme.mustGet(PVCS), { namespace: 'shop' }).items)
+      .toHaveLength(0);
+    expect(pvsOf(w)).toHaveLength(0);
+    expect(w.cluster.volumes.read(volumeName)).toEqual({});
+  });
+});
+
 describe('调度', () => {
   it('PVC 没绑上，Pod 就不调度，而且说得出原因', async () => {
     const w = await build([CLASS, claim(), pod()]);

--- a/tests/opslab/velero.test.ts
+++ b/tests/opslab/velero.test.ts
@@ -1,0 +1,333 @@
+/**
+ * 备份与恢复
+ *
+ * 这一组要钉住的是一句很扎心的话：**备份显示 Completed，不等于数据在里面。**
+ *
+ * 少打一个标签（让 Velero 认得的 VolumeSnapshotClass），备份照样绿，
+ * 恢复出来是一个一模一样的空盘。真 Velero 就是这个行为，所以这里也是。
+ */
+import { createExecHandler, createOpsWorld } from '../../src/lib/opslab/lab';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const APP_IMAGE = 'registry.corp.internal/ledger:3.2';
+const CSI_IMAGE = 'registry.k8s.io/sig-storage/csi-provisioner:v5.1.0';
+const SNAP_IMAGE = 'registry.k8s.io/sig-storage/snapshot-controller:v8.2.0';
+const VELERO_IMAGE = 'velero/velero:v1.16.1';
+
+const PVCS = { group: '', version: 'v1', resource: 'persistentvolumeclaims' } as const;
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+const BACKUPS = { group: 'velero.io', version: 'v1', resource: 'backups' } as const;
+const RESTORES = { group: 'velero.io', version: 'v1', resource: 'restores' } as const;
+const CONFIGMAPS = { group: '', version: 'v1', resource: 'configmaps' } as const;
+
+const deployment = (name: string, image: string) => ({
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name, namespace: 'kube-system', labels: { 'app.kubernetes.io/name': name } },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': name } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': name } },
+      spec: { containers: [{ name: 'main', image }] },
+    },
+  },
+});
+
+const VELERO = {
+  ...deployment('velero', VELERO_IMAGE),
+  metadata: {
+    name: 'velero', namespace: 'velero', labels: { 'app.kubernetes.io/name': 'velero' },
+  },
+};
+
+const LOCATION = {
+  apiVersion: 'velero.io/v1', kind: 'BackupStorageLocation',
+  metadata: { name: 'default', namespace: 'velero' },
+  spec: {
+    provider: 'aws', default: true,
+    objectStorage: { bucket: 'corp-backups' },
+    config: { region: 'internal', s3Url: 'http://minio.storage.svc:9000' },
+  },
+};
+
+const STORAGE_CLASS = {
+  apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass',
+  metadata: { name: 'standard', annotations: { 'storageclass.kubernetes.io/is-default-class': 'true' } },
+  provisioner: 'csi.corp.internal', reclaimPolicy: 'Delete', volumeBindingMode: 'Immediate',
+};
+
+const snapshotClass = (labelled: boolean) => ({
+  apiVersion: 'snapshot.storage.k8s.io/v1', kind: 'VolumeSnapshotClass',
+  metadata: {
+    name: 'csi-standard',
+    ...(labelled ? { labels: { 'velero.io/csi-volumesnapshot-class': 'true' } } : {}),
+  },
+  driver: 'csi.corp.internal', deletionPolicy: 'Delete',
+});
+
+const CLAIM = {
+  apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+  metadata: { name: 'data', namespace: 'payments' },
+  spec: { accessModes: ['ReadWriteOnce'], resources: { requests: { storage: '5Gi' } } },
+};
+
+const DEPLOY = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name: 'ledger', namespace: 'payments' },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { app: 'ledger' } },
+    template: {
+      metadata: { labels: { app: 'ledger' } },
+      spec: {
+        containers: [{ name: 'app', image: APP_IMAGE, volumeMounts: [{ name: 'data', mountPath: '/data' }] }],
+        volumes: [{ name: 'data', persistentVolumeClaim: { claimName: 'data' } }],
+      },
+    },
+  },
+};
+
+const CONFIG = {
+  apiVersion: 'v1', kind: 'ConfigMap',
+  metadata: { name: 'ledger-config', namespace: 'payments' },
+  data: { 'rates.json': '{"usd":1}' },
+};
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    namespaces: ['default', 'payments', 'kube-system', 'velero'],
+    images: {
+      [APP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [CSI_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [SNAP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [VELERO_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(labelled: boolean) {
+  const world = await createOpsWorld({
+    world: spec([
+      deployment('csi-driver', CSI_IMAGE),
+      deployment('snapshot-controller', SNAP_IMAGE),
+      VELERO, LOCATION, STORAGE_CLASS, snapshotClass(labelled),
+      CLAIM, DEPLOY, CONFIG,
+    ]),
+  });
+  await world.cluster.advanceBy(90_000);
+  // 写一笔数据进去
+  const pods = world.cluster.registry.list(
+    world.cluster.scheme.mustGet(PODS), { namespace: 'payments' }
+  ).items;
+  await createExecHandler(world.cluster)(
+    {
+      namespace: 'payments', pod: pods[0].metadata.name!,
+      command: ['sh', '-c', 'echo balance=42 > /data/ledger.txt'], stdin: false, tty: false,
+    },
+    ''
+  );
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+const create = (w: World, definition: any, namespace: string | undefined, object: unknown) =>
+  w.cluster.registry.create(w.cluster.scheme.mustGet(definition), namespace, object as KubeObject);
+
+const backupOf = (w: World, name: string) =>
+  (w.cluster.registry.get(w.cluster.scheme.mustGet(BACKUPS), 'velero', name).status ?? {}) as any;
+const restoreOf = (w: World, name: string) =>
+  (w.cluster.registry.get(w.cluster.scheme.mustGet(RESTORES), 'velero', name).status ?? {}) as any;
+
+const makeBackup = async (w: World, name = 'daily', overrides: Record<string, unknown> = {}) => {
+  create(w, BACKUPS, 'velero', {
+    apiVersion: 'velero.io/v1', kind: 'Backup',
+    metadata: { name, namespace: 'velero' },
+    spec: { includedNamespaces: ['payments'], storageLocation: 'default', ...overrides },
+  });
+  await w.cluster.advanceBy(60_000);
+};
+
+/** 把命名空间连同里面的东西一起抹掉 —— 模拟误删 */
+function wipe(w: World, namespace: string) {
+  for (const definition of w.cluster.scheme.list()) {
+    if (!definition.namespaced) continue;
+    for (const object of w.cluster.registry.list(definition, { namespace }).items) {
+      try {
+        w.cluster.registry.delete(definition, namespace, object.metadata.name!);
+      } catch {
+        // 已经被属主带走了
+      }
+    }
+  }
+}
+
+describe('备份', () => {
+  it('位置可用、快照类打了标签：对象和数据都在备份里', async () => {
+    const w = await build(true);
+    await makeBackup(w);
+
+    const status = backupOf(w, 'daily');
+    expect(status.phase).toBe('Completed');
+    expect(status.warnings).toBe(0);
+    expect(status.volumeSnapshotsAttempted).toBe(1);
+    expect(status.volumeSnapshotsCompleted).toBe(1);
+
+    const stored = w.cluster.backups.get('daily')!;
+    expect(stored.items.some((item) => item.kind === 'ConfigMap' && item.metadata.name === 'ledger-config')).toBe(true);
+    expect(Object.keys(stored.snapshots)).toEqual(['payments/data']);
+  });
+
+  /**
+   * 少打一个标签，备份**照样绿**。
+   * 这就是「我们有备份」和「我们能恢复」之间那道最贵的缝。
+   */
+  it('快照类没打 velero 标签：备份还是 Completed，只是数据不在里面', async () => {
+    const w = await build(false);
+    await makeBackup(w);
+
+    const status = backupOf(w, 'daily');
+    expect(status.phase).toBe('Completed');
+    expect(status.volumeSnapshotsAttempted).toBe(1);
+    expect(status.volumeSnapshotsCompleted).toBe(0);
+    expect(status.warnings).toBe(1);
+    expect(w.cluster.backups.get('daily')!.snapshots).toEqual({});
+  });
+
+  it('位置不可用：备份直接失败，而且说得出是哪个位置', async () => {
+    const w = await build(true);
+    create(w, BACKUPS, 'velero', {
+      apiVersion: 'velero.io/v1', kind: 'Backup',
+      metadata: { name: 'oops', namespace: 'velero' },
+      spec: { includedNamespaces: ['payments'], storageLocation: 'offsite' },
+    });
+    await w.cluster.advanceBy(30_000);
+
+    const status = backupOf(w, 'oops');
+    expect(status.phase).toBe('Failed');
+    expect(status.failureReason).toContain('"offsite" is unavailable');
+  });
+
+  it('snapshotVolumes: false 是明确只要对象图', async () => {
+    const w = await build(true);
+    await makeBackup(w, 'meta-only', { snapshotVolumes: false });
+    expect(backupOf(w, 'meta-only').volumeSnapshotsAttempted).toBe(0);
+    expect(w.cluster.backups.get('meta-only')!.snapshots).toEqual({});
+  });
+
+  it('Velero 没跑：Backup 对象建得出来，永远停在 New', async () => {
+    const w = await build(true);
+    w.cluster.registry.delete(
+      w.cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' }),
+      'velero', 'velero'
+    );
+    await w.cluster.advanceBy(30_000);
+    await makeBackup(w, 'nobody-home');
+    expect(backupOf(w, 'nobody-home')).toEqual({});
+  });
+
+  it('事件不进备份，打了 exclude 标签的也不进', async () => {
+    const w = await build(true);
+    create(w, CONFIGMAPS, 'payments', {
+      apiVersion: 'v1', kind: 'ConfigMap',
+      metadata: {
+        name: 'scratch', namespace: 'payments',
+        labels: { 'velero.io/exclude-from-backup': 'true' },
+      },
+      data: { a: 'b' },
+    });
+    await makeBackup(w);
+    const stored = w.cluster.backups.get('daily')!;
+    expect(stored.items.some((item) => item.kind === 'Event')).toBe(false);
+    expect(stored.items.some((item) => item.metadata.name === 'scratch')).toBe(false);
+  });
+});
+
+describe('恢复', () => {
+  async function backedUp(labelled: boolean) {
+    const w = await build(labelled);
+    await makeBackup(w);
+    wipe(w, 'payments');
+    await w.cluster.advanceBy(30_000);
+    return w;
+  }
+
+  const restoreInto = async (w: World, overrides: Record<string, unknown> = {}) => {
+    create(w, RESTORES, 'velero', {
+      apiVersion: 'velero.io/v1', kind: 'Restore',
+      metadata: { name: 'rescue', namespace: 'velero' },
+      spec: { backupName: 'daily', ...overrides },
+    });
+    await w.cluster.advanceBy(120_000);
+  };
+
+  it('连数据一起回来了', async () => {
+    const w = await backedUp(true);
+    expect(w.cluster.registry.list(w.cluster.scheme.mustGet(PVCS), { namespace: 'payments' }).items)
+      .toHaveLength(0);
+
+    await restoreInto(w);
+    expect(restoreOf(w, 'rescue').phase).toBe('Completed');
+
+    const claim = w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'payments', 'data');
+    expect((claim.status as any).phase).toBe('Bound');
+    expect(w.cluster.volumes.read((claim.spec as any).volumeName))
+      .toEqual({ 'ledger.txt': 'balance=42\n' });
+
+    // Deployment 回来了，Pod 由控制器自己重建
+    const pods = w.cluster.registry.list(w.cluster.scheme.mustGet(PODS), { namespace: 'payments' }).items;
+    expect(pods.length).toBeGreaterThan(0);
+    const read = await createExecHandler(w.cluster)(
+      { namespace: 'payments', pod: pods[0].metadata.name!, command: ['cat', '/data/ledger.txt'], stdin: false, tty: false },
+      ''
+    );
+    expect(read.stdout).toBe('balance=42\n');
+  });
+
+  /**
+   * 没有卷快照的备份，恢复出来的是一块**空盘**。
+   * PVC 是 Bound、Pod 是 Running、`kubectl get` 全绿 —— 只有数据没了。
+   */
+  it('备份里没有卷数据：恢复出来是一块空盘', async () => {
+    const w = await backedUp(false);
+    await restoreInto(w);
+
+    const claim = w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'payments', 'data');
+    expect((claim.status as any).phase).toBe('Bound');
+    expect(w.cluster.volumes.read((claim.spec as any).volumeName)).toEqual({});
+  });
+
+  it('恢复到另一个命名空间：演练不动生产', async () => {
+    const w = await build(true);
+    await makeBackup(w);
+    await restoreInto(w, { namespaceMapping: { payments: 'payments-drill' } });
+
+    const claim = w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'payments-drill', 'data');
+    expect(w.cluster.volumes.read((claim.spec as any).volumeName))
+      .toEqual({ 'ledger.txt': 'balance=42\n' });
+    // 生产那份原封不动
+    const original = w.cluster.registry.get(w.cluster.scheme.mustGet(PVCS), 'payments', 'data');
+    expect((original.spec as any).volumeName).not.toBe((claim.spec as any).volumeName);
+  });
+
+  /**
+   * 对象还在的时候恢复，Velero 默认**跳过**。
+   * 「恢复跑完了，phase 是 PartiallyFailed，但什么都没变」就是这么来的。
+   */
+  it('对象已经在了就跳过，并且记进 warnings', async () => {
+    const w = await build(true);
+    await makeBackup(w);
+    await restoreInto(w);
+    expect(restoreOf(w, 'rescue').phase).toBe('PartiallyFailed');
+    expect(restoreOf(w, 'rescue').warnings).toBeGreaterThan(0);
+  });
+
+  it('备份不存在：恢复直接失败', async () => {
+    const w = await build(true);
+    await restoreInto(w, { backupName: 'nope' });
+    expect(restoreOf(w, 'rescue').phase).toBe('Failed');
+    expect(restoreOf(w, 'rescue').failureReason).toContain('not found');
+  });
+});

--- a/tests/opslab/velero.test.ts
+++ b/tests/opslab/velero.test.ts
@@ -88,6 +88,12 @@ const DEPLOY = {
   },
 };
 
+const SERVICE = {
+  apiVersion: 'v1', kind: 'Service',
+  metadata: { name: 'ledger', namespace: 'payments' },
+  spec: { selector: { app: 'ledger' }, ports: [{ port: 5432, targetPort: 5432 }] },
+};
+
 const CONFIG = {
   apiVersion: 'v1', kind: 'ConfigMap',
   metadata: { name: 'ledger-config', namespace: 'payments' },
@@ -113,7 +119,7 @@ async function build(labelled: boolean) {
       deployment('csi-driver', CSI_IMAGE),
       deployment('snapshot-controller', SNAP_IMAGE),
       VELERO, LOCATION, STORAGE_CLASS, snapshotClass(labelled),
-      CLAIM, DEPLOY, CONFIG,
+      CLAIM, DEPLOY, SERVICE, CONFIG,
     ]),
   });
   await world.cluster.advanceBy(90_000);
@@ -322,6 +328,28 @@ describe('恢复', () => {
     await restoreInto(w);
     expect(restoreOf(w, 'rescue').phase).toBe('PartiallyFailed');
     expect(restoreOf(w, 'rescue').warnings).toBeGreaterThan(0);
+  });
+
+  /**
+   * clusterIP 是集群分配的，不是用户写的。
+   * 原样带回去就是两个 Service 抢同一个地址。
+   */
+  it('恢复出来的 Service 重新分地址，不抢原来那个', async () => {
+    const w = await build(true);
+    const services = { group: '', version: 'v1', resource: 'services' } as const;
+    const before = (w.cluster.registry.get(
+      w.cluster.scheme.mustGet(services), 'payments', 'ledger'
+    ).spec as any).clusterIP;
+    expect(before).toBeTruthy();
+
+    await makeBackup(w);
+    await restoreInto(w, { namespaceMapping: { payments: 'payments-drill' } });
+
+    const after = (w.cluster.registry.get(
+      w.cluster.scheme.mustGet(services), 'payments-drill', 'ledger'
+    ).spec as any).clusterIP;
+    expect(after).toBeTruthy();
+    expect(after).not.toBe(before);
   });
 
   it('备份不存在：恢复直接失败', async () => {


### PR DESCRIPTION
第 21 关 `disaster-recovery`：把「我们有备份」变成「我们能恢复」。

## 关卡

对账库 `ledgerdb` 的数据在一块 20Gi 的盘上。集群装了 Velero、配好了桶，
但从来没人跑过一次备份，更没人恢复过。学员要做三件事：让备份**连卷数据一起**
备走、把 payments 整个命名空间备下来、做一次恢复演练到**另一个命名空间**。

判定做完前两条的检查之后，会真的 `kubectl delete namespace payments`，
再从学员的备份恢复回来，然后 `kubectl exec` 进去 `cat` 一行数据出来对。

## 核心失效：备份是绿的，数据不在里面

刻意保留了真 Velero 最难受的那个行为。Velero 挑卷快照类靠一个标签
（`velero.io/csi-volumesnapshot-class: "true"`）；没有任何快照类打这个标签时，
备份**不报错** —— 它照样 `Completed`，只是 warnings 加一，卷数据一个字节都没进去。

所以这一关的判据看的是 `volumeSnapshotsCompleted`，不是 `phase`。
这类失效只会在恢复那天暴露，而那天恰好是最不能出错的一天。

## 实现里几处照着真行为做的

- **备份内容不在 apiserver 里**（`BackupStore` 单独存）。集群整个没了桶还在；
  反过来桶没了而 Backup 对象还在，`kubectl get backup` 照样显示 Completed。
- **拍完快照要把 content 改成 Retain**，否则命名空间一删，VolumeSnapshot 跟着没，
  content 和字节也跟着没，备份成了一张白纸。真 Velero 的 CSI 插件做的就是这一手。
- **恢复时建一张预置 VolumeSnapshot** 去认领那张没有主人的 content，PVC 才引用得到。
  快照控制器为此补了 pre-provisioned 这条路。
- **恢复默认跳过已经存在的对象**。原地恢复的结果是「跑完了，phase 是
  PartiallyFailed，集群一点没变」，很容易读成「恢复成功，只是有点小问题」。
- **`kubectl delete namespace` 现在真的会把里面的东西全部删掉**，包括 PVC；
  回收策略是 Delete 的话，盘和字节一起消失。这一关的灾难就是这条命令。

## 顺带

世界规格加了 `volumes`：盘上开局就有的数据。这些字节不在 apiserver 上，
写不进 `objects`；而没有数据的话，「恢复成功」和「恢复出一块空盘」
在判定里长得一模一样。

## 验证

- 反向验证：参考解全绿 / 什么都不做要挂
- 近似错误答案三种都探过，各自挂在该挂的用例上：不打标签、原地演练、
  `snapshotVolumes: false`
- 新增 `tests/opslab/velero.test.ts` 11 条
- `npx jest`：49 个 suite、1607 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)