### PR TITLE
feat(opslab): 第 23 关 写一个 Operator

### DIFF
--- a/projects/definitions/intranet-k8s.js
+++ b/projects/definitions/intranet-k8s.js
@@ -52,6 +52,8 @@ const CAPI_IMAGE = 'registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4';
 const AUTOSCALER_IMAGE = 'registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0';
 // 月末结算：一批算得很重的活，跑完就散
 const SETTLEMENT_IMAGE = 'harbor.corp.internal/team/settlement:2.1';
+// 平台组自己写的 Operator。镜像里装的就是学员写的那段 reconcile。
+const SITE_OPERATOR_IMAGE = 'harbor.corp.internal/platform/site-operator:0.1';
 
 /**
  * 跳板机上那份 kubeconfig。
@@ -158,7 +160,7 @@ const WORLD = {
   namespaces: [
     'default', 'kube-system', 'payments', 'analytics',
     'envoy-gateway-system', 'ingress-nginx', 'cert-manager', 'argocd', 'istio-system',
-    'kyverno', 'external-secrets', 'monitoring', 'velero', 'capi-system',
+    'kyverno', 'external-secrets', 'monitoring', 'velero', 'capi-system', 'platform-system',
   ],
   images: {
     [PORTAL_IMAGE]: {
@@ -211,6 +213,7 @@ const WORLD = {
     [CAPI_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300 },
     [AUTOSCALER_IMAGE]: { pullMs: 400, startupMs: 600, readyAfterMs: 300 },
     [SETTLEMENT_IMAGE]: { pullMs: 300, startupMs: 500, readyAfterMs: 200, memoryUsage: '256Mi' },
+    [SITE_OPERATOR_IMAGE]: { pullMs: 300, startupMs: 400, readyAfterMs: 200, memoryUsage: '128Mi' },
     [LEDGERDB_IMAGE]: {
       pullMs: 800, startupMs: 1200, readyAfterMs: 600,
       listens: [5432], memoryUsage: '512Mi', handlesSigterm: true,
@@ -7407,6 +7410,478 @@ const stage22 = {
   ),
 };
 
+/* ------------------------------------------------------------------ */
+/* 第 23 关：写一个 Operator                                           */
+/* ------------------------------------------------------------------ */
+
+/** 平台组的自助入口网关：hostname 是通配的，任何一个 Site 都能挂上来 */
+const SELF_SERVICE_GATEWAY = {
+  apiVersion: 'gateway.networking.k8s.io/v1', kind: 'Gateway',
+  metadata: { name: 'self-service', namespace: 'payments' },
+  spec: {
+    gatewayClassName: 'envoy-internal',
+    listeners: [
+      { name: 'http', port: 80, protocol: 'HTTP', hostname: '*.corp.internal' },
+    ],
+  },
+};
+
+/**
+ * Operator 自己。
+ *
+ * 它和别的平台组件没有任何区别：一个 Deployment。把它缩到 0，
+ * Site 还在、`kubectl get sites` 照样查得到，只是没有人再让它们成真 ——
+ * 「CRD 是数据结构，Operator 才是行为」在这里是能动手验证的。
+ */
+const SITE_OPERATOR = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: {
+    name: 'site-operator', namespace: 'platform-system',
+    labels: { 'app.kubernetes.io/name': 'site-operator' },
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'site-operator' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'site-operator' } },
+      spec: { containers: [{ name: 'manager', image: SITE_OPERATOR_IMAGE }] },
+    },
+  },
+};
+
+const SITE_CRD_STARTER = code`
+  # 待补：Site 这个类型还不存在。
+  #
+  # 需要一个 CustomResourceDefinition，让 apiserver 认识 platform.corp.internal/v1
+  # 下面的 Site。业务方提交的东西长这样（见 /root/sites/shop.yaml）：
+  #
+  #   spec:
+  #     host: shop.corp.internal
+  #     service:
+  #       name: portal
+  #       port: 80
+  #
+  # 两件容易漏的：Operator 要往 status 里写东西，以及
+  # \`kubectl get sites\` 应该一眼看得出 host —— 这两样都在 CRD 上声明。
+`;
+
+const SITE_CRD_REFERENCE = code`
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: sites.platform.corp.internal
+  spec:
+    group: platform.corp.internal
+    scope: Namespaced
+    names:
+      plural: sites
+      singular: site
+      kind: Site
+      shortNames:
+      - st
+    versions:
+    - name: v1
+      served: true
+      storage: true
+      # 不声明的话 status 就不是子资源，写 status 会连带改到 spec
+      subresources:
+        status: {}
+      # kubectl get sites 打出来的列。平台的自助入口，好不好用就看这几列。
+      additionalPrinterColumns:
+      - name: Host
+        type: string
+        jsonPath: .spec.host
+      - name: Ready
+        type: string
+        jsonPath: .status.ready
+`;
+
+const OPERATOR_STARTER = code`
+  /**
+   * Site Operator —— 待补
+   *
+   * 这个文件就是控制器本身。世界会 watch 你在 \`exports.watches\` 里声明的类型，
+   * 每次变化调一次 \`reconcile\`。CommonJS 写法，改完立刻生效
+   * （真集群里这一步是重新构建镜像再发布）。
+   *
+   * ctx 上有这些：
+   *
+   *   ctx.object                       触发这次 reconcile 的 Site
+   *   ctx.name / ctx.namespace
+   *   ctx.owner()                      属主引用，挂在你造出来的东西上
+   *   ctx.get(kind, name, namespace)   读不到返回 undefined
+   *   ctx.list(kind, namespace)
+   *   ctx.apply(object)                有就改，没有就建
+   *   ctx.delete(kind, name, namespace)
+   *   ctx.setStatus(patch)             只在真的变了的时候才写回
+   *   ctx.event(reason, message)       记一条事件
+   *   ctx.log(...)
+   *
+   * 要造的是一条 HTTPRoute：挂在 payments 命名空间里那个叫 self-service 的
+   * Gateway 上，hostname 用 Site 的 host，后端指向 Site 里写的 service。
+   */
+  exports.watches = ['Site'];
+
+  exports.reconcile = (ctx) => {
+    // TODO
+  };
+`;
+
+const OPERATOR_REFERENCE = code`
+  /**
+   * Site Operator
+   *
+   * 一个 Site 进来，保证有一条对应的 HTTPRoute 出去。
+   *
+   * 三件事是这段代码真正在做的：
+   *   1. 照着**现在**的 spec 收敛，而不是「创建时做一次」
+   *   2. 属主引用挂上，Site 没了路由跟着没
+   *   3. watch 自己造出来的类型，别人改坏了下一轮能改回去
+   */
+  exports.watches = ['Site', 'HTTPRoute'];
+
+  exports.reconcile = (ctx) => {
+    const site = ctx.object;
+    const backend = (site.spec || {}).service || {};
+
+    if (!site.spec || !site.spec.host || !backend.name) {
+      ctx.setStatus({ ready: false, reason: 'spec.host 和 spec.service.name 都是必填' });
+      ctx.event('InvalidSpec', 'host 或者 service 没写全', 'Warning');
+      return;
+    }
+
+    ctx.apply({
+      apiVersion: 'gateway.networking.k8s.io/v1',
+      kind: 'HTTPRoute',
+      metadata: {
+        name: site.metadata.name,
+        namespace: site.metadata.namespace,
+        // 不挂这个的话，Site 删了路由还在，变成没人管的孤儿
+        ownerReferences: [ctx.owner()],
+      },
+      spec: {
+        parentRefs: [{ name: 'self-service' }],
+        hostnames: [site.spec.host],
+        rules: [{
+          matches: [{ path: { type: 'PathPrefix', value: '/' } }],
+          backendRefs: [{ name: backend.name, port: backend.port || 80 }],
+        }],
+      },
+    });
+
+    // 只写观察到的事实，不写期望 —— 期望在 spec 里
+    ctx.setStatus({
+      ready: true,
+      url: 'http://' + site.spec.host,
+      observedGeneration: site.metadata.generation,
+    });
+  };
+`;
+
+const SHOP_SITE = code`
+  apiVersion: platform.corp.internal/v1
+  kind: Site
+  metadata:
+    name: shop
+    namespace: payments
+  spec:
+    host: shop.corp.internal
+    service:
+      name: portal
+      port: 80
+`;
+
+const SHOP_SITE_MOVED = code`
+  apiVersion: platform.corp.internal/v1
+  kind: Site
+  metadata:
+    name: shop
+    namespace: payments
+  spec:
+    host: shop2.corp.internal
+    service:
+      name: portal
+      port: 80
+`;
+
+const stage23 = {
+  id: 'write-an-operator',
+  title: t('写一个 Operator', 'Write an Operator'),
+  goal: t(
+    code`
+      业务方要一个对外入口，现在的流程是提工单：平台组手写一条 HTTPRoute，
+      改一次 host 再提一次工单。一周三四次，而且每次都有人写错后端端口。
+
+      这一关把这件事变成自助的：业务方提交一个 \`Site\`，平台负责让它成真。
+
+      两半：一半是 \`CustomResourceDefinition\`，让 apiserver 认识 Site 这个类型；
+      另一半是 \`/root/operator/site.js\` 里那个 \`reconcile\` —— 它就是控制器本身，
+      世界会 watch 你声明的类型，每次变化调它一次。
+
+      Site 长这样（\`/root/sites/shop.yaml\`）：
+
+      \`\`\`yaml
+      spec:
+        host: shop.corp.internal
+        service:
+          name: portal
+          port: 80
+      \`\`\`
+
+      要造出来的是一条挂在 \`self-service\` 这个 Gateway 上的 HTTPRoute。
+
+      ## 通关标准
+
+      1. \`kubectl get sites\` 查得到，而且一眼看得出 host；
+      2. 提交一个 Site，路由自动出现，而且**真的通** —— 从跳板机上 curl 得到 200；
+      3. 改了 Site 的 host，路由跟着改（声明式，不是「创建时做一次」）；
+      4. 有人手工把路由改坏，下一轮要改回去；
+      5. 删掉 Site，路由跟着没；
+      6. Site 的 status 里写得出它现在好不好。
+
+      ## 会用到的命令
+
+      \`\`\`bash
+      kubectl apply -f /root/operator/site-crd.yaml
+      kubectl apply -f /root/sites/shop.yaml
+      kubectl get sites -n payments
+      kubectl describe site shop -n payments
+      kubectl get httproute -n payments
+      \`\`\`
+    `,
+    code`
+      Teams that want a public entry point file a ticket, someone on the platform team
+      hand-writes an HTTPRoute, and changing a hostname means another ticket. Three or
+      four a week, and somebody always gets the backend port wrong.
+
+      This stage turns that into self-service: a team submits a \`Site\`, and the
+      platform makes it real.
+
+      Two halves. One is a \`CustomResourceDefinition\` that teaches the apiserver about
+      Site. The other is the \`reconcile\` function in \`/root/operator/site.js\`, which
+      *is* the controller: the world watches the kinds you declare and calls it on
+      every change.
+
+      A Site looks like this (\`/root/sites/shop.yaml\`):
+
+      \`\`\`yaml
+      spec:
+        host: shop.corp.internal
+        service:
+          name: portal
+          port: 80
+      \`\`\`
+
+      What it should produce is an HTTPRoute attached to the \`self-service\` Gateway.
+
+      ## Done when
+
+      1. \`kubectl get sites\` works and shows the host at a glance;
+      2. submitting a Site produces a route that **actually serves**: curl from the jump
+         host returns 200;
+      3. changing the host changes the route (declarative, not create-once);
+      4. if somebody edits the route by hand, the next reconcile puts it back;
+      5. deleting the Site removes the route;
+      6. the Site's status says whether it is working.
+
+      ## Commands you will need
+
+      \`\`\`bash
+      kubectl apply -f /root/operator/site-crd.yaml
+      kubectl apply -f /root/sites/shop.yaml
+      kubectl get sites -n payments
+      kubectl describe site shop -n payments
+      kubectl get httproute -n payments
+      \`\`\`
+    `
+  ),
+  checklist: [
+    t('新类型注册得上', 'The new kind is registered'),
+    t('路由自动出现而且通', 'The route appears and serves'),
+    t('改坏了能自己修回去', 'Drift is repaired'),
+  ],
+  hints: [
+    t(
+      'reconcile 不是「事件处理器」。它收到的只有「这个对象该看一眼了」，不告诉你变的是什么 —— 所以正确的写法永远是「照着**现在**的 spec，把世界收敛过去」，而不是「根据这次的变化做个增量」。这也是它必须可以被重复调用而不出错的原因。',
+      'Reconcile is not an event handler. All it gets is "look at this object again", never what changed, so the correct shape is always "converge the world to the spec as it is now", not "apply a delta for this change". That is also why it must be safe to call repeatedly.'
+    ),
+    t(
+      '想修偏差，就得 watch 自己造出来的那个类型。只 watch 主类型的话，别人手工改坏了路由，你要等到下一次有人动 Site 才会发现 —— 那不叫「持续收敛」，那叫「碰巧修好」。',
+      'To repair drift you must watch the kind you create. Watching only the primary kind means a hand-edited route stays broken until somebody happens to touch the Site again, which is not continuous convergence, it is coincidence.'
+    ),
+    t(
+      '删除不用你写代码。属主引用挂对了，Site 一删，垃圾回收会把路由一起带走。真正需要写删除逻辑的是「外部状态」—— 比如你在集群外面开了一个 DNS 记录，那才要 finalizer。',
+      'You do not write deletion logic. With the owner reference attached, garbage collection takes the route away with the Site. What actually needs a finalizer is **external** state, like a DNS record you created outside the cluster.'
+    ),
+  ],
+  pitfalls: [
+    t(
+      'status 里每次都写一个新时间戳。写 status 会触发一次新的 watch 事件，事件又触发 reconcile，reconcile 又写 status —— 控制器把自己吵醒，CPU 跑满而且什么都没做。只在**真的变了**的时候才写。',
+      'Writing a fresh timestamp into status every pass. Writing status produces a watch event, the event triggers reconcile, reconcile writes status: the controller wakes itself up forever, burning CPU and achieving nothing. Write only when something actually changed.'
+    ),
+    t(
+      '把期望状态放进 status。status 是**观察到的事实**，随时可以被重新算出来；spec 是期望，只有人能改。放反了的后果是：备份恢复之后、或者 status 被清掉之后，控制器不知道该收敛到哪儿去。',
+      'Putting desired state into status. Status is observed fact and must be recomputable at any moment; spec is desire and only humans change it. Get it backwards and the controller no longer knows what to converge to after a restore, or after status is cleared.'
+    ),
+    t(
+      '整体替换自己造出来的对象。apiserver 会往对象上补字段（resourceVersion、集群分配的那些），整体覆盖会把它们抹掉，于是每一轮 reconcile 都「发现不一样」再写一次，无限重写。只改你负责的那部分。',
+      'Replacing the object you create wholesale. The apiserver adds fields of its own (resourceVersion, cluster-assigned values); overwriting them means every reconcile "finds a difference" and writes again, forever. Touch only the parts you own.'
+    ),
+  ],
+  ops: {
+    setupCommands: [...PREVIOUS_STAGES],
+    objects: [
+      CNI_CILIUM,
+      ...GATEWAY_PLATFORM, ...CERT_MANAGER_PLATFORM, ...TLS_PLATFORM,
+      ...ROLLOUTS_PLATFORM, ...MONITORING_CARRIED,
+      ...PORTAL_ROLLOUT, PORTAL_ROUTE,
+      SELF_SERVICE_GATEWAY, SITE_OPERATOR,
+    ],
+    operator: { path: '/root/operator/site.js', kind: 'Site', name: 'site-operator' },
+    files: {
+      '/root/operator/site-crd.yaml': SITE_CRD_STARTER,
+      '/root/operator/site.js': OPERATOR_STARTER,
+      '/root/sites/shop.yaml': SHOP_SITE,
+      '/root/sites/shop-moved.yaml': SHOP_SITE_MOVED,
+    },
+    referenceFiles: {
+      '/root/operator/site-crd.yaml': SITE_CRD_REFERENCE,
+      '/root/operator/site.js': OPERATOR_REFERENCE,
+    },
+    referenceCommands: [
+      'kubectl apply -f /root/operator/site-crd.yaml',
+    ],
+  },
+  specs: [
+    spec('write-an-operator.spec.ts', code`
+      import { advance, get, list, sh } from '@ops/lab';
+
+      const SITE = () => get('Site', 'shop', 'payments');
+      const ROUTE = () => list('HTTPRoute', { namespace: 'payments' })
+        .filter((route) => route.metadata.name === 'shop')[0];
+
+      const gatewayAddress = () => {
+        const gateway = get('Gateway', 'self-service', 'payments');
+        return ((gateway.status || {}).addresses || [])[0].value;
+      };
+
+      describe('写一个 Operator', () => {
+        it('新类型注册得上，而且一眼看得出 host', async () => {
+          const crds = list('CustomResourceDefinition')
+            .filter((crd) => crd.spec.names.kind === 'Site');
+          expect(crds.length).toBe(1);
+          const established = (crds[0].status.conditions || [])
+            .filter((condition) => condition.type === 'Established');
+          expect(established[0].status).toBe('True');
+
+          await sh('kubectl apply -f /root/sites/shop.yaml');
+          await advance(30000);
+
+          const listed = await sh('kubectl get sites -n payments');
+          expect(listed.code).toBe(0);
+          expect(listed.stdout).toContain('shop.corp.internal');
+        });
+
+        it('路由自动出现，而且指向对的后端', () => {
+          const route = ROUTE();
+          expect(route).toBeTruthy();
+          expect(route.spec.hostnames).toEqual(['shop.corp.internal']);
+          const backend = route.spec.rules[0].backendRefs[0];
+          expect(backend.name).toBe('portal');
+          expect(backend.port).toBe(80);
+          // 属主引用要挂上，不然删了 Site 会留下孤儿
+          const owners = route.metadata.ownerReferences || [];
+          expect(owners.some((owner) => owner.kind === 'Site' && owner.name === 'shop')).toBe(true);
+        });
+
+        it('真的通：从跳板机上 curl 得到 200', async () => {
+          const result = await sh(
+            "curl -s -o /dev/null -w '%{http_code}' -H 'Host: shop.corp.internal' http://"
+            + gatewayAddress()
+          );
+          expect(result.stdout).toBe('200');
+        });
+
+        it('status 写得出它现在好不好', () => {
+          const status = SITE().status || {};
+          expect(status.ready).toBe(true);
+          expect(status.observedGeneration).toBe(SITE().metadata.generation);
+        });
+
+        it('改了 Site，路由跟着改', async () => {
+          await sh('kubectl apply -f /root/sites/shop-moved.yaml');
+          await advance(30000);
+          expect(ROUTE().spec.hostnames).toEqual(['shop2.corp.internal']);
+
+          const result = await sh(
+            "curl -s -o /dev/null -w '%{http_code}' -H 'Host: shop2.corp.internal' http://"
+            + gatewayAddress()
+          );
+          expect(result.stdout).toBe('200');
+        });
+
+        it('有人手工改坏了路由，下一轮改回去', async () => {
+          await sh(
+            'kubectl patch httproute shop -n payments --type=json -p '
+            + '\\'[{"op":"replace","path":"/spec/hostnames","value":["oops.corp.internal"]}]\\''
+          );
+          await advance(30000);
+          expect(ROUTE().spec.hostnames).toEqual(['shop2.corp.internal']);
+        });
+
+        it('删掉 Site，路由跟着没', async () => {
+          await sh('kubectl delete site shop -n payments');
+          await advance(30000);
+          expect(ROUTE()).toBeUndefined();
+        });
+      });
+    `),
+  ],
+  focus: ['architecture', 'operations'],
+  extension: t(
+    code`
+      写完这一关，值得回头看一眼整个项目：从第 1 关那条 \`kubectl get nodes\`
+      到这里，你一路见到的所有东西 —— Deployment、Gateway、Certificate、
+      Rollout、Backup、MachineDeployment —— 都是同一个形状：一个描述期望的对象，
+      加一个把期望变成现实的控制器。你刚才写的那三十行，和它们没有本质区别。
+
+      这就是 Kubernetes 真正的产品：不是容器编排，是一个**通用的声明式 API
+      服务器**加一套控制器模式。容器编排只是这套东西的第一个应用。
+      所以「用 CRD 管数据库」「用 CRD 管 DNS 记录」「用 CRD 管办公室门禁」
+      听起来离谱，但在架构上完全成立 —— 存储、鉴权、watch、审计、
+      kubectl 全套白送，你只要写那个 reconcile。
+
+      有两条边界值得记住。一是**不是所有东西都该做成 CRD**：一个只在部署时
+      跑一次的动作，写成 Job 或者 CI 的一步更合适 —— 控制器的成本是它要
+      永远活着、永远正确。二是**reconcile 一定要幂等且可重入**：它会在你
+      意料之外的时刻被调用（重启之后的全量 resync、别人改坏了、
+      你自己写 status 触发的那一次），任何「只能执行一次」的逻辑迟早会出事。
+    `,
+    code`
+      Now that this one is done, look back across the whole project. Everything you met
+      from that first \`kubectl get nodes\` onwards — Deployment, Gateway, Certificate,
+      Rollout, Backup, MachineDeployment — has the same shape: an object describing
+      desired state, plus a controller that makes it real. The thirty lines you just
+      wrote are not different in kind from any of them.
+
+      That is what Kubernetes actually is: not container orchestration, but a **general
+      declarative API server** plus a controller pattern. Container orchestration was
+      simply its first application. Which is why "manage databases with a CRD", "manage
+      DNS records with a CRD", or "manage office door badges with a CRD" sound absurd
+      and are architecturally sound: storage, authorization, watch, audit, and kubectl
+      all come for free, and you only write the reconcile.
+
+      Two boundaries are worth keeping. First, **not everything should be a CRD**: an
+      action that runs once at deploy time is better as a Job or a CI step, because a
+      controller costs you something that must stay alive and stay correct forever.
+      Second, **reconcile must be idempotent and re-entrant**: it will be called at
+      moments you did not plan for, including the full resync after a restart, after
+      somebody edits your output, and on the pass your own status write triggered.
+      Any logic that can only run once will eventually run twice.
+    `
+  ),
+};
+
 module.exports = {
   id: 'intranet-k8s',
   title: t('内网设施实战：接手一家公司的 Kubernetes', 'Intranet Infrastructure: Inheriting a Kubernetes Cluster'),
@@ -7453,6 +7928,6 @@ module.exports = {
     stage1, stage2, stage3, stage4, stage5, stage6,
     stage7, stage8, stage9, stage10, stage11, stage12,
     stage13, stage14, stage15, stage16, stage17, stage18, stage19, stage20,
-    stage21, stage22,
+    stage21, stage22, stage23,
   ],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -5623,7 +5623,8 @@
           "external-secrets",
           "monitoring",
           "velero",
-          "capi-system"
+          "capi-system",
+          "platform-system"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5782,6 +5783,12 @@
             "startupMs": 500,
             "readyAfterMs": 200,
             "memoryUsage": "256Mi"
+          },
+          "harbor.corp.internal/platform/site-operator:0.1": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "memoryUsage": "128Mi"
           },
           "harbor.corp.internal/team/ledgerdb:14.2": {
             "pullMs": 800,
@@ -14346,6 +14353,596 @@
         "primer": {
           "zh": "机器从哪儿来，是这一层的第一个问题。内网集群没有云厂商的弹性伸缩组，机器要么是人手装的，要么是 `Cluster API` 声明出来的。它的形状和工作负载那一套故意长得一样：`MachineDeployment` 对 Deployment，`MachineSet` 对 ReplicaSet，`Machine` 对 Pod。改副本数就是加机器，换模板就是换一批。\n\nMachine 和 Node 是两个对象，这个区别要记牢。Machine 是「我要一台机器」，Node 是「这台机器上的 kubelet 报到了」。中间隔着装机时间，表现为三段：`Provisioning`（provider 在造）、`Provisioned`（Node 对象出现但 NotReady）、`Running`（kubelet 报到，调度器才看得见它）。`kubectl get machines` 里 NODENAME 那一列在第一段是空的。另外机器的规格写在 infra 模板上，不在 MachineDeployment 上，「我改了副本数为什么新机器还是老规格」的答案就在这个分层里。\n\n`cluster-autoscaler` 做的事只有两件，而且都不看负载。扩容：看到**调度不上**的 Pod，问一句「加一台这种机器，它能落上去吗」，能就加，不能就一台都不加。所以一个请求 32 核的 Pod 在最大 8 核的池子里会永远 Pending 而机器数纹丝不动。这不是坏了，是它算出来加了也没用，理由写在 Pod 的 `NotTriggerScaleUp` 事件里。缩容：看到利用率低的节点，问一句「上面的 Pod 挪得走吗」。\n\n它怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它**看都不看**，这是「伸缩器装了但不工作」最常见的原因。上限不是调优参数，它是闸：一个写错的副本数或者一段死循环的重试，能让机器一台台加到天亮。\n\n缩容那一侧有三道门：利用率够低、闲得够久（默认十分钟）、上面的 Pod 挪得走。第三道最容易卡住，而且卡住的时候伸缩器是沉默的。能钉住一台机器的东西有：PDB 不允许再驱逐、Pod 没有属主（删了就不会被重建）、以及打了 `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"` 的 Pod。最后这一条最阴：加的时候是为了保护某个关键任务，忘了摘，那台机器就永远还不回去了。\n\n最后分清两件常被混着说成「自动扩容」的事：`HPA` 加的是**副本**，看的是指标；伸缩器加的是**机器**，看的是调度结果。顺序是 HPA 先加出一批调度不上的 Pod，伸缩器再为它们加机器。还要记住扩容有代价：装机要几分钟，这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。",
           "en": "Where machines come from is the first question at this layer. An intranet cluster has no cloud autoscaling group: machines are either installed by hand or declared through `Cluster API`. Its shape deliberately mirrors the workload API: `MachineDeployment` to Deployment, `MachineSet` to ReplicaSet, `Machine` to Pod. Changing a replica count adds machines; changing the template replaces a batch of them.\n\nMachine and Node are two objects, and the difference matters. A Machine is \"I want a machine\"; a Node is \"the kubelet on that machine has reported in\". Between them sits provisioning time, visible as three phases: `Provisioning` (the provider is building it), `Provisioned` (the Node object exists but is NotReady), and `Running` (the kubelet reported and the scheduler can finally see it). The NODENAME column of `kubectl get machines` is empty during the first phase. Note also that machine size lives on the infra template, not on the MachineDeployment, which is the answer to \"I changed the replica count, why are the new machines still the old size\".\n\n`cluster-autoscaler` does exactly two things, and neither of them looks at load. Scaling up: for pods that **cannot be scheduled**, it asks whether one more machine of this shape would fit them, and adds machines only if the answer is yes. A pod requesting 32 cores in a pool whose largest machine is 8 will therefore stay Pending forever while the machine count never moves. That is not a malfunction, it is the answer to the question, and the reason is recorded in a `NotTriggerScaleUp` event on the pod. Scaling down: for underutilised nodes, it asks whether the pods on them can move.\n\nHow does it know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is the usual reason an installed autoscaler does nothing. The maximum is not a tuning parameter but a brake: a wrong replica count or a retry loop can walk a group up machine by machine all night.\n\nScaling down has three gates: utilisation low enough, idle long enough (ten minutes by default), and the pods on the node able to move. The third is the one that jams, and the autoscaler is silent when it does. Things that pin a machine: a PDB that allows no further eviction, a pod with no controller (delete it and nothing recreates it), and any pod annotated `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"`. That last one is the sneakiest, added to protect something important and then forgotten, and the machine never goes back.\n\nFinally, separate the two things routinely called autoscaling. `HPA` adds **replicas** based on metrics; the autoscaler adds **machines** based on scheduling outcomes. The order is that HPA produces pods that cannot be scheduled and the autoscaler then provides machines for them. And remember that scaling up costs time: provisioning takes minutes during which requests queue, so genuine burst traffic is absorbed by headroom you kept, not by the autoscaler."
+        }
+      },
+      {
+        "id": "write-an-operator",
+        "title": {
+          "zh": "写一个 Operator",
+          "en": "Write an Operator"
+        },
+        "goal": {
+          "zh": "业务方要一个对外入口，现在的流程是提工单：平台组手写一条 HTTPRoute，\n改一次 host 再提一次工单。一周三四次，而且每次都有人写错后端端口。\n\n这一关把这件事变成自助的：业务方提交一个 `Site`，平台负责让它成真。\n\n两半：一半是 `CustomResourceDefinition`，让 apiserver 认识 Site 这个类型；\n另一半是 `/root/operator/site.js` 里那个 `reconcile` —— 它就是控制器本身，\n世界会 watch 你声明的类型，每次变化调它一次。\n\nSite 长这样（`/root/sites/shop.yaml`）：\n\n```yaml\nspec:\n  host: shop.corp.internal\n  service:\n    name: portal\n    port: 80\n```\n\n要造出来的是一条挂在 `self-service` 这个 Gateway 上的 HTTPRoute。\n\n## 通关标准\n\n1. `kubectl get sites` 查得到，而且一眼看得出 host；\n2. 提交一个 Site，路由自动出现，而且**真的通** —— 从跳板机上 curl 得到 200；\n3. 改了 Site 的 host，路由跟着改（声明式，不是「创建时做一次」）；\n4. 有人手工把路由改坏，下一轮要改回去；\n5. 删掉 Site，路由跟着没；\n6. Site 的 status 里写得出它现在好不好。\n\n## 会用到的命令\n\n```bash\nkubectl apply -f /root/operator/site-crd.yaml\nkubectl apply -f /root/sites/shop.yaml\nkubectl get sites -n payments\nkubectl describe site shop -n payments\nkubectl get httproute -n payments\n```\n",
+          "en": "Teams that want a public entry point file a ticket, someone on the platform team\nhand-writes an HTTPRoute, and changing a hostname means another ticket. Three or\nfour a week, and somebody always gets the backend port wrong.\n\nThis stage turns that into self-service: a team submits a `Site`, and the\nplatform makes it real.\n\nTwo halves. One is a `CustomResourceDefinition` that teaches the apiserver about\nSite. The other is the `reconcile` function in `/root/operator/site.js`, which\n*is* the controller: the world watches the kinds you declare and calls it on\nevery change.\n\nA Site looks like this (`/root/sites/shop.yaml`):\n\n```yaml\nspec:\n  host: shop.corp.internal\n  service:\n    name: portal\n    port: 80\n```\n\nWhat it should produce is an HTTPRoute attached to the `self-service` Gateway.\n\n## Done when\n\n1. `kubectl get sites` works and shows the host at a glance;\n2. submitting a Site produces a route that **actually serves**: curl from the jump\n   host returns 200;\n3. changing the host changes the route (declarative, not create-once);\n4. if somebody edits the route by hand, the next reconcile puts it back;\n5. deleting the Site removes the route;\n6. the Site's status says whether it is working.\n\n## Commands you will need\n\n```bash\nkubectl apply -f /root/operator/site-crd.yaml\nkubectl apply -f /root/sites/shop.yaml\nkubectl get sites -n payments\nkubectl describe site shop -n payments\nkubectl get httproute -n payments\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "新类型注册得上",
+            "en": "The new kind is registered"
+          },
+          {
+            "zh": "路由自动出现而且通",
+            "en": "The route appears and serves"
+          },
+          {
+            "zh": "改坏了能自己修回去",
+            "en": "Drift is repaired"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "reconcile 不是「事件处理器」。它收到的只有「这个对象该看一眼了」，不告诉你变的是什么 —— 所以正确的写法永远是「照着**现在**的 spec，把世界收敛过去」，而不是「根据这次的变化做个增量」。这也是它必须可以被重复调用而不出错的原因。",
+            "en": "Reconcile is not an event handler. All it gets is \"look at this object again\", never what changed, so the correct shape is always \"converge the world to the spec as it is now\", not \"apply a delta for this change\". That is also why it must be safe to call repeatedly."
+          },
+          {
+            "zh": "想修偏差，就得 watch 自己造出来的那个类型。只 watch 主类型的话，别人手工改坏了路由，你要等到下一次有人动 Site 才会发现 —— 那不叫「持续收敛」，那叫「碰巧修好」。",
+            "en": "To repair drift you must watch the kind you create. Watching only the primary kind means a hand-edited route stays broken until somebody happens to touch the Site again, which is not continuous convergence, it is coincidence."
+          },
+          {
+            "zh": "删除不用你写代码。属主引用挂对了，Site 一删，垃圾回收会把路由一起带走。真正需要写删除逻辑的是「外部状态」—— 比如你在集群外面开了一个 DNS 记录，那才要 finalizer。",
+            "en": "You do not write deletion logic. With the owner reference attached, garbage collection takes the route away with the Site. What actually needs a finalizer is **external** state, like a DNS record you created outside the cluster."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "status 里每次都写一个新时间戳。写 status 会触发一次新的 watch 事件，事件又触发 reconcile，reconcile 又写 status —— 控制器把自己吵醒，CPU 跑满而且什么都没做。只在**真的变了**的时候才写。",
+            "en": "Writing a fresh timestamp into status every pass. Writing status produces a watch event, the event triggers reconcile, reconcile writes status: the controller wakes itself up forever, burning CPU and achieving nothing. Write only when something actually changed."
+          },
+          {
+            "zh": "把期望状态放进 status。status 是**观察到的事实**，随时可以被重新算出来；spec 是期望，只有人能改。放反了的后果是：备份恢复之后、或者 status 被清掉之后，控制器不知道该收敛到哪儿去。",
+            "en": "Putting desired state into status. Status is observed fact and must be recomputable at any moment; spec is desire and only humans change it. Get it backwards and the controller no longer knows what to converge to after a restore, or after status is cleared."
+          },
+          {
+            "zh": "整体替换自己造出来的对象。apiserver 会往对象上补字段（resourceVersion、集群分配的那些），整体覆盖会把它们抹掉，于是每一轮 reconcile 都「发现不一样」再写一次，无限重写。只改你负责的那部分。",
+            "en": "Replacing the object you create wholesale. The apiserver adds fields of its own (resourceVersion, cluster-assigned values); overwriting them means every reconcile \"finds a difference\" and writes again, forever. Touch only the parts you own."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "self-service",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "*.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "site-operator",
+                "namespace": "platform-system",
+                "labels": {
+                  "app.kubernetes.io/name": "site-operator"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "site-operator"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "site-operator"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "manager",
+                        "image": "harbor.corp.internal/platform/site-operator:0.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "operator": {
+            "path": "/root/operator/site.js",
+            "kind": "Site",
+            "name": "site-operator"
+          },
+          "files": {
+            "/root/operator/site-crd.yaml": "# 待补：Site 这个类型还不存在。\n#\n# 需要一个 CustomResourceDefinition，让 apiserver 认识 platform.corp.internal/v1\n# 下面的 Site。业务方提交的东西长这样（见 /root/sites/shop.yaml）：\n#\n#   spec:\n#     host: shop.corp.internal\n#     service:\n#       name: portal\n#       port: 80\n#\n# 两件容易漏的：Operator 要往 status 里写东西，以及\n# `kubectl get sites` 应该一眼看得出 host —— 这两样都在 CRD 上声明。\n",
+            "/root/operator/site.js": "/**\n * Site Operator —— 待补\n *\n * 这个文件就是控制器本身。世界会 watch 你在 `exports.watches` 里声明的类型，\n * 每次变化调一次 `reconcile`。CommonJS 写法，改完立刻生效\n * （真集群里这一步是重新构建镜像再发布）。\n *\n * ctx 上有这些：\n *\n *   ctx.object                       触发这次 reconcile 的 Site\n *   ctx.name / ctx.namespace\n *   ctx.owner()                      属主引用，挂在你造出来的东西上\n *   ctx.get(kind, name, namespace)   读不到返回 undefined\n *   ctx.list(kind, namespace)\n *   ctx.apply(object)                有就改，没有就建\n *   ctx.delete(kind, name, namespace)\n *   ctx.setStatus(patch)             只在真的变了的时候才写回\n *   ctx.event(reason, message)       记一条事件\n *   ctx.log(...)\n *\n * 要造的是一条 HTTPRoute：挂在 payments 命名空间里那个叫 self-service 的\n * Gateway 上，hostname 用 Site 的 host，后端指向 Site 里写的 service。\n */\nexports.watches = ['Site'];\n\nexports.reconcile = (ctx) => {\n  // TODO\n};\n",
+            "/root/sites/shop.yaml": "apiVersion: platform.corp.internal/v1\nkind: Site\nmetadata:\n  name: shop\n  namespace: payments\nspec:\n  host: shop.corp.internal\n  service:\n    name: portal\n    port: 80\n",
+            "/root/sites/shop-moved.yaml": "apiVersion: platform.corp.internal/v1\nkind: Site\nmetadata:\n  name: shop\n  namespace: payments\nspec:\n  host: shop2.corp.internal\n  service:\n    name: portal\n    port: 80\n"
+          },
+          "referenceFiles": {
+            "/root/operator/site-crd.yaml": "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: sites.platform.corp.internal\nspec:\n  group: platform.corp.internal\n  scope: Namespaced\n  names:\n    plural: sites\n    singular: site\n    kind: Site\n    shortNames:\n    - st\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    # 不声明的话 status 就不是子资源，写 status 会连带改到 spec\n    subresources:\n      status: {}\n    # kubectl get sites 打出来的列。平台的自助入口，好不好用就看这几列。\n    additionalPrinterColumns:\n    - name: Host\n      type: string\n      jsonPath: .spec.host\n    - name: Ready\n      type: string\n      jsonPath: .status.ready\n",
+            "/root/operator/site.js": "/**\n * Site Operator\n *\n * 一个 Site 进来，保证有一条对应的 HTTPRoute 出去。\n *\n * 三件事是这段代码真正在做的：\n *   1. 照着**现在**的 spec 收敛，而不是「创建时做一次」\n *   2. 属主引用挂上，Site 没了路由跟着没\n *   3. watch 自己造出来的类型，别人改坏了下一轮能改回去\n */\nexports.watches = ['Site', 'HTTPRoute'];\n\nexports.reconcile = (ctx) => {\n  const site = ctx.object;\n  const backend = (site.spec || {}).service || {};\n\n  if (!site.spec || !site.spec.host || !backend.name) {\n    ctx.setStatus({ ready: false, reason: 'spec.host 和 spec.service.name 都是必填' });\n    ctx.event('InvalidSpec', 'host 或者 service 没写全', 'Warning');\n    return;\n  }\n\n  ctx.apply({\n    apiVersion: 'gateway.networking.k8s.io/v1',\n    kind: 'HTTPRoute',\n    metadata: {\n      name: site.metadata.name,\n      namespace: site.metadata.namespace,\n      // 不挂这个的话，Site 删了路由还在，变成没人管的孤儿\n      ownerReferences: [ctx.owner()],\n    },\n    spec: {\n      parentRefs: [{ name: 'self-service' }],\n      hostnames: [site.spec.host],\n      rules: [{\n        matches: [{ path: { type: 'PathPrefix', value: '/' } }],\n        backendRefs: [{ name: backend.name, port: backend.port || 80 }],\n      }],\n    },\n  });\n\n  // 只写观察到的事实，不写期望 —— 期望在 spec 里\n  ctx.setStatus({\n    ready: true,\n    url: 'http://' + site.spec.host,\n    observedGeneration: site.metadata.generation,\n  });\n};\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/operator/site-crd.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "write-an-operator.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst SITE = () => get('Site', 'shop', 'payments');\nconst ROUTE = () => list('HTTPRoute', { namespace: 'payments' })\n  .filter((route) => route.metadata.name === 'shop')[0];\n\nconst gatewayAddress = () => {\n  const gateway = get('Gateway', 'self-service', 'payments');\n  return ((gateway.status || {}).addresses || [])[0].value;\n};\n\ndescribe('写一个 Operator', () => {\n  it('新类型注册得上，而且一眼看得出 host', async () => {\n    const crds = list('CustomResourceDefinition')\n      .filter((crd) => crd.spec.names.kind === 'Site');\n    expect(crds.length).toBe(1);\n    const established = (crds[0].status.conditions || [])\n      .filter((condition) => condition.type === 'Established');\n    expect(established[0].status).toBe('True');\n\n    await sh('kubectl apply -f /root/sites/shop.yaml');\n    await advance(30000);\n\n    const listed = await sh('kubectl get sites -n payments');\n    expect(listed.code).toBe(0);\n    expect(listed.stdout).toContain('shop.corp.internal');\n  });\n\n  it('路由自动出现，而且指向对的后端', () => {\n    const route = ROUTE();\n    expect(route).toBeTruthy();\n    expect(route.spec.hostnames).toEqual(['shop.corp.internal']);\n    const backend = route.spec.rules[0].backendRefs[0];\n    expect(backend.name).toBe('portal');\n    expect(backend.port).toBe(80);\n    // 属主引用要挂上，不然删了 Site 会留下孤儿\n    const owners = route.metadata.ownerReferences || [];\n    expect(owners.some((owner) => owner.kind === 'Site' && owner.name === 'shop')).toBe(true);\n  });\n\n  it('真的通：从跳板机上 curl 得到 200', async () => {\n    const result = await sh(\n      \"curl -s -o /dev/null -w '%{http_code}' -H 'Host: shop.corp.internal' http://\"\n      + gatewayAddress()\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('status 写得出它现在好不好', () => {\n    const status = SITE().status || {};\n    expect(status.ready).toBe(true);\n    expect(status.observedGeneration).toBe(SITE().metadata.generation);\n  });\n\n  it('改了 Site，路由跟着改', async () => {\n    await sh('kubectl apply -f /root/sites/shop-moved.yaml');\n    await advance(30000);\n    expect(ROUTE().spec.hostnames).toEqual(['shop2.corp.internal']);\n\n    const result = await sh(\n      \"curl -s -o /dev/null -w '%{http_code}' -H 'Host: shop2.corp.internal' http://\"\n      + gatewayAddress()\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('有人手工改坏了路由，下一轮改回去', async () => {\n    await sh(\n      'kubectl patch httproute shop -n payments --type=json -p '\n      + '\\'[{\"op\":\"replace\",\"path\":\"/spec/hostnames\",\"value\":[\"oops.corp.internal\"]}]\\''\n    );\n    await advance(30000);\n    expect(ROUTE().spec.hostnames).toEqual(['shop2.corp.internal']);\n  });\n\n  it('删掉 Site，路由跟着没', async () => {\n    await sh('kubectl delete site shop -n payments');\n    await advance(30000);\n    expect(ROUTE()).toBeUndefined();\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "architecture",
+          "operations"
+        ],
+        "extension": {
+          "zh": "写完这一关，值得回头看一眼整个项目：从第 1 关那条 `kubectl get nodes`\n到这里，你一路见到的所有东西 —— Deployment、Gateway、Certificate、\nRollout、Backup、MachineDeployment —— 都是同一个形状：一个描述期望的对象，\n加一个把期望变成现实的控制器。你刚才写的那三十行，和它们没有本质区别。\n\n这就是 Kubernetes 真正的产品：不是容器编排，是一个**通用的声明式 API\n服务器**加一套控制器模式。容器编排只是这套东西的第一个应用。\n所以「用 CRD 管数据库」「用 CRD 管 DNS 记录」「用 CRD 管办公室门禁」\n听起来离谱，但在架构上完全成立 —— 存储、鉴权、watch、审计、\nkubectl 全套白送，你只要写那个 reconcile。\n\n有两条边界值得记住。一是**不是所有东西都该做成 CRD**：一个只在部署时\n跑一次的动作，写成 Job 或者 CI 的一步更合适 —— 控制器的成本是它要\n永远活着、永远正确。二是**reconcile 一定要幂等且可重入**：它会在你\n意料之外的时刻被调用（重启之后的全量 resync、别人改坏了、\n你自己写 status 触发的那一次），任何「只能执行一次」的逻辑迟早会出事。\n",
+          "en": "Now that this one is done, look back across the whole project. Everything you met\nfrom that first `kubectl get nodes` onwards — Deployment, Gateway, Certificate,\nRollout, Backup, MachineDeployment — has the same shape: an object describing\ndesired state, plus a controller that makes it real. The thirty lines you just\nwrote are not different in kind from any of them.\n\nThat is what Kubernetes actually is: not container orchestration, but a **general\ndeclarative API server** plus a controller pattern. Container orchestration was\nsimply its first application. Which is why \"manage databases with a CRD\", \"manage\nDNS records with a CRD\", or \"manage office door badges with a CRD\" sound absurd\nand are architecturally sound: storage, authorization, watch, audit, and kubectl\nall come for free, and you only write the reconcile.\n\nTwo boundaries are worth keeping. First, **not everything should be a CRD**: an\naction that runs once at deploy time is better as a Job or a CI step, because a\ncontroller costs you something that must stay alive and stay correct forever.\nSecond, **reconcile must be idempotent and re-entrant**: it will be called at\nmoments you did not plan for, including the full resync after a restart, after\nsomebody edits your output, and on the pass your own status write triggered.\nAny logic that can only run once will eventually run twice.\n"
+        },
+        "primer": {
+          "zh": "到这一关为止，你见过的每一个东西都是同一个形状：一个描述期望的对象，加一个把期望变成现实的控制器。Deployment 是这样，Gateway、Certificate、Rollout、Backup、MachineDeployment 全是这样。这一关要做的就是自己写一个，从而看清这个形状本身。\n\n`CustomResourceDefinition` 负责前半段：让 apiserver 多认识一种类型。认识之后，REST 端点、watch、RBAC 里的资源名、`kubectl get`、YAML apply，全套白送，所以写 Operator 的重点从来不在 CRD 上。CRD 上真正要想清楚的只有几件：`scope` 是命名空间级还是集群级、要不要 `subresources.status`（不声明的话 status 不是子资源，写 status 会连带改到 spec）、以及 `additionalPrinterColumns`，因为 `kubectl get` 打出来什么样，决定了这个自助入口好不好用。\n\n后半段是 `reconcile`。它最容易被误解成事件处理器，其实它收到的只有一句「这个对象该看一眼了」，不告诉你变的是什么。所以正确的写法永远是`照着现在的 spec 把世界收敛过去`，而不是「根据这次变化做个增量」。这条决定了它必须**幂等且可重入**：全量 resync、别人改坏了、你自己写 status 触发的那一次，都会让它被重复调用。\n\n要想修偏差，就得 watch 自己造出来的那个类型。只 watch 主类型的话，别人手工改坏了你造的东西，你要等到下一次有人动主对象才会发现，那不叫持续收敛。而顺着`属主引用`找回主对象，正是「附属对象变了该 reconcile 谁」的答案，所以属主引用不只是为了删除。\n\n删除通常不用写代码：属主引用挂对了，垃圾回收会把附属对象一起带走。真正需要 `finalizer` 的是**集群外面的状态**：你在别处开了一个 DNS 记录、一个云上的桶，这些东西 apiserver 不知道，只能靠 finalizer 拦住删除、清理完再放行。代价是 finalizer 摘不掉的对象会永远卡在 Terminating。\n\n最后是 `status` 的两条纪律。一是 status 只放**观察到的事实**，随时可以重新算出来；期望放在 spec 里，只有人能改。放反了的话，status 一被清掉控制器就不知道该收敛到哪儿。二是只在**真的变了**的时候才写 status：写 status 会产生一个 watch 事件，事件触发 reconcile，reconcile 又写 status，每次都写一个新时间戳的控制器会把自己吵醒，CPU 跑满而且什么都没做。",
+          "en": "Everything you have met up to this point has the same shape: an object describing desired state, plus a controller that makes it real. Deployment is that shape, and so are Gateway, Certificate, Rollout, Backup, and MachineDeployment. This stage is about writing one yourself, so the shape itself becomes visible.\n\nA `CustomResourceDefinition` covers the first half: it teaches the apiserver one more type. After that, REST endpoints, watch, the resource name in RBAC, `kubectl get`, and YAML apply all come free, which is why writing an operator is never really about the CRD. The few things worth thinking about on it: `scope` (namespaced or cluster), whether to declare `subresources.status` (without it status is not a subresource and writing status also rewrites spec), and `additionalPrinterColumns`, because what `kubectl get` prints decides whether the self-service entry point is pleasant to use.\n\nThe second half is `reconcile`. It is easily mistaken for an event handler, but all it receives is \"take another look at this object\", never what changed. The correct shape is therefore always `converge the world to the spec as it is now`, not \"apply a delta for this change\". That is what makes it necessarily **idempotent and re-entrant**: a full resync, somebody editing your output, and the pass your own status write triggered will all call it again.\n\nRepairing drift requires watching the kind you create. Watch only the primary kind and a hand-edited child stays broken until somebody happens to touch the primary object again, which is not continuous convergence. And following the `owner reference` back to the primary object is exactly how \"a child changed, whom do I reconcile\" is answered, so owner references are not only about deletion.\n\nDeletion usually needs no code: with owner references attached, garbage collection takes the children with the parent. What genuinely needs a `finalizer` is state **outside** the cluster, a DNS record or a bucket you created elsewhere that the apiserver knows nothing about; a finalizer holds the deletion until you have cleaned it up. The price is that an object whose finalizer never clears sits in Terminating forever.\n\nFinally, two rules about `status`. It holds **observed fact** only, recomputable at any time; desire lives in spec where only humans change it. Reverse them and the controller no longer knows what to converge to once status is cleared. And write status only when something actually changed: writing status produces a watch event, the event triggers reconcile, and reconcile writes status again, so a controller that stamps a fresh timestamp every pass wakes itself up forever, burning CPU and achieving nothing."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1382,6 +1382,25 @@ const primers = {
       )
     ),
 
+    'write-an-operator': t(
+      p(
+        '到这一关为止，你见过的每一个东西都是同一个形状：一个描述期望的对象，加一个把期望变成现实的控制器。Deployment 是这样，Gateway、Certificate、Rollout、Backup、MachineDeployment 全是这样。这一关要做的就是自己写一个，从而看清这个形状本身。',
+        '`CustomResourceDefinition` 负责前半段：让 apiserver 多认识一种类型。认识之后，REST 端点、watch、RBAC 里的资源名、`kubectl get`、YAML apply，全套白送，所以写 Operator 的重点从来不在 CRD 上。CRD 上真正要想清楚的只有几件：`scope` 是命名空间级还是集群级、要不要 `subresources.status`（不声明的话 status 不是子资源，写 status 会连带改到 spec）、以及 `additionalPrinterColumns`，因为 `kubectl get` 打出来什么样，决定了这个自助入口好不好用。',
+        '后半段是 `reconcile`。它最容易被误解成事件处理器，其实它收到的只有一句「这个对象该看一眼了」，不告诉你变的是什么。所以正确的写法永远是`照着现在的 spec 把世界收敛过去`，而不是「根据这次变化做个增量」。这条决定了它必须**幂等且可重入**：全量 resync、别人改坏了、你自己写 status 触发的那一次，都会让它被重复调用。',
+        '要想修偏差，就得 watch 自己造出来的那个类型。只 watch 主类型的话，别人手工改坏了你造的东西，你要等到下一次有人动主对象才会发现，那不叫持续收敛。而顺着`属主引用`找回主对象，正是「附属对象变了该 reconcile 谁」的答案，所以属主引用不只是为了删除。',
+        '删除通常不用写代码：属主引用挂对了，垃圾回收会把附属对象一起带走。真正需要 `finalizer` 的是**集群外面的状态**：你在别处开了一个 DNS 记录、一个云上的桶，这些东西 apiserver 不知道，只能靠 finalizer 拦住删除、清理完再放行。代价是 finalizer 摘不掉的对象会永远卡在 Terminating。',
+        '最后是 `status` 的两条纪律。一是 status 只放**观察到的事实**，随时可以重新算出来；期望放在 spec 里，只有人能改。放反了的话，status 一被清掉控制器就不知道该收敛到哪儿。二是只在**真的变了**的时候才写 status：写 status 会产生一个 watch 事件，事件触发 reconcile，reconcile 又写 status，每次都写一个新时间戳的控制器会把自己吵醒，CPU 跑满而且什么都没做。'
+      ),
+      p(
+        'Everything you have met up to this point has the same shape: an object describing desired state, plus a controller that makes it real. Deployment is that shape, and so are Gateway, Certificate, Rollout, Backup, and MachineDeployment. This stage is about writing one yourself, so the shape itself becomes visible.',
+        'A `CustomResourceDefinition` covers the first half: it teaches the apiserver one more type. After that, REST endpoints, watch, the resource name in RBAC, `kubectl get`, and YAML apply all come free, which is why writing an operator is never really about the CRD. The few things worth thinking about on it: `scope` (namespaced or cluster), whether to declare `subresources.status` (without it status is not a subresource and writing status also rewrites spec), and `additionalPrinterColumns`, because what `kubectl get` prints decides whether the self-service entry point is pleasant to use.',
+        'The second half is `reconcile`. It is easily mistaken for an event handler, but all it receives is "take another look at this object", never what changed. The correct shape is therefore always `converge the world to the spec as it is now`, not "apply a delta for this change". That is what makes it necessarily **idempotent and re-entrant**: a full resync, somebody editing your output, and the pass your own status write triggered will all call it again.',
+        'Repairing drift requires watching the kind you create. Watch only the primary kind and a hand-edited child stays broken until somebody happens to touch the primary object again, which is not continuous convergence. And following the `owner reference` back to the primary object is exactly how "a child changed, whom do I reconcile" is answered, so owner references are not only about deletion.',
+        'Deletion usually needs no code: with owner references attached, garbage collection takes the children with the parent. What genuinely needs a `finalizer` is state **outside** the cluster, a DNS record or a bucket you created elsewhere that the apiserver knows nothing about; a finalizer holds the deletion until you have cleaned it up. The price is that an object whose finalizer never clears sits in Terminating forever.',
+        'Finally, two rules about `status`. It holds **observed fact** only, recomputable at any time; desire lives in spec where only humans change it. Reverse them and the controller no longer knows what to converge to once status is cleared. And write status only when something actually changed: writing status produces a watch event, the event triggers reconcile, and reconcile writes status again, so a controller that stamps a fresh timestamp every pass wakes itself up forever, burning CPU and achieving nothing.'
+      )
+    ),
+
     'take-over-cluster': t(
       p(
         '`Kubernetes` 是一套管理容器的系统。你不直接告诉它「在哪台机器上起一个进程」，而是声明「我要三个这样的副本」，它自己去凑够三个。这套「声明期望、由控制器不断向期望收敛」的做法，是理解后面所有关卡的前提。',

--- a/public/projects.json
+++ b/public/projects.json
@@ -5623,7 +5623,8 @@
           "external-secrets",
           "monitoring",
           "velero",
-          "capi-system"
+          "capi-system",
+          "platform-system"
         ],
         "images": {
           "harbor.corp.internal/team/portal:1.4.0": {
@@ -5782,6 +5783,12 @@
             "startupMs": 500,
             "readyAfterMs": 200,
             "memoryUsage": "256Mi"
+          },
+          "harbor.corp.internal/platform/site-operator:0.1": {
+            "pullMs": 300,
+            "startupMs": 400,
+            "readyAfterMs": 200,
+            "memoryUsage": "128Mi"
           },
           "harbor.corp.internal/team/ledgerdb:14.2": {
             "pullMs": 800,
@@ -14346,6 +14353,596 @@
         "primer": {
           "zh": "机器从哪儿来，是这一层的第一个问题。内网集群没有云厂商的弹性伸缩组，机器要么是人手装的，要么是 `Cluster API` 声明出来的。它的形状和工作负载那一套故意长得一样：`MachineDeployment` 对 Deployment，`MachineSet` 对 ReplicaSet，`Machine` 对 Pod。改副本数就是加机器，换模板就是换一批。\n\nMachine 和 Node 是两个对象，这个区别要记牢。Machine 是「我要一台机器」，Node 是「这台机器上的 kubelet 报到了」。中间隔着装机时间，表现为三段：`Provisioning`（provider 在造）、`Provisioned`（Node 对象出现但 NotReady）、`Running`（kubelet 报到，调度器才看得见它）。`kubectl get machines` 里 NODENAME 那一列在第一段是空的。另外机器的规格写在 infra 模板上，不在 MachineDeployment 上，「我改了副本数为什么新机器还是老规格」的答案就在这个分层里。\n\n`cluster-autoscaler` 做的事只有两件，而且都不看负载。扩容：看到**调度不上**的 Pod，问一句「加一台这种机器，它能落上去吗」，能就加，不能就一台都不加。所以一个请求 32 核的 Pod 在最大 8 核的池子里会永远 Pending 而机器数纹丝不动。这不是坏了，是它算出来加了也没用，理由写在 Pod 的 `NotTriggerScaleUp` 事件里。缩容：看到利用率低的节点，问一句「上面的 Pod 挪得走吗」。\n\n它怎么知道哪些机器组归它管？靠 MachineDeployment 上的两个注解：`cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` 和 `...-max-size`。没打注解的机器组它**看都不看**，这是「伸缩器装了但不工作」最常见的原因。上限不是调优参数，它是闸：一个写错的副本数或者一段死循环的重试，能让机器一台台加到天亮。\n\n缩容那一侧有三道门：利用率够低、闲得够久（默认十分钟）、上面的 Pod 挪得走。第三道最容易卡住，而且卡住的时候伸缩器是沉默的。能钉住一台机器的东西有：PDB 不允许再驱逐、Pod 没有属主（删了就不会被重建）、以及打了 `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"` 的 Pod。最后这一条最阴：加的时候是为了保护某个关键任务，忘了摘，那台机器就永远还不回去了。\n\n最后分清两件常被混着说成「自动扩容」的事：`HPA` 加的是**副本**，看的是指标；伸缩器加的是**机器**，看的是调度结果。顺序是 HPA 先加出一批调度不上的 Pod，伸缩器再为它们加机器。还要记住扩容有代价：装机要几分钟，这几分钟里请求是排队的，所以真要扛突发流量得靠预留容量，不能指望伸缩器。",
           "en": "Where machines come from is the first question at this layer. An intranet cluster has no cloud autoscaling group: machines are either installed by hand or declared through `Cluster API`. Its shape deliberately mirrors the workload API: `MachineDeployment` to Deployment, `MachineSet` to ReplicaSet, `Machine` to Pod. Changing a replica count adds machines; changing the template replaces a batch of them.\n\nMachine and Node are two objects, and the difference matters. A Machine is \"I want a machine\"; a Node is \"the kubelet on that machine has reported in\". Between them sits provisioning time, visible as three phases: `Provisioning` (the provider is building it), `Provisioned` (the Node object exists but is NotReady), and `Running` (the kubelet reported and the scheduler can finally see it). The NODENAME column of `kubectl get machines` is empty during the first phase. Note also that machine size lives on the infra template, not on the MachineDeployment, which is the answer to \"I changed the replica count, why are the new machines still the old size\".\n\n`cluster-autoscaler` does exactly two things, and neither of them looks at load. Scaling up: for pods that **cannot be scheduled**, it asks whether one more machine of this shape would fit them, and adds machines only if the answer is yes. A pod requesting 32 cores in a pool whose largest machine is 8 will therefore stay Pending forever while the machine count never moves. That is not a malfunction, it is the answer to the question, and the reason is recorded in a `NotTriggerScaleUp` event on the pod. Scaling down: for underutilised nodes, it asks whether the pods on them can move.\n\nHow does it know which node groups are its business? Two annotations on the MachineDeployment: `cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size` and `...-max-size`. A group without them is invisible to it, which is the usual reason an installed autoscaler does nothing. The maximum is not a tuning parameter but a brake: a wrong replica count or a retry loop can walk a group up machine by machine all night.\n\nScaling down has three gates: utilisation low enough, idle long enough (ten minutes by default), and the pods on the node able to move. The third is the one that jams, and the autoscaler is silent when it does. Things that pin a machine: a PDB that allows no further eviction, a pod with no controller (delete it and nothing recreates it), and any pod annotated `cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"`. That last one is the sneakiest, added to protect something important and then forgotten, and the machine never goes back.\n\nFinally, separate the two things routinely called autoscaling. `HPA` adds **replicas** based on metrics; the autoscaler adds **machines** based on scheduling outcomes. The order is that HPA produces pods that cannot be scheduled and the autoscaler then provides machines for them. And remember that scaling up costs time: provisioning takes minutes during which requests queue, so genuine burst traffic is absorbed by headroom you kept, not by the autoscaler."
+        }
+      },
+      {
+        "id": "write-an-operator",
+        "title": {
+          "zh": "写一个 Operator",
+          "en": "Write an Operator"
+        },
+        "goal": {
+          "zh": "业务方要一个对外入口，现在的流程是提工单：平台组手写一条 HTTPRoute，\n改一次 host 再提一次工单。一周三四次，而且每次都有人写错后端端口。\n\n这一关把这件事变成自助的：业务方提交一个 `Site`，平台负责让它成真。\n\n两半：一半是 `CustomResourceDefinition`，让 apiserver 认识 Site 这个类型；\n另一半是 `/root/operator/site.js` 里那个 `reconcile` —— 它就是控制器本身，\n世界会 watch 你声明的类型，每次变化调它一次。\n\nSite 长这样（`/root/sites/shop.yaml`）：\n\n```yaml\nspec:\n  host: shop.corp.internal\n  service:\n    name: portal\n    port: 80\n```\n\n要造出来的是一条挂在 `self-service` 这个 Gateway 上的 HTTPRoute。\n\n## 通关标准\n\n1. `kubectl get sites` 查得到，而且一眼看得出 host；\n2. 提交一个 Site，路由自动出现，而且**真的通** —— 从跳板机上 curl 得到 200；\n3. 改了 Site 的 host，路由跟着改（声明式，不是「创建时做一次」）；\n4. 有人手工把路由改坏，下一轮要改回去；\n5. 删掉 Site，路由跟着没；\n6. Site 的 status 里写得出它现在好不好。\n\n## 会用到的命令\n\n```bash\nkubectl apply -f /root/operator/site-crd.yaml\nkubectl apply -f /root/sites/shop.yaml\nkubectl get sites -n payments\nkubectl describe site shop -n payments\nkubectl get httproute -n payments\n```\n",
+          "en": "Teams that want a public entry point file a ticket, someone on the platform team\nhand-writes an HTTPRoute, and changing a hostname means another ticket. Three or\nfour a week, and somebody always gets the backend port wrong.\n\nThis stage turns that into self-service: a team submits a `Site`, and the\nplatform makes it real.\n\nTwo halves. One is a `CustomResourceDefinition` that teaches the apiserver about\nSite. The other is the `reconcile` function in `/root/operator/site.js`, which\n*is* the controller: the world watches the kinds you declare and calls it on\nevery change.\n\nA Site looks like this (`/root/sites/shop.yaml`):\n\n```yaml\nspec:\n  host: shop.corp.internal\n  service:\n    name: portal\n    port: 80\n```\n\nWhat it should produce is an HTTPRoute attached to the `self-service` Gateway.\n\n## Done when\n\n1. `kubectl get sites` works and shows the host at a glance;\n2. submitting a Site produces a route that **actually serves**: curl from the jump\n   host returns 200;\n3. changing the host changes the route (declarative, not create-once);\n4. if somebody edits the route by hand, the next reconcile puts it back;\n5. deleting the Site removes the route;\n6. the Site's status says whether it is working.\n\n## Commands you will need\n\n```bash\nkubectl apply -f /root/operator/site-crd.yaml\nkubectl apply -f /root/sites/shop.yaml\nkubectl get sites -n payments\nkubectl describe site shop -n payments\nkubectl get httproute -n payments\n```\n"
+        },
+        "checklist": [
+          {
+            "zh": "新类型注册得上",
+            "en": "The new kind is registered"
+          },
+          {
+            "zh": "路由自动出现而且通",
+            "en": "The route appears and serves"
+          },
+          {
+            "zh": "改坏了能自己修回去",
+            "en": "Drift is repaired"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "reconcile 不是「事件处理器」。它收到的只有「这个对象该看一眼了」，不告诉你变的是什么 —— 所以正确的写法永远是「照着**现在**的 spec，把世界收敛过去」，而不是「根据这次的变化做个增量」。这也是它必须可以被重复调用而不出错的原因。",
+            "en": "Reconcile is not an event handler. All it gets is \"look at this object again\", never what changed, so the correct shape is always \"converge the world to the spec as it is now\", not \"apply a delta for this change\". That is also why it must be safe to call repeatedly."
+          },
+          {
+            "zh": "想修偏差，就得 watch 自己造出来的那个类型。只 watch 主类型的话，别人手工改坏了路由，你要等到下一次有人动 Site 才会发现 —— 那不叫「持续收敛」，那叫「碰巧修好」。",
+            "en": "To repair drift you must watch the kind you create. Watching only the primary kind means a hand-edited route stays broken until somebody happens to touch the Site again, which is not continuous convergence, it is coincidence."
+          },
+          {
+            "zh": "删除不用你写代码。属主引用挂对了，Site 一删，垃圾回收会把路由一起带走。真正需要写删除逻辑的是「外部状态」—— 比如你在集群外面开了一个 DNS 记录，那才要 finalizer。",
+            "en": "You do not write deletion logic. With the owner reference attached, garbage collection takes the route away with the Site. What actually needs a finalizer is **external** state, like a DNS record you created outside the cluster."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "status 里每次都写一个新时间戳。写 status 会触发一次新的 watch 事件，事件又触发 reconcile，reconcile 又写 status —— 控制器把自己吵醒，CPU 跑满而且什么都没做。只在**真的变了**的时候才写。",
+            "en": "Writing a fresh timestamp into status every pass. Writing status produces a watch event, the event triggers reconcile, reconcile writes status: the controller wakes itself up forever, burning CPU and achieving nothing. Write only when something actually changed."
+          },
+          {
+            "zh": "把期望状态放进 status。status 是**观察到的事实**，随时可以被重新算出来；spec 是期望，只有人能改。放反了的后果是：备份恢复之后、或者 status 被清掉之后，控制器不知道该收敛到哪儿去。",
+            "en": "Putting desired state into status. Status is observed fact and must be recomputable at any moment; spec is desire and only humans change it. Get it backwards and the controller no longer knows what to converge to after a restore, or after status is cleared."
+          },
+          {
+            "zh": "整体替换自己造出来的对象。apiserver 会往对象上补字段（resourceVersion、集群分配的那些），整体覆盖会把它们抹掉，于是每一轮 reconcile 都「发现不一样」再写一次，无限重写。只改你负责的那部分。",
+            "en": "Replacing the object you create wholesale. The apiserver adds fields of its own (resourceVersion, cluster-assigned values); overwriting them means every reconcile \"finds a difference\" and writes again, forever. Touch only the parts you own."
+          }
+        ],
+        "ops": {
+          "setupCommands": [
+            "kubectl config use-context prod"
+          ],
+          "objects": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                "name": "cilium",
+                "namespace": "kube-system",
+                "labels": {
+                  "app.kubernetes.io/name": "cilium"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cilium"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cilium"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "cilium-agent",
+                        "image": "quay.io/cilium/cilium:v1.19.2",
+                        "ports": [
+                          {
+                            "containerPort": 9962
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "envoy-gateway",
+                "namespace": "envoy-gateway-system",
+                "labels": {
+                  "app.kubernetes.io/name": "envoy-gateway"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "envoy-gateway"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "envoy-gateway"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "registry.k8s.io/gateway-api/envoy-gateway:v1.6.2"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "internal",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/office-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.envoyproxy.io/v1alpha1",
+              "kind": "EnvoyProxy",
+              "metadata": {
+                "name": "public",
+                "namespace": "envoy-gateway-system"
+              },
+              "spec": {
+                "provider": {
+                  "kubernetes": {
+                    "envoyService": {
+                      "loadBalancerClass": "corp.internal/public-lb"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-internal"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "internal",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "GatewayClass",
+              "metadata": {
+                "name": "envoy-public"
+              },
+              "spec": {
+                "controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+                "parametersRef": {
+                  "group": "gateway.envoyproxy.io",
+                  "kind": "EnvoyProxy",
+                  "name": "public",
+                  "namespace": "envoy-gateway-system"
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "cert-manager",
+                "namespace": "cert-manager",
+                "labels": {
+                  "app.kubernetes.io/name": "cert-manager"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "cert-manager"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "cert-manager"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/jetstack/cert-manager-controller:v1.19.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "ClusterIssuer",
+              "metadata": {
+                "name": "corp-ca"
+              },
+              "spec": {
+                "ca": {
+                  "secretName": "corp-issuing-ca"
+                }
+              }
+            },
+            {
+              "apiVersion": "cert-manager.io/v1",
+              "kind": "Certificate",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "secretName": "portal-tls",
+                "duration": "2160h",
+                "renewBefore": "720h",
+                "commonName": "portal.corp.internal",
+                "dnsNames": [
+                  "portal.corp.internal"
+                ],
+                "issuerRef": {
+                  "name": "corp-ca",
+                  "kind": "ClusterIssuer"
+                }
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "corp-gw",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "https",
+                    "port": 443,
+                    "protocol": "HTTPS",
+                    "hostname": "portal.corp.internal",
+                    "tls": {
+                      "mode": "Terminate",
+                      "certificateRefs": [
+                        {
+                          "name": "portal-tls"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "portal.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "argo-rollouts",
+                "namespace": "argocd",
+                "labels": {
+                  "app.kubernetes.io/name": "argo-rollouts"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "argo-rollouts"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "argo-rollouts"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "controller",
+                        "image": "quay.io/argoproj/argo-rollouts:v1.8.3"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "prometheus",
+                "namespace": "monitoring",
+                "labels": {
+                  "app.kubernetes.io/name": "prometheus"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "prometheus"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "prometheus"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "prometheus",
+                        "image": "quay.io/prometheus/prometheus:v3.9.1",
+                        "ports": [
+                          {
+                            "containerPort": 9090
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "monitoring.coreos.com/v1",
+              "kind": "ServiceMonitor",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "release": "kube-prom"
+                }
+              },
+              "spec": {
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "endpoints": [
+                  {
+                    "port": "http"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Rollout",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "replicas": 4,
+                "selector": {
+                  "matchLabels": {
+                    "app": "portal"
+                  }
+                },
+                "strategy": {
+                  "canary": {
+                    "steps": [
+                      {
+                        "setWeight": 25
+                      },
+                      {
+                        "setWeight": 100
+                      }
+                    ]
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "portal"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "web",
+                        "image": "harbor.corp.internal/team/portal:1.4.0",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "v1",
+              "kind": "Service",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments",
+                "labels": {
+                  "app": "portal"
+                }
+              },
+              "spec": {
+                "clusterIP": "10.96.1.10",
+                "selector": {
+                  "app": "portal"
+                },
+                "ports": [
+                  {
+                    "port": 80,
+                    "targetPort": 8080
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "HTTPRoute",
+              "metadata": {
+                "name": "portal",
+                "namespace": "payments"
+              },
+              "spec": {
+                "parentRefs": [
+                  {
+                    "name": "corp-gw"
+                  }
+                ],
+                "hostnames": [
+                  "portal.corp.internal"
+                ],
+                "rules": [
+                  {
+                    "matches": [
+                      {
+                        "path": {
+                          "type": "PathPrefix",
+                          "value": "/"
+                        }
+                      }
+                    ],
+                    "backendRefs": [
+                      {
+                        "name": "portal",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "gateway.networking.k8s.io/v1",
+              "kind": "Gateway",
+              "metadata": {
+                "name": "self-service",
+                "namespace": "payments"
+              },
+              "spec": {
+                "gatewayClassName": "envoy-internal",
+                "listeners": [
+                  {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "hostname": "*.corp.internal"
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "metadata": {
+                "name": "site-operator",
+                "namespace": "platform-system",
+                "labels": {
+                  "app.kubernetes.io/name": "site-operator"
+                }
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app.kubernetes.io/name": "site-operator"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app.kubernetes.io/name": "site-operator"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "manager",
+                        "image": "harbor.corp.internal/platform/site-operator:0.1"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "operator": {
+            "path": "/root/operator/site.js",
+            "kind": "Site",
+            "name": "site-operator"
+          },
+          "files": {
+            "/root/operator/site-crd.yaml": "# 待补：Site 这个类型还不存在。\n#\n# 需要一个 CustomResourceDefinition，让 apiserver 认识 platform.corp.internal/v1\n# 下面的 Site。业务方提交的东西长这样（见 /root/sites/shop.yaml）：\n#\n#   spec:\n#     host: shop.corp.internal\n#     service:\n#       name: portal\n#       port: 80\n#\n# 两件容易漏的：Operator 要往 status 里写东西，以及\n# `kubectl get sites` 应该一眼看得出 host —— 这两样都在 CRD 上声明。\n",
+            "/root/operator/site.js": "/**\n * Site Operator —— 待补\n *\n * 这个文件就是控制器本身。世界会 watch 你在 `exports.watches` 里声明的类型，\n * 每次变化调一次 `reconcile`。CommonJS 写法，改完立刻生效\n * （真集群里这一步是重新构建镜像再发布）。\n *\n * ctx 上有这些：\n *\n *   ctx.object                       触发这次 reconcile 的 Site\n *   ctx.name / ctx.namespace\n *   ctx.owner()                      属主引用，挂在你造出来的东西上\n *   ctx.get(kind, name, namespace)   读不到返回 undefined\n *   ctx.list(kind, namespace)\n *   ctx.apply(object)                有就改，没有就建\n *   ctx.delete(kind, name, namespace)\n *   ctx.setStatus(patch)             只在真的变了的时候才写回\n *   ctx.event(reason, message)       记一条事件\n *   ctx.log(...)\n *\n * 要造的是一条 HTTPRoute：挂在 payments 命名空间里那个叫 self-service 的\n * Gateway 上，hostname 用 Site 的 host，后端指向 Site 里写的 service。\n */\nexports.watches = ['Site'];\n\nexports.reconcile = (ctx) => {\n  // TODO\n};\n",
+            "/root/sites/shop.yaml": "apiVersion: platform.corp.internal/v1\nkind: Site\nmetadata:\n  name: shop\n  namespace: payments\nspec:\n  host: shop.corp.internal\n  service:\n    name: portal\n    port: 80\n",
+            "/root/sites/shop-moved.yaml": "apiVersion: platform.corp.internal/v1\nkind: Site\nmetadata:\n  name: shop\n  namespace: payments\nspec:\n  host: shop2.corp.internal\n  service:\n    name: portal\n    port: 80\n"
+          },
+          "referenceFiles": {
+            "/root/operator/site-crd.yaml": "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: sites.platform.corp.internal\nspec:\n  group: platform.corp.internal\n  scope: Namespaced\n  names:\n    plural: sites\n    singular: site\n    kind: Site\n    shortNames:\n    - st\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    # 不声明的话 status 就不是子资源，写 status 会连带改到 spec\n    subresources:\n      status: {}\n    # kubectl get sites 打出来的列。平台的自助入口，好不好用就看这几列。\n    additionalPrinterColumns:\n    - name: Host\n      type: string\n      jsonPath: .spec.host\n    - name: Ready\n      type: string\n      jsonPath: .status.ready\n",
+            "/root/operator/site.js": "/**\n * Site Operator\n *\n * 一个 Site 进来，保证有一条对应的 HTTPRoute 出去。\n *\n * 三件事是这段代码真正在做的：\n *   1. 照着**现在**的 spec 收敛，而不是「创建时做一次」\n *   2. 属主引用挂上，Site 没了路由跟着没\n *   3. watch 自己造出来的类型，别人改坏了下一轮能改回去\n */\nexports.watches = ['Site', 'HTTPRoute'];\n\nexports.reconcile = (ctx) => {\n  const site = ctx.object;\n  const backend = (site.spec || {}).service || {};\n\n  if (!site.spec || !site.spec.host || !backend.name) {\n    ctx.setStatus({ ready: false, reason: 'spec.host 和 spec.service.name 都是必填' });\n    ctx.event('InvalidSpec', 'host 或者 service 没写全', 'Warning');\n    return;\n  }\n\n  ctx.apply({\n    apiVersion: 'gateway.networking.k8s.io/v1',\n    kind: 'HTTPRoute',\n    metadata: {\n      name: site.metadata.name,\n      namespace: site.metadata.namespace,\n      // 不挂这个的话，Site 删了路由还在，变成没人管的孤儿\n      ownerReferences: [ctx.owner()],\n    },\n    spec: {\n      parentRefs: [{ name: 'self-service' }],\n      hostnames: [site.spec.host],\n      rules: [{\n        matches: [{ path: { type: 'PathPrefix', value: '/' } }],\n        backendRefs: [{ name: backend.name, port: backend.port || 80 }],\n      }],\n    },\n  });\n\n  // 只写观察到的事实，不写期望 —— 期望在 spec 里\n  ctx.setStatus({\n    ready: true,\n    url: 'http://' + site.spec.host,\n    observedGeneration: site.metadata.generation,\n  });\n};\n"
+          },
+          "referenceCommands": [
+            "kubectl apply -f /root/operator/site-crd.yaml"
+          ]
+        },
+        "specs": [
+          {
+            "path": "write-an-operator.spec.ts",
+            "content": "import { advance, get, list, sh } from '@ops/lab';\n\nconst SITE = () => get('Site', 'shop', 'payments');\nconst ROUTE = () => list('HTTPRoute', { namespace: 'payments' })\n  .filter((route) => route.metadata.name === 'shop')[0];\n\nconst gatewayAddress = () => {\n  const gateway = get('Gateway', 'self-service', 'payments');\n  return ((gateway.status || {}).addresses || [])[0].value;\n};\n\ndescribe('写一个 Operator', () => {\n  it('新类型注册得上，而且一眼看得出 host', async () => {\n    const crds = list('CustomResourceDefinition')\n      .filter((crd) => crd.spec.names.kind === 'Site');\n    expect(crds.length).toBe(1);\n    const established = (crds[0].status.conditions || [])\n      .filter((condition) => condition.type === 'Established');\n    expect(established[0].status).toBe('True');\n\n    await sh('kubectl apply -f /root/sites/shop.yaml');\n    await advance(30000);\n\n    const listed = await sh('kubectl get sites -n payments');\n    expect(listed.code).toBe(0);\n    expect(listed.stdout).toContain('shop.corp.internal');\n  });\n\n  it('路由自动出现，而且指向对的后端', () => {\n    const route = ROUTE();\n    expect(route).toBeTruthy();\n    expect(route.spec.hostnames).toEqual(['shop.corp.internal']);\n    const backend = route.spec.rules[0].backendRefs[0];\n    expect(backend.name).toBe('portal');\n    expect(backend.port).toBe(80);\n    // 属主引用要挂上，不然删了 Site 会留下孤儿\n    const owners = route.metadata.ownerReferences || [];\n    expect(owners.some((owner) => owner.kind === 'Site' && owner.name === 'shop')).toBe(true);\n  });\n\n  it('真的通：从跳板机上 curl 得到 200', async () => {\n    const result = await sh(\n      \"curl -s -o /dev/null -w '%{http_code}' -H 'Host: shop.corp.internal' http://\"\n      + gatewayAddress()\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('status 写得出它现在好不好', () => {\n    const status = SITE().status || {};\n    expect(status.ready).toBe(true);\n    expect(status.observedGeneration).toBe(SITE().metadata.generation);\n  });\n\n  it('改了 Site，路由跟着改', async () => {\n    await sh('kubectl apply -f /root/sites/shop-moved.yaml');\n    await advance(30000);\n    expect(ROUTE().spec.hostnames).toEqual(['shop2.corp.internal']);\n\n    const result = await sh(\n      \"curl -s -o /dev/null -w '%{http_code}' -H 'Host: shop2.corp.internal' http://\"\n      + gatewayAddress()\n    );\n    expect(result.stdout).toBe('200');\n  });\n\n  it('有人手工改坏了路由，下一轮改回去', async () => {\n    await sh(\n      'kubectl patch httproute shop -n payments --type=json -p '\n      + '\\'[{\"op\":\"replace\",\"path\":\"/spec/hostnames\",\"value\":[\"oops.corp.internal\"]}]\\''\n    );\n    await advance(30000);\n    expect(ROUTE().spec.hostnames).toEqual(['shop2.corp.internal']);\n  });\n\n  it('删掉 Site，路由跟着没', async () => {\n    await sh('kubectl delete site shop -n payments');\n    await advance(30000);\n    expect(ROUTE()).toBeUndefined();\n  });\n});\n"
+          }
+        ],
+        "focus": [
+          "architecture",
+          "operations"
+        ],
+        "extension": {
+          "zh": "写完这一关，值得回头看一眼整个项目：从第 1 关那条 `kubectl get nodes`\n到这里，你一路见到的所有东西 —— Deployment、Gateway、Certificate、\nRollout、Backup、MachineDeployment —— 都是同一个形状：一个描述期望的对象，\n加一个把期望变成现实的控制器。你刚才写的那三十行，和它们没有本质区别。\n\n这就是 Kubernetes 真正的产品：不是容器编排，是一个**通用的声明式 API\n服务器**加一套控制器模式。容器编排只是这套东西的第一个应用。\n所以「用 CRD 管数据库」「用 CRD 管 DNS 记录」「用 CRD 管办公室门禁」\n听起来离谱，但在架构上完全成立 —— 存储、鉴权、watch、审计、\nkubectl 全套白送，你只要写那个 reconcile。\n\n有两条边界值得记住。一是**不是所有东西都该做成 CRD**：一个只在部署时\n跑一次的动作，写成 Job 或者 CI 的一步更合适 —— 控制器的成本是它要\n永远活着、永远正确。二是**reconcile 一定要幂等且可重入**：它会在你\n意料之外的时刻被调用（重启之后的全量 resync、别人改坏了、\n你自己写 status 触发的那一次），任何「只能执行一次」的逻辑迟早会出事。\n",
+          "en": "Now that this one is done, look back across the whole project. Everything you met\nfrom that first `kubectl get nodes` onwards — Deployment, Gateway, Certificate,\nRollout, Backup, MachineDeployment — has the same shape: an object describing\ndesired state, plus a controller that makes it real. The thirty lines you just\nwrote are not different in kind from any of them.\n\nThat is what Kubernetes actually is: not container orchestration, but a **general\ndeclarative API server** plus a controller pattern. Container orchestration was\nsimply its first application. Which is why \"manage databases with a CRD\", \"manage\nDNS records with a CRD\", or \"manage office door badges with a CRD\" sound absurd\nand are architecturally sound: storage, authorization, watch, audit, and kubectl\nall come for free, and you only write the reconcile.\n\nTwo boundaries are worth keeping. First, **not everything should be a CRD**: an\naction that runs once at deploy time is better as a Job or a CI step, because a\ncontroller costs you something that must stay alive and stay correct forever.\nSecond, **reconcile must be idempotent and re-entrant**: it will be called at\nmoments you did not plan for, including the full resync after a restart, after\nsomebody edits your output, and on the pass your own status write triggered.\nAny logic that can only run once will eventually run twice.\n"
+        },
+        "primer": {
+          "zh": "到这一关为止，你见过的每一个东西都是同一个形状：一个描述期望的对象，加一个把期望变成现实的控制器。Deployment 是这样，Gateway、Certificate、Rollout、Backup、MachineDeployment 全是这样。这一关要做的就是自己写一个，从而看清这个形状本身。\n\n`CustomResourceDefinition` 负责前半段：让 apiserver 多认识一种类型。认识之后，REST 端点、watch、RBAC 里的资源名、`kubectl get`、YAML apply，全套白送，所以写 Operator 的重点从来不在 CRD 上。CRD 上真正要想清楚的只有几件：`scope` 是命名空间级还是集群级、要不要 `subresources.status`（不声明的话 status 不是子资源，写 status 会连带改到 spec）、以及 `additionalPrinterColumns`，因为 `kubectl get` 打出来什么样，决定了这个自助入口好不好用。\n\n后半段是 `reconcile`。它最容易被误解成事件处理器，其实它收到的只有一句「这个对象该看一眼了」，不告诉你变的是什么。所以正确的写法永远是`照着现在的 spec 把世界收敛过去`，而不是「根据这次变化做个增量」。这条决定了它必须**幂等且可重入**：全量 resync、别人改坏了、你自己写 status 触发的那一次，都会让它被重复调用。\n\n要想修偏差，就得 watch 自己造出来的那个类型。只 watch 主类型的话，别人手工改坏了你造的东西，你要等到下一次有人动主对象才会发现，那不叫持续收敛。而顺着`属主引用`找回主对象，正是「附属对象变了该 reconcile 谁」的答案，所以属主引用不只是为了删除。\n\n删除通常不用写代码：属主引用挂对了，垃圾回收会把附属对象一起带走。真正需要 `finalizer` 的是**集群外面的状态**：你在别处开了一个 DNS 记录、一个云上的桶，这些东西 apiserver 不知道，只能靠 finalizer 拦住删除、清理完再放行。代价是 finalizer 摘不掉的对象会永远卡在 Terminating。\n\n最后是 `status` 的两条纪律。一是 status 只放**观察到的事实**，随时可以重新算出来；期望放在 spec 里，只有人能改。放反了的话，status 一被清掉控制器就不知道该收敛到哪儿。二是只在**真的变了**的时候才写 status：写 status 会产生一个 watch 事件，事件触发 reconcile，reconcile 又写 status，每次都写一个新时间戳的控制器会把自己吵醒，CPU 跑满而且什么都没做。",
+          "en": "Everything you have met up to this point has the same shape: an object describing desired state, plus a controller that makes it real. Deployment is that shape, and so are Gateway, Certificate, Rollout, Backup, and MachineDeployment. This stage is about writing one yourself, so the shape itself becomes visible.\n\nA `CustomResourceDefinition` covers the first half: it teaches the apiserver one more type. After that, REST endpoints, watch, the resource name in RBAC, `kubectl get`, and YAML apply all come free, which is why writing an operator is never really about the CRD. The few things worth thinking about on it: `scope` (namespaced or cluster), whether to declare `subresources.status` (without it status is not a subresource and writing status also rewrites spec), and `additionalPrinterColumns`, because what `kubectl get` prints decides whether the self-service entry point is pleasant to use.\n\nThe second half is `reconcile`. It is easily mistaken for an event handler, but all it receives is \"take another look at this object\", never what changed. The correct shape is therefore always `converge the world to the spec as it is now`, not \"apply a delta for this change\". That is what makes it necessarily **idempotent and re-entrant**: a full resync, somebody editing your output, and the pass your own status write triggered will all call it again.\n\nRepairing drift requires watching the kind you create. Watch only the primary kind and a hand-edited child stays broken until somebody happens to touch the primary object again, which is not continuous convergence. And following the `owner reference` back to the primary object is exactly how \"a child changed, whom do I reconcile\" is answered, so owner references are not only about deletion.\n\nDeletion usually needs no code: with owner references attached, garbage collection takes the children with the parent. What genuinely needs a `finalizer` is state **outside** the cluster, a DNS record or a bucket you created elsewhere that the apiserver knows nothing about; a finalizer holds the deletion until you have cleaned it up. The price is that an object whose finalizer never clears sits in Terminating forever.\n\nFinally, two rules about `status`. It holds **observed fact** only, recomputable at any time; desire lives in spec where only humans change it. Reverse them and the controller no longer knows what to converge to once status is cleared. And write status only when something actually changed: writing status produces a watch event, the event triggers reconcile, and reconcile writes status again, so a controller that stamps a fresh timestamp every pass wakes itself up forever, burning CPU and achieving nothing."
         }
       }
     ]

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -414,6 +414,21 @@ export interface OpsStageSpec {
    * key 是 PVC 的 `命名空间/名字`，value 是卷内相对路径到内容。
    */
   volumes?: Record<string, Record<string, string>>;
+  /**
+   * 学员自己写的 Operator。
+   *
+   * 声明了它，世界就会把 `path` 那个文件当成一个控制器跑起来：watch 事件、
+   * 调它导出的 reconcile、给它一个 apiserver 客户端。文件改了立刻生效
+   * （真集群里这一步是重新构建镜像再发布）。
+   */
+  operator?: {
+    /** 代码在机器磁盘上的位置 */
+    path: string;
+    /** 它管的自定义资源的 kind */
+    kind: string;
+    /** 它那个 Deployment 的 `app.kubernetes.io/name`。停掉它，自定义资源就没人管了。 */
+    name: string;
+  };
 }
 
 export type WorkspaceSpec = CodeWorkspaceSpec | OpsWorkspaceSpec;

--- a/src/lib/opslab/controllers/cluster.ts
+++ b/src/lib/opslab/controllers/cluster.ts
@@ -524,6 +524,19 @@ export class Cluster {
     return (this.options.startTime ?? Date.parse('2026-01-01T00:00:00Z')) + this.kernel.now();
   }
 
+  /**
+   * 世界建好之后再挂一个控制器上去。
+   *
+   * 学员自己写的 Operator 就是这么接进来的 —— 它的代码在机器的磁盘上，
+   * 而机器是在集群之后才有的，所以没法在 start() 里一起建。
+   */
+  attach(create: (context: ControllerContext) => Controller): Controller {
+    const controller = create(this.context);
+    this.controllers.push(controller);
+    if (this.started) controller.start();
+    return controller;
+  }
+
   private get context(): ControllerContext {
     return {
       kernel: this.kernel,
@@ -647,7 +660,8 @@ export class Cluster {
     this.started = true;
 
     const context = this.context;
-    this.controllers = [
+    // 用 push 而不是赋值：start() 之前 attach 进来的（学员的 Operator）不能被冲掉
+    this.controllers.push(
       new SchedulerController(context),
       new ReplicaSetController(context),
       new DeploymentController(context),
@@ -723,8 +737,8 @@ export class Cluster {
           })]
         : []),
       new LoadBalancerController(context, this.options.addressPools ?? DEFAULT_POOLS),
-      ...this.nodeSpecs.flatMap((node) => this.kubeletFor(context, node.name)),
-    ];
+      ...this.nodeSpecs.flatMap((node) => this.kubeletFor(context, node.name))
+    );
     for (const controller of this.controllers) controller.start();
 
     /**

--- a/src/lib/opslab/controllers/workloads.ts
+++ b/src/lib/opslab/controllers/workloads.ts
@@ -1365,9 +1365,31 @@ export class NamespaceController extends Controller {
  * 摘掉那条引用，附属品就变成没人管的孤儿，而不是被删掉。
  */
 export class GarbageCollector extends Controller {
+  /** 已经在盯的类型。CRD 是后来注册的，所以这张表要能长。 */
+  private watched = new Set<string>();
+
   constructor(context: ControllerContext) {
     super(context, 'garbage-collector');
-    for (const definition of context.scheme.list()) {
+    this.syncInformers();
+    /**
+     * 自定义类型也要盯。
+     *
+     * CRD 是运行时注册进来的，构造这个控制器的时候它还不存在 ——
+     * 不补这一步的话，删掉一个自定义资源，它造出来的东西全变成孤儿留在集群里，
+     * 而这恰恰是最需要垃圾回收的场景（Operator 造出来的那些）。
+     */
+    const crds = this.track(new Informer(this.registry, {
+      group: 'apiextensions.k8s.io', version: 'v1', resource: 'customresourcedefinitions',
+      singular: 'customresourcedefinition', kind: 'CustomResourceDefinition', namespaced: false,
+    }));
+    crds.onChange(() => this.syncInformers());
+  }
+
+  private syncInformers(): void {
+    for (const definition of this.context.scheme.list()) {
+      const key = `${definition.group}/${definition.version}/${definition.resource}`;
+      if (this.watched.has(key)) continue;
+      this.watched.add(key);
       const informer = this.track(new Informer(this.registry, definition));
       /**
        * 只有删除才可能产生孤儿。每次变更都扫一遍的话，
@@ -1376,9 +1398,10 @@ export class GarbageCollector extends Controller {
        * 判断「这是一次删除」看的是缓存里还有没有它 —— 事件本身带的是
        * 被删掉的那个对象，不是 undefined。
        */
-      informer.onChange((key) => {
-        if (informer.get(key) === undefined) this.queue.add('sweep');
+      informer.onChange((eventKey) => {
+        if (informer.get(eventKey) === undefined) this.queue.add('sweep');
       });
+      informer.start();
     }
   }
 

--- a/src/lib/opslab/lab/world.ts
+++ b/src/lib/opslab/lab/world.ts
@@ -23,6 +23,7 @@ import { materializePki } from './pki';
 import { GitNetwork, createGitCommand, parseCommit, readTree, seedRepository } from '../git';
 import { createIstioctlCommand } from '../mesh';
 import { createVeleroCommand } from '../backup';
+import { OperatorController } from '../operator';
 import { SignatureStore, createCosignCommand } from '../admission';
 import { OpenBao, createBaoCommand } from '../secrets';
 import { createPromtoolCommand } from '../observability';
@@ -403,6 +404,22 @@ export async function createOpsWorld(options: OpsWorldOptions = {}): Promise<Ops
       return undefined;
     }
   };
+
+  /**
+   * 学员自己写的 Operator。
+   *
+   * 代码在机器磁盘上，所以只能等机器建好之后再挂。文件不在也没关系 ——
+   * 那就是「还没开始写」，控制器什么都不做。
+   */
+  if (stage.operator) {
+    const { path: operatorPath, kind, name } = stage.operator;
+    cluster.attach((context) => new OperatorController(context, {
+      name, kind,
+      source: () => (machine.vfs.exists(operatorPath)
+        ? machine.vfs.readFile(operatorPath)
+        : undefined),
+    }));
+  }
 
   // `kubectl exec` 落到 Pod 里那个 shell 上
   cluster.execHandler = createExecHandler(cluster);

--- a/src/lib/opslab/operator/index.ts
+++ b/src/lib/opslab/operator/index.ts
@@ -1,0 +1,7 @@
+/**
+ * 学员写的 Operator
+ *
+ * 到这里两种工作台合流：逻辑是代码，作用对象是真的 apiserver。
+ */
+export { OperatorController, OperatorError } from './runtime';
+export type { OperatorOptions } from './runtime';

--- a/src/lib/opslab/operator/runtime.ts
+++ b/src/lib/opslab/operator/runtime.ts
@@ -1,0 +1,295 @@
+/**
+ * 学员自己写的 Operator，跑在这个集群上
+ *
+ * 两种工作台在这里合流：控制器的逻辑是**代码**，而它读写的是**真的 apiserver**。
+ * 这一层做的事只有一件 —— 把学员写的那个函数接到 watch 事件上，
+ * 并给它一个够用的客户端。
+ *
+ * 有三件事是刻意不替学员做的，因为它们正是这一关要教的：
+ *
+ *   1. 属主引用要自己挂。不挂的话删掉自定义资源，造出来的东西全变成孤儿。
+ *   2. 要 watch 自己造出来的那些类型。不 watch 的话别人改坏了你不知道，
+ *      「声明式」就退化成「创建时做一次」。
+ *   3. status 要自己写，而且只在变了的时候写。每次都写一个新时间戳的话，
+ *      写回去又触发一次 reconcile，世界永远静不下来。
+ */
+import type { KubeObject, ResourceDefinition } from '../apiserver';
+import { createModuleRuntime } from '../../engineering/moduleRuntime';
+import {
+  Controller, ControllerContext, Informer, isNotFound, objectKey, splitKey,
+} from '../controllers/framework';
+import { DEPLOYMENTS } from '../controllers/resources';
+import { ignoreConflict, updateStatusIfChanged } from '../controllers/workloads';
+import { CUSTOMRESOURCEDEFINITIONS } from '../crd';
+
+export interface OperatorOptions {
+  /** 这个 Operator 的名字，同时也是它那个 Deployment 的 `app.kubernetes.io/name` */
+  name: string;
+  /** 它管的自定义资源的 kind */
+  kind: string;
+  /** 去哪儿取代码。返回 undefined 就是「文件还不在」。 */
+  source(): string | undefined;
+}
+
+interface OperatorModule {
+  reconcile?: (ctx: unknown) => unknown;
+  watches?: string[];
+}
+
+/** 学员的代码抛异常时，把它变成对象上的一条事件，而不是把世界搞崩 */
+export class OperatorError extends Error {}
+
+export class OperatorController extends Controller {
+  private crds: Informer;
+  private deployments: Informer;
+  /** kind -> informer，CRD 注册之后才建得起来。基类那个 informers 是数组，名字不能撞。 */
+  private dynamic = new Map<string, Informer>();
+  private loaded?: { source: string; module: OperatorModule };
+  private logs: string[] = [];
+
+  constructor(context: ControllerContext, private readonly options: OperatorOptions) {
+    super(context, `operator:${options.name}`);
+    this.crds = this.track(new Informer(this.registry, CUSTOMRESOURCEDEFINITIONS));
+    this.deployments = this.track(new Informer(this.registry, DEPLOYMENTS));
+    // CRD 注册进来之后才有得 watch；Operator 那个 Deployment 起来之后才该干活
+    this.crds.onChange(() => this.sync());
+    this.deployments.onChange(() => this.resync());
+  }
+
+  start(): void {
+    super.start();
+    this.sync();
+  }
+
+  stop(): void {
+    for (const informer of this.dynamic.values()) informer.stop();
+    this.dynamic.clear();
+    super.stop();
+  }
+
+  /** 给判定看的：这个 Operator 打过哪些日志 */
+  logLines(): string[] {
+    return [...this.logs];
+  }
+
+  /**
+   * 它是不是在跑。
+   *
+   * Operator 也是集群里的一个工作负载 —— 把它的 Deployment 缩到 0，
+   * 自定义资源还在、`kubectl get` 照样查得到，但**没有人再让它们成真**。
+   * 这是「CRD 只是数据结构，Operator 才是行为」最直观的演示。
+   */
+  private installed(): boolean {
+    return this.deployments.list().some((deployment) => {
+      if (deployment.metadata.labels?.['app.kubernetes.io/name'] !== this.options.name) return false;
+      return (((deployment.status ?? {}) as { availableReplicas?: number }).availableReplicas ?? 0) > 0;
+    });
+  }
+
+  private definitionFor(kind: string): ResourceDefinition | undefined {
+    return this.context.scheme.list().find((item) => item.kind === kind);
+  }
+
+  private module(): OperatorModule | undefined {
+    const source = this.options.source();
+    if (source === undefined) return undefined;
+    if (this.loaded?.source === source) return this.loaded.module;
+
+    const runtime = createModuleRuntime({
+      files: { 'operator.js': source },
+      builtins: {},
+      globals: {
+        console: {
+          log: (...args: unknown[]) => this.logs.push(args.map(String).join(' ')),
+          error: (...args: unknown[]) => this.logs.push(`ERROR ${args.map(String).join(' ')}`),
+        },
+      },
+    });
+    const module = runtime.require('./operator.js') as OperatorModule;
+    this.loaded = { source, module };
+    return module;
+  }
+
+  /** 建立还缺的 informer。CRD 是后来才注册的，所以这一步要反复做。 */
+  private sync(): void {
+    let kinds: string[];
+    try {
+      kinds = [this.options.kind, ...(this.module()?.watches ?? [])];
+    } catch {
+      kinds = [this.options.kind];
+    }
+    let added = false;
+    for (const kind of new Set(kinds)) {
+      if (this.dynamic.has(kind)) continue;
+      const definition = this.definitionFor(kind);
+      if (!definition) continue;
+      const informer = new Informer(this.registry, definition);
+      informer.onChange((key, object) => this.route(kind, key, object));
+      informer.start();
+      this.dynamic.set(kind, informer);
+      added = true;
+    }
+    if (added) this.resync();
+  }
+
+  /**
+   * 一个事件该 reconcile 谁。
+   *
+   * 主类型的事件对应它自己；附属类型的事件顺着属主引用找回去 ——
+   * 这也是为什么属主引用不只是为了删除：**没有它，控制器不知道
+   * 这个被改坏的东西是谁的**，也就修不回去。
+   */
+  private route(kind: string, key: string, object: KubeObject | undefined): void {
+    if (kind === this.options.kind) {
+      this.queue.add(key);
+      return;
+    }
+    const namespace = splitKey(key).namespace;
+    const owner = (object?.metadata.ownerReferences ?? []).find((ref) => ref.kind === this.options.kind);
+    if (owner) {
+      this.queue.add(namespace ? `${namespace}/${owner.name}` : owner.name);
+      return;
+    }
+    this.resync();
+  }
+
+  private resync(): void {
+    const definition = this.definitionFor(this.options.kind);
+    if (!definition) return;
+    for (const object of this.registry.list(definition).items) this.queue.add(objectKey(object));
+  }
+
+  protected async reconcile(key: string): Promise<void> {
+    if (!this.installed()) return;
+    const definition = this.definitionFor(this.options.kind);
+    if (!definition) return;
+
+    let module: OperatorModule | undefined;
+    try {
+      module = this.module();
+    } catch (error) {
+      this.logs.push(`ERROR failed to load operator: ${(error as Error).message}`);
+      return;
+    }
+    if (typeof module?.reconcile !== 'function') return;
+
+    const { namespace, name } = splitKey(key);
+    let object: KubeObject;
+    try {
+      object = this.registry.get(definition, namespace, name);
+    } catch (error) {
+      if (isNotFound(error)) return;                 // 删除交给属主引用，不用学员操心
+      throw error;
+    }
+    if (object.metadata.deletionTimestamp) return;
+
+    try {
+      await module.reconcile(this.contextFor(definition, object));
+    } catch (error) {
+      const message = (error as Error).message ?? String(error);
+      this.logs.push(`ERROR reconcile ${key}: ${message}`);
+      this.context.recordEvent({
+        object, type: 'Warning', reason: 'ReconcileError', message,
+      });
+    }
+  }
+
+  /** 交给学员代码的那个客户端。刻意做得小：够写一个真 Operator，不多一个字。 */
+  private contextFor(definition: ResourceDefinition, object: KubeObject): Record<string, unknown> {
+    const resolve = (kind: string): ResourceDefinition => {
+      const found = this.definitionFor(kind);
+      if (!found) throw new OperatorError(`no kind "${kind}" registered in this cluster`);
+      return found;
+    };
+
+    return {
+      object: JSON.parse(JSON.stringify(object)) as KubeObject,
+      name: object.metadata.name,
+      namespace: object.metadata.namespace,
+
+      /** 挂在自己造出来的东西上：属主没了它们跟着没 */
+      owner: () => ({
+        apiVersion: object.apiVersion,
+        kind: object.kind,
+        name: object.metadata.name,
+        uid: object.metadata.uid,
+        controller: true,
+        blockOwnerDeletion: true,
+      }),
+
+      get: (kind: string, name: string, namespace?: string) => {
+        try {
+          const found = this.registry.get(resolve(kind), namespace ?? object.metadata.namespace, name);
+          return JSON.parse(JSON.stringify(found));
+        } catch (error) {
+          if (isNotFound(error)) return undefined;
+          throw error;
+        }
+      },
+
+      list: (kind: string, namespace?: string) => this.registry
+        .list(resolve(kind), { namespace: namespace ?? object.metadata.namespace }).items
+        .map((item) => JSON.parse(JSON.stringify(item))),
+
+      /**
+       * 有就改，没有就建。
+       *
+       * 改的时候只覆盖 spec 和 metadata 里学员给的部分 —— 直接整体替换会
+       * 把 apiserver 补上的字段（resourceVersion、集群分配的那些）抹掉，
+       * 然后每次 reconcile 都「发现不一样」，无限重写。
+       */
+      apply: (body: KubeObject) => {
+        const target = resolve(body.kind);
+        const namespace = body.metadata?.namespace ?? object.metadata.namespace;
+        const name = body.metadata?.name;
+        if (!name) throw new OperatorError('apply() needs metadata.name');
+        try {
+          const existing = this.registry.get(target, namespace, name);
+          const next = {
+            ...existing,
+            metadata: {
+              ...existing.metadata,
+              labels: body.metadata?.labels ?? existing.metadata.labels,
+              annotations: body.metadata?.annotations ?? existing.metadata.annotations,
+              ownerReferences: body.metadata?.ownerReferences ?? existing.metadata.ownerReferences,
+            },
+            spec: body.spec ?? existing.spec,
+          } as KubeObject;
+          if (JSON.stringify(next) === JSON.stringify(existing)) return existing;
+          return this.registry.update(target, namespace, name, next);
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+          return this.registry.create(target, namespace, {
+            ...body,
+            metadata: { ...(body.metadata ?? {}), name, namespace },
+          } as KubeObject);
+        }
+      },
+
+      delete: (kind: string, name: string, namespace?: string) => {
+        try {
+          this.registry.delete(resolve(kind), namespace ?? object.metadata.namespace, name);
+        } catch (error) {
+          if (!isNotFound(error)) throw error;
+        }
+      },
+
+      /** 只在真的变了的时候才写。每次都写的话，写回去又触发一次 reconcile。 */
+      setStatus: (patch: Record<string, unknown>) => {
+        void ignoreConflict(() => {
+          const latest = this.registry.get(definition, object.metadata.namespace, object.metadata.name!);
+          updateStatusIfChanged(
+            this.registry, definition, latest.metadata.namespace, latest.metadata.name!,
+            { ...((latest.status ?? {}) as Record<string, unknown>), ...patch }
+          );
+        });
+      },
+
+      event: (reason: string, message: string, type: 'Normal' | 'Warning' = 'Normal') => {
+        this.context.recordEvent({ object, type, reason, message });
+      },
+
+      log: (...args: unknown[]) => { this.logs.push(args.map(String).join(' ')); },
+    };
+  }
+}

--- a/tests/opslab/operator.test.ts
+++ b/tests/opslab/operator.test.ts
@@ -1,0 +1,236 @@
+/**
+ * 学员自己写的 Operator
+ *
+ * 这一组钉的是 Operator 这件事本身的性质，不是某一段代码：
+ *   1. 它是**声明式**的：改了自定义资源，造出来的东西跟着变
+ *   2. 它**修偏差**：别人改坏了它造出来的东西，下一轮会改回去
+ *   3. 属主引用是它的删除机制，不是它自己删
+ *   4. 它是一个工作负载：停掉它，自定义资源还在，只是没人让它们成真
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import type { OpsWorldSpec } from '../../src/lib/engineering/types';
+import type { KubeObject } from '../../src/lib/opslab/apiserver';
+
+const OPERATOR_IMAGE = 'harbor.corp.internal/platform/site-operator:0.1';
+const CRDS = { group: 'apiextensions.k8s.io', version: 'v1', resource: 'customresourcedefinitions' } as const;
+const SITES = { group: 'platform.corp.internal', version: 'v1', resource: 'sites' } as const;
+const CONFIGMAPS = { group: '', version: 'v1', resource: 'configmaps' } as const;
+
+const SITE_CRD = {
+  apiVersion: 'apiextensions.k8s.io/v1', kind: 'CustomResourceDefinition',
+  metadata: { name: 'sites.platform.corp.internal' },
+  spec: {
+    group: 'platform.corp.internal', scope: 'Namespaced',
+    names: { plural: 'sites', singular: 'site', kind: 'Site' },
+    versions: [{ name: 'v1', served: true, storage: true, subresources: { status: {} } }],
+  },
+};
+
+const OPERATOR_DEPLOYMENT = {
+  apiVersion: 'apps/v1', kind: 'Deployment',
+  metadata: {
+    name: 'site-operator', namespace: 'default',
+    labels: { 'app.kubernetes.io/name': 'site-operator' },
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: { 'app.kubernetes.io/name': 'site-operator' } },
+    template: {
+      metadata: { labels: { 'app.kubernetes.io/name': 'site-operator' } },
+      spec: { containers: [{ name: 'manager', image: OPERATOR_IMAGE }] },
+    },
+  },
+};
+
+/** 一个够小但完整的 Operator：Site -> ConfigMap */
+const OPERATOR_CODE = `
+exports.watches = ['Site', 'ConfigMap'];
+
+exports.reconcile = (ctx) => {
+  const site = ctx.object;
+  ctx.apply({
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: site.metadata.name + '-site',
+      namespace: site.metadata.namespace,
+      ownerReferences: [ctx.owner()],
+    },
+    data: { host: site.spec.host },
+    spec: { host: site.spec.host },
+  });
+  ctx.setStatus({ ready: true, host: site.spec.host, observedGeneration: site.metadata.generation });
+};
+`;
+
+/** 不 watch 附属类型的版本：别人改坏了它不知道 */
+const BLIND_CODE = OPERATOR_CODE.replace("exports.watches = ['Site', 'ConfigMap'];", "exports.watches = ['Site'];");
+
+/** 不挂属主引用的版本：删掉 Site 之后 ConfigMap 变成孤儿 */
+const ORPHAN_CODE = OPERATOR_CODE.replace('ownerReferences: [ctx.owner()],', '');
+
+function spec(objects: unknown[]): OpsWorldSpec {
+  return {
+    namespaces: ['default'],
+    images: { [OPERATOR_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 } },
+    objects: objects as never,
+  };
+}
+
+async function build(code: string) {
+  const world = await createOpsWorld({
+    world: spec([SITE_CRD, OPERATOR_DEPLOYMENT]),
+    stage: {
+      files: { '/root/operator/site.js': code },
+      operator: { path: '/root/operator/site.js', kind: 'Site', name: 'site-operator' },
+    },
+  });
+  await world.cluster.advanceBy(30_000);
+  return world;
+}
+
+type World = Awaited<ReturnType<typeof build>>;
+
+const createSite = async (w: World, name: string, host: string) => {
+  w.cluster.registry.create(w.cluster.scheme.mustGet(SITES), 'default', {
+    apiVersion: 'platform.corp.internal/v1', kind: 'Site',
+    metadata: { name, namespace: 'default' },
+    spec: { host },
+  } as KubeObject);
+  await w.cluster.advanceBy(10_000);
+};
+
+const configMap = (w: World, name: string) => {
+  try {
+    return w.cluster.registry.get(w.cluster.scheme.mustGet(CONFIGMAPS), 'default', name);
+  } catch {
+    return undefined;
+  }
+};
+const siteOf = (w: World, name: string) =>
+  w.cluster.registry.get(w.cluster.scheme.mustGet(SITES), 'default', name);
+
+describe('reconcile', () => {
+  it('提交一个自定义资源，它造出该造的东西', async () => {
+    const w = await build(OPERATOR_CODE);
+    await createSite(w, 'portal', 'portal.corp.internal');
+
+    const created = configMap(w, 'portal-site');
+    expect(created).toBeDefined();
+    expect((created!.spec as any).host).toBe('portal.corp.internal');
+    expect((siteOf(w, 'portal').status as any).ready).toBe(true);
+  });
+
+  /**
+   * 声明式的意思是「照着现在的 spec 收敛」，不是「创建时做一次」。
+   * 改了 host，路由要跟着改 —— 这一条不过的 Operator 只是个安装脚本。
+   */
+  it('改了 spec，造出来的东西跟着变', async () => {
+    const w = await build(OPERATOR_CODE);
+    await createSite(w, 'portal', 'portal.corp.internal');
+
+    const definition = w.cluster.scheme.mustGet(SITES);
+    const live = w.cluster.registry.get(definition, 'default', 'portal');
+    w.cluster.registry.update(definition, 'default', 'portal', {
+      ...live, spec: { host: 'new.corp.internal' },
+    } as KubeObject);
+    await w.cluster.advanceBy(10_000);
+
+    expect((configMap(w, 'portal-site')!.spec as any).host).toBe('new.corp.internal');
+  });
+
+  /**
+   * 修偏差才是 Operator 的核心价值：别人手工改坏了它造出来的东西，
+   * 下一轮 reconcile 要把它改回去。前提是**它 watch 了那个类型**。
+   */
+  it('别人改坏了它造出来的东西，下一轮改回去', async () => {
+    const w = await build(OPERATOR_CODE);
+    await createSite(w, 'portal', 'portal.corp.internal');
+
+    const definition = w.cluster.scheme.mustGet(CONFIGMAPS);
+    const live = w.cluster.registry.get(definition, 'default', 'portal-site');
+    w.cluster.registry.update(definition, 'default', 'portal-site', {
+      ...live, spec: { host: 'someone-edited-this' },
+    } as KubeObject);
+    await w.cluster.advanceBy(10_000);
+
+    expect((configMap(w, 'portal-site')!.spec as any).host).toBe('portal.corp.internal');
+  });
+
+  it('不 watch 附属类型：改坏了就一直坏着', async () => {
+    const w = await build(BLIND_CODE);
+    await createSite(w, 'portal', 'portal.corp.internal');
+
+    const definition = w.cluster.scheme.mustGet(CONFIGMAPS);
+    const live = w.cluster.registry.get(definition, 'default', 'portal-site');
+    w.cluster.registry.update(definition, 'default', 'portal-site', {
+      ...live, spec: { host: 'someone-edited-this' },
+    } as KubeObject);
+    await w.cluster.advanceBy(60_000);
+
+    expect((configMap(w, 'portal-site')!.spec as any).host).toBe('someone-edited-this');
+  });
+});
+
+describe('删除', () => {
+  it('挂了属主引用：删掉自定义资源，造出来的东西跟着没', async () => {
+    const w = await build(OPERATOR_CODE);
+    await createSite(w, 'portal', 'portal.corp.internal');
+    expect(configMap(w, 'portal-site')).toBeDefined();
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(SITES), 'default', 'portal');
+    await w.cluster.advanceBy(10_000);
+    expect(configMap(w, 'portal-site')).toBeUndefined();
+  });
+
+  it('没挂属主引用：删掉之后留下一个没人管的孤儿', async () => {
+    const w = await build(ORPHAN_CODE);
+    await createSite(w, 'portal', 'portal.corp.internal');
+
+    w.cluster.registry.delete(w.cluster.scheme.mustGet(SITES), 'default', 'portal');
+    await w.cluster.advanceBy(10_000);
+    expect(configMap(w, 'portal-site')).toBeDefined();
+  });
+});
+
+describe('Operator 也是一个工作负载', () => {
+  it('把它停掉：自定义资源还在，只是没人让它成真', async () => {
+    const w = await build(OPERATOR_CODE);
+    w.cluster.registry.delete(
+      w.cluster.scheme.mustGet({ group: 'apps', version: 'v1', resource: 'deployments' }),
+      'default', 'site-operator'
+    );
+    await w.cluster.advanceBy(30_000);
+
+    await createSite(w, 'portal', 'portal.corp.internal');
+    expect(siteOf(w, 'portal')).toBeDefined();
+    expect(configMap(w, 'portal-site')).toBeUndefined();
+    expect(siteOf(w, 'portal').status ?? {}).toEqual({});
+  });
+
+  it('CRD 还没建：Operator 空转，不报错', async () => {
+    const world = await createOpsWorld({
+      world: spec([OPERATOR_DEPLOYMENT]),
+      stage: {
+        files: { '/root/operator/site.js': OPERATOR_CODE },
+        operator: { path: '/root/operator/site.js', kind: 'Site', name: 'site-operator' },
+      },
+    });
+    await world.cluster.advanceBy(30_000);
+    expect(world.cluster.scheme.get(SITES)).toBeUndefined();
+  });
+});
+
+describe('学员代码出错', () => {
+  it('抛异常不会把世界搞崩，而是变成对象上的一条事件', async () => {
+    const w = await build('exports.reconcile = () => { throw new Error("boom"); };');
+    await createSite(w, 'portal', 'portal.corp.internal');
+
+    const events = w.cluster.registry.list(
+      w.cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'events' }), { namespace: 'default' }
+    ).items;
+    const failures = events.filter((event) => (event as any).reason === 'ReconcileError');
+    expect(failures.length).toBeGreaterThan(0);
+    expect(String((failures[0] as any).message)).toContain('boom');
+  });
+});


### PR DESCRIPTION
最后一关。两种工作台在这里合流：控制器的逻辑是**代码**，作用对象是**真的 apiserver**。

## 关卡

业务方要一个对外入口，现在的流程是提工单，平台组手写一条 HTTPRoute。
这一关把它变成自助：业务方提交一个 `Site`，平台负责让它成真。

一半是 CRD（让 apiserver 认识 Site），另一半是 `/root/operator/site.js` 里那个
`reconcile` —— 它就是控制器本身。世界 watch 学员声明的类型，每次变化调它一次，
给它一个够小的客户端：`ctx.object / owner() / get / list / apply / delete /
setStatus / event / log`。

判定里那条「从跳板机 curl 得到 200」是这一关的分量所在：学员自己写的三十行
代码造出来的路由，真的在转发流量。

## 刻意不替学员做的三件事

1. **属主引用要自己挂**。不挂的话删掉 Site，造出来的路由变成没人管的孤儿。
2. **要 watch 自己造出来的类型**。只 watch 主类型的话，别人手工改坏了路由，
   要等到下一次有人动 Site 才会发现 —— 那不叫持续收敛，那叫碰巧修好。
3. **status 只在变了的时候写**。写 status 会触发 watch 事件，事件触发 reconcile，
   reconcile 又写 status；每次都写一个新时间戳的控制器会把自己吵醒。

这三条各有一个判定用例钉着，近似错误答案都探过：不挂属主引用挂在两条上，
只 watch 主类型挂在「改坏了能自己修回去」，CRD 不声明打印列挂在第一条。

## 顺带修的两个真 bug

- `Cluster.start()` 直接给 `controllers` **赋值**，会把 start 之前 attach 进来的
  控制器整个冲掉。
- 垃圾回收只盯构造时就存在的类型。CRD 是运行时注册的，于是删掉一个自定义资源
  之后，Operator 造出来的东西全变成孤儿留在集群里 —— 而这恰恰是最需要垃圾回收
  的场景。

## 验证

- 反向验证：参考解全绿 / 什么都不做要挂
- 新增 `tests/opslab/operator.test.ts` 9 条（声明式收敛、修偏差、属主引用、
  Operator 停掉之后自定义资源就没人管、学员代码抛异常不搞崩世界）
- `npx jest`：53 个 suite、1644 条全绿；`npx tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)