### PR TITLE
feat(opslab): Cluster API，机器也是声明出来的

### DIFF
--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -355,6 +355,92 @@ export const TABLE_PRINTERS: Record<string, TablePrinter> = {
       age,
     ],
   },
+  machinedeployments: {
+    columns: [
+      NAME_COLUMN,
+      col('Cluster', 'The cluster this MachineDeployment belongs to.'),
+      col('Desired', 'The desired number of machines.'),
+      col('Replicas', 'The current number of machines.'),
+      col('Ready', 'The number of machines that have joined the cluster.'),
+      col('Updated', 'The number of machines on the latest template.'),
+      col('Unavailable', 'The number of machines not yet available.'),
+      col('Phase', 'The phase of this MachineDeployment.'),
+      AGE_COLUMN,
+      col('Version', 'The Kubernetes version of the machines.', 1),
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      const desired = spec.replicas ?? 0;
+      const ready = status.readyReplicas ?? 0;
+      return [
+        object.metadata.name,
+        spec.clusterName ?? '',
+        String(desired),
+        String(status.replicas ?? 0),
+        String(ready),
+        String(status.updatedReplicas ?? 0),
+        String(Math.max(0, desired - ready)),
+        status.phase ?? 'ScalingUp',
+        age,
+        spec.template?.spec?.version ?? '',
+      ];
+    },
+  },
+  machinesets: {
+    columns: [
+      NAME_COLUMN,
+      col('Cluster', 'The cluster this MachineSet belongs to.'),
+      col('Desired', 'The desired number of machines.'),
+      col('Replicas', 'The current number of machines.'),
+      col('Ready', 'The number of machines that have joined the cluster.'),
+      col('Available', 'The number of available machines.'),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        spec.clusterName ?? '',
+        String(spec.replicas ?? 0),
+        String(status.replicas ?? 0),
+        String(status.readyReplicas ?? 0),
+        String(status.availableReplicas ?? 0),
+        age,
+      ];
+    },
+  },
+  /**
+   * NODENAME 那一列是重点。
+   *
+   * Machine 有了不等于 Node 有了：Provisioning 阶段这一列是空的，
+   * 机器在造；Provisioned 阶段 Node 出现但还 NotReady。
+   */
+  machines: {
+    columns: [
+      NAME_COLUMN,
+      col('Cluster', 'The cluster this machine belongs to.'),
+      col('Nodename', 'The node backing this machine.'),
+      col('Providerid', 'The infrastructure provider ID.'),
+      col('Phase', 'The phase of this machine.'),
+      AGE_COLUMN,
+      col('Version', 'The Kubernetes version of this machine.', 1),
+    ],
+    cells: (object, age) => {
+      const spec = (object.spec ?? {}) as any;
+      const status = (object.status ?? {}) as any;
+      return [
+        object.metadata.name,
+        spec.clusterName ?? '',
+        status.nodeRef?.name ?? '',
+        spec.providerID ?? '',
+        status.phase ?? 'Pending',
+        age,
+        spec.version ?? '',
+      ];
+    },
+  },
   poddisruptionbudgets: {
     columns: [
       NAME_COLUMN,

--- a/src/lib/opslab/capi/controller.ts
+++ b/src/lib/opslab/capi/controller.ts
@@ -1,0 +1,487 @@
+/**
+ * Cluster API 的两个控制器
+ *
+ * MachineDeployment -> MachineSet -> Machine，形状照抄 Deployment 那一套；
+ * 再由 Machine 变出 Node。后半段是这一层真正的内容：**机器不是立刻就有的**。
+ *
+ * 一台机器从「声明出来」到「能接 Pod」要过三关：
+ *
+ *   Provisioning  provider 在造（克隆模板、开机）
+ *   Provisioned   机器起来了，kubelet 还没报到 —— Node 对象已经存在，但 NotReady
+ *   Running       kubelet 报到，Node Ready，调度器才看得见它
+ *
+ * 弹性伸缩里所有的等待都来自这两段。学员会看到 Pod 先 Pending，
+ * 然后有台 NotReady 的机器出现，再过一会儿 Pod 才落上去。
+ */
+import type { KubeObject } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS, NODES, PODS, templateHash } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import {
+  CAPI_LABEL, MACHINEDEPLOYMENTS, MACHINES, MACHINESETS,
+  MACHINE_DEPLOYMENT_LABEL, MACHINE_SET_LABEL, VSPHEREMACHINETEMPLATES,
+} from './resources';
+
+/** 造机器要多久：克隆模板、开机 */
+export const PROVISION_MS = 90_000;
+/** 开机之后 kubelet 报到要多久 */
+export const BOOTSTRAP_MS = 60_000;
+
+export interface CapiOptions {
+  /** 新机器的 IP 从这个网段里分 */
+  subnet?: string;
+}
+
+/** 规格从 infra 模板上读，不在 MachineDeployment 上 */
+function shapeOf(template: KubeObject | undefined): { cpu: string; memory: string } {
+  const spec = ((template?.spec ?? {}) as any)?.template?.spec ?? {};
+  const cpu = String(spec.numCPUs ?? 4);
+  const memoryMiB = Number(spec.memoryMiB ?? 8192);
+  return { cpu, memory: `${Math.round(memoryMiB / 1024)}Gi` };
+}
+
+export class MachineDeploymentController extends Controller {
+  private deployments: Informer;
+  private sets: Informer;
+  private machines: Informer;
+  private workloads: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'cluster-api');
+    this.deployments = new Informer(this.registry, MACHINEDEPLOYMENTS);
+    this.sets = this.track(new Informer(this.registry, MACHINESETS));
+    this.machines = this.track(new Informer(this.registry, MACHINES));
+    this.workloads = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.watch(this.deployments);
+    for (const informer of [this.sets, this.machines, this.workloads]) {
+      informer.onChange(() => {
+        for (const item of this.deployments.list()) this.enqueue(objectKey(item));
+      });
+    }
+  }
+
+  private installed(): boolean {
+    return this.workloads.list().some((deployment) => {
+      if (deployment.metadata.labels?.[CAPI_LABEL.key] !== CAPI_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let deployment: KubeObject;
+    try {
+      deployment = this.registry.get(MACHINEDEPLOYMENTS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (deployment.metadata.deletionTimestamp) return;
+
+    const spec = (deployment.spec ?? {}) as any;
+    const desired = spec.replicas ?? 1;
+    const hash = templateHash(spec.template);
+    const setName = `${name}-${hash}`;
+
+    let set: KubeObject;
+    try {
+      set = this.registry.get(MACHINESETS, namespace, setName);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      set = this.registry.create(MACHINESETS, namespace, {
+        apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'MachineSet',
+        metadata: {
+          name: setName, namespace,
+          labels: { ...(deployment.metadata.labels ?? {}), [MACHINE_DEPLOYMENT_LABEL]: name },
+          ownerReferences: [{
+            apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'MachineDeployment',
+            name, uid: deployment.metadata.uid!, controller: true, blockOwnerDeletion: true,
+          }],
+        },
+        spec: {
+          replicas: desired,
+          clusterName: spec.clusterName,
+          selector: { matchLabels: { [MACHINE_SET_LABEL]: setName } },
+          template: spec.template,
+        },
+      } as KubeObject);
+    }
+
+    // 模板变了：新的拉起来，旧的缩到 0。真 CAPI 会按 maxSurge/maxUnavailable
+    // 一台一台换，这里简化 —— 换机器的**节奏**不是这一关要教的东西。
+    for (const other of this.ownedSets(deployment)) {
+      if (other.metadata.name === setName) continue;
+      await this.scaleSet(other, 0);
+    }
+    await this.scaleSet(set, desired);
+
+    const machines = this.machinesOf(name, namespace);
+    const ready = machines.filter((machine) => ((machine.status ?? {}) as any).phase === 'Running');
+    await ignoreConflict(() => {
+      updateStatusIfChanged(this.registry, MACHINEDEPLOYMENTS, namespace, name, {
+        replicas: machines.length,
+        readyReplicas: ready.length,
+        availableReplicas: ready.length,
+        updatedReplicas: machines.filter(
+          (machine) => machine.metadata.labels?.[MACHINE_SET_LABEL] === setName
+        ).length,
+        phase: ready.length >= desired ? 'Running' : 'ScalingUp',
+        selector: `${MACHINE_DEPLOYMENT_LABEL}=${name}`,
+      });
+    });
+  }
+
+  private ownedSets(deployment: KubeObject): KubeObject[] {
+    return this.sets.list().filter((set) => (set.metadata.ownerReferences ?? [])
+      .some((ref) => ref.uid === deployment.metadata.uid));
+  }
+
+  private machinesOf(deploymentName: string, namespace: string | undefined): KubeObject[] {
+    return this.machines.list().filter(
+      (machine) => machine.metadata.namespace === namespace
+        && machine.metadata.labels?.[MACHINE_DEPLOYMENT_LABEL] === deploymentName
+    );
+  }
+
+  private async scaleSet(set: KubeObject, replicas: number): Promise<void> {
+    const namespace = set.metadata.namespace;
+    const name = set.metadata.name!;
+    const spec = (set.spec ?? {}) as any;
+    if (spec.replicas !== replicas) {
+      await ignoreConflict(() => {
+        const latest = this.registry.get(MACHINESETS, namespace, name);
+        this.registry.update(MACHINESETS, namespace, name, {
+          ...latest, spec: { ...((latest.spec ?? {}) as any), replicas },
+        });
+      });
+    }
+  }
+}
+
+/**
+ * MachineSet：把副本数变成一台台 Machine。
+ *
+ * 缩容时删哪一台是有讲究的：真 CAPI 默认删最新的那台（Newest），
+ * 因为老机器上跑的东西更可能是「已经稳定的」。这里照做。
+ */
+export class MachineSetController extends Controller {
+  private sets: Informer;
+  private machines: Informer;
+  private workloads: Informer;
+
+  constructor(context: ControllerContext) {
+    super(context, 'machineset');
+    this.sets = new Informer(this.registry, MACHINESETS);
+    this.machines = this.track(new Informer(this.registry, MACHINES));
+    this.workloads = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.watch(this.sets);
+    this.machines.onChange(() => {
+      for (const set of this.sets.list()) this.enqueue(objectKey(set));
+    });
+    this.workloads.onChange(() => {
+      for (const set of this.sets.list()) this.enqueue(objectKey(set));
+    });
+  }
+
+  private installed(): boolean {
+    return this.workloads.list().some((deployment) => {
+      if (deployment.metadata.labels?.[CAPI_LABEL.key] !== CAPI_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let set: KubeObject;
+    try {
+      set = this.registry.get(MACHINESETS, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    if (set.metadata.deletionTimestamp) return;
+
+    const spec = (set.spec ?? {}) as any;
+    const desired = spec.replicas ?? 0;
+    const owned = this.machines.list().filter(
+      (machine) => machine.metadata.namespace === namespace
+        && machine.metadata.labels?.[MACHINE_SET_LABEL] === name
+        && !machine.metadata.deletionTimestamp
+    );
+
+    for (let index = owned.length; index < desired; index += 1) {
+      this.createMachine(set, index);
+    }
+    // 缩容删最新的那台
+    const extra = owned
+      .slice()
+      .sort((a, b) => (a.metadata.creationTimestamp! < b.metadata.creationTimestamp! ? 1 : -1))
+      .slice(0, Math.max(0, owned.length - desired));
+    for (const machine of extra) {
+      try {
+        this.registry.delete(MACHINES, namespace, machine.metadata.name!);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+
+    const ready = owned.filter((machine) => ((machine.status ?? {}) as any).phase === 'Running');
+    await ignoreConflict(() => {
+      updateStatusIfChanged(this.registry, MACHINESETS, namespace, name, {
+        replicas: owned.length,
+        readyReplicas: ready.length,
+        availableReplicas: ready.length,
+        fullyLabeledReplicas: owned.length,
+      });
+    });
+  }
+
+  private createMachine(set: KubeObject, index: number): void {
+    const namespace = set.metadata.namespace;
+    const spec = (set.spec ?? {}) as any;
+    const name = `${set.metadata.name}-${suffix(set.metadata.uid ?? '', index)}`;
+    try {
+      this.registry.create(MACHINES, namespace, {
+        apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'Machine',
+        metadata: {
+          name, namespace,
+          labels: {
+            ...(spec.template?.metadata?.labels ?? {}),
+            [MACHINE_SET_LABEL]: set.metadata.name!,
+            [MACHINE_DEPLOYMENT_LABEL]: set.metadata.labels?.[MACHINE_DEPLOYMENT_LABEL] ?? '',
+          },
+          ownerReferences: [{
+            apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'MachineSet',
+            name: set.metadata.name!, uid: set.metadata.uid!,
+            controller: true, blockOwnerDeletion: true,
+          }],
+        },
+        spec: {
+          clusterName: spec.clusterName,
+          ...(spec.template?.spec ?? {}),
+        },
+      } as KubeObject);
+    } catch (error) {
+      // 同一刻两轮 reconcile 撞上，后一轮让给前一轮
+      if (!isNotFound(error)) return;
+      throw error;
+    }
+  }
+}
+
+/** 名字后缀：同一个 MachineSet 里稳定、可复现 */
+function suffix(seed: string, index: number): string {
+  const alphabet = 'bcdfghjklmnpqrstvwxz2456789';
+  let hash = 2166136261;
+  const text = `${seed}/${index}`;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  let out = '';
+  let value = hash;
+  for (let i = 0; i < 5; i += 1) {
+    out += alphabet[value % alphabet.length];
+    value = Math.floor(value / alphabet.length);
+  }
+  return out;
+}
+
+/**
+ * Machine：一台机器的一生。
+ *
+ * 三段状态之外还有一件事要做对：**删机器要先把 Node 摘掉**。
+ * 真 CAPI 删 Machine 时会先 cordon + drain 那个节点，再删机器。
+ * 不这么做的话，Pod 会跟着机器一起消失，而不是被重新调度 ——
+ * 「缩容把服务打断了」多半就是这条链子没接好。
+ */
+export class MachineController extends Controller {
+  private machines: Informer;
+  private templates: Informer;
+  private workloads: Informer;
+  private nodes: Informer;
+  private wakeups = new Map<string, number>();
+  private ips = new Map<string, string>();
+
+  constructor(context: ControllerContext, private readonly options: CapiOptions = {}) {
+    super(context, 'machine');
+    this.machines = new Informer(this.registry, MACHINES);
+    this.templates = this.track(new Informer(this.registry, VSPHEREMACHINETEMPLATES));
+    this.workloads = this.track(new Informer(this.registry, DEPLOYMENTS));
+    this.nodes = this.track(new Informer(this.registry, NODES));
+    this.watch(this.machines);
+    this.workloads.onChange(() => {
+      for (const machine of this.machines.list()) this.enqueue(objectKey(machine));
+    });
+  }
+
+  stop(): void {
+    for (const id of this.wakeups.values()) this.kernel.clearTimer(id);
+    this.wakeups.clear();
+    super.stop();
+  }
+
+  private installed(): boolean {
+    return this.workloads.list().some((deployment) => {
+      if (deployment.metadata.labels?.[CAPI_LABEL.key] !== CAPI_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  /** 同一台机器只挂一条唤醒定时器 */
+  private wakeAfter(key: string, ms: number): void {
+    const pending = this.wakeups.get(key);
+    if (pending !== undefined) this.kernel.clearTimer(pending);
+    this.wakeups.set(key, this.kernel.setTimeout(() => {
+      this.wakeups.delete(key);
+      this.enqueue(key);
+    }, ms, { label: `machine:${key}` }));
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const { namespace, name } = splitKey(key);
+    let machine: KubeObject;
+    try {
+      machine = this.registry.get(MACHINES, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return this.removeNodeFor(key);
+      throw error;
+    }
+
+    const status = (machine.status ?? {}) as any;
+    const now = this.context.now();
+    const createdAt = Date.parse(machine.metadata.creationTimestamp!);
+    const age = now - createdAt;
+
+    if (age < PROVISION_MS) {
+      await this.setPhase(machine, { phase: 'Provisioning' });
+      this.wakeAfter(key, PROVISION_MS - age);
+      return;
+    }
+
+    const nodeName = status.nodeRef?.name ?? name;
+    this.ips.set(key, this.ips.get(key) ?? this.nextIp());
+    this.ensureNode(machine, nodeName, age >= PROVISION_MS + BOOTSTRAP_MS);
+
+    if (age < PROVISION_MS + BOOTSTRAP_MS) {
+      await this.setPhase(machine, {
+        phase: 'Provisioned',
+        nodeRef: { apiVersion: 'v1', kind: 'Node', name: nodeName },
+        addresses: [{ type: 'InternalIP', address: this.ips.get(key) }],
+      });
+      this.wakeAfter(key, PROVISION_MS + BOOTSTRAP_MS - age);
+      return;
+    }
+
+    await this.setPhase(machine, {
+      phase: 'Running',
+      nodeRef: { apiVersion: 'v1', kind: 'Node', name: nodeName },
+      addresses: [{ type: 'InternalIP', address: this.ips.get(key) }],
+      lastUpdated: new Date(now).toISOString(),
+    });
+  }
+
+  private async setPhase(machine: KubeObject, status: Record<string, unknown>): Promise<void> {
+    await ignoreConflict(() => {
+      const latest = this.registry.get(MACHINES, machine.metadata.namespace, machine.metadata.name!);
+      updateStatusIfChanged(
+        this.registry, MACHINES, latest.metadata.namespace, latest.metadata.name!,
+        { ...((latest.status ?? {}) as any), ...status }
+      );
+    });
+  }
+
+  private ensureNode(machine: KubeObject, nodeName: string, ready: boolean): void {
+    const template = this.templates.list().find((item) => {
+      const ref = ((machine.spec ?? {}) as any)?.infrastructureRef;
+      return ref && item.metadata.name === ref.name && item.metadata.namespace === machine.metadata.namespace;
+    });
+    const shape = shapeOf(template);
+    const conditions = [{
+      type: 'Ready',
+      status: ready ? 'True' : 'False',
+      reason: ready ? 'KubeletReady' : 'KubeletNotReady',
+      message: ready ? 'kubelet is posting ready status' : 'kubelet has not reported yet',
+    }];
+
+    try {
+      const existing = this.registry.get(NODES, undefined, nodeName);
+      updateStatusIfChanged(this.registry, NODES, undefined, nodeName, {
+        ...((existing.status ?? {}) as any), conditions,
+      });
+      return;
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+
+    this.registry.create(NODES, undefined, {
+      apiVersion: 'v1', kind: 'Node',
+      metadata: {
+        name: nodeName,
+        labels: {
+          'kubernetes.io/hostname': nodeName,
+          'kubernetes.io/os': 'linux',
+          ...(machine.metadata.labels ?? {}),
+        },
+      },
+      spec: { unschedulable: false, providerID: `vsphere://${nodeName}` },
+      status: {
+        capacity: { cpu: shape.cpu, memory: shape.memory, pods: '110' },
+        allocatable: { cpu: shape.cpu, memory: shape.memory, pods: '110' },
+        conditions,
+        addresses: [{
+          type: 'InternalIP',
+          address: this.ips.get(`${machine.metadata.namespace}/${machine.metadata.name}`) ?? '10.0.1.1',
+        }],
+        nodeInfo: {
+          kubeletVersion: 'v1.36.0',
+          osImage: 'Debian GNU/Linux 12 (bookworm)',
+          kernelVersion: '6.1.0-opslab',
+          containerRuntimeVersion: 'containerd://2.0.0',
+        },
+      },
+    } as KubeObject);
+  }
+
+  /**
+   * 机器没了，节点也要跟着走。
+   *
+   * 上面的 Pod 先删掉 —— 机器都没了，Pod 不可能还在跑。删掉之后
+   * 它们的属主（ReplicaSet 之类）会在别处重建，这正是缩容不该打断服务的原因。
+   */
+  private removeNodeFor(key: string): void {
+    const { name } = splitKey(key);
+    this.ips.delete(key);
+    let node: KubeObject;
+    try {
+      node = this.registry.get(NODES, undefined, name);
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    for (const pod of this.registry.list(PODS).items) {
+      if ((pod.spec as any)?.nodeName !== name) continue;
+      try {
+        this.registry.delete(PODS, pod.metadata.namespace, pod.metadata.name!);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+    this.registry.delete(NODES, undefined, node.metadata.name!);
+  }
+
+  private nextIp(): string {
+    const prefix = this.options.subnet ?? '10.0.1';
+    const used = new Set(this.ips.values());
+    for (let host = 10; host < 250; host += 1) {
+      const candidate = `${prefix}.${host}`;
+      if (!used.has(candidate)) return candidate;
+    }
+    return `${prefix}.250`;
+  }
+}

--- a/src/lib/opslab/capi/index.ts
+++ b/src/lib/opslab/capi/index.ts
@@ -1,0 +1,15 @@
+/**
+ * 机器也是声明出来的
+ *
+ * Cluster API 把「加一台机器」变成「改一个副本数」。形状和工作负载那一套
+ * 完全对应，而多出来的那件事是**时间**：机器不是立刻就有的。
+ */
+export {
+  CLUSTERS, MACHINEDEPLOYMENTS, MACHINESETS, MACHINES, VSPHEREMACHINETEMPLATES,
+  CAPI_RESOURCES, CAPI_LABEL, MACHINE_SET_LABEL, MACHINE_DEPLOYMENT_LABEL,
+} from './resources';
+export {
+  MachineDeploymentController, MachineSetController, MachineController,
+  PROVISION_MS, BOOTSTRAP_MS,
+} from './controller';
+export type { CapiOptions } from './controller';

--- a/src/lib/opslab/capi/resources.ts
+++ b/src/lib/opslab/capi/resources.ts
@@ -1,0 +1,68 @@
+/**
+ * Cluster API
+ *
+ * 内网集群没有云厂商的弹性伸缩组，机器要么是人手装的，要么是 Cluster API
+ * 声明出来的。它的形状和工作负载那一套**故意长得一样**：
+ *
+ *   Deployment        -> MachineDeployment
+ *   ReplicaSet        -> MachineSet
+ *   Pod               -> Machine        -> Node
+ *
+ * 这个对应关系本身就是要教的东西：机器也是声明出来的，改副本数就是加机器，
+ * 而「加机器」这件事从此有了和滚动更新一样的语义（模板变了就换一批）。
+ *
+ * Machine 和 Node 是两个对象。Machine 是「我要一台机器」，Node 是「这台机器
+ * 上的 kubelet 报到了」。中间隔着装机时间 —— 弹性伸缩里所有的等待都来自这段。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const CLUSTERS: ResourceDefinition = {
+  group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'clusters',
+  singular: 'cluster', kind: 'Cluster', namespaced: true,
+  shortNames: ['cl'], subresources: ['status'],
+};
+
+export const MACHINEDEPLOYMENTS: ResourceDefinition = {
+  group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machinedeployments',
+  singular: 'machinedeployment', kind: 'MachineDeployment', namespaced: true,
+  shortNames: ['md'], subresources: ['status', 'scale'],
+};
+
+export const MACHINESETS: ResourceDefinition = {
+  group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machinesets',
+  singular: 'machineset', kind: 'MachineSet', namespaced: true,
+  shortNames: ['ms'], subresources: ['status', 'scale'],
+};
+
+export const MACHINES: ResourceDefinition = {
+  group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machines',
+  singular: 'machine', kind: 'Machine', namespaced: true,
+  shortNames: ['ma'], subresources: ['status'],
+};
+
+/**
+ * 基础设施那一侧。
+ *
+ * CAPI 自己不知道怎么造机器，造机器是 provider 的事。内网最常见的是
+ * vSphere，所以这里用 CAPV 的模板类型 —— 机器的规格（几核几 G）写在它上面，
+ * 而不是写在 MachineDeployment 上。这个分层解释了一个常见困惑：
+ * 「我改了副本数，为什么新机器还是老规格」—— 规格不在你改的那个对象上。
+ */
+export const VSPHEREMACHINETEMPLATES: ResourceDefinition = {
+  group: 'infrastructure.cluster.x-k8s.io', version: 'v1beta1',
+  resource: 'vspheremachinetemplates',
+  singular: 'vspheremachinetemplate', kind: 'VSphereMachineTemplate', namespaced: true,
+  shortNames: ['vspheremachinetemplates'],
+};
+
+export const CAPI_RESOURCES: ResourceDefinition[] = [
+  CLUSTERS, MACHINEDEPLOYMENTS, MACHINESETS, MACHINES, VSPHEREMACHINETEMPLATES,
+];
+
+/** 控制器自己。没有它，MachineDeployment 就只是一个对象，一台机器都不会出现。 */
+export const CAPI_LABEL = { key: 'app.kubernetes.io/name', value: 'cluster-api' };
+
+/** MachineSet 给自己的 Machine 打的标签 */
+export const MACHINE_SET_LABEL = 'cluster.x-k8s.io/set-name';
+/** Machine 属于哪个 MachineDeployment */
+export const MACHINE_DEPLOYMENT_LABEL = 'cluster.x-k8s.io/deployment-name';

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -15,7 +15,7 @@ import {
   ResourceDefinition,
   Scheme,
 } from '../apiserver';
-import { Controller, ControllerContext } from './framework';
+import { Controller, ControllerContext, Informer } from './framework';
 import { createServiceIpDefaulter } from './serviceip';
 import {
   KYVERNO_LABEL, KYVERNO_RESOURCES, createPsaValidator, digestOf, reviewWithKyverno,
@@ -41,6 +41,9 @@ import {
 import {
   BackupStore, SNAPSHOT_RESOURCES, SnapshotController, VELERO_RESOURCES, VeleroController,
 } from '../backup';
+import {
+  CAPI_RESOURCES, MachineController, MachineDeploymentController, MachineSetController,
+} from '../capi';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -182,7 +185,7 @@ export class Cluster {
       ...CORE_RESOURCES, ...GATEWAY_RESOURCES, ...CERT_RESOURCES, ...ARGOCD_RESOURCES,
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
       ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES, ...ROLLOUT_RESOURCES,
-      ...STORAGE_RESOURCES, ...SNAPSHOT_RESOURCES, ...VELERO_RESOURCES,
+      ...STORAGE_RESOURCES, ...SNAPSHOT_RESOURCES, ...VELERO_RESOURCES, ...CAPI_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -655,6 +658,13 @@ export class Cluster {
       new SnapshotController(context, { volumes: this.volumes }),
       // 备份。Backup 对象在集群里，备份内容在桶里 —— 所以 store 不在 registry 上。
       new VeleroController(context, { store: this.backups }),
+      /**
+       * 机器。形状照抄 Deployment 那一套，多出来的是装机时间 ——
+       * 弹性伸缩里所有的等待都来自那一段。
+       */
+      new MachineDeploymentController(context),
+      new MachineSetController(context),
+      new MachineController(context),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发
@@ -695,16 +705,45 @@ export class Cluster {
           })]
         : []),
       new LoadBalancerController(context, this.options.addressPools ?? DEFAULT_POOLS),
-      ...this.nodeSpecs.flatMap((node) => [
-        new KubeletController(context, node.name, {
-          images: this.options.images,
-          registries: this.options.registries,
-          resolveImage: this.options.resolveImage,
-        }),
-        new NodePressureController(node.name, context, this.options.images ?? {}),
-      ]),
+      ...this.nodeSpecs.flatMap((node) => this.kubeletFor(context, node.name)),
     ];
     for (const controller of this.controllers) controller.start();
+
+    /**
+     * 后来才出现的节点也要有 kubelet。
+     *
+     * kubelet 是**每台机器上**的进程，不是集群里的一个控制器 —— 所以它按节点
+     * 起。Cluster API 造出来的机器如果没人给它起 kubelet，落上去的 Pod 会
+     * 永远 Pending 而且一个事件都没有：这正是真集群里「节点 NotReady，
+     * 但 kubelet 根本没装」的样子，只不过在这里它是我们自己的 bug。
+     */
+    const nodes = new Informer(this.registry, NODES);
+    const known = new Set(this.nodeSpecs.map((node) => node.name));
+    nodes.onChange(() => {
+      for (const node of nodes.list()) {
+        const name = node.metadata.name!;
+        if (known.has(name)) continue;
+        known.add(name);
+        for (const controller of this.kubeletFor(context, name)) {
+          this.controllers.push(controller);
+          controller.start();
+        }
+      }
+    });
+    nodes.start();
+    this.controllers.push({ stop: () => nodes.stop() } as Controller);
+  }
+
+  /** 一台机器上的两个东西：kubelet，以及盯着它资源水位的那部分 */
+  private kubeletFor(context: ControllerContext, name: string): Controller[] {
+    return [
+      new KubeletController(context, name, {
+        images: this.options.images,
+        registries: this.options.registries,
+        resolveImage: this.options.resolveImage,
+      }),
+      new NodePressureController(name, context, this.options.images ?? {}),
+    ];
   }
 
   /** 把世界推到静止 */

--- a/tests/opslab/capi.test.ts
+++ b/tests/opslab/capi.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Cluster API
+ *
+ * 要钉住的三件：
+ *   1. 形状和 Deployment 那一套对应：改副本数就是加机器
+ *   2. 机器不是立刻就有的 —— Provisioning / Provisioned / Running 三段
+ *   3. 删机器要先把 Node 和上面的 Pod 摘掉，缩容才不至于打断服务
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import { printerFor } from '../../src/lib/opslab/apiserver';
+import { BOOTSTRAP_MS, PROVISION_MS } from '../../src/lib/opslab/capi';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const CAPI_IMAGE = 'registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4';
+const APP_IMAGE = 'registry.corp.internal/batch:1.0';
+
+const MDS = { group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machinedeployments' } as const;
+const MSS = { group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machinesets' } as const;
+const MACHINES = { group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machines' } as const;
+const NODES = { group: '', version: 'v1', resource: 'nodes' } as const;
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+
+const CAPI = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: {
+    name: 'capi-controller-manager', namespace: 'capi-system',
+    labels: { 'app.kubernetes.io/name': 'cluster-api' },
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'cluster-api' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'cluster-api' } },
+      spec: { containers: [{ name: 'manager', image: CAPI_IMAGE }] },
+    },
+  },
+};
+
+const TEMPLATE = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1', kind: 'VSphereMachineTemplate',
+  metadata: { name: 'worker-medium', namespace: 'capi-system' },
+  spec: { template: { spec: { numCPUs: 8, memoryMiB: 16384, diskGiB: 100 } } },
+};
+
+const machineDeployment = (replicas: number, templateName = 'worker-medium') => ({
+  apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'MachineDeployment',
+  metadata: { name: 'workers', namespace: 'capi-system' },
+  spec: {
+    clusterName: 'corp',
+    replicas,
+    selector: { matchLabels: { pool: 'workers' } },
+    template: {
+      metadata: { labels: { pool: 'workers' } },
+      spec: {
+        clusterName: 'corp',
+        version: 'v1.36.0',
+        infrastructureRef: {
+          apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+          kind: 'VSphereMachineTemplate', name: templateName,
+        },
+      },
+    },
+  },
+});
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    nodes: [{ name: 'cp-1', cpu: '4', memory: '8Gi' }],
+    namespaces: ['default', 'capi-system'],
+    images: {
+      [CAPI_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [APP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(objects: unknown[]) {
+  const world = await createOpsWorld({ world: spec(objects) });
+  await world.cluster.advanceBy(30_000);
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+const listOf = (w: World, definition: any, namespace?: string) =>
+  w.cluster.registry.list(w.cluster.scheme.mustGet(definition), namespace ? { namespace } : {}).items;
+const machinesOf = (w: World) => listOf(w, MACHINES, 'capi-system');
+const nodeNames = (w: World) => listOf(w, NODES).map((node) => node.metadata.name!).sort();
+const isReady = (node: KubeObject) => ((node.status ?? {}) as any).conditions
+  ?.some((condition: any) => condition.type === 'Ready' && condition.status === 'True');
+
+/**
+ * 世界建好之后再声明机器。
+ *
+ * 放进初始对象里的话，建世界那一次 settle 会把装机时间一并走完，
+ * 三段状态就看不见了 —— 而这三段正是这一层要教的东西。
+ */
+async function declare(w: World, replicas: number, templateName = 'worker-medium') {
+  w.cluster.registry.create(
+    w.cluster.scheme.mustGet(MDS), 'capi-system',
+    machineDeployment(replicas, templateName) as unknown as KubeObject
+  );
+  await w.cluster.advanceBy(1_000);
+}
+
+describe('机器的一生', () => {
+  it('声明三台，就真的出现三台，规格来自 infra 模板', async () => {
+    const w = await build([CAPI, TEMPLATE]);
+    await declare(w, 3);
+    expect(machinesOf(w)).toHaveLength(3);
+    // 刚声明出来的时候还在造，Node 一个都没有
+    expect(machinesOf(w).every((m) => (m.status as any).phase === 'Provisioning')).toBe(true);
+    expect(nodeNames(w)).toEqual(['cp-1']);
+
+    await w.cluster.advanceBy(PROVISION_MS + 1000);
+    // 机器起来了，但 kubelet 还没报到：Node 在，NotReady
+    expect(nodeNames(w)).toHaveLength(4);
+    expect(listOf(w, NODES).filter((node) => node.metadata.name !== 'cp-1').every(isReady)).toBe(false);
+    expect(machinesOf(w).every((m) => (m.status as any).phase === 'Provisioned')).toBe(true);
+
+    await w.cluster.advanceBy(BOOTSTRAP_MS + 1000);
+    expect(machinesOf(w).every((m) => (m.status as any).phase === 'Running')).toBe(true);
+    const workers = listOf(w, NODES).filter((node) => node.metadata.name !== 'cp-1');
+    expect(workers.every(isReady)).toBe(true);
+    // 8 核 16Gi 是模板上写的，不是 MachineDeployment 上写的
+    expect((workers[0].status as any).capacity).toEqual({ cpu: '8', memory: '16Gi', pods: '110' });
+  });
+
+  it('控制器不在时，MachineDeployment 就只是一个对象', async () => {
+    const w = await build([TEMPLATE, machineDeployment(3)]);
+    await w.cluster.advanceBy(PROVISION_MS * 2);
+    expect(machinesOf(w)).toHaveLength(0);
+    expect(nodeNames(w)).toEqual(['cp-1']);
+  });
+
+  it('改副本数就是加机器', async () => {
+    const w = await build([CAPI, TEMPLATE, machineDeployment(1)]);
+    expect(nodeNames(w)).toHaveLength(2);
+
+    const definition = w.cluster.scheme.mustGet(MDS);
+    const live = w.cluster.registry.get(definition, 'capi-system', 'workers');
+    w.cluster.registry.update(definition, 'capi-system', 'workers', {
+      ...live, spec: { ...(live.spec as any), replicas: 3 },
+    } as KubeObject);
+    await w.cluster.advanceBy(PROVISION_MS + BOOTSTRAP_MS + 5_000);
+
+    expect(machinesOf(w)).toHaveLength(3);
+    expect(nodeNames(w)).toHaveLength(4);
+  });
+
+  /**
+   * 缩容删的是**最新**那台。老机器上跑的东西更可能是已经稳定的，
+   * 真 CAPI 的默认删除策略也是 Newest。
+   */
+  it('缩容：机器没了，节点跟着走，上面的 Pod 被重新调度', async () => {
+    const w = await build([CAPI, TEMPLATE, machineDeployment(2)]);
+    expect(nodeNames(w)).toHaveLength(3);
+
+    w.cluster.registry.create(w.cluster.scheme.mustGet(
+      { group: 'apps', version: 'v1', resource: 'deployments' }
+    ), 'default', {
+      apiVersion: 'apps/v1', kind: 'Deployment',
+      metadata: { name: 'batch', namespace: 'default' },
+      spec: {
+        replicas: 4,
+        selector: { matchLabels: { app: 'batch' } },
+        template: {
+          metadata: { labels: { app: 'batch' } },
+          spec: { containers: [{ name: 'app', image: APP_IMAGE }] },
+        },
+      },
+    } as KubeObject);
+    await w.cluster.advanceBy(60_000);
+    const before = listOf(w, PODS, 'default').filter((pod) => (pod.status as any).phase === 'Running');
+    expect(before).toHaveLength(4);
+
+    const definition = w.cluster.scheme.mustGet(MDS);
+    const live = w.cluster.registry.get(definition, 'capi-system', 'workers');
+    w.cluster.registry.update(definition, 'capi-system', 'workers', {
+      ...live, spec: { ...(live.spec as any), replicas: 1 },
+    } as KubeObject);
+    await w.cluster.advanceBy(120_000);
+
+    expect(machinesOf(w)).toHaveLength(1);
+    expect(nodeNames(w)).toHaveLength(2);
+    // 服务没被打断：副本数还是 4，只是落在别处
+    const after = listOf(w, PODS, 'default').filter((pod) => (pod.status as any).phase === 'Running');
+    expect(after).toHaveLength(4);
+  });
+
+  it('换模板就是换一批机器', async () => {
+    const big = {
+      ...TEMPLATE,
+      metadata: { name: 'worker-large', namespace: 'capi-system' },
+      spec: { template: { spec: { numCPUs: 16, memoryMiB: 32768, diskGiB: 200 } } },
+    };
+    const w = await build([CAPI, TEMPLATE, big, machineDeployment(2)]);
+    const oldNames = machinesOf(w).map((m) => m.metadata.name).sort();
+
+    const definition = w.cluster.scheme.mustGet(MDS);
+    const live = w.cluster.registry.get(definition, 'capi-system', 'workers');
+    const nextSpec = JSON.parse(JSON.stringify(live.spec));
+    nextSpec.template.spec.infrastructureRef.name = 'worker-large';
+    w.cluster.registry.update(definition, 'capi-system', 'workers', { ...live, spec: nextSpec } as KubeObject);
+    await w.cluster.advanceBy(PROVISION_MS + BOOTSTRAP_MS + 10_000);
+
+    expect(machinesOf(w).map((m) => m.metadata.name).sort()).not.toEqual(oldNames);
+    expect(listOf(w, MSS, 'capi-system')).toHaveLength(2);
+    const workers = listOf(w, NODES).filter((node) => node.metadata.name !== 'cp-1');
+    expect(workers).toHaveLength(2);
+    expect((workers[0].status as any).capacity.cpu).toBe('16');
+  });
+});
+
+describe('表格', () => {
+  it('machine 的列跟 clusterctl 一致，NODENAME 在造机器的时候是空的', async () => {
+    const w = await build([CAPI, TEMPLATE]);
+    await declare(w, 1);
+    const printer = printerFor('machines');
+    expect(printer.columns.map((column) => column.name)).toEqual([
+      'Name', 'Cluster', 'Nodename', 'Providerid', 'Phase', 'Age', 'Version',
+    ]);
+    expect(printer.cells(machinesOf(w)[0], '10s')[2]).toBe('');
+    expect(printer.cells(machinesOf(w)[0], '10s')[4]).toBe('Provisioning');
+
+    await w.cluster.advanceBy(PROVISION_MS + BOOTSTRAP_MS + 5_000);
+    expect(printer.cells(machinesOf(w)[0], '3m')[2]).toBeTruthy();
+    expect(printer.cells(machinesOf(w)[0], '3m')[4]).toBe('Running');
+  });
+});


### PR DESCRIPTION
第 22 关（弹性）的地基。要谈「机器按需出现」，先得有「机器是声明出来的」。

## 形状

    Deployment   ->  MachineDeployment
    ReplicaSet   ->  MachineSet
    Pod          ->  Machine  ->  Node

这个对应关系本身就是要教的东西：改副本数就是加机器，换模板就是换一批，
「加机器」从此有了和滚动更新一样的语义。

## 多出来的是时间

一台机器从声明到能接 Pod 要过三段：

- `Provisioning` — provider 在造（克隆模板、开机）
- `Provisioned` — 机器起来了，kubelet 还没报到：**Node 对象已经存在，但 NotReady**
- `Running` — kubelet 报到，调度器才看得见它

下一片的弹性伸缩，所有的等待都来自这两段。`kubectl get machines` 的
NODENAME 那一列在第一段是空的，这一列就是拿来看这个的。

## 几处有意做对的

- **规格写在 infra 模板上**（这里用 CAPV 的 `VSphereMachineTemplate`，内网最常见），
  不在 MachineDeployment 上。「我改了副本数，为什么新机器还是老规格」的答案
  就在这个分层里。
- **删 Machine 要先把 Node 和上面的 Pod 摘掉**，属主会在别处重建。
  缩容不该打断服务，靠的就是这条链子接得上。
- **缩容删最新那台**，和真 CAPI 的默认删除策略（Newest）一致 ——
  老机器上跑的东西更可能是已经稳定的。

## 顺带修的一个真 bug

kubelet 是**每台机器上**的进程，不是集群里的一个控制器。原来只在建集群时
按初始节点起一遍，于是后来出现的节点没有 kubelet，落上去的 Pod 会永远
Pending 而且一个事件都没有。现在 Node 一出现就给它起一个。

## 验证

- 新增 `tests/opslab/capi.test.ts` 6 条
- `npx jest`：50 个 suite、1614 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)