### PR TITLE
ci: 在 release 流程里构建 opslab 的 CLI WASM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,63 @@ jobs:
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
 
+  # 构建 opslab 的多合一 CLI（真 kubectl + helm，编译成 WebAssembly）
+  #
+  # 产物约 136MB，不进仓库（见 .gitignore），所以必须在 CI 里现编 ——
+  # 少了它，安装包里 /opslab/opslab-cli.wasm 会 404，整个 ops 工作台一条命令都跑不了。
+  #
+  # 只编一次给四个平台共用：产物是 GOOS=js GOARCH=wasm 交叉编译出来的，
+  # 跟 runner 的操作系统无关，所以在三种 runner 上各编一遍纯属浪费。
+  build-wasm:
+    name: Build opslab WASM
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 脚本生成的 go.mod 要求 go 1.26；1.27 是本地验证过能复现产物的那个版本
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.27'
+          # 构建脚本是现生成 go.mod 的，仓库里没有 go.sum，开缓存只会报警告
+          cache: false
+
+      - name: Build opslab CLI WASM
+        run: bash scripts/build-opslab-wasm.sh
+
+      # 产物没出来就当场失败，别让后面四个 job 白跑一遍再发一个坏包
+      - name: Verify build output
+        run: |
+          ls -l public/opslab/
+          test -s public/opslab/opslab-cli.wasm
+          test -s public/opslab/wasm_exec.js
+          SIZE=$(stat -c%s public/opslab/opslab-cli.wasm)
+          echo "opslab-cli.wasm: $SIZE bytes"
+          # 正常在 130MB 上下；小于 50MB 基本可以断定链接阶段出了问题
+          if [ "$SIZE" -lt 50000000 ]; then
+            echo "::error::opslab-cli.wasm is only $SIZE bytes — build looks truncated."
+            exit 1
+          fi
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opslab-wasm
+          # 两个文件的公共前缀是 public/opslab，所以 artifact 里就是这两个文件名，
+          # 下载时 path: public/opslab 正好落回原位
+          path: |
+            public/opslab/opslab-cli.wasm
+            public/opslab/wasm_exec.js
+          if-no-files-found: error
+          retention-days: 1
+
   # 构建 macOS 版本
   build-macos:
     name: Build macOS
     runs-on: macos-latest
-    needs: changelog
+    needs: [changelog, build-wasm]
     strategy:
       matrix:
         arch: [x64, arm64]
@@ -57,6 +109,21 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # build-wasm 编好的多合一 CLI。落回 public/opslab/，electron-builder 才打得进包。
+      - name: Download opslab WASM
+        uses: actions/download-artifact@v4
+        with:
+          name: opslab-wasm
+          path: public/opslab
+
+      # 路径错一格就是一个功能全灭的包，所以这里当场验，而不是等发出去才发现
+      - name: Verify opslab WASM is in place
+        shell: bash
+        run: |
+          ls -l public/opslab/
+          test -s public/opslab/opslab-cli.wasm
+          test -s public/opslab/wasm_exec.js
 
       - name: Generate icons
         run: npm run icons:generate
@@ -174,7 +241,7 @@ jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
-    needs: changelog
+    needs: [changelog, build-wasm]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -187,6 +254,21 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # build-wasm 编好的多合一 CLI。落回 public/opslab/，electron-builder 才打得进包。
+      - name: Download opslab WASM
+        uses: actions/download-artifact@v4
+        with:
+          name: opslab-wasm
+          path: public/opslab
+
+      # 路径错一格就是一个功能全灭的包，所以这里当场验，而不是等发出去才发现
+      - name: Verify opslab WASM is in place
+        shell: bash
+        run: |
+          ls -l public/opslab/
+          test -s public/opslab/opslab-cli.wasm
+          test -s public/opslab/wasm_exec.js
 
       - name: Generate icons
         run: npm run icons:generate
@@ -212,7 +294,7 @@ jobs:
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest
-    needs: changelog
+    needs: [changelog, build-wasm]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -225,6 +307,21 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # build-wasm 编好的多合一 CLI。落回 public/opslab/，electron-builder 才打得进包。
+      - name: Download opslab WASM
+        uses: actions/download-artifact@v4
+        with:
+          name: opslab-wasm
+          path: public/opslab
+
+      # 路径错一格就是一个功能全灭的包，所以这里当场验，而不是等发出去才发现
+      - name: Verify opslab WASM is in place
+        shell: bash
+        run: |
+          ls -l public/opslab/
+          test -s public/opslab/opslab-cli.wasm
+          test -s public/opslab/wasm_exec.js
 
       - name: Generate icons
         run: npm run icons:generate

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -47,6 +47,13 @@ module.exports = {
     'styles/**/*',
     '.next/**/*',
     'public/**/*',
+    // public/opslab 是构建产物的落脚点，不是源码目录。这里改成白名单：
+    // 通配符会把别人工作区里遗留的旧产物一起打进包 —— 早先那个 120MB 的
+    // kubectl.wasm（spike 时期的单 CLI 版本，代码里已经零引用）就是这么混进去的。
+    '!public/opslab/*.wasm',
+    'public/opslab/opslab-cli.wasm',
+    'public/opslab/web-tree-sitter.wasm',
+    'public/opslab/tree-sitter-bash.wasm',
     'problems/**/*',
     'projects/**/*',
     'locales/**/*',
@@ -114,10 +121,13 @@ module.exports = {
     // 需要直接文件访问的资源
     'public/problems.json',
     'public/projects.json',
-    // opslab 的 WebAssembly 制品（真 kubectl 等）必须解包：
+    // opslab 的 WebAssembly 制品（真 kubectl 与 helm）必须解包：
     // 一百多 MB 的文件留在 asar 里，WebAssembly.compileStreaming 读不到真实文件，
     // 只能整份读进内存再编译，启动慢一倍、峰值内存也翻倍。
-    'public/opslab/*.wasm',
+    // 同样逐个列名，理由见上面 files 里那段。
+    'public/opslab/opslab-cli.wasm',
+    'public/opslab/web-tree-sitter.wasm',
+    'public/opslab/tree-sitter-bash.wasm',
     'public/icon.png',
     'public/favicon.ico'
   ],


### PR DESCRIPTION
发版前的预检发现的阻断项：**CI 从来没有构建过 opslab 的多合一 CLI WASM**，
所以 v0.16.0 如果就这么发出去，新加的 23 关一条命令都敲不了。

## 问题

`public/opslab/opslab-cli.wasm`（真 kubectl + helm 编成的 WebAssembly，约 136MB）
在 `.gitignore` 里，仓库不跟踪；而 `.github/` 全目录 grep `setup-go|golang|opslab|wasm`
零命中，`scripts/build-opslab-wasm.sh` 只在文档和测试注释里被提到过。

**实测确认**（不是读代码猜的）：把两个产物移走模拟干净检出，重跑
`npm run build` + `electron-builder --dir`，包里 `public/opslab/` 只剩两个
tree-sitter 的 wasm，`opslab-cli.wasm` 和 `wasm_exec.js` 都不在。
运行时会在 `runtime.ts:142` 抛 `/opslab/opslab-cli.wasm 取不到（404）`。

## 改法

加一条 `build-wasm` job，四个构建 job 依赖它并把产物 download 回 `public/opslab/`。

**只编一次**：产物是 `GOOS=js GOARCH=wasm` 交叉编译出来的，跟 runner 的操作系统
无关，在三种 runner 上各编一遍纯属浪费。

artifact 的路径对应关系（这次最容易错的地方）：upload 时给的两个路径公共前缀是
`public/opslab`，所以 artifact 内容就是这两个文件名；download 时 `path: public/opslab`
正好落回原位。

两处防呆，因为路径错一格就是一个功能全灭的包：
- `build-wasm` 里校验产物存在且 ≥50MB（链接阶段出问题时体积会塌）
- 三个构建 job 下载完当场 `test -s` 一遍（Windows 上显式 `shell: bash`）

## 顺带：打包规则改成白名单

`public/opslab` 是构建产物的落脚点，不是源码目录。原来的 `public/opslab/*.wasm`
会把工作区里遗留的旧产物一起打进包 —— spike 时期那个 120MB 的 `kubectl.wasm`
（代码里零引用）就是这么混进去的，白白多 115 MiB。

改成显式列名 + `!public/opslab/*.wasm` 兜底。**已实测**：往目录里放一个假的
`stale-test.wasm`，打包后包里没有它；`opslab-cli.wasm` 照常进 `app.asar.unpacked`，
`wasm_exec.js` 照常在 asar 里。

## 验证

- YAML 解析通过，job 依赖图：`build-wasm` 无依赖，三个构建 job
  `needs: [changelog, build-wasm]`，`release` 依赖三个构建 job（传递性地等到 wasm）
- 本地 `electron-builder --dir` 实测了三种情形：产物在（正常进包）、
  产物不在（复现故障）、有遗留产物（被白名单挡住）
- workflow 本身没法本地验，`build-wasm` 这条要靠这次 tag 实跑

🤖 Generated with [Claude Code](https://claude.com/claude-code)