### PR TITLE
feat(opslab): CustomResourceDefinition

### DIFF
--- a/src/lib/opslab/apiserver/http.ts
+++ b/src/lib/opslab/apiserver/http.ts
@@ -12,7 +12,7 @@
 import { Registry } from './registry';
 import { Scheme, ResourceDefinition } from './scheme';
 import { ApiError, badRequest, forbidden, invalid, notFound, toStatus } from './errors';
-import { renderTable, wantsTable } from './tables';
+import { renderTable, wantsTable, type TablePrinter } from './tables';
 import type { KubeObject, PropagationPolicy, WatchEventOut } from './types';
 
 export interface ApiServerDeps {
@@ -45,6 +45,13 @@ export interface ApiServerDeps {
   authenticate?(token: string | undefined): UserInfo | undefined;
   /** 鉴权。不给就是不鉴权。 */
   authorize?(user: UserInfo, attributes: ResourceAttributes): { allowed: boolean; reason: string };
+  /**
+   * CRD 自带的表格列。
+   *
+   * 内置类型的列写死在 tables.ts 里，CRD 的列由学员在 CRD 上声明 ——
+   * `kubectl get sites` 打出来的东西是他们自己定的。
+   */
+  tablePrinter?(resource: string): TablePrinter | undefined;
 }
 import { openApiDocument, openApiRoot } from './openapi';
 import type { PatchType } from './patch';
@@ -190,6 +197,7 @@ export class ApiServer {
   private readonly authenticate?: ApiServerDeps['authenticate'];
   private readonly authorizeFn?: ApiServerDeps['authorize'];
   private readonly evict?: ApiServerDeps['evict'];
+  private readonly tablePrinter?: ApiServerDeps['tablePrinter'];
   /** 收到的请求，调试与测试用 */
   readonly requestLog: string[] = [];
 
@@ -202,6 +210,7 @@ export class ApiServer {
     this.authenticate = deps.authenticate;
     this.authorizeFn = deps.authorize;
     this.evict = deps.evict;
+    this.tablePrinter = deps.tablePrinter;
   }
 
   /**
@@ -542,7 +551,10 @@ export class ApiServer {
       return statusResponse(badRequest(`the server could not find the requested resource`));
     }
     if (wantsTable(accept)) {
-      return json(renderTable(definition.resource, [object], object.metadata.resourceVersion!, this.now()));
+      return json(renderTable(
+        definition.resource, [object], object.metadata.resourceVersion!, this.now(),
+        this.tablePrinter?.(definition.resource)
+      ));
     }
     return json(object);
   }
@@ -563,7 +575,10 @@ export class ApiServer {
     });
 
     if (wantsTable(accept)) {
-      return json(renderTable(definition.resource, list.items, list.metadata.resourceVersion, this.now()));
+      return json(renderTable(
+        definition.resource, list.items, list.metadata.resourceVersion, this.now(),
+        this.tablePrinter?.(definition.resource)
+      ));
     }
     return json(list);
   }

--- a/src/lib/opslab/apiserver/index.ts
+++ b/src/lib/opslab/apiserver/index.ts
@@ -17,7 +17,9 @@ export type { Defaulter, RegistryDeps, Validator } from './registry';
 export { Scheme, createScheme, storageKey, storagePrefix } from './scheme';
 export { ApiServer, createApiServer, parsePath } from './http';
 export type { ApiServerDeps } from './http';
-export { humanDuration, printerFor, renderTable, wantsTable, TABLE_PRINTERS } from './tables';
+export {
+  humanDuration, printerFor, printerFromColumns, renderTable, wantsTable, TABLE_PRINTERS,
+} from './tables';
 export type { Table, TableColumnDefinition, TablePrinter, TableRow } from './tables';
 export type { GVR, ResourceDefinition } from './scheme';
 export {

--- a/src/lib/opslab/apiserver/scheme.ts
+++ b/src/lib/opslab/apiserver/scheme.ts
@@ -58,6 +58,16 @@ export class Scheme {
     this.byKey.set(this.key(complete), complete);
   }
 
+  /**
+   * 注销一个类型。CRD 被删掉时用。
+   *
+   * 真集群里删 CRD 会连带删掉这个类型的**所有对象**，而且这一步不可逆 ——
+   * 删错一个 CRD 和删错一个命名空间是同一个量级的事故。
+   */
+  unregister(definition: { group: string; version: string; resource: string }): boolean {
+    return this.byKey.delete(this.key(definition as ResourceDefinition));
+  }
+
   registerAll(definitions: ResourceDefinition[]): void {
     for (const definition of definitions) this.register(definition);
   }

--- a/src/lib/opslab/apiserver/tables.ts
+++ b/src/lib/opslab/apiserver/tables.ts
@@ -641,9 +641,11 @@ export function renderTable(
   resource: string,
   objects: KubeObject[],
   resourceVersion: string,
-  nowEpochMs: number
+  nowEpochMs: number,
+  /** CRD 自带的列。给了就用它，不然退回内置那张表。 */
+  override?: TablePrinter
 ): Table {
-  const printer = printerFor(resource);
+  const printer = override ?? printerFor(resource);
   return {
     kind: 'Table',
     apiVersion: 'meta.k8s.io/v1',
@@ -663,6 +665,49 @@ export function renderTable(
       },
     })),
   };
+}
+
+/**
+ * 按 CRD 的 additionalPrinterColumns 造一个打印器。
+ *
+ * JSONPath 只支持最常见的那一种：`.spec.foo.bar`。真 CRD 里 99% 的列
+ * 就是这个形状，而支持完整 JSONPath 会把这一层变成另一个项目。
+ */
+export function printerFromColumns(
+  columns: Array<{ name: string; jsonPath?: string; type?: string; priority?: number; description?: string }>
+): TablePrinter {
+  const extra = columns.filter((column) => column.jsonPath !== '.metadata.creationTimestamp');
+  return {
+    columns: [
+      NAME_COLUMN,
+      ...extra.map((column) => col(
+        column.name,
+        column.description ?? '',
+        column.priority ?? 0,
+        (column.type as TableColumnDefinition['type']) ?? 'string'
+      )),
+      AGE_COLUMN,
+    ],
+    cells: (object, age) => [
+      object.metadata.name,
+      ...extra.map((column) => {
+        const value = readPath(object, column.jsonPath ?? '');
+        if (value === undefined || value === null) return '<none>';
+        return typeof value === 'object' ? JSON.stringify(value) : String(value);
+      }),
+      age,
+    ],
+  };
+}
+
+function readPath(object: unknown, jsonPath: string): unknown {
+  const parts = jsonPath.replace(/^\$?\.?/, '').split('.').filter(Boolean);
+  let cursor: unknown = object;
+  for (const part of parts) {
+    if (cursor === null || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
 }
 
 /** kubectl 想要表格吗 —— 看 Accept 里有没有 `as=Table` */

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -45,6 +45,7 @@ import {
   AutoscalerController, CAPI_RESOURCES, MachineController, MachineDeploymentController,
   MachineSetController,
 } from '../capi';
+import { CRD_RESOURCES, CrdController } from '../crd';
 import { CORE_RESOURCES, EVENTS, NAMESPACES, NODES } from './resources';
 import {
   DeploymentController,
@@ -166,6 +167,9 @@ export class Cluster {
    */
   readonly backups = new BackupStore();
 
+  /** CRD 自己声明的表格列。`kubectl get <自定义资源>` 打出来的东西由它决定。 */
+  private readonly crdPrinters = new Map<string, import('../apiserver').TablePrinter>();
+
   /** 监控。世界没配 metrics 就是 undefined。 */
   prometheus?: PrometheusController;
   /** 由外面装上（createOpsWorld 会接一个 Pod 里的 shell 进来） */
@@ -188,6 +192,7 @@ export class Cluster {
       ...MESH_RESOURCES, ...RBAC_RESOURCES, ...KYVERNO_RESOURCES, ...ESO_RESOURCES,
       ...OBSERVABILITY_RESOURCES, ...DISRUPTION_RESOURCES, ...ROLLOUT_RESOURCES,
       ...STORAGE_RESOURCES, ...SNAPSHOT_RESOURCES, ...VELERO_RESOURCES, ...CAPI_RESOURCES,
+      ...CRD_RESOURCES,
       ...(options.extraResources ?? []),
     ]);
     this.registry = new Registry({
@@ -198,6 +203,8 @@ export class Cluster {
     });
     this.apiServer = createApiServer({
       registry: this.registry, scheme: this.scheme, now,
+      // CRD 上声明的列。内置类型的列写死在 tables.ts 里，自定义类型的由 CRD 说了算。
+      tablePrinter: (resource) => this.crdPrinters.get(resource),
       ...(options.users
         ? {
             authenticate: (token) => {
@@ -671,6 +678,11 @@ export class Cluster {
       new MachineController(context),
       // 弹性。它只认调度器的结论，不认「负载」——「CPU 高了加 Pod」是 HPA 的事。
       new AutoscalerController(context),
+      /**
+       * CRD 的注册。真集群里这是 apiserver 的一部分（apiextensions-apiserver），
+       * 不是能被卸载的工作负载，所以它无条件跑。
+       */
+      new CrdController(context, { scheme: this.scheme, printers: this.crdPrinters }),
       // 入口：控制器自己是集群里的一个工作负载，卸载掉 Gateway 就不再被 program
       new GatewayController(context),
       // 内网 PKI：同样是集群里的一个工作负载，卸载掉就不再签发

--- a/src/lib/opslab/crd/controller.ts
+++ b/src/lib/opslab/crd/controller.ts
@@ -1,0 +1,139 @@
+/**
+ * CRD 的注册
+ *
+ * 真集群里这件事由 apiextensions-apiserver 做，它是 kube-apiserver 的一部分，
+ * 不是一个能被卸载的工作负载 —— 所以这个控制器无条件跑。
+ *
+ * 注册完要把 `Established` 条件写上。kubectl 在 apply 一个自定义资源之前会
+ * 看 discovery，而 discovery 里有没有它取决于注册有没有完成：
+ * 「CRD 和 CR 写在同一个 YAML 里，一次 apply 报 no matches for kind」
+ * 就是这半秒钟的时间差。
+ */
+import type { KubeObject, ResourceDefinition, Scheme, TablePrinter } from '../apiserver';
+import { printerFromColumns } from '../apiserver';
+import {
+  Controller, ControllerContext, Informer, isNotFound, splitKey,
+} from '../controllers/framework';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { CUSTOMRESOURCEDEFINITIONS } from './resources';
+
+export interface CrdOptions {
+  scheme: Scheme;
+  /** CRD 声明的列，交给 apiserver 打表格用 */
+  printers: Map<string, TablePrinter>;
+}
+
+/** 从 CRD 里读出一条类型定义。用 storage 那个版本 —— 存进去的就是它。 */
+export function definitionOf(crd: KubeObject): ResourceDefinition | undefined {
+  const spec = (crd.spec ?? {}) as any;
+  const versions: any[] = spec.versions ?? [];
+  const version = versions.find((item) => item.storage) ?? versions.find((item) => item.served) ?? versions[0];
+  if (!spec.group || !spec.names?.plural || !version?.name) return undefined;
+  return {
+    group: spec.group,
+    version: version.name,
+    resource: spec.names.plural,
+    singular: spec.names.singular ?? String(spec.names.kind ?? '').toLowerCase(),
+    kind: spec.names.kind,
+    namespaced: (spec.scope ?? 'Namespaced') === 'Namespaced',
+    shortNames: spec.names.shortNames ?? [],
+    categories: spec.names.categories ?? [],
+    subresources: [
+      ...(version.subresources?.status ? ['status'] : []),
+      ...(version.subresources?.scale ? ['scale'] : []),
+    ],
+  };
+}
+
+export class CrdController extends Controller {
+  private crds: Informer;
+  /** 注册过的类型，用来在 CRD 消失时注销 */
+  private registered = new Map<string, ResourceDefinition>();
+
+  constructor(context: ControllerContext, private readonly options: CrdOptions) {
+    super(context, 'apiextensions');
+    this.crds = new Informer(this.registry, CUSTOMRESOURCEDEFINITIONS);
+    this.watch(this.crds);
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    const { name } = splitKey(key);
+    let crd: KubeObject;
+    try {
+      crd = this.registry.get(CUSTOMRESOURCEDEFINITIONS, undefined, name);
+    } catch (error) {
+      if (isNotFound(error)) return this.retire(name);
+      throw error;
+    }
+
+    const definition = definitionOf(crd);
+    if (!definition) {
+      await ignoreConflict(() => {
+        updateStatusIfChanged(this.registry, CUSTOMRESOURCEDEFINITIONS, undefined, name, {
+          conditions: [{
+            type: 'NamesAccepted', status: 'False', reason: 'InvalidNames',
+            message: 'spec.group, spec.names.plural and a version are required',
+          }],
+        });
+      });
+      return;
+    }
+
+    this.options.scheme.register(definition);
+    this.registered.set(name, definition);
+
+    const spec = (crd.spec ?? {}) as any;
+    const versions: any[] = spec.versions ?? [];
+    const version = versions.find((item) => item.storage) ?? versions[0];
+    const columns = version?.additionalPrinterColumns ?? [];
+    if (columns.length > 0) {
+      this.options.printers.set(definition.resource, printerFromColumns(columns));
+    } else {
+      this.options.printers.delete(definition.resource);
+    }
+
+    await ignoreConflict(() => {
+      updateStatusIfChanged(this.registry, CUSTOMRESOURCEDEFINITIONS, undefined, name, {
+        acceptedNames: {
+          plural: definition.resource,
+          singular: definition.singular,
+          kind: definition.kind,
+          shortNames: definition.shortNames,
+          listKind: `${definition.kind}List`,
+        },
+        storedVersions: [definition.version],
+        conditions: [
+          {
+            type: 'NamesAccepted', status: 'True', reason: 'NoConflicts',
+            message: 'no conflicts found',
+          },
+          {
+            type: 'Established', status: 'True', reason: 'InitialNamesAccepted',
+            message: 'the initial names have been accepted',
+          },
+        ],
+      });
+    });
+  }
+
+  /**
+   * CRD 没了：这个类型的对象**全部**跟着没。
+   *
+   * 这一步真集群里也是这样，而且没有回收站。所以 `kubectl delete crd`
+   * 是那种应该先深呼吸再敲回车的命令。
+   */
+  private retire(name: string): void {
+    const definition = this.registered.get(name);
+    if (!definition) return;
+    this.registered.delete(name);
+    for (const object of this.registry.list(definition).items) {
+      try {
+        this.registry.delete(definition, object.metadata.namespace, object.metadata.name!);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+    this.options.printers.delete(definition.resource);
+    this.options.scheme.unregister(definition);
+  }
+}

--- a/src/lib/opslab/crd/index.ts
+++ b/src/lib/opslab/crd/index.ts
@@ -1,0 +1,10 @@
+/**
+ * 自定义资源
+ *
+ * CRD 让 apiserver 多认识一种类型；认识之后，存储、watch、RBAC、kubectl
+ * 全套白送。控制器只是这套设施的消费者 —— 这也是为什么「写一个 Operator」
+ * 的重点从来不是写 CRD，而是写那个 reconcile。
+ */
+export { CUSTOMRESOURCEDEFINITIONS, CRD_RESOURCES } from './resources';
+export { CrdController, definitionOf } from './controller';
+export type { CrdOptions } from './controller';

--- a/src/lib/opslab/crd/resources.ts
+++ b/src/lib/opslab/crd/resources.ts
@@ -1,0 +1,21 @@
+/**
+ * CustomResourceDefinition
+ *
+ * 一个 CRD 干的事只有一件：**让 apiserver 多认识一种类型**。
+ * 认识之后，这种类型就自动拥有全套东西 —— REST 端点、watch、RBAC 里的
+ * 资源名、`kubectl get` 能查、YAML 能 apply。这就是「Kubernetes 是一个
+ * 通用的声明式 API 服务器」这句话的具体含义：控制器只是消费者，
+ * 存储和分发是白送的。
+ *
+ * 反过来也要记住：**删 CRD 会连带删掉这个类型的所有对象**，
+ * 和删命名空间一个量级。
+ */
+import type { ResourceDefinition } from '../apiserver';
+
+export const CUSTOMRESOURCEDEFINITIONS: ResourceDefinition = {
+  group: 'apiextensions.k8s.io', version: 'v1', resource: 'customresourcedefinitions',
+  singular: 'customresourcedefinition', kind: 'CustomResourceDefinition', namespaced: false,
+  shortNames: ['crd', 'crds'], subresources: ['status'],
+};
+
+export const CRD_RESOURCES: ResourceDefinition[] = [CUSTOMRESOURCEDEFINITIONS];

--- a/tests/opslab/crd.test.ts
+++ b/tests/opslab/crd.test.ts
@@ -1,0 +1,148 @@
+/**
+ * CustomResourceDefinition
+ *
+ * 一个 CRD 干的事只有一件：让 apiserver 多认识一种类型。认识之后，
+ * 存储、watch、`kubectl get`、YAML apply 全套白送 —— 这一组就是在钉这件事。
+ *
+ * 反过来那一半同样重要：删 CRD 会连带删掉这个类型的**所有对象**。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const CRDS = { group: 'apiextensions.k8s.io', version: 'v1', resource: 'customresourcedefinitions' } as const;
+const SITES = { group: 'platform.corp.internal', version: 'v1', resource: 'sites' } as const;
+
+const SITE_CRD = {
+  apiVersion: 'apiextensions.k8s.io/v1', kind: 'CustomResourceDefinition',
+  metadata: { name: 'sites.platform.corp.internal' },
+  spec: {
+    group: 'platform.corp.internal',
+    scope: 'Namespaced',
+    names: { plural: 'sites', singular: 'site', kind: 'Site', shortNames: ['st'] },
+    versions: [{
+      name: 'v1', served: true, storage: true,
+      subresources: { status: {} },
+      additionalPrinterColumns: [
+        { name: 'Host', type: 'string', jsonPath: '.spec.host' },
+        { name: 'Ready', type: 'string', jsonPath: '.status.ready' },
+      ],
+    }],
+  },
+};
+
+const site = (name: string, host: string) => ({
+  apiVersion: 'platform.corp.internal/v1', kind: 'Site',
+  metadata: { name, namespace: 'default' },
+  spec: { host, service: { name: 'portal', port: 80 } },
+});
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return { namespaces: ['default'], objects: objects as never };
+}
+
+async function build(objects: unknown[] = []) {
+  const world = await createOpsWorld({ world: spec(objects) });
+  await world.cluster.advanceBy(10_000);
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+const apply = (w: World, definition: any, namespace: string | undefined, object: unknown) =>
+  w.cluster.registry.create(w.cluster.scheme.mustGet(definition), namespace, object as KubeObject);
+
+describe('注册一种新类型', () => {
+  it('apply 一个 CRD 之后，这个类型就存在了', async () => {
+    const w = await build();
+    expect(w.cluster.scheme.get(SITES)).toBeUndefined();
+
+    apply(w, CRDS, undefined, SITE_CRD);
+    await w.cluster.advanceBy(5_000);
+
+    const definition = w.cluster.scheme.get(SITES);
+    expect(definition).toBeDefined();
+    expect(definition!.kind).toBe('Site');
+    expect(definition!.namespaced).toBe(true);
+    expect(definition!.shortNames).toEqual(['st']);
+    expect(definition!.subresources).toContain('status');
+  });
+
+  /**
+   * kubectl 在 apply 一个自定义资源之前会看 discovery，
+   * 而 discovery 里有没有它取决于 Established 有没有写上。
+   * 「CRD 和 CR 写在同一个 YAML 里，一次 apply 报 no matches for kind」
+   * 就是这半秒钟的时间差。
+   */
+  it('注册完会把 Established 写上，名字也接受了', async () => {
+    const w = await build([SITE_CRD]);
+    const crd = w.cluster.registry.get(w.cluster.scheme.mustGet(CRDS), undefined, 'sites.platform.corp.internal');
+    const status = (crd.status ?? {}) as any;
+    expect(status.conditions.map((condition: any) => [condition.type, condition.status]))
+      .toEqual([['NamesAccepted', 'True'], ['Established', 'True']]);
+    expect(status.acceptedNames.kind).toBe('Site');
+    expect(status.storedVersions).toEqual(['v1']);
+  });
+
+  it('缺 group 或者没有版本：不注册，而且说得出为什么', async () => {
+    const w = await build([{
+      apiVersion: 'apiextensions.k8s.io/v1', kind: 'CustomResourceDefinition',
+      metadata: { name: 'broken.example.com' },
+      spec: { scope: 'Namespaced', names: { plural: 'broken', kind: 'Broken' }, versions: [] },
+    }]);
+    const crd = w.cluster.registry.get(w.cluster.scheme.mustGet(CRDS), undefined, 'broken.example.com');
+    const conditions = ((crd.status ?? {}) as any).conditions ?? [];
+    expect(conditions[0]).toMatchObject({ type: 'NamesAccepted', status: 'False' });
+  });
+
+  it('注册之后就能存对象，watch 和 status 子资源都白送', async () => {
+    const w = await build([SITE_CRD]);
+    apply(w, SITES, 'default', site('portal', 'portal.corp.internal'));
+
+    const definition = w.cluster.scheme.mustGet(SITES);
+    const stored = w.cluster.registry.get(definition, 'default', 'portal');
+    expect((stored.spec as any).host).toBe('portal.corp.internal');
+
+    w.cluster.registry.updateStatus(definition, 'default', 'portal', {
+      ...stored, status: { ready: true },
+    });
+    expect((w.cluster.registry.get(definition, 'default', 'portal').status as any).ready).toBe(true);
+  });
+});
+
+describe('表格列', () => {
+  it('kubectl get 打出来的列是 CRD 上声明的那些', async () => {
+    const w = await build([SITE_CRD]);
+    apply(w, SITES, 'default', site('portal', 'portal.corp.internal'));
+    const definition = w.cluster.scheme.mustGet(SITES);
+    const stored = w.cluster.registry.get(definition, 'default', 'portal');
+    w.cluster.registry.updateStatus(definition, 'default', 'portal', { ...stored, status: { ready: true } });
+
+    const response = await w.cluster.apiServer.handle(
+      '/apis/platform.corp.internal/v1/namespaces/default/sites',
+      { headers: { accept: 'application/json;as=Table;g=meta.k8s.io;v=v1' } }
+    );
+    const table = await response.json();
+    expect(table.columnDefinitions.map((column: any) => column.name))
+      .toEqual(['Name', 'Host', 'Ready', 'Age']);
+    expect(table.rows[0].cells.slice(0, 3)).toEqual(['portal', 'portal.corp.internal', 'true']);
+  });
+});
+
+describe('删掉 CRD', () => {
+  /**
+   * 这一步真集群里也是这样，而且没有回收站。
+   * `kubectl delete crd` 属于该先深呼吸再敲回车的命令。
+   */
+  it('CRD 没了，这个类型的对象全部跟着没', async () => {
+    const w = await build([SITE_CRD]);
+    apply(w, SITES, 'default', site('portal', 'portal.corp.internal'));
+    apply(w, SITES, 'default', site('reports', 'reports.corp.internal'));
+    expect(w.cluster.registry.list(w.cluster.scheme.mustGet(SITES), {}).items).toHaveLength(2);
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(CRDS), undefined, 'sites.platform.corp.internal');
+    await w.cluster.advanceBy(5_000);
+
+    expect(w.cluster.scheme.get(SITES)).toBeUndefined();
+  });
+});

--- a/tests/opslab/kubectl-integration.test.ts
+++ b/tests/opslab/kubectl-integration.test.ts
@@ -352,6 +352,66 @@ describeIfBuilt('跳板机 -> Pod -> 集群网络', () => {
     ],
   };
 
+  /**
+   * CRD 那条链子要能整个走通：apply 一个 CRD，discovery 里立刻有它，
+   * 然后就能 apply 这个类型的对象、`kubectl get` 得到，列还是 CRD 上声明的那些。
+   * 中间任何一环断了，学员写的 Operator 就无从谈起。
+   */
+  it('apply 一个 CRD 之后，真 kubectl 立刻认得这个类型', async () => {
+    const world = await createOpsWorld({ world: WORLD as never, runtime: runtime() });
+    const manifest = [
+      'apiVersion: apiextensions.k8s.io/v1',
+      'kind: CustomResourceDefinition',
+      'metadata:',
+      '  name: sites.platform.corp.internal',
+      'spec:',
+      '  group: platform.corp.internal',
+      '  scope: Namespaced',
+      '  names:',
+      '    plural: sites',
+      '    singular: site',
+      '    kind: Site',
+      '    shortNames:',
+      '    - st',
+      '  versions:',
+      '  - name: v1',
+      '    served: true',
+      '    storage: true',
+      '    subresources:',
+      '      status: {}',
+      '    additionalPrinterColumns:',
+      '    - name: Host',
+      '      type: string',
+      '      jsonPath: .spec.host',
+      '',
+    ].join('\n');
+    world.machine.vfs.writeFile('/root/site-crd.yaml', manifest);
+    const applied = await world.run('kubectl apply -f /root/site-crd.yaml');
+    expect(applied.stderr).toBe('');
+    expect(applied.stdout).toContain('customresourcedefinition.apiextensions.k8s.io/sites.platform.corp.internal');
+
+    world.machine.vfs.writeFile('/root/site.yaml', [
+      'apiVersion: platform.corp.internal/v1',
+      'kind: Site',
+      'metadata:',
+      '  name: portal',
+      '  namespace: shop',
+      'spec:',
+      '  host: portal.corp.internal',
+      '',
+    ].join('\n'));
+    const created = await world.run('kubectl apply -f /root/site.yaml');
+    expect(created.stderr).toBe('');
+
+    const listed = await world.run('kubectl get sites -n shop');
+    expect(listed.stdout).toMatch(/NAME\s+HOST\s+AGE/);
+    expect(listed.stdout).toContain('portal.corp.internal');
+
+    // 简称也要认
+    const byShortName = await world.run('kubectl get st -n shop -o name');
+    expect(byShortName.stdout.trim()).toBe('site.platform.corp.internal/portal');
+  });
+
   it('kubectl exec deploy/portal -- curl payments —— 从 Pod 里打得通', async () => {
     const world = await createOpsWorld({ world: WORLD as never, runtime: runtime() });
     const result = await world.run(


### PR DESCRIPTION
第 23 关（写一个 Operator）的地基。

## 一个 CRD 干的事只有一件

让 apiserver **多认识一种类型**。认识之后，这种类型自动拥有全套东西：
REST 端点、watch、RBAC 里的资源名、`kubectl get` 能查、YAML 能 apply。

这就是「Kubernetes 是一个通用的声明式 API 服务器」这句话的具体含义 ——
也是下一关的前提：写 Operator 的重点从来不是写 CRD，而是写那个 reconcile，
因为存储和分发是白送的。

## 做进去的几件

- **动态注册/注销类型**，discovery 立刻可见。用真 kubectl 验过整条链子：
  `kubectl apply -f crd.yaml` → `kubectl apply -f site.yaml` →
  `kubectl get sites` → `kubectl get st -o name`，全通。
- **`Established` / `NamesAccepted` 条件**。kubectl 在 apply 一个自定义资源前
  会看 discovery，而 discovery 里有没有它取决于注册完没完 ——「CRD 和 CR 写在
  同一个 YAML 里，一次 apply 报 no matches for kind」就是这半秒钟的时间差。
- **`additionalPrinterColumns`**：`kubectl get sites` 打出来的列由 CRD 自己声明。
  JSONPath 只支持 `.spec.foo.bar` 这一种形状 —— 真 CRD 里 99% 的列就是它，
  支持完整 JSONPath 会把这一层变成另一个项目。
- **删 CRD 连带删掉这个类型的所有对象**。真集群里也是这样，而且没有回收站。

CRD 的注册由 apiserver 自己做（真集群里是 apiextensions-apiserver，
是 kube-apiserver 的一部分），所以这个控制器无条件跑，不是工作负载。

## 验证

- 新增 `tests/opslab/crd.test.ts` 6 条，另加一条真 kubectl 的端到端集成
- `npx jest`：52 个 suite、1632 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)