### PR TITLE
feat(opslab): 第 22 关 弹性

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -48,6 +48,10 @@ const SNAPSHOT_IMAGE = 'registry.k8s.io/sig-storage/snapshot-controller:v8.2.0';
 const VELERO_IMAGE = 'velero/velero:v1.16.1';
 // 对账库。数据在盘上，不在镜像里 —— 这一关整关都建立在这个区别上。
 const LEDGERDB_IMAGE = 'harbor.corp.internal/team/ledgerdb:14.2';
+const CAPI_IMAGE = 'registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4';
+const AUTOSCALER_IMAGE = 'registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0';
+// 月末结算：一批算得很重的活，跑完就散
+const SETTLEMENT_IMAGE = 'harbor.corp.internal/team/settlement:2.1';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -154,7 +158,7 @@ const WORLD = {
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
     'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
-    'kyverno', 'external-secrets', 'monitoring', 'velero',
+    'kyverno', 'external-secrets', 'monitoring', 'velero', 'capi-system',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -204,6 +208,9 @@ const WORLD = {
     [CSI_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200 },
     [SNAPSHOT_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200 },
     [VELERO_IMAGE]: { pullMs: 700, startupMs: 900, readyAfterMs: 400 },
+    [CAPI_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300 },
+    [AUTOSCALER_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300 },
+    [SETTLEMENT_IMAGE]: { pullMs: 300, startupMs: 500, readyAfterMs: 200, memoryUsage: '256Mi' },
     [LEDGERDB_IMAGE]: {
       pullMs: 800, startupMs: 1200, readyAfterMs: 600,
       listens: [5432], memoryUsage: '512Mi', handlesSigterm: true,
@@ -7065,6 +7072,341 @@ const stage21 = {
   ),
 };
 
+/* ------------------------------------------------------------------ */
+/* 第 22 关：弹性                                                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 机器那一套。
+ *
+ * Cluster API 装了，机器组也建了，但 MachineDeployment 上**没有 min/max 注解** ——
+ * 伸缩器因此看都不看它。这是「伸缩器装了但不工作」最常见的原因。
+ */
+const CAPACITY_PLATFORM = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'capi-controller-manager', namespace: 'capi-system',
+      labels: { 'app.kubernetes.io/name': 'cluster-api' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'cluster-api' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'cluster-api' } },
+        spec: { containers: [{ name: 'manager', image: CAPI_IMAGE }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: {
+      name: 'cluster-autoscaler', namespace: 'capi-system',
+      labels: { 'app.kubernetes.io/name': 'cluster-autoscaler' },
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { 'app.kubernetes.io/name': 'cluster-autoscaler' } },
+      template: {
+        metadata: { labels: { 'app.kubernetes.io/name': 'cluster-autoscaler' } },
+        spec: { containers: [{ name: 'autoscaler', image: AUTOSCALER_IMAGE }] },
+      },
+    },
+  },
+  {
+    apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1', kind: 'VSphereMachineTemplate',
+    metadata: { name: 'worker-8c', namespace: 'capi-system' },
+    spec: { template: { spec: { numCPUs: 8, memoryMiB: 16384, diskGiB: 120 } } },
+  },
+  {
+    apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'MachineDeployment',
+    metadata: { name: 'workers', namespace: 'capi-system' },
+    spec: {
+      clusterName: 'corp',
+      replicas: 1,
+      selector: { matchLabels: { pool: 'workers' } },
+      template: {
+        metadata: { labels: { pool: 'workers' } },
+        spec: {
+          clusterName: 'corp',
+          version: 'v1.36.0',
+          infrastructureRef: {
+            apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+            kind: 'VSphereMachineTemplate', name: 'worker-8c',
+          },
+        },
+      },
+    },
+  },
+];
+
+/**
+ * 月末结算。
+ *
+ * 六个算得很重的分片，外加一个协调器 —— 协调器的 CPU 请求写成了 32 核，
+ * 而池子里最大的机器是 8 核。它会永远 Pending，而伸缩器一台机器都不会加：
+ * 加了也装不下。这不是伸缩器坏了，是它算出来「加了没用」。
+ */
+const SETTLEMENT_WORKLOAD = [
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'settlement', namespace: 'payments' },
+    spec: {
+      replicas: 6,
+      selector: { matchLabels: { app: 'settlement' } },
+      template: {
+        metadata: { labels: { app: 'settlement' } },
+        spec: {
+          containers: [{
+            name: 'shard', image: SETTLEMENT_IMAGE,
+            resources: { requests: { cpu: '3', memory: '256Mi' } },
+          }],
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name: 'settlement-reconciler', namespace: 'payments' },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'settlement-reconciler' } },
+      template: {
+        metadata: { labels: { app: 'settlement-reconciler' } },
+        spec: {
+          containers: [{
+            name: 'reconciler', image: SETTLEMENT_IMAGE,
+            // 有人把 32 核当成了「给它多一点」。池子里最大的机器就是 8 核。
+            resources: { requests: { cpu: '32', memory: '256Mi' } },
+          }],
+        },
+      },
+    },
+  },
+];
+
+const stage22 = {
+  id: 'elastic-capacity',
+  title: t('让机器按需出现，也按需消失', 'Capacity That Comes and Goes'),
+  goal: t(
+    code`
+      月末结算今天要跑。六个分片，每个要 3 核；集群里手工装的那三台各 4 核，
+      装不下。运维的做法一直是提前一天手工加机器，跑完再手工删掉 ——
+      有一次忘了删，多花了两个月的钱。
+
+      集群里已经有 Cluster API 和 cluster-autoscaler，机器组 \`workers\` 也建好了，
+      但从来没生效过：伸缩器**看都不看**它。
+
+      还有一件事：那个协调器 \`settlement-reconciler\` 一直 Pending，
+      而伸缩器一台机器都不给它加。先搞清楚为什么，再让它跑起来。
+
+      ## 通关标准
+
+      1. 机器组 \`workers\` 归伸缩器管，而且有上限（无上限的弹性是账单事故）；
+      2. 结算的六个分片全部 Running，扩出来的机器是 Cluster API 造的；
+      3. 协调器也跑起来了；
+      4. 活干完之后机器要还回去 —— 判定会删掉结算负载并等一段时间，
+         机器组要缩回下限。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl get machinedeployment,machine -n capi-system
+      kubectl get nodes
+      kubectl describe pod -n payments <pod>
+      kubectl annotate machinedeployment workers -n capi-system <key>=<value>
+      kubectl set resources deployment <name> -n payments --requests=cpu=<n>
+      \`\`\`
+    `,
+    code`
+      Month-end settlement runs today. Six shards, three cores each; the three
+      hand-installed nodes have four cores apiece and cannot take them. Ops has always
+      added machines by hand the day before and removed them afterwards, except for the
+      time somebody forgot and the bill ran for two extra months.
+
+      The cluster already has Cluster API and cluster-autoscaler, and the \`workers\`
+      node group exists, but it has never done anything: the autoscaler does not even
+      look at it.
+
+      There is one more thing. The \`settlement-reconciler\` pod stays Pending and the
+      autoscaler adds nothing for it. Work out why before you make it run.
+
+      ## Done when
+
+      1. the \`workers\` group is managed by the autoscaler and has an upper bound
+         (elasticity without a ceiling is a billing incident);
+      2. all six settlement shards are Running on machines created by Cluster API;
+      3. the reconciler runs too;
+      4. the capacity goes away afterwards: the grader deletes the settlement workloads,
+         waits, and expects the group back at its lower bound.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl get machinedeployment,machine -n capi-system
+      kubectl get nodes
+      kubectl describe pod -n payments <pod>
+      kubectl annotate machinedeployment workers -n capi-system <key>=<value>
+      kubectl set resources deployment <name> -n payments --requests=cpu=<n>
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('机器组归伸缩器管', 'The node group is managed'),
+    t('结算跑得完', 'Settlement completes'),
+    t('机器会还回去', 'Capacity is returned'),
+  ],
+  hints: [
+    t(
+      '伸缩器怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：\`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size\` 和 \`...-max-size\`。没打注解的机器组它看都不看 —— 这就是「装了但不工作」。',
+      'How does the autoscaler know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is exactly what "installed but does nothing" looks like.'
+    ),
+    t(
+      '协调器的问题不在伸缩器上。伸缩器每次都会问一句「加一台这种机器，这个 Pod 能落上去吗」—— 请求 32 核而池子里最大的机器是 8 核，答案是不能，所以它一台都不加。`kubectl describe pod` 里那条 NotTriggerScaleUp 事件写着原因。',
+      'The reconciler problem is not in the autoscaler. It asks one question every time: would this pod fit on a new machine of this shape? Requesting 32 cores when the biggest machine is 8 means no, so it adds nothing. The reason is in the NotTriggerScaleUp event on the pod.'
+    ),
+    t(
+      '缩容不是立刻发生的。一台机器要「闲得够久」才会被回收（默认十分钟），这是为了避免抖一下就还机器、下一批活来了又得等装机。判定会自己把时间推过去。',
+      'Scale-down is not immediate. A machine must be idle for long enough (ten minutes by default) before it is reclaimed, so that a brief lull does not cost you a full provisioning wait when the next batch arrives. The grader advances time for you.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      '以为伸缩器会看「CPU 使用率」。它不看负载，只看**调度器的结论**：有 Pod 调度不上就加机器，没有就不加。CPU 用满而 Pod 都调度得上，它一台都不会加 —— 那是 HPA 的活。',
+      'Expecting the autoscaler to watch CPU usage. It does not look at load at all, only at the scheduler verdict: pods that cannot be scheduled mean add machines, nothing else does. A cluster pegged at 100% CPU with everything scheduled gets no new machines, because that is HPA territory.'
+    ),
+    t(
+      '上限设成一个很大的数「以防万一」。一个写错的副本数或者一段死循环的重试，能在一夜之间把机器开到上限 —— 上限就是这类事故的最后一道闸。',
+      'Setting the maximum to something huge "just in case". A wrong replica count or a retry loop can run the group to the ceiling overnight, and the ceiling is the last thing standing between that and the invoice.'
+    ),
+    t(
+      '给关键负载加 \`cluster-autoscaler.kubernetes.io/safe-to-evict: "false"\`，然后忘了。这个注解会把它所在的整台机器**永远**钉住，缩容再也发生不了。「为什么半夜三点还有十台空机器」十次有八次是它。',
+      'Annotating something important with `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` and forgetting. That annotation pins the entire machine it lands on, permanently, and scale-down never happens again. It is the usual answer to "why are ten empty machines still running at 3am".'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM,
+      ...ROLLOUTS_PLATFORM, ...MONITORING_CARRIED,
+      ...PORTAL_ROLLOUT, PORTAL_ROUTE,
+      ...CAPACITY_PLATFORM, ...SETTLEMENT_WORKLOAD,
+    ],
+    referenceCommands: [
+      'kubectl annotate machinedeployment workers -n capi-system'
+        + ' cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size=1'
+        + ' cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size=6',
+      'kubectl set resources deployment settlement-reconciler -n payments --requests=cpu=4',
+    ],
+  },
+  specs: [
+    spec('elastic-capacity.spec.ts', code`
+      import { advance, get, list, sh } from '@ops/lab';
+
+      const MIN = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size';
+      const MAX = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size';
+      const POOL = () => get('MachineDeployment', 'workers', 'capi-system');
+
+      const runningIn = (namespace, app) => list('Pod', { namespace })
+        .filter((pod) => (pod.metadata.labels || {}).app === app)
+        .filter((pod) => pod.status.phase === 'Running');
+
+      describe('弹性', () => {
+        it('机器组归伸缩器管，而且有上限', () => {
+          const annotations = POOL().metadata.annotations || {};
+          const min = Number(annotations[MIN]);
+          const max = Number(annotations[MAX]);
+          expect(Number.isFinite(min)).toBe(true);
+          expect(Number.isFinite(max)).toBe(true);
+          expect(max).toBeGreaterThan(min);
+        });
+
+        it('结算的六个分片都跑起来了', () => {
+          expect(runningIn('payments', 'settlement').length).toBe(6);
+        });
+
+        it('多出来的机器是 Cluster API 造的，不是手工加的', () => {
+          const machines = list('Machine', { namespace: 'capi-system' });
+          expect(machines.length).toBeGreaterThan(1);
+
+          const nodeNames = machines
+            .map((machine) => (machine.status.nodeRef || {}).name)
+            .filter(Boolean);
+          const shards = runningIn('payments', 'settlement');
+          // 分片确实落在新机器上，而不是全挤在原来那三台上
+          expect(shards.some((pod) => nodeNames.includes(pod.spec.nodeName))).toBe(true);
+
+          const max = Number(POOL().metadata.annotations[MAX]);
+          expect(POOL().spec.replicas).toBeLessThanOrEqual(max);
+        });
+
+        it('那个要 32 核的协调器也跑起来了', () => {
+          expect(runningIn('payments', 'settlement-reconciler').length).toBe(1);
+        });
+
+        it('活干完了机器要还回去', async () => {
+          const peak = POOL().spec.replicas;
+          expect(peak).toBeGreaterThan(1);
+
+          await sh('kubectl delete deployment settlement settlement-reconciler -n payments');
+          await advance(60000);
+          // 刚闲下来不缩：抖一下就还机器，下一批活来了又得等装机
+          expect(POOL().spec.replicas).toBe(peak);
+
+          await advance(900000);
+          const min = Number(POOL().metadata.annotations[MIN]);
+          expect(POOL().spec.replicas).toBe(min);
+          expect(list('Machine', { namespace: 'capi-system' }).length).toBe(min);
+        });
+      });
+    `),
+  ],
+  focus: ['resilience', 'operations'],
+  extension: t(
+    code`
+      弹性伸缩最容易被误解的一点是**它不看负载**。cluster-autoscaler 只认调度器的
+      结论：有 Pod 调度不上就加机器，没有就不加。一个 CPU 跑满但所有 Pod 都调度
+      得上的集群，它一台机器都不会加 —— 那是 HPA 的事。两个东西经常被混着说成
+      「自动扩容」，但它们工作在完全不同的层：HPA 加的是副本，伸缩器加的是机器，
+      而且伸缩器是被 HPA 加出来的那些 Pod 触发的。
+
+      第二点是**扩容有代价而缩容有风险**。扩容的代价是时间：装机几分钟，
+      这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。
+      缩容的风险是打断：机器上的 Pod 要挪走，挪的过程中就是有一段服务能力
+      的缺口 —— 这也是为什么缩容要等「闲够十分钟」，以及为什么 PDB 在这里
+      同样管用。
+
+      第三点是**上限就是闸**。弹性系统最贵的故障不是不扩容，是扩容失控：
+      一个写错的副本数、一段死循环的重试、一个刷不出来的镜像导致 Pod 一直
+      Pending，都能让机器一台台加下去。上限不是「性能调优参数」，
+      它和 ResourceQuota、LimitRange 一样，是防止一个错误变成一场事故的东西。
+    `,
+    code`
+      The most misunderstood thing about the cluster autoscaler is that **it does not
+      watch load**. It reads one signal: the scheduler's verdict. Pods that cannot be
+      scheduled mean add machines; anything else means do nothing. A cluster pegged at
+      100% CPU with everything scheduled gets no new machines, because that is HPA
+      territory. The two are often lumped together as "autoscaling" while working at
+      completely different layers: HPA adds replicas, the autoscaler adds machines, and
+      it is the pods HPA created that trigger it.
+
+      The second thing is that **scaling up costs time and scaling down carries risk**.
+      Provisioning takes minutes, and requests queue during those minutes, so real burst
+      traffic is absorbed by headroom you kept, not by the autoscaler. Scaling down
+      moves pods off a machine, and that movement is a real gap in capacity, which is
+      why a node must be idle for ten minutes first and why PDBs matter here too.
+
+      The third is that **the ceiling is the brake**. The expensive failure in an elastic
+      system is not failing to scale up, it is scaling without end: a wrong replica
+      count, a retry loop, an image that never pulls leaving pods Pending forever, each
+      one can walk the group up machine by machine. The maximum is not a tuning
+      parameter. Like ResourceQuota and LimitRange, it is there so one mistake does not
+      become an incident.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -7111,6 +7453,6 @@ module.exports = {
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
     stage13, stage14, stage15, stage16, stage17, stage18, stage19, stage20,
-    stage21,
+    stage21, stage22,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5622,7 +5622,8 @@
           "kyverno",
           "external-secrets",
           "monitoring",
-          "velero"
+          "velero",
+          "capi-system"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5765,6 +5766,22 @@
             "pullMs": 700,
             "startupMs": 900,
             "readyAfterMs": 400
+          },
+          "registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300
+          },
+          "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300
+          },
+          "harbor.corp.internal/team/settlement:2.1": {
+            "pullMs": 300,
+            "startupMs": 500,
+            "readyAfterMs": 200,
+            "memoryUsage": "256Mi"
           },
           "harbor.corp.internal/team/ledgerdb:14.2": {
             "pullMs": 800,
@@ -13614,6 +13631,721 @@
         "primer": {
           "zh": "接手一个系统之后最该问的一句话不是「有没有备份」，是「上次从备份恢复是什么时候」。这两句差得很远：备份任务天天绿，不代表那个桶里的东西能把服务拉起来。这一关要做的就是把第二句变成真的。\n\nKubernetes 里的数据分两层，这一层的所有困惑都从这儿来。`PersistentVolumeClaim` 是一个**对象**，住在 apiserver 里；盘上的字节不在 apiserver 里，它们在存储后端上。所以把 apiserver 里的对象全导出来，得到的是一份完整的 YAML 和**零字节数据**。恢复出来是一个一模一样的空盘，而 `kubectl get pvc` 看不出空盘和满盘的区别。\n\n要把字节也带上，得靠 `CSI 卷快照`。三个对象：`VolumeSnapshotClass` 说谁来拍、拍完怎么处置，`VolumeSnapshot` 是应用侧的一次请求，`VolumeSnapshotContent` 是存储上真正那张。快照是`时间点`：拍完之后往盘里再写什么都跟它无关。另外要留意拍快照的是 `snapshot-controller` 这个工作负载，它和 CSI 驱动是两个东西，只装驱动的话 VolumeSnapshot 建得出来然后永远不就绪。\n\n`Velero` 把这两件事缝起来：它自己导出对象图放进桶里，卷数据则委托给 CSI 快照。缝的地方有一个标签：`velero.io/csi-volumesnapshot-class: \"true\"`。没有任何快照类打这个标签时，Velero **不报错**，备份照样 `Completed`，只是 warnings 加一，卷数据一个字节都没进去。所以判断一次备份好不好，要看的是 `volumeSnapshotsCompleted` 而不是 `phase`。\n\n恢复这一侧有一条默认行为要记住：Velero **跳过**已经存在的对象。所以往原地恢复的结果通常是「跑完了，phase 是 PartiallyFailed，集群一点没变」，很容易被读成「恢复成功，只是有点小问题」。演练要用 `--namespace-mappings` 恢复到一个新命名空间，进去读一行真数据出来对一下，再把它删掉。\n\n最后是灾难本身。`kubectl delete namespace` 不只是删掉一堆对象，它会一起带走 PVC；回收策略是 `Delete` 的话，盘和盘上的字节跟着消失，apiserver 里再也查不到它存在过。一条命令、一个词的差别，带走的是整个环境，这也正是备份存在的理由。",
           "en": "The first question to ask about a system you have just inherited is not whether it has backups, it is when somebody last restored from one. Those are far apart: a backup job going green every day says nothing about whether the contents of that bucket can bring the service back. This stage is about making the second sentence true.\n\nData in Kubernetes lives on two levels, and every confusion here comes from that split. A `PersistentVolumeClaim` is an **object** in the apiserver; the bytes on the volume are not, they live on the storage backend. So exporting every object from the apiserver gives you a complete set of YAML and **zero bytes of data**. What comes back is an identical empty disk, and `kubectl get pvc` shows no difference between an empty one and a full one.\n\nCarrying the bytes as well takes `CSI volume snapshots`. Three objects: a `VolumeSnapshotClass` says who takes them and what happens afterwards, a `VolumeSnapshot` is the request from the application side, and a `VolumeSnapshotContent` is the real snapshot on the storage system. A snapshot is a `point in time`: whatever is written to the volume afterwards is not in it. Note also that snapshots are taken by the `snapshot-controller` workload, which is separate from the CSI driver: install only the driver and a VolumeSnapshot will be created and then never become ready.\n\n`Velero` stitches the two together: it exports the object graph into the bucket itself and delegates volume data to CSI snapshots. The seam is a label, `velero.io/csi-volumesnapshot-class: \"true\"`. When no snapshot class carries it, Velero does **not** fail. The backup still reports `Completed`, just with one more warning, and not a byte of volume data goes in. So the health of a backup is read from `volumeSnapshotsCompleted`, not from `phase`.\n\nOn the restore side there is one default worth memorising: Velero **skips** resources that already exist. Restoring in place therefore usually means \"it ran, phase is PartiallyFailed, and nothing in the cluster changed\", which reads a lot like \"restored, with minor issues\". Drill with `--namespace-mappings` into a fresh namespace, read a row of real data out of it, and delete it afterwards.\n\nFinally the disaster itself. `kubectl delete namespace` does not just remove a pile of objects, it takes the PVCs with it; with a `Delete` reclaim policy the volume and every byte on it go too, leaving no record in the apiserver that they ever existed. One command, one word of difference, and an entire environment is gone, which is the whole reason backups exist."
+        }
+      },
+      {
+        "id": "elastic-capacity",
+        "title": {
+          "zh": "让机器按需出现，也按需消失",
+          "en": "Capacity That Comes and Goes"
+        },
+        "goal": {
+          "zh": "月末结算今天要跑。六个分片，每个要 3 核；集群里手工装的那三台各 4 核，\n装不下。运维的做法一直是提前一天手工加机器，跑完再手工删掉 ——\n有一次忘了删，多花了两个月的钱。\n\n集群里已经有 Cluster API 和 cluster-autoscaler，机器组 `workers` 也建好了，\n但从来没生效过：伸缩器**看都不看**它。\n\n还有一件事：那个协调器 `settlement-reconciler` 一直 Pending，\n而伸缩器一台机器都不给它加。先搞清楚为什么，再让它跑起来。\n\n## 通关标准\n\n1. 机器组 `workers` 归伸缩器管，而且有上限（无上限的弹性是账单事故）；\n2. 结算的六个分片全部 Running，扩出来的机器是 Cluster API 造的；\n3. 协调器也跑起来了；\n4. 活干完之后机器要还回去 —— 判定会删掉结算负载并等一段时间，\n   机器组要缩回下限。\n\n## 会用到的命令\n\n```bash\nkubectl get machinedeployment,machine -n capi-system\nkubectl get nodes\nkubectl describe pod -n payments <pod>\nkubectl annotate machinedeployment workers -n capi-system <key>=<value>\nkubectl set resources deployment <name> -n payments --requests=cpu=<n>\n```\n",
+          "en": "Month-end settlement runs today. Six shards, three cores each; the three\nhand-installed nodes have four cores apiece and cannot take them. Ops has always\nadded machines by hand the day before and removed them afterwards, except for the\ntime somebody forgot and the bill ran for two extra months.\n\nThe cluster already has Cluster API and cluster-autoscaler, and the `workers`\nnode group exists, but it has never done anything: the autoscaler does not even\nlook at it.\n\nThere is one more thing. The `settlement-reconciler` pod stays Pending and the\nautoscaler adds nothing for it. Work out why before you make it run.\n\n## Done when\n\n1. the `workers` group is managed by the autoscaler and has an upper bound\n   (elasticity without a ceiling is a billing incident);\n2. all six settlement shards are Running on machines created by Cluster API;\n3. the reconciler runs too;\n4. the capacity goes away afterwards: the grader deletes the settlement workloads,\n   waits, and expects the group back at its lower bound.\n\n## Commands you will need\n\n```bash\nkubectl get machinedeployment,machine -n capi-system\nkubectl get nodes\nkubectl describe pod -n payments <pod>\nkubectl annotate machinedeployment workers -n capi-system <key>=<value>\nkubectl set resources deployment <name> -n payments --requests=cpu=<n>\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "机器组归伸缩器管",
+            "en": "The node group is managed"
+          },
+          {
+            "zh": "结算跑得完",
+            "en": "Settlement completes"
+          },
+          {
+            "zh": "机器会还回去",
+            "en": "Capacity is returned"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "伸缩器怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它看都不看 —— 这就是「装了但不工作」。",
+            "en": "How does the autoscaler know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is exactly what \"installed but does nothing\" looks like."
+          },
+          {
+            "zh": "协调器的问题不在伸缩器上。伸缩器每次都会问一句「加一台这种机器，这个 Pod 能落上去吗」—— 请求 32 核而池子里最大的机器是 8 核，答案是不能，所以它一台都不加。`kubectl describe pod` 里那条 NotTriggerScaleUp 事件写着原因。",
+            "en": "The reconciler problem is not in the autoscaler. It asks one question every time: would this pod fit on a new machine of this shape? Requesting 32 cores when the biggest machine is 8 means no, so it adds nothing. The reason is in the NotTriggerScaleUp event on the pod."
+          },
+          {
+            "zh": "缩容不是立刻发生的。一台机器要「闲得够久」才会被回收（默认十分钟），这是为了避免抖一下就还机器、下一批活来了又得等装机。判定会自己把时间推过去。",
+            "en": "Scale-down is not immediate. A machine must be idle for long enough (ten minutes by default) before it is reclaimed, so that a brief lull does not cost you a full provisioning wait when the next batch arrives. The grader advances time for you."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "以为伸缩器会看「CPU 使用率」。它不看负载，只看**调度器的结论**：有 Pod 调度不上就加机器，没有就不加。CPU 用满而 Pod 都调度得上，它一台都不会加 —— 那是 HPA 的活。",
+            "en": "Expecting the autoscaler to watch CPU usage. It does not look at load at all, only at the scheduler verdict: pods that cannot be scheduled mean add machines, nothing else does. A cluster pegged at 100% CPU with everything scheduled gets no new machines, because that is HPA territory."
+          },
+          {
+            "zh": "上限设成一个很大的数「以防万一」。一个写错的副本数或者一段死循环的重试，能在一夜之间把机器开到上限 —— 上限就是这类事故的最后一道闸。",
+            "en": "Setting the maximum to something huge \"just in case\". A wrong replica count or a retry loop can run the group to the ceiling overnight, and the ceiling is the last thing standing between that and the invoice."
+          },
+          {
+            "zh": "给关键负载加 `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"`，然后忘了。这个注解会把它所在的整台机器**永远**钉住，缩容再也发生不了。「为什么半夜三点还有十台空机器」十次有八次是它。",
+            "en": "Annotating something important with `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"` and forgetting. That annotation pins the entire machine it lands on, permanently, and scale-down never happens again. It is the usual answer to \"why are ten empty machines still running at 3am\"."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "capi-controller-manager",
+                "namespace": "capi-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cluster-api"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cluster-api"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cluster-api"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "manager",
+                        "image": "registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cluster-autoscaler",
+                "namespace": "capi-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cluster-autoscaler"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cluster-autoscaler"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cluster-autoscaler"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "autoscaler",
+                        "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+              "kind": "VSphereMachineTemplate",
+              "metadata": {
+                "name": "worker-8c",
+                "namespace": "capi-system"
+              },
+              "spec": {
+                "template": {
+                  "spec": {
+                    "numCPUs": 8,
+                    "memoryMiB": 16384,
+                    "diskGiB": 120
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cluster.x-k8s.io/v1beta1",
+              "kind": "MachineDeployment",
+              "metadata": {
+                "name": "workers",
+                "namespace": "capi-system"
+              },
+              "spec": {
+                "clusterName": "corp",
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "pool": "workers"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "pool": "workers"
+                    }
+                  },
+                  "spec": {
+                    "clusterName": "corp",
+                    "version": "v1.36.0",
+                    "infrastructureRef": {
+                      "apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+                      "kind": "VSphereMachineTemplate",
+                      "name": "worker-8c"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "settlement",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 6,
+                "selector": {
+                  "matchLabels": {
+                    "app": "settlement"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "settlement"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "shard",
+                        "image": "harbor.corp.internal/team/settlement:2.1",
+                        "resources": {
+                          "requests": {
+                            "cpu": "3",
+                            "memory": "256Mi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "settlement-reconciler",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "settlement-reconciler"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "settlement-reconciler"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "reconciler",
+                        "image": "harbor.corp.internal/team/settlement:2.1",
+                        "resources": {
+                          "requests": {
+                            "cpu": "32",
+                            "memory": "256Mi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "referenceCommands": [
+            "kubectl annotate machinedeployment workers -n capi-system cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size=1 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size=6",
+            "kubectl set resources deployment settlement-reconciler -n payments --requests=cpu=4"
+          ]
+        },
+        "specs": [
+          {
+            "path": "elastic-capacity.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst MIN = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size';\nconst MAX = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size';\nconst POOL = () => get('MachineDeployment', 'workers', 'capi-system');\n\nconst runningIn = (namespace, app) => list('Pod', { namespace })\n  .filter((pod) => (pod.metadata.labels || {}).app === app)\n  .filter((pod) => pod.status.phase === 'Running');\n\ndescribe('弹性', () => {\n  it('机器组归伸缩器管，而且有上限', () => {\n    const annotations = POOL().metadata.annotations || {};\n    const min = Number(annotations[MIN]);\n    const max = Number(annotations[MAX]);\n    expect(Number.isFinite(min)).toBe(true);\n    expect(Number.isFinite(max)).toBe(true);\n    expect(max).toBeGreaterThan(min);\n  });\n\n  it('结算的六个分片都跑起来了', () => {\n    expect(runningIn('payments', 'settlement').length).toBe(6);\n  });\n\n  it('多出来的机器是 Cluster API 造的，不是手工加的', () => {\n    const machines = list('Machine', { namespace: 'capi-system' });\n    expect(machines.length).toBeGreaterThan(1);\n\n    const nodeNames = machines\n      .map((machine) => (machine.status.nodeRef || {}).name)\n      .filter(Boolean);\n    const shards = runningIn('payments', 'settlement');\n    // 分片确实落在新机器上，而不是全挤在原来那三台上\n    expect(shards.some((pod) => nodeNames.includes(pod.spec.nodeName))).toBe(true);\n\n    const max = Number(POOL().metadata.annotations[MAX]);\n    expect(POOL().spec.replicas).toBeLessThanOrEqual(max);\n  });\n\n  it('那个要 32 核的协调器也跑起来了', () => {\n    expect(runningIn('payments', 'settlement-reconciler').length).toBe(1);\n  });\n\n  it('活干完了机器要还回去', async () => {\n    const peak = POOL().spec.replicas;\n    expect(peak).toBeGreaterThan(1);\n\n    await sh('kubectl delete deployment settlement settlement-reconciler -n payments');\n    await advance(60000);\n    // 刚闲下来不缩：抖一下就还机器，下一批活来了又得等装机\n    expect(POOL().spec.replicas).toBe(peak);\n\n    await advance(900000);\n    const min = Number(POOL().metadata.annotations[MIN]);\n    expect(POOL().spec.replicas).toBe(min);\n    expect(list('Machine', { namespace: 'capi-system' }).length).toBe(min);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "resilience",
+          "operations"
+        ],
+        "extension": {
+          "zh": "弹性伸缩最容易被误解的一点是**它不看负载**。cluster-autoscaler 只认调度器的\n结论：有 Pod 调度不上就加机器，没有就不加。一个 CPU 跑满但所有 Pod 都调度\n得上的集群，它一台机器都不会加 —— 那是 HPA 的事。两个东西经常被混着说成\n「自动扩容」，但它们工作在完全不同的层：HPA 加的是副本，伸缩器加的是机器，\n而且伸缩器是被 HPA 加出来的那些 Pod 触发的。\n\n第二点是**扩容有代价而缩容有风险**。扩容的代价是时间：装机几分钟，\n这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。\n缩容的风险是打断：机器上的 Pod 要挪走，挪的过程中就是有一段服务能力\n的缺口 —— 这也是为什么缩容要等「闲够十分钟」，以及为什么 PDB 在这里\n同样管用。\n\n第三点是**上限就是闸**。弹性系统最贵的故障不是不扩容，是扩容失控：\n一个写错的副本数、一段死循环的重试、一个刷不出来的镜像导致 Pod 一直\nPending，都能让机器一台台加下去。上限不是「性能调优参数」，\n它和 ResourceQuota、LimitRange 一样，是防止一个错误变成一场事故的东西。\n",
+          "en": "The most misunderstood thing about the cluster autoscaler is that **it does not\nwatch load**. It reads one signal: the scheduler's verdict. Pods that cannot be\nscheduled mean add machines; anything else means do nothing. A cluster pegged at\n100% CPU with everything scheduled gets no new machines, because that is HPA\nterritory. The two are often lumped together as \"autoscaling\" while working at\ncompletely different layers: HPA adds replicas, the autoscaler adds machines, and\nit is the pods HPA created that trigger it.\n\nThe second thing is that **scaling up costs time and scaling down carries risk**.\nProvisioning takes minutes, and requests queue during those minutes, so real burst\ntraffic is absorbed by headroom you kept, not by the autoscaler. Scaling down\nmoves pods off a machine, and that movement is a real gap in capacity, which is\nwhy a node must be idle for ten minutes first and why PDBs matter here too.\n\nThe third is that **the ceiling is the brake**. The expensive failure in an elastic\nsystem is not failing to scale up, it is scaling without end: a wrong replica\ncount, a retry loop, an image that never pulls leaving pods Pending forever, each\none can walk the group up machine by machine. The maximum is not a tuning\nparameter. Like ResourceQuota and LimitRange, it is there so one mistake does not\nbecome an incident.\n"
+        },
+        "primer": {
+          "zh": "机器从哪儿来，是这一层的第一个问题。内网集群没有云厂商的弹性伸缩组，机器要么是人手装的，要么是 `Cluster API` 声明出来的。它的形状和工作负载那一套故意长得一样：`MachineDeployment` 对 Deployment，`MachineSet` 对 ReplicaSet，`Machine` 对 Pod。改副本数就是加机器，换模板就是换一批。\n\nMachine 和 Node 是两个对象，这个区别要记牢。Machine 是「我要一台机器」，Node 是「这台机器上的 kubelet 报到了」。中间隔着装机时间，表现为三段：`Provisioning`（provider 在造）、`Provisioned`（Node 对象出现但 NotReady）、`Running`（kubelet 报到，调度器才看得见它）。`kubectl get machines` 里 NODENAME 那一列在第一段是空的。另外机器的规格写在 infra 模板上，不在 MachineDeployment 上，「我改了副本数为什么新机器还是老规格」的答案就在这个分层里。\n\n`cluster-autoscaler` 做的事只有两件，而且都不看负载。扩容：看到**调度不上**的 Pod，问一句「加一台这种机器，它能落上去吗」，能就加，不能就一台都不加。所以一个请求 32 核的 Pod 在最大 8 核的池子里会永远 Pending 而机器数纹丝不动。这不是坏了，是它算出来加了也没用，理由写在 Pod 的 `NotTriggerScaleUp` 事件里。缩容：看到利用率低的节点，问一句「上面的 Pod 挪得走吗」。\n\n它怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它**看都不看**，这是「伸缩器装了但不工作」最常见的原因。上限不是调优参数，它是闸：一个写错的副本数或者一段死循环的重试，能让机器一台台加到天亮。\n\n缩容那一侧有三道门：利用率够低、闲得够久（默认十分钟）、上面的 Pod 挪得走。第三道最容易卡住，而且卡住的时候伸缩器是沉默的。能钉住一台机器的东西有：PDB 不允许再驱逐、Pod 没有属主（删了就不会被重建）、以及打了 `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"` 的 Pod。最后这一条最阴：加的时候是为了保护某个关键任务，忘了摘，那台机器就永远还不回去了。\n\n最后分清两件常被混着说成「自动扩容」的事：`HPA` 加的是**副本**，看的是指标；伸缩器加的是**机器**，看的是调度结果。顺序是 HPA 先加出一批调度不上的 Pod，伸缩器再为它们加机器。还要记住扩容有代价：装机要几分钟，这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。",
+          "en": "Where machines come from is the first question at this layer. An intranet cluster has no cloud autoscaling group: machines are either installed by hand or declared through `Cluster API`. Its shape deliberately mirrors the workload API: `MachineDeployment` to Deployment, `MachineSet` to ReplicaSet, `Machine` to Pod. Changing a replica count adds machines; changing the template replaces a batch of them.\n\nMachine and Node are two objects, and the difference matters. A Machine is \"I want a machine\"; a Node is \"the kubelet on that machine has reported in\". Between them sits provisioning time, visible as three phases: `Provisioning` (the provider is building it), `Provisioned` (the Node object exists but is NotReady), and `Running` (the kubelet reported and the scheduler can finally see it). The NODENAME column of `kubectl get machines` is empty during the first phase. Note also that machine size lives on the infra template, not on the MachineDeployment, which is the answer to \"I changed the replica count, why are the new machines still the old size\".\n\n`cluster-autoscaler` does exactly two things, and neither of them looks at load. Scaling up: for pods that **cannot be scheduled**, it asks whether one more machine of this shape would fit them, and adds machines only if the answer is yes. A pod requesting 32 cores in a pool whose largest machine is 8 will therefore stay Pending forever while the machine count never moves. That is not a malfunction, it is the answer to the question, and the reason is recorded in a `NotTriggerScaleUp` event on the pod. Scaling down: for underutilised nodes, it asks whether the pods on them can move.\n\nHow does it know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is the usual reason an installed autoscaler does nothing. The maximum is not a tuning parameter but a brake: a wrong replica count or a retry loop can walk a group up machine by machine all night.\n\nScaling down has three gates: utilisation low enough, idle long enough (ten minutes by default), and the pods on the node able to move. The third is the one that jams, and the autoscaler is silent when it does. Things that pin a machine: a PDB that allows no further eviction, a pod with no controller (delete it and nothing recreates it), and any pod annotated `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"`. That last one is the sneakiest, added to protect something important and then forgotten, and the machine never goes back.\n\nFinally, separate the two things routinely called autoscaling. `HPA` adds **replicas** based on metrics; the autoscaler adds **machines** based on scheduling outcomes. The order is that HPA produces pods that cannot be scheduled and the autoscaler then provides machines for them. And remember that scaling up costs time: provisioning takes minutes during which requests queue, so genuine burst traffic is absorbed by headroom you kept, not by the autoscaler."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1363,6 +1363,25 @@ const primers = {
       )
     ),
 
+    'elastic-capacity': t(
+      p(
+        '机器从哪儿来，是这一层的第一个问题。内网集群没有云厂商的弹性伸缩组，机器要么是人手装的，要么是 `Cluster API` 声明出来的。它的形状和工作负载那一套故意长得一样：`MachineDeployment` 对 Deployment，`MachineSet` 对 ReplicaSet，`Machine` 对 Pod。改副本数就是加机器，换模板就是换一批。',
+        'Machine 和 Node 是两个对象，这个区别要记牢。Machine 是「我要一台机器」，Node 是「这台机器上的 kubelet 报到了」。中间隔着装机时间，表现为三段：`Provisioning`（provider 在造）、`Provisioned`（Node 对象出现但 NotReady）、`Running`（kubelet 报到，调度器才看得见它）。`kubectl get machines` 里 NODENAME 那一列在第一段是空的。另外机器的规格写在 infra 模板上，不在 MachineDeployment 上，「我改了副本数为什么新机器还是老规格」的答案就在这个分层里。',
+        '`cluster-autoscaler` 做的事只有两件，而且都不看负载。扩容：看到**调度不上**的 Pod，问一句「加一台这种机器，它能落上去吗」，能就加，不能就一台都不加。所以一个请求 32 核的 Pod 在最大 8 核的池子里会永远 Pending 而机器数纹丝不动。这不是坏了，是它算出来加了也没用，理由写在 Pod 的 `NotTriggerScaleUp` 事件里。缩容：看到利用率低的节点，问一句「上面的 Pod 挪得走吗」。',
+        '它怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它**看都不看**，这是「伸缩器装了但不工作」最常见的原因。上限不是调优参数，它是闸：一个写错的副本数或者一段死循环的重试，能让机器一台台加到天亮。',
+        '缩容那一侧有三道门：利用率够低、闲得够久（默认十分钟）、上面的 Pod 挪得走。第三道最容易卡住，而且卡住的时候伸缩器是沉默的。能钉住一台机器的东西有：PDB 不允许再驱逐、Pod 没有属主（删了就不会被重建）、以及打了 `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` 的 Pod。最后这一条最阴：加的时候是为了保护某个关键任务，忘了摘，那台机器就永远还不回去了。',
+        '最后分清两件常被混着说成「自动扩容」的事：`HPA` 加的是**副本**，看的是指标；伸缩器加的是**机器**，看的是调度结果。顺序是 HPA 先加出一批调度不上的 Pod，伸缩器再为它们加机器。还要记住扩容有代价：装机要几分钟，这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。'
+      ),
+      p(
+        'Where machines come from is the first question at this layer. An intranet cluster has no cloud autoscaling group: machines are either installed by hand or declared through `Cluster API`. Its shape deliberately mirrors the workload API: `MachineDeployment` to Deployment, `MachineSet` to ReplicaSet, `Machine` to Pod. Changing a replica count adds machines; changing the template replaces a batch of them.',
+        'Machine and Node are two objects, and the difference matters. A Machine is "I want a machine"; a Node is "the kubelet on that machine has reported in". Between them sits provisioning time, visible as three phases: `Provisioning` (the provider is building it), `Provisioned` (the Node object exists but is NotReady), and `Running` (the kubelet reported and the scheduler can finally see it). The NODENAME column of `kubectl get machines` is empty during the first phase. Note also that machine size lives on the infra template, not on the MachineDeployment, which is the answer to "I changed the replica count, why are the new machines still the old size".',
+        '`cluster-autoscaler` does exactly two things, and neither of them looks at load. Scaling up: for pods that **cannot be scheduled**, it asks whether one more machine of this shape would fit them, and adds machines only if the answer is yes. A pod requesting 32 cores in a pool whose largest machine is 8 will therefore stay Pending forever while the machine count never moves. That is not a malfunction, it is the answer to the question, and the reason is recorded in a `NotTriggerScaleUp` event on the pod. Scaling down: for underutilised nodes, it asks whether the pods on them can move.',
+        'How does it know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is the usual reason an installed autoscaler does nothing. The maximum is not a tuning parameter but a brake: a wrong replica count or a retry loop can walk a group up machine by machine all night.',
+        'Scaling down has three gates: utilisation low enough, idle long enough (ten minutes by default), and the pods on the node able to move. The third is the one that jams, and the autoscaler is silent when it does. Things that pin a machine: a PDB that allows no further eviction, a pod with no controller (delete it and nothing recreates it), and any pod annotated `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"`. That last one is the sneakiest, added to protect something important and then forgotten, and the machine never goes back.',
+        'Finally, separate the two things routinely called autoscaling. `HPA` adds **replicas** based on metrics; the autoscaler adds **machines** based on scheduling outcomes. The order is that HPA produces pods that cannot be scheduled and the autoscaler then provides machines for them. And remember that scaling up costs time: provisioning takes minutes during which requests queue, so genuine burst traffic is absorbed by headroom you kept, not by the autoscaler.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5622,7 +5622,8 @@
           "kyverno",
           "external-secrets",
           "monitoring",
-          "velero"
+          "velero",
+          "capi-system"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5765,6 +5766,22 @@
             "pullMs": 700,
             "startupMs": 900,
             "readyAfterMs": 400
+          },
+          "registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300
+          },
+          "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0": {
+            "pullMs": 400,
+            "startupMs": 600,
+            "readyAfterMs": 300
+          },
+          "harbor.corp.internal/team/settlement:2.1": {
+            "pullMs": 300,
+            "startupMs": 500,
+            "readyAfterMs": 200,
+            "memoryUsage": "256Mi"
           },
           "harbor.corp.internal/team/ledgerdb:14.2": {
             "pullMs": 800,
@@ -13614,6 +13631,721 @@
         "primer": {
           "zh": "接手一个系统之后最该问的一句话不是「有没有备份」，是「上次从备份恢复是什么时候」。这两句差得很远：备份任务天天绿，不代表那个桶里的东西能把服务拉起来。这一关要做的就是把第二句变成真的。\n\nKubernetes 里的数据分两层，这一层的所有困惑都从这儿来。`PersistentVolumeClaim` 是一个**对象**，住在 apiserver 里；盘上的字节不在 apiserver 里，它们在存储后端上。所以把 apiserver 里的对象全导出来，得到的是一份完整的 YAML 和**零字节数据**。恢复出来是一个一模一样的空盘，而 `kubectl get pvc` 看不出空盘和满盘的区别。\n\n要把字节也带上，得靠 `CSI 卷快照`。三个对象：`VolumeSnapshotClass` 说谁来拍、拍完怎么处置，`VolumeSnapshot` 是应用侧的一次请求，`VolumeSnapshotContent` 是存储上真正那张。快照是`时间点`：拍完之后往盘里再写什么都跟它无关。另外要留意拍快照的是 `snapshot-controller` 这个工作负载，它和 CSI 驱动是两个东西，只装驱动的话 VolumeSnapshot 建得出来然后永远不就绪。\n\n`Velero` 把这两件事缝起来：它自己导出对象图放进桶里，卷数据则委托给 CSI 快照。缝的地方有一个标签：`velero.io/csi-volumesnapshot-class: \"true\"`。没有任何快照类打这个标签时，Velero **不报错**，备份照样 `Completed`，只是 warnings 加一，卷数据一个字节都没进去。所以判断一次备份好不好，要看的是 `volumeSnapshotsCompleted` 而不是 `phase`。\n\n恢复这一侧有一条默认行为要记住：Velero **跳过**已经存在的对象。所以往原地恢复的结果通常是「跑完了，phase 是 PartiallyFailed，集群一点没变」，很容易被读成「恢复成功，只是有点小问题」。演练要用 `--namespace-mappings` 恢复到一个新命名空间，进去读一行真数据出来对一下，再把它删掉。\n\n最后是灾难本身。`kubectl delete namespace` 不只是删掉一堆对象，它会一起带走 PVC；回收策略是 `Delete` 的话，盘和盘上的字节跟着消失，apiserver 里再也查不到它存在过。一条命令、一个词的差别，带走的是整个环境，这也正是备份存在的理由。",
           "en": "The first question to ask about a system you have just inherited is not whether it has backups, it is when somebody last restored from one. Those are far apart: a backup job going green every day says nothing about whether the contents of that bucket can bring the service back. This stage is about making the second sentence true.\n\nData in Kubernetes lives on two levels, and every confusion here comes from that split. A `PersistentVolumeClaim` is an **object** in the apiserver; the bytes on the volume are not, they live on the storage backend. So exporting every object from the apiserver gives you a complete set of YAML and **zero bytes of data**. What comes back is an identical empty disk, and `kubectl get pvc` shows no difference between an empty one and a full one.\n\nCarrying the bytes as well takes `CSI volume snapshots`. Three objects: a `VolumeSnapshotClass` says who takes them and what happens afterwards, a `VolumeSnapshot` is the request from the application side, and a `VolumeSnapshotContent` is the real snapshot on the storage system. A snapshot is a `point in time`: whatever is written to the volume afterwards is not in it. Note also that snapshots are taken by the `snapshot-controller` workload, which is separate from the CSI driver: install only the driver and a VolumeSnapshot will be created and then never become ready.\n\n`Velero` stitches the two together: it exports the object graph into the bucket itself and delegates volume data to CSI snapshots. The seam is a label, `velero.io/csi-volumesnapshot-class: \"true\"`. When no snapshot class carries it, Velero does **not** fail. The backup still reports `Completed`, just with one more warning, and not a byte of volume data goes in. So the health of a backup is read from `volumeSnapshotsCompleted`, not from `phase`.\n\nOn the restore side there is one default worth memorising: Velero **skips** resources that already exist. Restoring in place therefore usually means \"it ran, phase is PartiallyFailed, and nothing in the cluster changed\", which reads a lot like \"restored, with minor issues\". Drill with `--namespace-mappings` into a fresh namespace, read a row of real data out of it, and delete it afterwards.\n\nFinally the disaster itself. `kubectl delete namespace` does not just remove a pile of objects, it takes the PVCs with it; with a `Delete` reclaim policy the volume and every byte on it go too, leaving no record in the apiserver that they ever existed. One command, one word of difference, and an entire environment is gone, which is the whole reason backups exist."
+        }
+      },
+      {
+        "id": "elastic-capacity",
+        "title": {
+          "zh": "让机器按需出现，也按需消失",
+          "en": "Capacity That Comes and Goes"
+        },
+        "goal": {
+          "zh": "月末结算今天要跑。六个分片，每个要 3 核；集群里手工装的那三台各 4 核，\n装不下。运维的做法一直是提前一天手工加机器，跑完再手工删掉 ——\n有一次忘了删，多花了两个月的钱。\n\n集群里已经有 Cluster API 和 cluster-autoscaler，机器组 `workers` 也建好了，\n但从来没生效过：伸缩器**看都不看**它。\n\n还有一件事：那个协调器 `settlement-reconciler` 一直 Pending，\n而伸缩器一台机器都不给它加。先搞清楚为什么，再让它跑起来。\n\n## 通关标准\n\n1. 机器组 `workers` 归伸缩器管，而且有上限（无上限的弹性是账单事故）；\n2. 结算的六个分片全部 Running，扩出来的机器是 Cluster API 造的；\n3. 协调器也跑起来了；\n4. 活干完之后机器要还回去 —— 判定会删掉结算负载并等一段时间，\n   机器组要缩回下限。\n\n## 会用到的命令\n\n```bash\nkubectl get machinedeployment,machine -n capi-system\nkubectl get nodes\nkubectl describe pod -n payments <pod>\nkubectl annotate machinedeployment workers -n capi-system <key>=<value>\nkubectl set resources deployment <name> -n payments --requests=cpu=<n>\n```\n",
+          "en": "Month-end settlement runs today. Six shards, three cores each; the three\nhand-installed nodes have four cores apiece and cannot take them. Ops has always\nadded machines by hand the day before and removed them afterwards, except for the\ntime somebody forgot and the bill ran for two extra months.\n\nThe cluster already has Cluster API and cluster-autoscaler, and the `workers`\nnode group exists, but it has never done anything: the autoscaler does not even\nlook at it.\n\nThere is one more thing. The `settlement-reconciler` pod stays Pending and the\nautoscaler adds nothing for it. Work out why before you make it run.\n\n## Done when\n\n1. the `workers` group is managed by the autoscaler and has an upper bound\n   (elasticity without a ceiling is a billing incident);\n2. all six settlement shards are Running on machines created by Cluster API;\n3. the reconciler runs too;\n4. the capacity goes away afterwards: the grader deletes the settlement workloads,\n   waits, and expects the group back at its lower bound.\n\n## Commands you will need\n\n```bash\nkubectl get machinedeployment,machine -n capi-system\nkubectl get nodes\nkubectl describe pod -n payments <pod>\nkubectl annotate machinedeployment workers -n capi-system <key>=<value>\nkubectl set resources deployment <name> -n payments --requests=cpu=<n>\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "机器组归伸缩器管",
+            "en": "The node group is managed"
+          },
+          {
+            "zh": "结算跑得完",
+            "en": "Settlement completes"
+          },
+          {
+            "zh": "机器会还回去",
+            "en": "Capacity is returned"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "伸缩器怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它看都不看 —— 这就是「装了但不工作」。",
+            "en": "How does the autoscaler know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is exactly what \"installed but does nothing\" looks like."
+          },
+          {
+            "zh": "协调器的问题不在伸缩器上。伸缩器每次都会问一句「加一台这种机器，这个 Pod 能落上去吗」—— 请求 32 核而池子里最大的机器是 8 核，答案是不能，所以它一台都不加。`kubectl describe pod` 里那条 NotTriggerScaleUp 事件写着原因。",
+            "en": "The reconciler problem is not in the autoscaler. It asks one question every time: would this pod fit on a new machine of this shape? Requesting 32 cores when the biggest machine is 8 means no, so it adds nothing. The reason is in the NotTriggerScaleUp event on the pod."
+          },
+          {
+            "zh": "缩容不是立刻发生的。一台机器要「闲得够久」才会被回收（默认十分钟），这是为了避免抖一下就还机器、下一批活来了又得等装机。判定会自己把时间推过去。",
+            "en": "Scale-down is not immediate. A machine must be idle for long enough (ten minutes by default) before it is reclaimed, so that a brief lull does not cost you a full provisioning wait when the next batch arrives. The grader advances time for you."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "以为伸缩器会看「CPU 使用率」。它不看负载，只看**调度器的结论**：有 Pod 调度不上就加机器，没有就不加。CPU 用满而 Pod 都调度得上，它一台都不会加 —— 那是 HPA 的活。",
+            "en": "Expecting the autoscaler to watch CPU usage. It does not look at load at all, only at the scheduler verdict: pods that cannot be scheduled mean add machines, nothing else does. A cluster pegged at 100% CPU with everything scheduled gets no new machines, because that is HPA territory."
+          },
+          {
+            "zh": "上限设成一个很大的数「以防万一」。一个写错的副本数或者一段死循环的重试，能在一夜之间把机器开到上限 —— 上限就是这类事故的最后一道闸。",
+            "en": "Setting the maximum to something huge \"just in case\". A wrong replica count or a retry loop can run the group to the ceiling overnight, and the ceiling is the last thing standing between that and the invoice."
+          },
+          {
+            "zh": "给关键负载加 `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"`，然后忘了。这个注解会把它所在的整台机器**永远**钉住，缩容再也发生不了。「为什么半夜三点还有十台空机器」十次有八次是它。",
+            "en": "Annotating something important with `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"` and forgetting. That annotation pins the entire machine it lands on, permanently, and scale-down never happens again. It is the usual answer to \"why are ten empty machines still running at 3am\"."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "capi-controller-manager",
+                "namespace": "capi-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cluster-api"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cluster-api"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cluster-api"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "manager",
+                        "image": "registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cluster-autoscaler",
+                "namespace": "capi-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cluster-autoscaler"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cluster-autoscaler"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cluster-autoscaler"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "autoscaler",
+                        "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+              "kind": "VSphereMachineTemplate",
+              "metadata": {
+                "name": "worker-8c",
+                "namespace": "capi-system"
+              },
+              "spec": {
+                "template": {
+                  "spec": {
+                    "numCPUs": 8,
+                    "memoryMiB": 16384,
+                    "diskGiB": 120
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cluster.x-k8s.io/v1beta1",
+              "kind": "MachineDeployment",
+              "metadata": {
+                "name": "workers",
+                "namespace": "capi-system"
+              },
+              "spec": {
+                "clusterName": "corp",
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "pool": "workers"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "pool": "workers"
+                    }
+                  },
+                  "spec": {
+                    "clusterName": "corp",
+                    "version": "v1.36.0",
+                    "infrastructureRef": {
+                      "apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+                      "kind": "VSphereMachineTemplate",
+                      "name": "worker-8c"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "settlement",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 6,
+                "selector": {
+                  "matchLabels": {
+                    "app": "settlement"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "settlement"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "shard",
+                        "image": "harbor.corp.internal/team/settlement:2.1",
+                        "resources": {
+                          "requests": {
+                            "cpu": "3",
+                            "memory": "256Mi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "settlement-reconciler",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "settlement-reconciler"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "settlement-reconciler"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "reconciler",
+                        "image": "harbor.corp.internal/team/settlement:2.1",
+                        "resources": {
+                          "requests": {
+                            "cpu": "32",
+                            "memory": "256Mi"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "referenceCommands": [
+            "kubectl annotate machinedeployment workers -n capi-system cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size=1 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size=6",
+            "kubectl set resources deployment settlement-reconciler -n payments --requests=cpu=4"
+          ]
+        },
+        "specs": [
+          {
+            "path": "elastic-capacity.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst MIN = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size';\nconst MAX = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size';\nconst POOL = () => get('MachineDeployment', 'workers', 'capi-system');\n\nconst runningIn = (namespace, app) => list('Pod', { namespace })\n  .filter((pod) => (pod.metadata.labels || {}).app === app)\n  .filter((pod) => pod.status.phase === 'Running');\n\ndescribe('弹性', () => {\n  it('机器组归伸缩器管，而且有上限', () => {\n    const annotations = POOL().metadata.annotations || {};\n    const min = Number(annotations[MIN]);\n    const max = Number(annotations[MAX]);\n    expect(Number.isFinite(min)).toBe(true);\n    expect(Number.isFinite(max)).toBe(true);\n    expect(max).toBeGreaterThan(min);\n  });\n\n  it('结算的六个分片都跑起来了', () => {\n    expect(runningIn('payments', 'settlement').length).toBe(6);\n  });\n\n  it('多出来的机器是 Cluster API 造的，不是手工加的', () => {\n    const machines = list('Machine', { namespace: 'capi-system' });\n    expect(machines.length).toBeGreaterThan(1);\n\n    const nodeNames = machines\n      .map((machine) => (machine.status.nodeRef || {}).name)\n      .filter(Boolean);\n    const shards = runningIn('payments', 'settlement');\n    // 分片确实落在新机器上，而不是全挤在原来那三台上\n    expect(shards.some((pod) => nodeNames.includes(pod.spec.nodeName))).toBe(true);\n\n    const max = Number(POOL().metadata.annotations[MAX]);\n    expect(POOL().spec.replicas).toBeLessThanOrEqual(max);\n  });\n\n  it('那个要 32 核的协调器也跑起来了', () => {\n    expect(runningIn('payments', 'settlement-reconciler').length).toBe(1);\n  });\n\n  it('活干完了机器要还回去', async () => {\n    const peak = POOL().spec.replicas;\n    expect(peak).toBeGreaterThan(1);\n\n    await sh('kubectl delete deployment settlement settlement-reconciler -n payments');\n    await advance(60000);\n    // 刚闲下来不缩：抖一下就还机器，下一批活来了又得等装机\n    expect(POOL().spec.replicas).toBe(peak);\n\n    await advance(900000);\n    const min = Number(POOL().metadata.annotations[MIN]);\n    expect(POOL().spec.replicas).toBe(min);\n    expect(list('Machine', { namespace: 'capi-system' }).length).toBe(min);\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "resilience",
+          "operations"
+        ],
+        "extension": {
+          "zh": "弹性伸缩最容易被误解的一点是**它不看负载**。cluster-autoscaler 只认调度器的\n结论：有 Pod 调度不上就加机器，没有就不加。一个 CPU 跑满但所有 Pod 都调度\n得上的集群，它一台机器都不会加 —— 那是 HPA 的事。两个东西经常被混着说成\n「自动扩容」，但它们工作在完全不同的层：HPA 加的是副本，伸缩器加的是机器，\n而且伸缩器是被 HPA 加出来的那些 Pod 触发的。\n\n第二点是**扩容有代价而缩容有风险**。扩容的代价是时间：装机几分钟，\n这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。\n缩容的风险是打断：机器上的 Pod 要挪走，挪的过程中就是有一段服务能力\n的缺口 —— 这也是为什么缩容要等「闲够十分钟」，以及为什么 PDB 在这里\n同样管用。\n\n第三点是**上限就是闸**。弹性系统最贵的故障不是不扩容，是扩容失控：\n一个写错的副本数、一段死循环的重试、一个刷不出来的镜像导致 Pod 一直\nPending，都能让机器一台台加下去。上限不是「性能调优参数」，\n它和 ResourceQuota、LimitRange 一样，是防止一个错误变成一场事故的东西。\n",
+          "en": "The most misunderstood thing about the cluster autoscaler is that **it does not\nwatch load**. It reads one signal: the scheduler's verdict. Pods that cannot be\nscheduled mean add machines; anything else means do nothing. A cluster pegged at\n100% CPU with everything scheduled gets no new machines, because that is HPA\nterritory. The two are often lumped together as \"autoscaling\" while working at\ncompletely different layers: HPA adds replicas, the autoscaler adds machines, and\nit is the pods HPA created that trigger it.\n\nThe second thing is that **scaling up costs time and scaling down carries risk**.\nProvisioning takes minutes, and requests queue during those minutes, so real burst\ntraffic is absorbed by headroom you kept, not by the autoscaler. Scaling down\nmoves pods off a machine, and that movement is a real gap in capacity, which is\nwhy a node must be idle for ten minutes first and why PDBs matter here too.\n\nThe third is that **the ceiling is the brake**. The expensive failure in an elastic\nsystem is not failing to scale up, it is scaling without end: a wrong replica\ncount, a retry loop, an image that never pulls leaving pods Pending forever, each\none can walk the group up machine by machine. The maximum is not a tuning\nparameter. Like ResourceQuota and LimitRange, it is there so one mistake does not\nbecome an incident.\n"
+        },
+        "primer": {
+          "zh": "机器从哪儿来，是这一层的第一个问题。内网集群没有云厂商的弹性伸缩组，机器要么是人手装的，要么是 `Cluster API` 声明出来的。它的形状和工作负载那一套故意长得一样：`MachineDeployment` 对 Deployment，`MachineSet` 对 ReplicaSet，`Machine` 对 Pod。改副本数就是加机器，换模板就是换一批。\n\nMachine 和 Node 是两个对象，这个区别要记牢。Machine 是「我要一台机器」，Node 是「这台机器上的 kubelet 报到了」。中间隔着装机时间，表现为三段：`Provisioning`（provider 在造）、`Provisioned`（Node 对象出现但 NotReady）、`Running`（kubelet 报到，调度器才看得见它）。`kubectl get machines` 里 NODENAME 那一列在第一段是空的。另外机器的规格写在 infra 模板上，不在 MachineDeployment 上，「我改了副本数为什么新机器还是老规格」的答案就在这个分层里。\n\n`cluster-autoscaler` 做的事只有两件，而且都不看负载。扩容：看到**调度不上**的 Pod，问一句「加一台这种机器，它能落上去吗」，能就加，不能就一台都不加。所以一个请求 32 核的 Pod 在最大 8 核的池子里会永远 Pending 而机器数纹丝不动。这不是坏了，是它算出来加了也没用，理由写在 Pod 的 `NotTriggerScaleUp` 事件里。缩容：看到利用率低的节点，问一句「上面的 Pod 挪得走吗」。\n\n它怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它**看都不看**，这是「伸缩器装了但不工作」最常见的原因。上限不是调优参数，它是闸：一个写错的副本数或者一段死循环的重试，能让机器一台台加到天亮。\n\n缩容那一侧有三道门：利用率够低、闲得够久（默认十分钟）、上面的 Pod 挪得走。第三道最容易卡住，而且卡住的时候伸缩器是沉默的。能钉住一台机器的东西有：PDB 不允许再驱逐、Pod 没有属主（删了就不会被重建）、以及打了 `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"` 的 Pod。最后这一条最阴：加的时候是为了保护某个关键任务，忘了摘，那台机器就永远还不回去了。\n\n最后分清两件常被混着说成「自动扩容」的事：`HPA` 加的是**副本**，看的是指标；伸缩器加的是**机器**，看的是调度结果。顺序是 HPA 先加出一批调度不上的 Pod，伸缩器再为它们加机器。还要记住扩容有代价：装机要几分钟，这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。",
+          "en": "Where machines come from is the first question at this layer. An intranet cluster has no cloud autoscaling group: machines are either installed by hand or declared through `Cluster API`. Its shape deliberately mirrors the workload API: `MachineDeployment` to Deployment, `MachineSet` to ReplicaSet, `Machine` to Pod. Changing a replica count adds machines; changing the template replaces a batch of them.\n\nMachine and Node are two objects, and the difference matters. A Machine is \"I want a machine\"; a Node is \"the kubelet on that machine has reported in\". Between them sits provisioning time, visible as three phases: `Provisioning` (the provider is building it), `Provisioned` (the Node object exists but is NotReady), and `Running` (the kubelet reported and the scheduler can finally see it). The NODENAME column of `kubectl get machines` is empty during the first phase. Note also that machine size lives on the infra template, not on the MachineDeployment, which is the answer to \"I changed the replica count, why are the new machines still the old size\".\n\n`cluster-autoscaler` does exactly two things, and neither of them looks at load. Scaling up: for pods that **cannot be scheduled**, it asks whether one more machine of this shape would fit them, and adds machines only if the answer is yes. A pod requesting 32 cores in a pool whose largest machine is 8 will therefore stay Pending forever while the machine count never moves. That is not a malfunction, it is the answer to the question, and the reason is recorded in a `NotTriggerScaleUp` event on the pod. Scaling down: for underutilised nodes, it asks whether the pods on them can move.\n\nHow does it know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is the usual reason an installed autoscaler does nothing. The maximum is not a tuning parameter but a brake: a wrong replica count or a retry loop can walk a group up machine by machine all night.\n\nScaling down has three gates: utilisation low enough, idle long enough (ten minutes by default), and the pods on the node able to move. The third is the one that jams, and the autoscaler is silent when it does. Things that pin a machine: a PDB that allows no further eviction, a pod with no controller (delete it and nothing recreates it), and any pod annotated `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"`. That last one is the sneakiest, added to protect something important and then forgotten, and the machine never goes back.\n\nFinally, separate the two things routinely called autoscaling. `HPA` adds **replicas** based on metrics; the autoscaler adds **machines** based on scheduling outcomes. The order is that HPA produces pods that cannot be scheduled and the autoscaler then provides machines for them. And remember that scaling up costs time: provisioning takes minutes during which requests queue, so genuine burst traffic is absorbed by headroom you kept, not by the autoscaler."
         }
       }
     ]

--- a/src/lib/opslab/capi/autoscaler.ts
+++ b/src/lib/opslab/capi/autoscaler.ts
@@ -1,0 +1,397 @@
+/**
+ * cluster-autoscaler
+ *
+ * 它只做两件事，但两件都常被误解：
+ *
+ *   扩容：看到**调度不上**的 Pod，问一句「加一台这种机器，它能落上去吗」。
+ *         能，就加；不能，就什么都不做 —— 加了也白加。所以一个请求 32 核的
+ *         Pod 在最大 8 核的池子里会永远 Pending，而伸缩器一台机器都不会加。
+ *         这不是坏了，这是它算出来「加了也没用」。
+ *
+ *   缩容：看到**利用率低**的节点，问一句「上面的 Pod 挪得走吗」。
+ *         挪得走才缩。PDB、没有属主的 Pod、打了 safe-to-evict: "false" 的 Pod，
+ *         任何一个都能把一台机器永远钉在那儿。「为什么半夜三点还有十台空机器」
+ *         的答案通常就在这几条里。
+ *
+ * 还有一件事必须强调：**它管的是机器，不是副本**。它不会因为 CPU 高就给你
+ * 加 Pod（那是 HPA），也不认识「负载」这个概念 —— 它只认调度器的结论。
+ *
+ * 哪些机器归它管，靠 MachineDeployment 上的两个注解。没打注解的机器组
+ * 它**看都不看** —— 这是最常见的「伸缩器装了但不工作」。
+ */
+import type { KubeObject } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound,
+} from '../controllers/framework';
+import { DEPLOYMENTS, NODES, PODS } from '../controllers/resources';
+import { ignoreConflict, parseCpu } from '../controllers/workloads';
+import { PODDISRUPTIONBUDGETS, evictionVerdict } from '../disruption';
+import { MACHINEDEPLOYMENTS, MACHINES, MACHINE_DEPLOYMENT_LABEL } from './resources';
+
+export const MIN_SIZE_ANNOTATION = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size';
+export const MAX_SIZE_ANNOTATION = 'cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size';
+/** 打在 Machine 上：下一次缩容删这台 */
+export const DELETE_MACHINE_ANNOTATION = 'cluster.x-k8s.io/delete-machine';
+/** 打在 Pod 上：这台机器不许因为缩容被回收 */
+export const SAFE_TO_EVICT_ANNOTATION = 'cluster-autoscaler.kubernetes.io/safe-to-evict';
+
+export const AUTOSCALER_LABEL = { key: 'app.kubernetes.io/name', value: 'cluster-autoscaler' };
+
+/** 伸缩器多久看一眼。真 CA 默认 10 秒。 */
+export const SCAN_INTERVAL_MS = 10_000;
+/** 一台机器闲多久才回收。真 CA 默认 10 分钟。 */
+export const UNNEEDED_MS = 10 * 60_000;
+/** 利用率低于这个就算闲着 */
+export const UTILIZATION_THRESHOLD = 0.5;
+
+interface NodeGroup {
+  deployment: KubeObject;
+  min: number;
+  max: number;
+  cpu: number;
+  nodes: KubeObject[];
+}
+
+export class AutoscalerController extends Controller {
+  private machineDeployments: Informer;
+  private machines: Informer;
+  private nodes: Informer;
+  private pods: Informer;
+  private budgets: Informer;
+  private workloads: Informer;
+  private timer: number;
+  private stopped = false;
+  /** 节点第一次被判定为「闲着」的时刻 */
+  private unneededSince = new Map<string, number>();
+
+  constructor(context: ControllerContext) {
+    super(context, 'cluster-autoscaler');
+    this.machineDeployments = this.track(new Informer(this.registry, MACHINEDEPLOYMENTS));
+    this.machines = this.track(new Informer(this.registry, MACHINES));
+    this.nodes = this.track(new Informer(this.registry, NODES));
+    this.pods = this.track(new Informer(this.registry, PODS));
+    this.budgets = this.track(new Informer(this.registry, PODDISRUPTIONBUDGETS));
+    this.workloads = this.track(new Informer(this.registry, DEPLOYMENTS));
+
+    /**
+     * 伸缩器是**轮询**的，不是事件驱动的。
+     *
+     * 这一点有实际后果：从「Pod 变成 Pending」到「机器开始造」之间，
+     * 最坏要等一整个扫描周期。加上装机时间，学员看到的那段空白是真的。
+     */
+    this.timer = this.kernel.setInterval(() => { void this.scan(); }, SCAN_INTERVAL_MS, {
+      background: true,
+      label: 'cluster-autoscaler:scan',
+    });
+
+    /**
+     * 除了定时扫，Pod 一旦被判定为调度不上也立刻看一眼。
+     *
+     * 真 CA 只有定时那一路，两者的差别只是延迟。这里加这一路是因为
+     * 这个世界的时间是被命令推着走的：不加的话，学员敲完 annotate 之后
+     * 什么都不会发生，得再敲十条无关命令把时钟推过去 —— 那不是在教弹性，
+     * 是在教怎么等。缩容仍然只走定时那一路，因为它本来就该等够时间。
+     */
+    this.pods.onChange((_key, pod) => {
+      if (!pod) return;
+      const status = (pod.status ?? {}) as any;
+      if (status.phase !== 'Pending') return;
+      const unschedulable = (status.conditions ?? []).some(
+        (condition: any) => condition.type === 'PodScheduled' && condition.reason === 'Unschedulable'
+      );
+      if (unschedulable) this.enqueue('scale-up');
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.kernel.clearTimer(this.timer);
+    super.stop();
+  }
+
+  /** 定时那一路在 scan 里；这一路只管「有 Pod 调度不上」这一件事 */
+  protected async reconcile(key: string): Promise<void> {
+    if (key !== 'scale-up' || this.stopped || !this.installed()) return;
+    const groups = this.groups();
+    if (groups.length > 0) await this.scaleUp(groups);
+  }
+
+  private installed(): boolean {
+    return this.workloads.list().some((deployment) => {
+      if (deployment.metadata.labels?.[AUTOSCALER_LABEL.key] !== AUTOSCALER_LABEL.value) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  async scan(): Promise<void> {
+    if (this.stopped || !this.installed()) return;
+    const groups = this.groups();
+    if (groups.length === 0) return;
+    // 先扩后缩：一次扫描里两件事都做的话，刚加的机器不该马上被判定为闲着
+    if (await this.scaleUp(groups)) return;
+    await this.scaleDown(groups);
+  }
+
+  /**
+   * 哪些机器组归它管。
+   *
+   * 没打 min/max 注解的 MachineDeployment 不在名单里 —— 伸缩器**看都不看**。
+   * 「装了但不工作」十次有九次是这个。
+   */
+  private groups(): NodeGroup[] {
+    const out: NodeGroup[] = [];
+    for (const deployment of this.machineDeployments.list()) {
+      const annotations = deployment.metadata.annotations ?? {};
+      const min = Number(annotations[MIN_SIZE_ANNOTATION]);
+      const max = Number(annotations[MAX_SIZE_ANNOTATION]);
+      if (!Number.isFinite(min) || !Number.isFinite(max)) continue;
+
+      const machines = this.machines.list().filter(
+        (machine) => machine.metadata.namespace === deployment.metadata.namespace
+          && machine.metadata.labels?.[MACHINE_DEPLOYMENT_LABEL] === deployment.metadata.name
+      );
+      const nodeNames = new Set(machines
+        .map((machine) => ((machine.status ?? {}) as any)?.nodeRef?.name)
+        .filter(Boolean) as string[]);
+      const nodes = this.nodes.list().filter((node) => nodeNames.has(node.metadata.name!));
+      out.push({ deployment, min, max, cpu: this.groupCpu(nodes), nodes });
+    }
+    return out;
+  }
+
+  /**
+   * 这个组的机器有多大。
+   *
+   * 现有机器上量出来的。一台都没有时（组缩到 0）伸缩器就不知道该组机器
+   * 多大了 —— 真 CA 也一样，从零扩容要另外在注解里声明容量。
+   */
+  private groupCpu(nodes: KubeObject[]): number {
+    const values = nodes.map((node) => parseCpu(((node.status ?? {}) as any)?.allocatable?.cpu));
+    return values.length > 0 ? Math.max(...values) : 0;
+  }
+
+  private unschedulable(): KubeObject[] {
+    return this.pods.list().filter((pod) => {
+      if ((pod.spec as any)?.nodeName) return false;
+      if (pod.metadata.deletionTimestamp) return false;
+      const status = (pod.status ?? {}) as any;
+      if (status.phase !== 'Pending') return false;
+      return (status.conditions ?? []).some(
+        (condition: any) => condition.type === 'PodScheduled' && condition.reason === 'Unschedulable'
+      );
+    });
+  }
+
+  private requestedCpu(pod: KubeObject): number {
+    const containers: any[] = (pod.spec as any)?.containers ?? [];
+    return containers.reduce((sum, c) => sum + parseCpu(c.resources?.requests?.cpu ?? '0'), 0);
+  }
+
+  /**
+   * 扩容。
+   *
+   * 先把装不下的 Pod 按「一台新机器能装多少」摞一摞，算出还差几台。
+   * 装不进任何一台新机器的 Pod 直接被排除在外，并且记一条事件 ——
+   * 这是伸缩器唯一会说话的时候，而绝大多数人从来没去看过这条事件。
+   */
+  private async scaleUp(groups: NodeGroup[]): Promise<boolean> {
+    const pending = this.unschedulable();
+    if (pending.length === 0) return false;
+    let scaled = false;
+
+    for (const group of groups) {
+      if (group.cpu <= 0) continue;
+      const current = (group.deployment.spec as any)?.replicas ?? 0;
+      if (current >= group.max) {
+        for (const pod of pending) {
+          this.context.recordEvent({
+            object: pod, type: 'Normal', reason: 'NotTriggerScaleUp',
+            message: `pod didn't trigger scale-up: 1 max node group size reached`,
+          });
+        }
+        continue;
+      }
+
+      // 摞箱子：每台新机器能装多少个装得下的 Pod
+      const fits = pending.filter((pod) => this.requestedCpu(pod) <= group.cpu);
+      for (const pod of pending) {
+        if (fits.includes(pod)) continue;
+        this.context.recordEvent({
+          object: pod, type: 'Normal', reason: 'NotTriggerScaleUp',
+          message: `pod didn't trigger scale-up: 1 Insufficient cpu`,
+        });
+      }
+      if (fits.length === 0) continue;
+
+      let needed = 0;
+      let room = 0;
+      for (const pod of [...fits].sort((a, b) => this.requestedCpu(b) - this.requestedCpu(a))) {
+        const cost = this.requestedCpu(pod);
+        if (cost > room) { needed += 1; room = group.cpu; }
+        room -= cost;
+      }
+
+      /**
+       * 已经在路上的机器要算数。
+       *
+       * 装机要好几分钟，这期间 Pod 一直是 Pending。不把在造的那些算进来的话，
+       * 每一轮扫描都会再加一批 —— 等机器全起来，多出来一堆空机器，
+       * 然后又被缩容一台台还回去。真 CA 把这些叫 upcoming nodes。
+       */
+      const ready = group.nodes.filter((node) => (((node.status ?? {}) as any).conditions ?? [])
+        .some((condition: any) => condition.type === 'Ready' && condition.status === 'True')).length;
+      const upcoming = Math.max(0, current - ready);
+      const next = Math.min(group.max, current + Math.max(0, needed - upcoming));
+      if (next === current) continue;
+
+      await this.setReplicas(group.deployment, next);
+      for (const pod of fits) {
+        this.context.recordEvent({
+          object: pod, type: 'Normal', reason: 'TriggeredScaleUp',
+          message: `pod triggered scale-up: [{${group.deployment.metadata.name} ${current}->${next}}]`,
+        });
+      }
+      scaled = true;
+      // 刚加的机器还没起来，别让它马上被判定为闲着
+      this.unneededSince.clear();
+    }
+    return scaled;
+  }
+
+  /**
+   * 缩容。
+   *
+   * 三道门：利用率够低、闲得够久、上面的 Pod 挪得走。
+   * 第三道最容易卡住 —— 而卡住的时候伸缩器是**沉默**的，
+   * 只有它自己的日志里有一行。所以这里把原因记成事件，让它说得出话。
+   */
+  private async scaleDown(groups: NodeGroup[]): Promise<void> {
+    const now = this.context.now();
+    for (const group of groups) {
+      const current = (group.deployment.spec as any)?.replicas ?? 0;
+      if (current <= group.min) continue;
+
+      /**
+       * 先看最闲的那台。
+       *
+       * 一样闲的时候挑**后加的**：老机器上跑的东西更可能是已经稳定的，
+       * 而且刚扩出来的那批本来就是为这一阵活加的。
+       */
+      const candidates = [...group.nodes].sort((a, b) => {
+        const diff = this.utilization(a) - this.utilization(b);
+        if (diff !== 0) return diff;
+        return a.metadata.creationTimestamp! < b.metadata.creationTimestamp! ? 1 : -1;
+      });
+
+      for (const node of candidates) {
+        const name = node.metadata.name!;
+        const pods = this.podsOn(name);
+        const utilization = this.utilization(node);
+        if (utilization >= UTILIZATION_THRESHOLD) {
+          this.unneededSince.delete(name);
+          continue;
+        }
+
+        const blocker = this.blocker(pods);
+        if (blocker) {
+          this.unneededSince.delete(name);
+          this.context.recordEvent({
+            object: node, type: 'Normal', reason: 'ScaleDownBlocked', message: blocker,
+          });
+          continue;
+        }
+
+        const since = this.unneededSince.get(name) ?? now;
+        this.unneededSince.set(name, since);
+        if (now - since < UNNEEDED_MS) continue;
+
+        await this.remove(group, name);
+        this.unneededSince.delete(name);
+        return;
+      }
+    }
+  }
+
+  /** 这台机器上的请求量占了多少 */
+  private utilization(node: KubeObject): number {
+    const allocatable = parseCpu(((node.status ?? {}) as any)?.allocatable?.cpu);
+    if (allocatable <= 0) return 1;
+    const used = this.podsOn(node.metadata.name!)
+      .reduce((sum, pod) => sum + this.requestedCpu(pod), 0);
+    return used / allocatable;
+  }
+
+  private podsOn(nodeName: string): KubeObject[] {
+    return this.pods.list().filter(
+      (pod) => (pod.spec as any)?.nodeName === nodeName && !pod.metadata.deletionTimestamp
+    );
+  }
+
+  /** 有没有东西钉住这台机器。返回一句人话，没有就是 undefined。 */
+  private blocker(pods: KubeObject[]): string | undefined {
+    const budgets = this.budgets.list();
+    for (const pod of pods) {
+      if (pod.metadata.annotations?.[SAFE_TO_EVICT_ANNOTATION] === 'false') {
+        return `cannot scale down: pod ${pod.metadata.namespace}/${pod.metadata.name} `
+          + 'has cluster-autoscaler.kubernetes.io/safe-to-evict: "false"';
+      }
+      // DaemonSet 的 Pod 不算 —— 它本来就跟着机器走
+      const owners = pod.metadata.ownerReferences ?? [];
+      if (owners.some((ref) => ref.kind === 'DaemonSet')) continue;
+      if (owners.length === 0) {
+        return `cannot scale down: pod ${pod.metadata.namespace}/${pod.metadata.name} `
+          + 'is not backed by a controller and would not be recreated';
+      }
+      const inNamespace = this.pods.list().filter(
+        (other) => other.metadata.namespace === pod.metadata.namespace
+      );
+      const verdict = evictionVerdict(pod, budgets, inNamespace);
+      if (!verdict.allowed) {
+        return `cannot scale down: ${verdict.message}`;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * 指定删哪一台。
+   *
+   * 真 CA 的做法是在 Machine 上打一个 `delete-machine` 注解，再把副本数减一 ——
+   * 不然减副本数只是「少一台」，具体少哪一台由 MachineSet 决定，
+   * 很可能不是它算好的那台。
+   */
+  private async remove(group: NodeGroup, nodeName: string): Promise<void> {
+    const machine = this.machines.list().find(
+      (item) => ((item.status ?? {}) as any)?.nodeRef?.name === nodeName
+    );
+    if (machine) {
+      await ignoreConflict(() => {
+        const latest = this.registry.get(MACHINES, machine.metadata.namespace, machine.metadata.name!);
+        this.registry.update(MACHINES, latest.metadata.namespace, latest.metadata.name!, {
+          ...latest,
+          metadata: {
+            ...latest.metadata,
+            annotations: { ...(latest.metadata.annotations ?? {}), [DELETE_MACHINE_ANNOTATION]: '' },
+          },
+        });
+      });
+    }
+    const current = (group.deployment.spec as any)?.replicas ?? 0;
+    await this.setReplicas(group.deployment, Math.max(group.min, current - 1));
+  }
+
+  private async setReplicas(deployment: KubeObject, replicas: number): Promise<void> {
+    await ignoreConflict(() => {
+      let latest: KubeObject;
+      try {
+        latest = this.registry.get(MACHINEDEPLOYMENTS, deployment.metadata.namespace, deployment.metadata.name!);
+      } catch (error) {
+        if (isNotFound(error)) return;
+        throw error;
+      }
+      this.registry.update(MACHINEDEPLOYMENTS, latest.metadata.namespace, latest.metadata.name!, {
+        ...latest, spec: { ...((latest.spec ?? {}) as any), replicas },
+      });
+    });
+  }
+}

--- a/src/lib/opslab/capi/controller.ts
+++ b/src/lib/opslab/capi/controller.ts
@@ -216,10 +216,23 @@ export class MachineSetController extends Controller {
     for (let index = owned.length; index < desired; index += 1) {
       this.createMachine(set, index);
     }
-    // 缩容删最新的那台
+    /**
+     * 缩容删哪一台。
+     *
+     * 先删打了 `delete-machine` 注解的 —— 伸缩器算好了要回收哪一台，
+     * 光减副本数的话具体少哪台由这里说了算，很可能不是它挑的那台。
+     * 剩下的按「最新的先删」：老机器上跑的东西更可能是已经稳定的。
+     */
     const extra = owned
       .slice()
-      .sort((a, b) => (a.metadata.creationTimestamp! < b.metadata.creationTimestamp! ? 1 : -1))
+      .sort((a, b) => {
+        const marked = (item: KubeObject) => (
+          item.metadata.annotations?.['cluster.x-k8s.io/delete-machine'] !== undefined ? 0 : 1
+        );
+        const byMark = marked(a) - marked(b);
+        if (byMark !== 0) return byMark;
+        return a.metadata.creationTimestamp! < b.metadata.creationTimestamp! ? 1 : -1;
+      })
       .slice(0, Math.max(0, owned.length - desired));
     for (const machine of extra) {
       try {

--- a/src/lib/opslab/capi/index.ts
+++ b/src/lib/opslab/capi/index.ts
@@ -13,3 +13,8 @@ export {
   PROVISION_MS, BOOTSTRAP_MS,
 } from './controller';
 export type { CapiOptions } from './controller';
+export {
+  AutoscalerController, AUTOSCALER_LABEL, MIN_SIZE_ANNOTATION, MAX_SIZE_ANNOTATION,
+  DELETE_MACHINE_ANNOTATION, SAFE_TO_EVICT_ANNOTATION,
+  SCAN_INTERVAL_MS, UNNEEDED_MS, UTILIZATION_THRESHOLD,
+} from './autoscaler';

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -42,12 +42,14 @@ import {
   BackupStore, SNAPSHOT_RESOURCES, SnapshotController, VELERO_RESOURCES, VeleroController,
 } from '../backup';
 import {
-  CAPI_RESOURCES, MachineController, MachineDeploymentController, MachineSetController,
+  AutoscalerController, CAPI_RESOURCES, MachineController, MachineDeploymentController,
+  MachineSetController,
 } from '../capi';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
   EndpointsController,
+  GarbageCollector,
   NamespaceController,
   ImageSpec,
   KubeletController,
@@ -647,6 +649,8 @@ export class Cluster {
       new EndpointsController(context),
       // 删掉一个命名空间，里面的东西全部跟着没 —— 包括 PVC，也就包括数据
       new NamespaceController(context),
+      // 属主没了，附属品跟着没。`kubectl delete deployment` 靠的就是它。
+      new GarbageCollector(context),
       // PDB 的状态。`kubectl get pdb` 里 ALLOWED DISRUPTIONS 那一列就是它写的。
       new PdbController(context),
       /**
@@ -665,6 +669,8 @@ export class Cluster {
       new MachineDeploymentController(context),
       new MachineSetController(context),
       new MachineController(context),
+      // 弹性。它只认调度器的结论，不认「负载」——「CPU 高了加 Pod」是 HPA 的事。
+      new AutoscalerController(context),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发

--- a/src/lib/opslab/controllers/index.ts
+++ b/src/lib/opslab/controllers/index.ts
@@ -13,7 +13,8 @@ export {
   matchesSelector, templateHash,
 } from './resources';
 export {
-  DeploymentController, EndpointsController, KubeletController, NamespaceController,
+  DeploymentController, EndpointsController, GarbageCollector, KubeletController,
+  NamespaceController,
   NodePressureController,
   ReplicaSetController, SchedulerController, isPodReady, parseCpu, resolveCount,
 } from './workloads';

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -339,6 +339,16 @@ export class ReplicaSetController extends Controller {
         name: `${replicaSet.metadata.name}-${suffix}`,
         namespace: replicaSet.metadata.namespace,
         labels: { ...(template.metadata?.labels ?? {}) },
+        /**
+         * 注解也要带过来。
+         *
+         * 很多东西是靠 Pod 上的注解生效的：伸缩器的 safe-to-evict、
+         * 采集的 scrape 提示、注入的开关。模板上写了而 Pod 上没有，
+         * 现象是「我明明配了，但一点用都没有」。
+         */
+        ...(template.metadata?.annotations
+          ? { annotations: { ...template.metadata.annotations } }
+          : {}),
         ownerReferences: [{
           apiVersion: 'apps/v1', kind: 'ReplicaSet',
           name: replicaSet.metadata.name, uid: replicaSet.metadata.uid!,
@@ -1333,6 +1343,64 @@ export class NamespaceController extends Controller {
           // 属主先被删掉时，级联已经把它带走了
           if (!isNotFound(error)) throw error;
         }
+      }
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 垃圾回收                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 属主没了，附属品也要跟着没。
+ *
+ * `kubectl delete deployment x` 只删了一个对象 —— ReplicaSet 和 Pod 是靠
+ * **属主引用**被连带删掉的，干这件事的是 kube-controller-manager 里的
+ * garbage collector。没有它，删掉 Deployment 之后 Pod 还在跑，
+ * 而且再也没有人管它们。
+ *
+ * 只认 `controller: true` 那条引用：一个对象可以有多个属主，但「谁管它的
+ * 生命周期」只能有一个。这也是 `kubectl delete --cascade=orphan` 的作用点 ——
+ * 摘掉那条引用，附属品就变成没人管的孤儿，而不是被删掉。
+ */
+export class GarbageCollector extends Controller {
+  constructor(context: ControllerContext) {
+    super(context, 'garbage-collector');
+    for (const definition of context.scheme.list()) {
+      const informer = this.track(new Informer(this.registry, definition));
+      /**
+       * 只有删除才可能产生孤儿。每次变更都扫一遍的话，
+       * 一个几百对象的世界会把大部分时间花在这上面。
+       *
+       * 判断「这是一次删除」看的是缓存里还有没有它 —— 事件本身带的是
+       * 被删掉的那个对象，不是 undefined。
+       */
+      informer.onChange((key) => {
+        if (informer.get(key) === undefined) this.queue.add('sweep');
+      });
+    }
+  }
+
+  protected reconcile(key: string): void {
+    if (key !== 'sweep') return;
+    const alive = new Set<string>();
+    const all: Array<{ definition: ResourceDefinition; object: KubeObject }> = [];
+    for (const definition of this.context.scheme.list()) {
+      for (const object of this.registry.list(definition).items) {
+        if (object.metadata.uid) alive.add(object.metadata.uid);
+        all.push({ definition, object });
+      }
+    }
+
+    for (const { definition, object } of all) {
+      const owners = object.metadata.ownerReferences ?? [];
+      const orphaned = owners.some((ref) => ref.controller && ref.uid && !alive.has(ref.uid));
+      if (!orphaned) continue;
+      try {
+        this.registry.delete(definition, object.metadata.namespace, object.metadata.name!);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
       }
     }
   }

--- a/tests/opslab/autoscaler.test.ts
+++ b/tests/opslab/autoscaler.test.ts
@@ -1,0 +1,286 @@
+/**
+ * cluster-autoscaler
+ *
+ * 要钉住的四件，每一件都对应一种「伸缩器装了但没用」：
+ *   1. 没打 min/max 注解的机器组它看都不看
+ *   2. 它只认调度器的结论：装不进任何一台新机器的 Pod，它一台都不加
+ *   3. 缩容要等「闲得够久」，而且上面的 Pod 得挪得走
+ *   4. safe-to-evict: "false" / 没有属主的 Pod / PDB，任何一个都能钉住一台机器
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import {
+  BOOTSTRAP_MS, MAX_SIZE_ANNOTATION, MIN_SIZE_ANNOTATION, PROVISION_MS,
+  SAFE_TO_EVICT_ANNOTATION, UNNEEDED_MS,
+} from '../../src/lib/opslab/capi';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const CAPI_IMAGE = 'registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4';
+const CA_IMAGE = 'registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0';
+const APP_IMAGE = 'registry.corp.internal/batch:1.0';
+
+const MDS = { group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machinedeployments' } as const;
+const MACHINES = { group: 'cluster.x-k8s.io', version: 'v1beta1', resource: 'machines' } as const;
+const NODES = { group: '', version: 'v1', resource: 'nodes' } as const;
+const PODS = { group: '', version: 'v1', resource: 'pods' } as const;
+const DEPLOYMENTS = { group: 'apps', version: 'v1', resource: 'deployments' } as const;
+const EVENTS = { group: '', version: 'v1', resource: 'events' } as const;
+
+const platform = (name: string, image: string) => ({
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: { name, namespace: 'capi-system', labels: { 'app.kubernetes.io/name': name } },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': name } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': name } },
+      spec: { containers: [{ name: 'manager', image }] },
+    },
+  },
+});
+
+const TEMPLATE = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1', kind: 'VSphereMachineTemplate',
+  metadata: { name: 'worker', namespace: 'capi-system' },
+  spec: { template: { spec: { numCPUs: 8, memoryMiB: 16384 } } },
+};
+
+const machineDeployment = (annotations?: Record<string, string>) => ({
+  apiVersion: 'cluster.x-k8s.io/v1beta1', kind: 'MachineDeployment',
+  metadata: { name: 'workers', namespace: 'capi-system', ...(annotations ? { annotations } : {}) },
+  spec: {
+    clusterName: 'corp', replicas: 1,
+    selector: { matchLabels: { pool: 'workers' } },
+    template: {
+      metadata: { labels: { pool: 'workers' } },
+      spec: {
+        clusterName: 'corp', version: 'v1.36.0',
+        infrastructureRef: {
+          apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+          kind: 'VSphereMachineTemplate', name: 'worker',
+        },
+      },
+    },
+  },
+});
+
+const MANAGED = {
+  [MIN_SIZE_ANNOTATION]: '1',
+  [MAX_SIZE_ANNOTATION]: '4',
+};
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    // 控制面那台故意小：批处理放不上去，扩容才有意义
+    nodes: [{ name: 'cp-1', cpu: '2', memory: '4Gi' }],
+    namespaces: ['default', 'capi-system'],
+    images: {
+      [CAPI_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [CA_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      [APP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(annotations?: Record<string, string>) {
+  const world = await createOpsWorld({
+    world: spec([
+      platform('cluster-api', CAPI_IMAGE),
+      platform('cluster-autoscaler', CA_IMAGE),
+      TEMPLATE, machineDeployment(annotations),
+    ]),
+  });
+  await world.cluster.advanceBy(30_000);
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+const listOf = (w: World, definition: any, namespace?: string) =>
+  w.cluster.registry.list(w.cluster.scheme.mustGet(definition), namespace ? { namespace } : {}).items;
+const replicasOf = (w: World) =>
+  ((w.cluster.registry.get(w.cluster.scheme.mustGet(MDS), 'capi-system', 'workers').spec ?? {}) as any).replicas;
+const runningPods = (w: World) =>
+  listOf(w, PODS, 'default').filter((pod) => (pod.status as any).phase === 'Running');
+const messagesOn = (w: World, name: string) => listOf(w, EVENTS, 'default')
+  .filter((event) => (event as any).involvedObject?.name?.startsWith(name))
+  .map((event) => String((event as any).message));
+
+/** 一批要 cpu 的 Pod */
+function batch(w: World, name: string, replicas: number, cpu: string, extra: Record<string, unknown> = {}) {
+  w.cluster.registry.create(w.cluster.scheme.mustGet(DEPLOYMENTS), 'default', {
+    apiVersion: 'apps/v1', kind: 'Deployment',
+    metadata: { name, namespace: 'default' },
+    spec: {
+      replicas,
+      selector: { matchLabels: { app: name } },
+      template: {
+        metadata: { labels: { app: name }, ...(extra.podMetadata ?? {}) as object },
+        spec: {
+          containers: [{ name: 'app', image: APP_IMAGE, resources: { requests: { cpu } } }],
+        },
+      },
+    },
+  } as KubeObject);
+}
+
+/** 装机 + 一轮扫描 */
+const settleFleet = (w: World, extra = 0) =>
+  w.cluster.advanceBy(PROVISION_MS + BOOTSTRAP_MS + 30_000 + extra);
+
+describe('扩容', () => {
+  it('装不下就加机器，加到装得下为止', async () => {
+    const w = await build(MANAGED);
+    await settleFleet(w);
+    expect(listOf(w, NODES)).toHaveLength(2);
+
+    // 一台 8 核的机器装得下两个 3 核的 Pod，6 个要三台
+    batch(w, 'settlement', 6, '3');
+    await settleFleet(w);
+    await settleFleet(w);
+
+    expect(replicasOf(w)).toBe(3);
+    expect(runningPods(w)).toHaveLength(6);
+  });
+
+  /**
+   * 没打注解的机器组，伸缩器**看都不看**。
+   * 「伸缩器装了但不工作」十次有九次是这个。
+   */
+  it('没打 min/max 注解：一台都不加', async () => {
+    const w = await build();
+    await settleFleet(w);
+    batch(w, 'settlement', 6, '3');
+    await settleFleet(w);
+    await settleFleet(w);
+
+    expect(replicasOf(w)).toBe(1);
+    expect(runningPods(w).length).toBeLessThan(6);
+  });
+
+  /**
+   * 请求比一整台机器还大的 Pod：加了也白加，所以它一台都不加。
+   * 这不是坏了，是它算出来「加了没用」—— 而它会把这句话记成事件。
+   */
+  it('一台机器都装不下的 Pod：不加机器，但说得出为什么', async () => {
+    const w = await build(MANAGED);
+    await settleFleet(w);
+    batch(w, 'reconciler', 1, '32');
+    await settleFleet(w);
+    await settleFleet(w);
+
+    expect(replicasOf(w)).toBe(1);
+    expect(messagesOn(w, 'reconciler').join('\n')).toContain('Insufficient cpu');
+  });
+
+  it('加到上限就停，并且说得出是撞了上限', async () => {
+    const w = await build({ [MIN_SIZE_ANNOTATION]: '1', [MAX_SIZE_ANNOTATION]: '2' });
+    await settleFleet(w);
+    batch(w, 'settlement', 6, '3');
+    await settleFleet(w);
+    await settleFleet(w);
+
+    expect(replicasOf(w)).toBe(2);
+    expect(runningPods(w).length).toBeLessThan(6);
+    expect(messagesOn(w, 'settlement').join('\n')).toContain('max node group size reached');
+  });
+});
+
+describe('反应速度', () => {
+  /**
+   * Pod 一旦被判定为调度不上，伸缩器立刻就看 —— 不用等下一次定时扫描。
+   * 真 CA 只有定时那一路，差别只是延迟；这里两路都有，因为这个世界的
+   * 时间是被命令推着走的。
+   */
+  it('不用等定时扫描，Pod 挂在那儿就会触发扩容', async () => {
+    const w = await build(MANAGED);
+    await settleFleet(w);
+    batch(w, 'settlement', 4, '3');
+    // 只给刚够装机的时间，中间不留额外的扫描周期
+    await w.cluster.advanceBy(PROVISION_MS + BOOTSTRAP_MS + 2_000);
+    expect(replicasOf(w)).toBeGreaterThan(1);
+  });
+});
+
+describe('缩容', () => {
+  async function scaledUp() {
+    const w = await build(MANAGED);
+    await settleFleet(w);
+    batch(w, 'settlement', 4, '3');
+    await settleFleet(w);
+    await settleFleet(w);
+    expect(replicasOf(w)).toBeGreaterThan(1);
+    return w;
+  }
+
+  it('活干完了机器要还回去，但要闲够时间才还', async () => {
+    const w = await scaledUp();
+    const peak = replicasOf(w);
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(DEPLOYMENTS), 'default', 'settlement');
+    await w.cluster.advanceBy(60_000);
+    // 刚闲下来还不能缩 —— 抖一下就回收机器，下一批活来了又得等装机
+    expect(replicasOf(w)).toBe(peak);
+
+    await w.cluster.advanceBy(UNNEEDED_MS + 60_000);
+    await settleFleet(w);
+    expect(replicasOf(w)).toBe(1);
+    expect(listOf(w, MACHINES, 'capi-system')).toHaveLength(1);
+  });
+
+  /**
+   * safe-to-evict: "false" 能把一台机器永远钉在那儿。
+   * 「为什么半夜三点还有十台空机器」的答案通常就在这儿，
+   * 而伸缩器本身是沉默的 —— 所以这里让它把原因说出来。
+   */
+  /**
+   * safe-to-evict: "false" 能把一台机器永远钉在那儿。
+   *
+   * 这里把下限设成 0，好把「钉住」这件事单独拎出来：不然缩到下限就停了，
+   * 分不清是被钉住还是撞了下限。「为什么半夜三点还有十台空机器」的答案
+   * 通常就在这一条上，而伸缩器本身是沉默的 —— 所以要让它说得出话。
+   */
+  it('打了 safe-to-evict: "false" 的 Pod 钉住整台机器', async () => {
+    const w = await build({ [MIN_SIZE_ANNOTATION]: '0', [MAX_SIZE_ANNOTATION]: '4' });
+    await settleFleet(w);
+    batch(w, 'settlement', 4, '3');
+    await settleFleet(w);
+    await settleFleet(w);
+    expect(replicasOf(w)).toBeGreaterThan(1);
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(DEPLOYMENTS), 'default', 'settlement');
+    await w.cluster.advanceBy(60_000);
+    batch(w, 'pinned', 1, '100m', {
+      podMetadata: { annotations: { [SAFE_TO_EVICT_ANNOTATION]: 'false' } },
+    });
+    await settleFleet(w);
+    const pinnedNode = (listOf(w, PODS, 'default')[0].spec as any).nodeName;
+
+    await w.cluster.advanceBy(UNNEEDED_MS + 60_000);
+    await settleFleet(w);
+
+    // 下限是 0，空机器全还回去了，钉住的那台还在
+    expect(replicasOf(w)).toBe(1);
+    expect(listOf(w, NODES).map((node) => node.metadata.name)).toContain(pinnedNode);
+    const blocked = listOf(w, EVENTS)
+      .map((event) => String((event as any).message))
+      .filter((message) => message.includes('safe-to-evict'));
+    expect(blocked.length).toBeGreaterThan(0);
+  });
+
+  it('缩容还回去的是后加的那几台，不是随便少一台', async () => {
+    const w = await scaledUp();
+    const oldest = listOf(w, MACHINES, 'capi-system')
+      .slice()
+      .sort((a, b) => (a.metadata.creationTimestamp! < b.metadata.creationTimestamp! ? -1 : 1))[0];
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(DEPLOYMENTS), 'default', 'settlement');
+    await w.cluster.advanceBy(UNNEEDED_MS + 60_000);
+    await settleFleet(w);
+
+    const left = listOf(w, MACHINES, 'capi-system');
+    expect(left).toHaveLength(1);
+    expect(left[0].metadata.name).toBe(oldest.metadata.name);
+  });
+});


### PR DESCRIPTION
第 22 关 `elastic-capacity`：让机器按需出现，也按需消失。

## 关卡

月末结算六个分片、每个 3 核，手工装的三台各 4 核装不下。集群里 Cluster API
和 cluster-autoscaler 都有，机器组也建了，但从来没生效过 —— MachineDeployment
上没有 min/max 注解，伸缩器**看都不看**它。

另外那个协调器 `settlement-reconciler` 一直 Pending，而伸缩器一台机器都不给它加。

## 要纠正的认知：伸缩器不看负载

它只认调度器的结论：有 Pod 调度不上就加机器，没有就不加。所以请求 32 核的
协调器在最大 8 核的池子里会永远 Pending 而机器数纹丝不动 —— 加了也装不下，
它算出来「加了没用」。理由写在 Pod 的 `NotTriggerScaleUp` 事件里，
而绝大多数人从来没去看过这条事件。

（顺带：把机器模板改大也是这一关的合法解，探过，能过。）

## 照着真行为做的几处

- **归谁管靠注解**：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size`
  和 `...-max-size`。没打注解的组不在名单里，这是「装了但不工作」最常见的原因。
- **扩容要算在路上的机器**（upcoming nodes）。装机要几分钟，不算的话每轮扫描
  都再加一批，等机器全起来多出一堆空的，然后又一台台还回去。
- **缩容三道门**：利用率够低、闲得够久（默认十分钟）、上面的 Pod 挪得走。
  PDB、没有属主的 Pod、`safe-to-evict: "false"`，任何一个都能把一台机器永远钉住 ——
  而伸缩器卡住的时候是沉默的，所以这里把原因记成了事件。
- **缩容前在 Machine 上打 `delete-machine` 注解**再减副本数。光减副本数的话
  具体少哪台由 MachineSet 说了算，很可能不是伸缩器挑的那台。

## 顺带修的两个真 bug

1. **没有属主引用的垃圾回收**。`kubectl delete deployment x` 只删了一个对象，
   ReplicaSet 和 Pod 全留着继续跑 —— 干这件事的本该是 kube-controller-manager
   里的 garbage collector。补上了，只认 `controller: true` 那条引用。
2. **Pod 模板上的注解没传给 Pod**。safe-to-evict、采集提示、注入开关都靠它，
   现象是「我明明配了，但一点用都没有」。

## 验证

- 反向验证：参考解全绿 / 什么都不做要挂
- 近似答案探过：只打注解不修协调器、只修协调器不打注解，都挂在该挂的用例上
- 新增 `tests/opslab/autoscaler.test.ts` 8 条
- `npx jest`：51 个 suite、1625 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)