### PR TITLE
feat(gpulab): CUDA 前端与 warp 锁步 VM

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -56,6 +56,7 @@ module.exports = {
     '!public/opslab/*.wasm',
     'public/labkit/web-tree-sitter.wasm',
     'public/labkit/tree-sitter-bash.wasm',
+    'public/gpulab/tree-sitter-cuda.wasm',
     'public/opslab/opslab-cli.wasm',
     'problems/**/*',
     'projects/**/*',
@@ -131,6 +132,7 @@ module.exports = {
     'public/opslab/opslab-cli.wasm',
     'public/labkit/web-tree-sitter.wasm',
     'public/labkit/tree-sitter-bash.wasm',
+    'public/gpulab/tree-sitter-cuda.wasm',
     'public/icon.png',
     'public/favicon.ico'
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "tree-sitter-bash": "^0.25.1",
+        "tree-sitter-cuda": "^0.21.1",
         "typescript": "5.1.6",
         "web-tree-sitter": "^0.26.13"
       },
@@ -12800,6 +12801,112 @@
       }
     },
     "node_modules/tree-sitter-bash/node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter-c": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.24.1.tgz",
+      "integrity": "sha512-lkYwWN3SRecpvaeqmFKkuPNR3ZbtnvHU+4XAEEkJdrp3JfSp2pBrhXOtvfsENUneye76g889Y0ddF2DM0gEDpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-c/node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter-cpp": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cpp/-/tree-sitter-cpp-0.23.4.tgz",
+      "integrity": "sha512-qR5qUDyhZ5jJ6V8/umiBxokRbe89bCGmcq/dk94wI4kN86qfdV8k0GHIUEKaqWgcu42wKal5E97LKpLeVW8sKw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-c": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-cpp/node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter-cpp/node_modules/tree-sitter-c": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.23.6.tgz",
+      "integrity": "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-cuda": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cuda/-/tree-sitter-cuda-0.21.1.tgz",
+      "integrity": "sha512-V8zI22cfiQyt0Q3v7KPkM4KVMPXqIgHrcbYCYvfFByLcM7PM6+mpzhRWGvUP4QgmwXkWHdcJoJcJC+ef6V9Z6A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4",
+        "tree-sitter-c": "0.24.1",
+        "tree-sitter-cpp": "0.23.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-cuda/node_modules/node-addon-api": {
       "version": "8.9.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
       "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "tree-sitter-bash": "^0.25.1",
+    "tree-sitter-cuda": "^0.21.1",
     "typescript": "5.1.6",
     "web-tree-sitter": "^0.26.13"
   },

--- a/scripts/copy-lab-assets.js
+++ b/scripts/copy-lab-assets.js
@@ -24,6 +24,7 @@ const ROOT = path.join(__dirname, '..');
 const ASSETS = [
   ['web-tree-sitter/web-tree-sitter.wasm', 'labkit/web-tree-sitter.wasm'],
   ['tree-sitter-bash/tree-sitter-bash.wasm', 'labkit/tree-sitter-bash.wasm'],
+  ['tree-sitter-cuda/tree-sitter-cuda.wasm', 'gpulab/tree-sitter-cuda.wasm'],
 ];
 
 let copied = 0;

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -52,6 +52,11 @@ class TestRunner {
         description: 'apiserver semantics, controllers, the real kubectl/helm WASM runtime, and byte-identical replay of dozens of concurrent entities'
       },
       {
+        name: 'Gpulab CUDA VM',
+        file: 'tests/gpulab',
+        description: 'The CUDA frontend, the warp-lockstep VM, coalescing and bank-conflict measurement, and byte-identical replay'
+      },
+      {
         name: 'Desktop Menus',
         file: 'tests/desktop',
         description: 'Application and context menus, including the edit roles that ⌘V depends on'

--- a/src/lib/gpulab/cuda/ast.ts
+++ b/src/lib/gpulab/cuda/ast.ts
@@ -1,0 +1,165 @@
+/**
+ * 我们自己的 CUDA AST
+ *
+ * tree-sitter 给的是完整的具体语法树，节点又多又碎。这一层把它翻成一棵
+ * 小得多的抽象树，好让后面的编译器不必到处认 tree-sitter 的节点名。
+ *
+ * 这棵树只覆盖 design/gpulab.md 里写明的 C99 子集 + CUDA 扩展。
+ * 子集之外的语法在 lower.ts 里**明确报错**。
+ */
+
+export interface SourceSpan {
+  line: number;
+  column: number;
+}
+
+/* ------------------------------------------------------------------ */
+/* 类型                                                                */
+/* ------------------------------------------------------------------ */
+
+export type ScalarKind = 'int' | 'uint' | 'float' | 'bool' | 'void';
+
+export interface ScalarType {
+  kind: 'scalar';
+  scalar: ScalarKind;
+}
+
+export interface PointerType {
+  kind: 'pointer';
+  to: CudaType;
+}
+
+/** 定长数组。共享内存的 `__shared__ float t[32][33]` 就是它。 */
+export interface ArrayType {
+  kind: 'array';
+  of: CudaType;
+  length: number;
+}
+
+export type CudaType = ScalarType | PointerType | ArrayType;
+
+export const INT: ScalarType = { kind: 'scalar', scalar: 'int' };
+export const UINT: ScalarType = { kind: 'scalar', scalar: 'uint' };
+export const FLOAT: ScalarType = { kind: 'scalar', scalar: 'float' };
+export const BOOL: ScalarType = { kind: 'scalar', scalar: 'bool' };
+export const VOID: ScalarType = { kind: 'scalar', scalar: 'void' };
+
+export function isFloat(type: CudaType): boolean {
+  return type.kind === 'scalar' && type.scalar === 'float';
+}
+
+export function isPointer(type: CudaType): type is PointerType {
+  return type.kind === 'pointer';
+}
+
+/** 一个元素占几个字节。指针按 4 字节算（我们的地址空间是 32 位偏移）。 */
+export function sizeOf(type: CudaType): number {
+  switch (type.kind) {
+    case 'scalar':
+      return type.scalar === 'void' ? 0 : 4;
+    case 'pointer':
+      return 4;
+    case 'array':
+      return sizeOf(type.of) * type.length;
+  }
+}
+
+export function typeName(type: CudaType): string {
+  switch (type.kind) {
+    case 'scalar':
+      return type.scalar;
+    case 'pointer':
+      return `${typeName(type.to)}*`;
+    case 'array':
+      return `${typeName(type.of)}[${type.length}]`;
+  }
+}
+
+export function sameType(a: CudaType, b: CudaType): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'scalar' && b.kind === 'scalar') return a.scalar === b.scalar;
+  if (a.kind === 'pointer' && b.kind === 'pointer') return sameType(a.to, b.to);
+  if (a.kind === 'array' && b.kind === 'array') return a.length === b.length && sameType(a.of, b.of);
+  return false;
+}
+
+/* ------------------------------------------------------------------ */
+/* 表达式                                                              */
+/* ------------------------------------------------------------------ */
+
+export type BinaryOp =
+  | '+' | '-' | '*' | '/' | '%'
+  | '<<' | '>>' | '&' | '|' | '^'
+  | '<' | '<=' | '>' | '>=' | '==' | '!='
+  | '&&' | '||';
+
+export type UnaryOp = '-' | '!' | '~' | '+';
+
+/** 内建变量。`.x/.y/.z` 在这里已经拆开了。 */
+export type BuiltinVar =
+  | 'threadIdx.x' | 'threadIdx.y' | 'threadIdx.z'
+  | 'blockIdx.x' | 'blockIdx.y' | 'blockIdx.z'
+  | 'blockDim.x' | 'blockDim.y' | 'blockDim.z'
+  | 'gridDim.x' | 'gridDim.y' | 'gridDim.z'
+  | 'warpSize';
+
+export type Expr =
+  | { kind: 'intLit'; value: number; span: SourceSpan }
+  | { kind: 'floatLit'; value: number; span: SourceSpan }
+  | { kind: 'boolLit'; value: boolean; span: SourceSpan }
+  | { kind: 'name'; name: string; span: SourceSpan }
+  | { kind: 'builtin'; which: BuiltinVar; span: SourceSpan }
+  | { kind: 'binary'; op: BinaryOp; left: Expr; right: Expr; span: SourceSpan }
+  | { kind: 'unary'; op: UnaryOp; operand: Expr; span: SourceSpan }
+  | { kind: 'ternary'; cond: Expr; then: Expr; otherwise: Expr; span: SourceSpan }
+  | { kind: 'subscript'; array: Expr; index: Expr; span: SourceSpan }
+  | { kind: 'deref'; pointer: Expr; span: SourceSpan }
+  | { kind: 'cast'; to: CudaType; operand: Expr; span: SourceSpan }
+  | { kind: 'call'; callee: string; args: Expr[]; span: SourceSpan }
+  | { kind: 'assign'; target: Expr; op: BinaryOp | null; value: Expr; span: SourceSpan }
+  /** `++i` / `i++`；`postfix` 决定表达式的值是旧的还是新的 */
+  | { kind: 'incdec'; target: Expr; delta: 1 | -1; postfix: boolean; span: SourceSpan };
+
+/* ------------------------------------------------------------------ */
+/* 语句                                                                */
+/* ------------------------------------------------------------------ */
+
+export interface VarDecl {
+  name: string;
+  type: CudaType;
+  /** `__shared__` 的变量住在共享内存里，不是寄存器 */
+  shared: boolean;
+  init?: Expr;
+  span: SourceSpan;
+}
+
+export type Stmt =
+  | { kind: 'expr'; expr: Expr; span: SourceSpan }
+  | { kind: 'decl'; decls: VarDecl[]; span: SourceSpan }
+  | { kind: 'block'; body: Stmt[]; span: SourceSpan }
+  | { kind: 'if'; cond: Expr; then: Stmt; otherwise?: Stmt; span: SourceSpan }
+  | { kind: 'for'; init?: Stmt; cond?: Expr; step?: Expr; body: Stmt; span: SourceSpan }
+  | { kind: 'while'; cond: Expr; body: Stmt; span: SourceSpan }
+  | { kind: 'return'; value?: Expr; span: SourceSpan }
+  | { kind: 'syncthreads'; span: SourceSpan };
+
+/* ------------------------------------------------------------------ */
+/* 顶层                                                                */
+/* ------------------------------------------------------------------ */
+
+export interface Param {
+  name: string;
+  type: CudaType;
+  span: SourceSpan;
+}
+
+export interface KernelDecl {
+  name: string;
+  params: Param[];
+  body: Stmt;
+  span: SourceSpan;
+}
+
+export interface TranslationUnit {
+  kernels: KernelDecl[];
+}

--- a/src/lib/gpulab/cuda/lower.ts
+++ b/src/lib/gpulab/cuda/lower.ts
@@ -1,0 +1,646 @@
+/**
+ * tree-sitter 的具体语法树 → 我们的 AST
+ *
+ * 这一层的职责有两条，第二条比第一条重要：
+ *  1. 把节点翻过去；
+ *  2. **翻不动的语法明确报错**，绝不悄悄降级。
+ *
+ * 一个学员写了 `struct` 或调用了自己写的 `__device__` 函数，得到的应该是
+ * 「第 12 行：暂不支持 struct」，而不是一个能跑但算错的 kernel。模拟器最怕的
+ * 就是「看起来跑了」。
+ *
+ * 不依赖 tree-sitter 的 field 名（这个语法里大多数节点没有挂 field），
+ * 一律按子节点的 type 扫 —— 更啰嗦，但不会因为上游改了 field 名而无声失效。
+ */
+import type { TsNode } from './parser';
+import {
+  BOOL, FLOAT, INT, UINT, VOID,
+  type BinaryOp, type BuiltinVar, type CudaType, type Expr, type KernelDecl,
+  type Param, type SourceSpan, type Stmt, type TranslationUnit, type UnaryOp, type VarDecl,
+} from './ast';
+
+export class CudaCompileError extends Error {
+  line: number;
+  column: number;
+  constructor(message: string, span: SourceSpan) {
+    super(`${span.line}:${span.column}: ${message}`);
+    this.name = 'CudaCompileError';
+    this.line = span.line;
+    this.column = span.column;
+  }
+}
+
+function spanOf(node: TsNode): SourceSpan {
+  return { line: node.startPosition.row + 1, column: node.startPosition.column + 1 };
+}
+
+function fail(node: TsNode, message: string): never {
+  throw new CudaCompileError(message, spanOf(node));
+}
+
+/** 只要具名子节点，跳过标点与关键字 */
+function namedChildren(node: TsNode): TsNode[] {
+  const out: TsNode[] = [];
+  for (let i = 0; i < node.namedChildCount; i += 1) {
+    const child = node.namedChild(i);
+    if (child) out.push(child);
+  }
+  return out;
+}
+
+/** 所有子节点，含标点 —— 判断 `++i` 还是 `i++` 要用到 */
+function allChildren(node: TsNode): TsNode[] {
+  const out: TsNode[] = [];
+  for (let i = 0; i < node.childCount; i += 1) {
+    const child = node.child(i);
+    if (child) out.push(child);
+  }
+  return out;
+}
+
+/** 这些限定符我们读得懂，但对语义没有影响 */
+const IGNORED_QUALIFIERS = new Set(['const', '__restrict__', 'restrict', 'volatile', '__volatile__']);
+
+const BUILTIN_STRUCTS = new Set(['threadIdx', 'blockIdx', 'blockDim', 'gridDim']);
+
+const BINARY_OPS = new Set<string>([
+  '+', '-', '*', '/', '%', '<<', '>>', '&', '|', '^',
+  '<', '<=', '>', '>=', '==', '!=', '&&', '||',
+]);
+
+/* ------------------------------------------------------------------ */
+/* 类型                                                                */
+/* ------------------------------------------------------------------ */
+
+function lowerTypeSpecifier(node: TsNode): CudaType {
+  const text = node.text.trim();
+  switch (node.type) {
+    case 'primitive_type':
+      switch (text) {
+        case 'float': return FLOAT;
+        case 'int': return INT;
+        case 'unsigned': case 'unsigned int': return UINT;
+        case 'bool': return BOOL;
+        case 'void': return VOID;
+        case 'double':
+          fail(node, 'double 暂不支持 —— 这个工作台的算术全部在 fp32 上做，见 design/gpulab.md');
+          break;
+        default:
+          fail(node, `暂不支持的类型：${text}`);
+      }
+      break;
+    case 'sized_type_specifier': {
+      const normalized = text.replace(/\s+/g, ' ');
+      if (normalized === 'unsigned' || normalized === 'unsigned int') return UINT;
+      if (normalized === 'signed' || normalized === 'signed int' || normalized === 'long') return INT;
+      fail(node, `暂不支持的类型：${text}`);
+      break;
+    }
+    case 'type_identifier':
+      fail(node, `暂不支持自定义类型 \`${text}\` —— 当前子集只有 int / unsigned / float / bool`);
+      break;
+    default:
+      fail(node, `暂不支持的类型写法：${node.type}`);
+  }
+}
+
+/** 从一串子节点里挑出类型说明符 */
+function findTypeSpecifier(children: TsNode[], at: TsNode): CudaType {
+  for (const child of children) {
+    if (child.type === 'type_qualifier' || child.type === 'storage_class_specifier') continue;
+    if (child.type === '__shared__' || child.type === '__device__' || child.type === '__global__') continue;
+    if (
+      child.type === 'primitive_type' ||
+      child.type === 'sized_type_specifier' ||
+      child.type === 'type_identifier'
+    ) {
+      return lowerTypeSpecifier(child);
+    }
+  }
+  fail(at, '看不出这个声明的类型');
+}
+
+interface Declared {
+  name: string;
+  type: CudaType;
+  init?: TsNode;
+}
+
+/**
+ * 走一个 declarator，把指针与数组的层次叠到基础类型上。
+ *
+ * `float* a` 的 declarator 是 `pointer_declarator(* , identifier)`；
+ * `float t[16][17]` 是 `array_declarator(array_declarator(identifier, 16), 17)` ——
+ * 注意外层才是最后一维，所以数组维度要从里往外读。
+ */
+function lowerDeclarator(node: TsNode, base: CudaType): Declared {
+  switch (node.type) {
+    case 'identifier':
+      return { name: node.text, type: base };
+
+    case 'pointer_declarator': {
+      const inner = namedChildren(node).find(
+        (child) => child.type !== 'type_qualifier' && !IGNORED_QUALIFIERS.has(child.type)
+      );
+      if (!inner) fail(node, '指针声明缺少名字');
+      return lowerDeclarator(inner, { kind: 'pointer', to: base });
+    }
+
+    case 'array_declarator': {
+      const children = namedChildren(node);
+      const inner = children[0];
+      const sizeNode = children[1];
+      if (!inner) fail(node, '数组声明缺少名字');
+      if (!sizeNode) {
+        fail(node, '数组必须写出长度 —— 变长数组（VLA）在设备代码里本来也不能用');
+      }
+      const size = constIntOf(sizeNode);
+      // 先把外层这一维套上，再往里走：外层是最后一维
+      const declared = lowerDeclarator(inner, base);
+      return { name: declared.name, type: appendDimension(declared.type, size) };
+    }
+
+    case 'init_declarator': {
+      const children = namedChildren(node);
+      const declared = lowerDeclarator(children[0], base);
+      return { ...declared, init: children[1] };
+    }
+
+    case 'function_declarator':
+      fail(node, '暂不支持函数指针与嵌套函数声明');
+      break;
+
+    default:
+      fail(node, `暂不支持的声明写法：${node.type}`);
+  }
+}
+
+/** 把一维追加到数组类型的最内层，让 `t[16][17]` 变成 array(16, array(17, float)) */
+function appendDimension(type: CudaType, length: number): CudaType {
+  if (type.kind === 'array') return { kind: 'array', of: appendDimension(type.of, length), length: type.length };
+  return { kind: 'array', of: type, length };
+}
+
+/** 数组维度、模板参数这类地方要的是一个编译期常量 */
+function constIntOf(node: TsNode): number {
+  if (node.type === 'number_literal') {
+    const value = parseNumberLiteral(node);
+    if (!Number.isInteger(value.value) || value.isFloat) fail(node, '这里需要一个整数常量');
+    return value.value;
+  }
+  if (node.type === 'binary_expression') {
+    const children = namedChildren(node);
+    const op = operatorOf(node);
+    const a = constIntOf(children[0]);
+    const b = constIntOf(children[1]);
+    switch (op) {
+      case '+': return a + b;
+      case '-': return a - b;
+      case '*': return a * b;
+      case '/': return Math.trunc(a / b);
+      case '<<': return a << b;
+      default: fail(node, `数组长度里暂不支持 \`${op}\``);
+    }
+  }
+  fail(node, '数组长度必须是编译期常量');
+}
+
+/** 取一个二元/赋值/一元节点的运算符文本 */
+function operatorOf(node: TsNode): string {
+  for (const child of allChildren(node)) {
+    if (child.namedChildCount === 0 && child.type !== 'comment' && !child.type.match(/^[a-z_]+$/)) {
+      return child.type;
+    }
+  }
+  // 兜底：找第一个不是具名子节点的
+  const named = new Set(namedChildren(node));
+  for (const child of allChildren(node)) {
+    if (!named.has(child)) return child.type;
+  }
+  fail(node, '看不出这里的运算符');
+}
+
+interface ParsedNumber {
+  value: number;
+  isFloat: boolean;
+}
+
+function parseNumberLiteral(node: TsNode): ParsedNumber {
+  const raw = node.text.trim();
+  const cleaned = raw.replace(/[uUlL]+$/, '');
+  if (/^[+-]?0[xX]/.test(cleaned)) {
+    return { value: Number(cleaned), isFloat: false };
+  }
+  const isFloat = /[.eEfF]/.test(cleaned) && !/^[+-]?0[xX]/.test(cleaned);
+  const withoutSuffix = cleaned.replace(/[fF]$/, '');
+  const value = Number(withoutSuffix);
+  if (!Number.isFinite(value)) fail(node, `看不懂的数字：${raw}`);
+  return { value, isFloat };
+}
+
+/* ------------------------------------------------------------------ */
+/* 表达式                                                              */
+/* ------------------------------------------------------------------ */
+
+function lowerExpr(node: TsNode): Expr {
+  const span = spanOf(node);
+
+  switch (node.type) {
+    case 'number_literal': {
+      const parsed = parseNumberLiteral(node);
+      return parsed.isFloat
+        ? { kind: 'floatLit', value: parsed.value, span }
+        : { kind: 'intLit', value: parsed.value, span };
+    }
+
+    case 'true':
+      return { kind: 'boolLit', value: true, span };
+    case 'false':
+      return { kind: 'boolLit', value: false, span };
+
+    case 'identifier':
+      if (node.text === 'warpSize') return { kind: 'builtin', which: 'warpSize', span };
+      if (BUILTIN_STRUCTS.has(node.text)) {
+        fail(node, `${node.text} 要带分量，比如 ${node.text}.x`);
+      }
+      return { kind: 'name', name: node.text, span };
+
+    case 'field_expression': {
+      const children = namedChildren(node);
+      const base = children[0];
+      const field = children[1];
+      if (base.type === 'identifier' && BUILTIN_STRUCTS.has(base.text)) {
+        const component = field.text;
+        if (component !== 'x' && component !== 'y' && component !== 'z') {
+          fail(field, `${base.text} 只有 .x / .y / .z`);
+        }
+        return { kind: 'builtin', which: `${base.text}.${component}` as BuiltinVar, span };
+      }
+      fail(node, '暂不支持结构体成员访问 —— 当前子集没有 struct');
+      break;
+    }
+
+    case 'parenthesized_expression':
+      return lowerExpr(namedChildren(node)[0]);
+
+    case 'binary_expression': {
+      const children = namedChildren(node);
+      const op = operatorOf(node);
+      if (!BINARY_OPS.has(op)) fail(node, `暂不支持运算符 \`${op}\``);
+      return {
+        kind: 'binary',
+        op: op as BinaryOp,
+        left: lowerExpr(children[0]),
+        right: lowerExpr(children[1]),
+        span,
+      };
+    }
+
+    case 'unary_expression': {
+      const children = namedChildren(node);
+      const op = operatorOf(node);
+      if (op !== '-' && op !== '!' && op !== '~' && op !== '+') {
+        fail(node, `暂不支持一元运算符 \`${op}\``);
+      }
+      return { kind: 'unary', op: op as UnaryOp, operand: lowerExpr(children[0]), span };
+    }
+
+    case 'conditional_expression': {
+      const children = namedChildren(node);
+      return {
+        kind: 'ternary',
+        cond: lowerExpr(children[0]),
+        then: lowerExpr(children[1]),
+        otherwise: lowerExpr(children[2]),
+        span,
+      };
+    }
+
+    case 'subscript_expression': {
+      const children = namedChildren(node);
+      const array = lowerExpr(children[0]);
+      const argList = children[1];
+      const index = argList.type === 'subscript_argument_list'
+        ? namedChildren(argList)[0]
+        : argList;
+      if (!index) fail(node, '下标是空的');
+      return { kind: 'subscript', array, index: lowerExpr(index), span };
+    }
+
+    case 'pointer_expression': {
+      const children = namedChildren(node);
+      const op = operatorOf(node);
+      if (op === '&') fail(node, '暂不支持取地址运算符 `&`');
+      return { kind: 'deref', pointer: lowerExpr(children[0]), span };
+    }
+
+    case 'cast_expression': {
+      const children = namedChildren(node);
+      const descriptor = children[0];
+      const target = findTypeSpecifier(namedChildren(descriptor), descriptor);
+      const pointerDepth = namedChildren(descriptor).filter(
+        (child) => child.type === 'abstract_pointer_declarator'
+      ).length;
+      let to = target;
+      for (let i = 0; i < pointerDepth; i += 1) to = { kind: 'pointer', to };
+      return { kind: 'cast', to, operand: lowerExpr(children[1]), span };
+    }
+
+    case 'call_expression': {
+      const children = namedChildren(node);
+      const callee = children[0];
+      if (callee.type !== 'identifier') {
+        fail(node, '暂不支持通过表达式调用函数');
+      }
+      const argList = children[1];
+      const args = argList && argList.type === 'argument_list' ? namedChildren(argList) : [];
+      return { kind: 'call', callee: callee.text, args: args.map(lowerExpr), span };
+    }
+
+    case 'assignment_expression': {
+      const children = namedChildren(node);
+      const op = operatorOf(node);
+      const compound = op === '=' ? null : (op.slice(0, -1) as BinaryOp);
+      if (compound && !BINARY_OPS.has(compound)) fail(node, `暂不支持复合赋值 \`${op}\``);
+      return {
+        kind: 'assign',
+        target: lowerExpr(children[0]),
+        op: compound,
+        value: lowerExpr(children[1]),
+        span,
+      };
+    }
+
+    case 'update_expression': {
+      const children = allChildren(node);
+      const opNode = children.find((child) => child.type === '++' || child.type === '--');
+      if (!opNode) fail(node, '看不出是 ++ 还是 --');
+      const target = namedChildren(node)[0];
+      // 前缀的话运算符在名字前面
+      const postfix = opNode.startIndex > target.startIndex;
+      return {
+        kind: 'incdec',
+        target: lowerExpr(target),
+        delta: opNode.type === '++' ? 1 : -1,
+        postfix,
+        span,
+      };
+    }
+
+    case 'comma_expression':
+      fail(node, '暂不支持逗号表达式');
+      break;
+
+    case 'concatenated_string':
+    case 'string_literal':
+      fail(node, '设备代码里暂不支持字符串');
+      break;
+
+    default:
+      fail(node, `暂不支持的表达式：${node.type}`);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 语句                                                                */
+/* ------------------------------------------------------------------ */
+
+function lowerDeclaration(node: TsNode): Stmt {
+  const children = namedChildren(node);
+  const shared = allChildren(node).some(
+    (child) => child.text.trim() === '__shared__' || child.type === '__shared__'
+  );
+  if (allChildren(node).some((child) => child.text.trim() === 'extern')) {
+    fail(node, '暂不支持 `extern __shared__`（动态共享内存）—— 先用定长的 __shared__ 数组');
+  }
+  const base = findTypeSpecifier(children, node);
+
+  const decls: VarDecl[] = [];
+  for (const child of children) {
+    if (
+      child.type === 'type_qualifier' ||
+      child.type === 'primitive_type' ||
+      child.type === 'sized_type_specifier' ||
+      child.type === 'storage_class_specifier'
+    ) continue;
+
+    const declared = lowerDeclarator(child, base);
+    decls.push({
+      name: declared.name,
+      type: declared.type,
+      shared,
+      init: declared.init ? lowerExpr(declared.init) : undefined,
+      span: spanOf(child),
+    });
+  }
+
+  if (!decls.length) fail(node, '这个声明里没有变量');
+  return { kind: 'decl', decls, span: spanOf(node) };
+}
+
+/** `if (...)` / `while (...)` 的条件被包在 condition_clause 里 */
+function conditionOf(node: TsNode): Expr {
+  const clause = namedChildren(node).find((child) => child.type === 'condition_clause');
+  if (!clause) fail(node, '缺少条件');
+  const inner = namedChildren(clause)[0];
+  if (!inner) fail(clause, '条件是空的');
+  return lowerExpr(inner);
+}
+
+function lowerStmt(node: TsNode): Stmt {
+  const span = spanOf(node);
+
+  switch (node.type) {
+    case 'compound_statement':
+      return { kind: 'block', body: namedChildren(node).map(lowerStmt), span };
+
+    case 'declaration':
+      return lowerDeclaration(node);
+
+    case 'expression_statement': {
+      const inner = namedChildren(node)[0];
+      if (!inner) return { kind: 'block', body: [], span };
+      // `__syncthreads();` 是语句而不是普通调用 —— 它要让整个 warp 停下来
+      if (inner.type === 'call_expression') {
+        const callee = namedChildren(inner)[0];
+        if (callee?.type === 'identifier' && callee.text === '__syncthreads') {
+          return { kind: 'syncthreads', span };
+        }
+      }
+      return { kind: 'expr', expr: lowerExpr(inner), span };
+    }
+
+    case 'if_statement': {
+      const cond = conditionOf(node);
+      const children = namedChildren(node);
+      const thenNode = children.find(
+        (child) => child.type !== 'condition_clause' && child.type !== 'else_clause'
+      );
+      if (!thenNode) fail(node, 'if 缺少主体');
+      const elseClause = children.find((child) => child.type === 'else_clause');
+      const elseNode = elseClause ? namedChildren(elseClause)[0] : undefined;
+      return {
+        kind: 'if',
+        cond,
+        then: lowerStmt(thenNode),
+        otherwise: elseNode ? lowerStmt(elseNode) : undefined,
+        span,
+      };
+    }
+
+    case 'while_statement': {
+      const cond = conditionOf(node);
+      const body = namedChildren(node).find((child) => child.type !== 'condition_clause');
+      if (!body) fail(node, 'while 缺少主体');
+      return { kind: 'while', cond, body: lowerStmt(body), span };
+    }
+
+    case 'for_statement': {
+      // 子节点是位置性的：for ( <init> <cond> ; <step> ) <body>
+      // init 如果是 declaration，它自己带分号；如果是表达式，分号是独立的 token。
+      const parts = namedChildren(node);
+      let init: Stmt | undefined;
+      let cond: Expr | undefined;
+      let step: Expr | undefined;
+      let body: TsNode | undefined;
+
+      const semicolons = allChildren(node).filter((child) => child.type === ';');
+      const lastSemicolon = semicolons.length ? semicolons[semicolons.length - 1].startIndex : -1;
+      const closeParen = allChildren(node).filter((child) => child.type === ')').pop();
+      const closeAt = closeParen ? closeParen.startIndex : Number.MAX_SAFE_INTEGER;
+
+      for (const part of parts) {
+        if (part.startIndex > closeAt) { body = part; continue; }
+        if (part.type === 'declaration') { init = lowerDeclaration(part); continue; }
+        if (part.startIndex > lastSemicolon) { step = lowerExpr(part); continue; }
+        if (!init && !cond && isStatementLike(part)) { init = { kind: 'expr', expr: lowerExpr(part), span: spanOf(part) }; continue; }
+        cond = lowerExpr(part);
+      }
+
+      if (!body) fail(node, 'for 缺少主体');
+      return { kind: 'for', init, cond, step, body: lowerStmt(body), span };
+    }
+
+    case 'return_statement': {
+      const value = namedChildren(node)[0];
+      return { kind: 'return', value: value ? lowerExpr(value) : undefined, span };
+    }
+
+    case 'break_statement':
+      fail(node, '暂不支持 break —— 用循环条件表达同样的意思');
+      break;
+    case 'continue_statement':
+      fail(node, '暂不支持 continue');
+      break;
+    case 'switch_statement':
+      fail(node, '暂不支持 switch');
+      break;
+    case 'do_statement':
+      fail(node, '暂不支持 do-while');
+      break;
+    case 'goto_statement':
+      fail(node, 'goto 不在支持范围内');
+      break;
+
+    case 'comment':
+      return { kind: 'block', body: [], span };
+
+    default:
+      fail(node, `暂不支持的语句：${node.type}`);
+  }
+}
+
+/**
+ * for 的第一段是初始化还是条件？
+ *
+ * `for (i = 0; ...)` 的第一段是 assignment_expression，是初始化；
+ * `for (; i < n; ...)` 的第一段直接就是条件。用「是不是带副作用的语句」区分。
+ */
+function isStatementLike(node: TsNode): boolean {
+  return node.type === 'assignment_expression' || node.type === 'update_expression';
+}
+
+/* ------------------------------------------------------------------ */
+/* 顶层                                                                */
+/* ------------------------------------------------------------------ */
+
+function lowerParam(node: TsNode): Param {
+  const children = namedChildren(node);
+  const base = findTypeSpecifier(children, node);
+  const declarator = children.find(
+    (child) =>
+      child.type === 'identifier' ||
+      child.type === 'pointer_declarator' ||
+      child.type === 'array_declarator'
+  );
+  if (!declarator) fail(node, '参数缺少名字');
+  const declared = lowerDeclarator(declarator, base);
+  return { name: declared.name, type: declared.type, span: spanOf(node) };
+}
+
+function lowerFunction(node: TsNode): KernelDecl | null {
+  const kinds = allChildren(node).map((child) => child.text.trim());
+  const isGlobal = kinds.includes('__global__');
+  const isDevice = kinds.includes('__device__');
+
+  if (!isGlobal) {
+    if (isDevice) {
+      fail(node, '暂不支持自己写的 __device__ 函数 —— 先把逻辑内联进 kernel');
+    }
+    fail(node, '这一版只支持 __global__ kernel，还不支持宿主函数');
+  }
+
+  const declarator = namedChildren(node).find((child) => child.type === 'function_declarator');
+  if (!declarator) fail(node, '看不出这个 kernel 的名字与参数');
+
+  const nameNode = namedChildren(declarator).find((child) => child.type === 'identifier');
+  if (!nameNode) fail(declarator, 'kernel 缺少名字');
+
+  const paramList = namedChildren(declarator).find((child) => child.type === 'parameter_list');
+  const params = paramList
+    ? namedChildren(paramList)
+        .filter((child) => child.type === 'parameter_declaration')
+        .map(lowerParam)
+    : [];
+
+  const body = namedChildren(node).find((child) => child.type === 'compound_statement');
+  if (!body) fail(node, 'kernel 缺少函数体');
+
+  const returnType = findTypeSpecifier(namedChildren(node), node);
+  if (!(returnType.kind === 'scalar' && returnType.scalar === 'void')) {
+    fail(node, 'kernel 的返回类型必须是 void');
+  }
+
+  return { name: nameNode.text, params, body: lowerStmt(body), span: spanOf(node) };
+}
+
+export function lowerTranslationUnit(root: TsNode): TranslationUnit {
+  const kernels: KernelDecl[] = [];
+
+  for (const child of namedChildren(root)) {
+    switch (child.type) {
+      case 'function_definition': {
+        const kernel = lowerFunction(child);
+        if (kernel) kernels.push(kernel);
+        break;
+      }
+      case 'comment':
+      case 'preproc_include':
+        break;
+      case 'preproc_def':
+      case 'preproc_function_def':
+        fail(child, '暂不支持 #define —— 用 const 变量代替');
+        break;
+      case 'declaration':
+        fail(child, '暂不支持全局变量');
+        break;
+      default:
+        fail(child, `暂不支持的顶层写法：${child.type}`);
+    }
+  }
+
+  if (!kernels.length) {
+    throw new CudaCompileError('这份源码里没有 __global__ kernel', { line: 1, column: 1 });
+  }
+  return { kernels };
+}

--- a/src/lib/gpulab/cuda/parser.ts
+++ b/src/lib/gpulab/cuda/parser.ts
@@ -1,0 +1,135 @@
+/**
+ * CUDA 语法解析
+ *
+ * 用 tree-sitter 的 CUDA 语法（tree-sitter-cuda，MIT，包里自带预编译 wasm），
+ * 而不是自己写一个 C 解析器 —— C 的声明语法边角极多（`float *(*f)(int)` 那类），
+ * 手写出来的东西会在学员写出合法代码时莫名其妙地挂。
+ *
+ * 加载方式和 labkit 的 shell 解析器完全一样：运行时与语法都是 WASM，
+ * 浏览器里由 scripts/copy-lab-assets.js 拷到 /gpulab/tree-sitter-cuda.wasm。
+ *
+ * 这一层只负责「拿到具体语法树」。翻成我们自己的 AST 是 lower.ts 的事，
+ * 翻不动的语法在那里**明确报错**，绝不悄悄降级成能跑但不对的东西。
+ */
+import { createTreeSitterParser } from '../../labkit/treesitter';
+
+interface TsNode {
+  type: string;
+  text: string;
+  startIndex: number;
+  endIndex: number;
+  startPosition: { row: number; column: number };
+  childCount: number;
+  namedChildCount: number;
+  isMissing: boolean;
+  hasError: boolean;
+  child(index: number): TsNode | null;
+  namedChild(index: number): TsNode | null;
+  childForFieldName(name: string): TsNode | null;
+}
+
+interface TsTree {
+  rootNode: TsNode;
+}
+
+interface TsParser {
+  parse(source: string): TsTree;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+export type { TsNode, TsTree };
+
+let parserPromise: Promise<TsParser> | null = null;
+
+export interface CudaParserOptions {
+  /** web-tree-sitter 运行时 wasm 的地址 */
+  runtimeWasmUrl?: string;
+  /** CUDA 语法：给地址或者直接给字节 */
+  grammar?: string | Uint8Array;
+}
+
+/**
+ * 语法 wasm 在哪。
+ *
+ * 浏览器里由构建脚本拷到 /gpulab/tree-sitter-cuda.wasm；
+ * Node（测试、出题脚本）里直接从 node_modules 取。
+ */
+function defaultGrammarPath(): string {
+  return isBrowser()
+    ? '/gpulab/tree-sitter-cuda.wasm'
+    : 'node_modules/tree-sitter-cuda/tree-sitter-cuda.wasm';
+}
+
+/** tree-sitter 的运行时与语法都是 WASM，加载一次复用 */
+export async function loadCudaParser(options: CudaParserOptions = {}): Promise<TsParser> {
+  if (parserPromise) return parserPromise;
+  parserPromise = createTreeSitterParser<TsParser>({
+    runtimeWasmUrl: options.runtimeWasmUrl,
+    grammar: options.grammar ?? defaultGrammarPath(),
+  });
+  return parserPromise;
+}
+
+/** 测试之间要能换 wasm 路径重来 */
+export function resetCudaParser(): void {
+  parserPromise = null;
+}
+
+export class CudaSyntaxError extends Error {
+  /** 1 起算，和编译器报错的习惯一致 */
+  line: number;
+  column: number;
+  constructor(message: string, line: number, column: number) {
+    super(`${line}:${column}: ${message}`);
+    this.name = 'CudaSyntaxError';
+    this.line = line;
+    this.column = column;
+  }
+}
+
+/**
+ * 找出树里第一个语法错误。
+ *
+ * tree-sitter 是容错解析器：写错了它照样给一棵树，只是里面有 ERROR 与 MISSING
+ * 节点。不主动查的话，一个少写分号的 kernel 会被我们当成合法程序编出来，
+ * 然后在完全无关的地方给出一个看不懂的错。
+ */
+export function firstSyntaxError(root: TsNode): CudaSyntaxError | null {
+  const stack: TsNode[] = [root];
+  let best: TsNode | null = null;
+
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (!node.hasError && !node.isMissing) continue;
+
+    if (node.type === 'ERROR' || node.isMissing) {
+      // 取位置最靠前的那个，报错才指向真正出问题的地方
+      if (!best || node.startIndex < best.startIndex) best = node;
+    }
+    for (let i = node.childCount - 1; i >= 0; i -= 1) {
+      const child = node.child(i);
+      if (child) stack.push(child);
+    }
+  }
+
+  if (!best) return null;
+  const what = best.isMissing ? `缺少 ${best.type}` : `无法解析：${truncate(best.text)}`;
+  return new CudaSyntaxError(what, best.startPosition.row + 1, best.startPosition.column + 1);
+}
+
+function truncate(text: string): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 40 ? `${oneLine.slice(0, 40)}…` : oneLine;
+}
+
+/** 解析一段 CUDA 源码；有语法错误就抛 */
+export async function parseCuda(source: string, options?: CudaParserOptions): Promise<TsNode> {
+  const parser = await loadCudaParser(options);
+  const tree = parser.parse(source);
+  const error = firstSyntaxError(tree.rootNode);
+  if (error) throw error;
+  return tree.rootNode;
+}

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -1,0 +1,143 @@
+/**
+ * gpulab —— CUDA GPU 编程实战工作台
+ *
+ * 设计见 design/gpulab.md。这一层是给关卡与判定用的门面：
+ * 一段 CUDA 源码进去，跑完之后的内存与指标出来。
+ */
+import { compileKernel } from './ir/compile';
+import { encode, type ExecutableKernel } from './ir/program';
+import type { CompiledKernel } from './ir/types';
+import { lowerTranslationUnit } from './cuda/lower';
+import { parseCuda, type CudaParserOptions } from './cuda/parser';
+import { flattenMetrics, toMetrics, type GpuMetrics } from './metrics';
+import { LinearMemory } from './vm/memory';
+import { launchKernel, type Dim3, type GpuCounters, type LaunchConfig, type KernelArg } from './vm/vm';
+
+export { CudaSyntaxError, parseCuda, resetCudaParser } from './cuda/parser';
+export { CudaCompileError } from './cuda/lower';
+export { KernelError, dim3, launchKernel } from './vm/vm';
+export { LinearMemory, MemoryFault, SECTOR_BYTES, WARP_SIZE } from './vm/memory';
+export { flattenMetrics, toMetrics } from './metrics';
+export type { GpuMetrics } from './metrics';
+export type { CompiledKernel } from './ir/types';
+export { encode } from './ir/program';
+export type { ExecutableKernel } from './ir/program';
+export type { Dim3, LaunchConfig, KernelArg, GpuCounters } from './vm/vm';
+
+/** 编译一份源码，返回里面所有的 kernel */
+export async function compileSource(
+  source: string,
+  options?: CudaParserOptions
+): Promise<Map<string, ExecutableKernel>> {
+  const root = await parseCuda(source, options);
+  const unit = lowerTranslationUnit(root);
+  const kernels = new Map<string, ExecutableKernel>();
+  for (const kernel of unit.kernels) {
+    // 编码只做一次 —— 一关会 launch 很多次，每次重编是白费的
+    kernels.set(kernel.name, encode(compileKernel(kernel)));
+  }
+  return kernels;
+}
+
+export interface DeviceOptions {
+  /** 全局显存大小。默认 64MB —— 关卡的规模远小于此，超了就是题目出大了。 */
+  globalBytes?: number;
+  /** 每个 block 的共享内存上限。默认 48KB，和不显式提高时的 CUDA 一致。 */
+  sharedBytesPerBlock?: number;
+  /**
+   * 执行预算：跑到这么多条 warp 指令还没停就报错。
+   *
+   * 防的是学员写错的死循环。默认按「判定最多跑十来秒」定，
+   * 关卡可以按自己的规模调小，好让出错时更快看到反馈。
+   */
+  maxWarpInsts?: number;
+}
+
+/**
+ * 一台（模拟的）设备。
+ *
+ * 显存、分配器、指标都挂在它上面 —— 一次判定就是「建一台设备、
+ * 拷数据进去、launch 几次、把结果拷出来看」。
+ */
+export class GpuDevice {
+  readonly memory: LinearMemory;
+  private readonly sharedCapacity: number;
+  private readonly maxWarpInsts: number | undefined;
+  private counters = emptyTotals();
+
+  constructor(options: DeviceOptions = {}) {
+    this.memory = new LinearMemory(options.globalBytes ?? 64 * 1024 * 1024, 'global');
+    this.sharedCapacity = options.sharedBytesPerBlock ?? 48 * 1024;
+    this.maxWarpInsts = options.maxWarpInsts;
+  }
+
+  /** cudaMalloc：返回设备地址 */
+  malloc(bytes: number): number {
+    return this.memory.allocate(bytes);
+  }
+
+  /** 一次拷进去 count 个 float */
+  copyIn(address: number, values: ArrayLike<number>): void {
+    this.memory.writeFloats(address, values);
+  }
+
+  copyOut(address: number, count: number): Float32Array {
+    return this.memory.readFloats(address, count);
+  }
+
+  copyInInts(address: number, values: ArrayLike<number>): void {
+    this.memory.writeInts(address, values);
+  }
+
+  copyOutInts(address: number, count: number): Int32Array {
+    return this.memory.readInts(address, count);
+  }
+
+  /** 已经分配掉多少字节 —— 峰值显存那个门槛读它 */
+  get usedBytes(): number {
+    return this.memory.used;
+  }
+
+  launch(kernel: CompiledKernel | ExecutableKernel, config: LaunchConfig, args: KernelArg[]): void {
+    const result = launchKernel(kernel, config, args, {
+      memory: this.memory,
+      sharedCapacity: this.sharedCapacity,
+      maxWarpInsts: this.maxWarpInsts,
+    });
+    accumulate(this.counters, result.counters);
+  }
+
+  /** 这台设备上到目前为止的全部指标 */
+  metrics(): GpuMetrics {
+    return toMetrics(this.counters);
+  }
+
+  /** 摊平成 `gpu.` 路径，直接喂给 MetricGate */
+  flatMetrics(): Record<string, number> {
+    return flattenMetrics(this.metrics());
+  }
+
+  resetMetrics(): void {
+    this.counters = emptyTotals();
+  }
+}
+
+function emptyTotals(): GpuCounters {
+  return {
+    warpInsts: 0, laneInsts: 0, instFma: 0, instLdSt: 0,
+    globalLoadRequests: 0, globalStoreRequests: 0,
+    globalLoadSectors: 0, globalStoreSectors: 0,
+    sharedLoadRequests: 0, sharedStoreRequests: 0, sharedBankConflicts: 0,
+    divergentBranches: 0, activeLanes: 0,
+    barriers: 0, blocksLaunched: 0, warpsLaunched: 0,
+  };
+}
+
+/** 每次 launch 的计数器累加到设备上 —— 一关可能 launch 很多次 */
+function accumulate(total: GpuCounters, delta: GpuCounters): void {
+  for (const key of Object.keys(total) as (keyof GpuCounters)[]) {
+    total[key] += delta[key];
+  }
+}
+
+export type { Dim3 as GpuDim3 };

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -11,7 +11,7 @@ import { lowerTranslationUnit } from './cuda/lower';
 import { parseCuda, type CudaParserOptions } from './cuda/parser';
 import { flattenMetrics, toMetrics, type GpuMetrics } from './metrics';
 import { LinearMemory } from './vm/memory';
-import { launchKernel, type Dim3, type GpuCounters, type LaunchConfig, type KernelArg } from './vm/vm';
+import { emptyCounters, launchKernel, type Dim3, type GpuCounters, type LaunchConfig, type KernelArg } from './vm/vm';
 
 export { CudaSyntaxError, parseCuda, resetCudaParser } from './cuda/parser';
 export { CudaCompileError } from './cuda/lower';
@@ -63,7 +63,7 @@ export class GpuDevice {
   readonly memory: LinearMemory;
   private readonly sharedCapacity: number;
   private readonly maxWarpInsts: number | undefined;
-  private counters = emptyTotals();
+  private counters = emptyCounters();
 
   constructor(options: DeviceOptions = {}) {
     this.memory = new LinearMemory(options.globalBytes ?? 64 * 1024 * 1024, 'global');
@@ -118,19 +118,8 @@ export class GpuDevice {
   }
 
   resetMetrics(): void {
-    this.counters = emptyTotals();
+    this.counters = emptyCounters();
   }
-}
-
-function emptyTotals(): GpuCounters {
-  return {
-    warpInsts: 0, laneInsts: 0, instFma: 0, instLdSt: 0,
-    globalLoadRequests: 0, globalStoreRequests: 0,
-    globalLoadSectors: 0, globalStoreSectors: 0,
-    sharedLoadRequests: 0, sharedStoreRequests: 0, sharedBankConflicts: 0,
-    divergentBranches: 0, activeLanes: 0,
-    barriers: 0, blocksLaunched: 0, warpsLaunched: 0,
-  };
 }
 
 /** 每次 launch 的计数器累加到设备上 —— 一关可能 launch 很多次 */

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -9,7 +9,7 @@
  * int 和 unsigned 混算提升到 unsigned。够用，且和真 nvcc 在这个子集上一致。
  */
 import {
-  isFloat, isPointer, sizeOf, typeName,
+  isPointer, sizeOf, typeName,
   type BinaryOp, type CudaType, type Expr, type KernelDecl, type Stmt, type VarDecl,
 } from '../cuda/ast';
 import { CudaCompileError } from '../cuda/lower';
@@ -742,4 +742,3 @@ export function compileKernel(kernel: KernelDecl): CompiledKernel {
   return new Compiler(kernel).compile();
 }
 
-export { isFloat };

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -1,0 +1,745 @@
+/**
+ * AST → 扁平 IR
+ *
+ * 一个直白的表达式求值 + 结构化控制流降级。没有优化，也不该有优化：
+ * 这个工作台的全部意义是「学员写了什么就跑什么，指令数与访存次数都算数」。
+ * 编译器替他把重复的下标计算提出去，`gpu.inst.*` 就不再反映他写的东西了。
+ *
+ * 类型规则按 C 的通常算术转换裁剪过：int 和 float 混算提升到 float，
+ * int 和 unsigned 混算提升到 unsigned。够用，且和真 nvcc 在这个子集上一致。
+ */
+import {
+  isFloat, isPointer, sizeOf, typeName,
+  type BinaryOp, type CudaType, type Expr, type KernelDecl, type Stmt, type VarDecl,
+} from '../cuda/ast';
+import { CudaCompileError } from '../cuda/lower';
+import type {
+  BinKind, BuiltinFn, CompiledKernel, Inst, IrType, KernelParam, SharedVar, Space,
+} from './types';
+
+/** 一个值：寄存器编号 + 它的 CUDA 类型 */
+interface Value {
+  reg: number;
+  type: CudaType;
+}
+
+/** 变量住在哪 */
+type Binding =
+  | { where: 'reg'; reg: number; type: CudaType }
+  /** `__shared__` 的数组：住在共享内存，名字对应一个基地址 */
+  | { where: 'shared'; offset: number; type: CudaType }
+  /** kernel 参数里的指针：寄存器里存的是字节地址 */
+  | { where: 'param'; reg: number; type: CudaType };
+
+const BUILTIN_FNS: Record<string, { fn: BuiltinFn; arity: number; ty: IrType }> = {
+  fmaf: { fn: 'fmaf', arity: 3, ty: 'f32' },
+  fabsf: { fn: 'fabsf', arity: 1, ty: 'f32' },
+  fminf: { fn: 'fminf', arity: 2, ty: 'f32' },
+  fmaxf: { fn: 'fmaxf', arity: 2, ty: 'f32' },
+  sqrtf: { fn: 'sqrtf', arity: 1, ty: 'f32' },
+  rsqrtf: { fn: 'rsqrtf', arity: 1, ty: 'f32' },
+  expf: { fn: 'expf', arity: 1, ty: 'f32' },
+  logf: { fn: 'logf', arity: 1, ty: 'f32' },
+  tanhf: { fn: 'tanhf', arity: 1, ty: 'f32' },
+  powf: { fn: 'powf', arity: 2, ty: 'f32' },
+  __expf: { fn: '__expf', arity: 1, ty: 'f32' },
+  __logf: { fn: '__logf', arity: 1, ty: 'f32' },
+  __fdividef: { fn: '__fdividef', arity: 2, ty: 'f32' },
+  min: { fn: 'min', arity: 2, ty: 'i32' },
+  max: { fn: 'max', arity: 2, ty: 'i32' },
+  abs: { fn: 'abs', arity: 1, ty: 'i32' },
+};
+
+const COMPARISONS = new Set<BinaryOp>(['<', '<=', '>', '>=', '==', '!=']);
+
+const BIN_KIND: Partial<Record<BinaryOp, BinKind>> = {
+  '+': 'add', '-': 'sub', '*': 'mul', '/': 'div', '%': 'rem',
+  '<<': 'shl', '>>': 'shr', '&': 'and', '|': 'or', '^': 'xor',
+  '<': 'lt', '<=': 'le', '>': 'gt', '>=': 'ge', '==': 'eq', '!=': 'ne',
+};
+
+function irTypeOf(type: CudaType): IrType {
+  if (type.kind === 'pointer') return 'u32';
+  if (type.kind === 'array') return 'u32';
+  switch (type.scalar) {
+    case 'float': return 'f32';
+    case 'uint': return 'u32';
+    default: return 'i32';
+  }
+}
+
+class Compiler {
+  private insts: Inst[] = [];
+  private lines: number[] = [];
+  private scopes: Map<string, Binding>[] = [];
+  private numRegs = 0;
+  private sharedBytes = 0;
+  private sharedVars: SharedVar[] = [];
+  private params: KernelParam[] = [];
+
+  constructor(private kernel: KernelDecl) {}
+
+  compile(): CompiledKernel {
+    this.scopes.push(new Map());
+
+    this.kernel.params.forEach((param, index) => {
+      if (param.type.kind === 'array') {
+        this.fail(param.span.line, param.span.column, 'kernel 参数不能是数组，用指针');
+      }
+      const reg = this.alloc();
+      const pointer = isPointer(param.type);
+      this.emit(
+        { op: 'param', dst: reg, index, ty: pointer ? 'u32' : irTypeOf(param.type) },
+        param.span.line
+      );
+      this.bind(param.name, { where: 'param', reg, type: param.type });
+      this.params.push({
+        name: param.name,
+        ty: pointer ? 'u32' : irTypeOf(param.type),
+        isPointer: pointer,
+        elementBytes: pointer ? sizeOf((param.type as { to: CudaType }).to) : 4,
+      });
+    });
+
+    this.stmt(this.kernel.body);
+    this.emit({ op: 'ret' }, this.kernel.span.line);
+
+    return {
+      name: this.kernel.name,
+      insts: this.insts,
+      params: this.params,
+      numRegs: this.numRegs,
+      sharedBytes: this.sharedBytes,
+      sharedVars: this.sharedVars,
+      lines: this.lines,
+    };
+  }
+
+  /* ---------------- 基础设施 ---------------- */
+
+  private fail(line: number, column: number, message: string): never {
+    throw new CudaCompileError(message, { line, column });
+  }
+
+  private alloc(): number {
+    return this.numRegs++;
+  }
+
+  private emit(inst: Inst, line: number): number {
+    this.insts.push(inst);
+    this.lines.push(line);
+    return this.insts.length - 1;
+  }
+
+  private here(): number {
+    return this.insts.length;
+  }
+
+  private bind(name: string, binding: Binding): void {
+    this.scopes[this.scopes.length - 1].set(name, binding);
+  }
+
+  private lookup(name: string): Binding | undefined {
+    for (let i = this.scopes.length - 1; i >= 0; i -= 1) {
+      const found = this.scopes[i].get(name);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  private pushScope(): void {
+    this.scopes.push(new Map());
+  }
+
+  private popScope(): void {
+    this.scopes.pop();
+  }
+
+  private constant(value: number, ty: IrType, line: number): number {
+    const reg = this.alloc();
+    this.emit({ op: 'const', dst: reg, value, ty }, line);
+    return reg;
+  }
+
+  /* ---------------- 类型 ---------------- */
+
+  /** C 的通常算术转换，裁剪到我们的四种标量 */
+  private unify(a: CudaType, b: CudaType, line: number, column: number): CudaType {
+    if (a.kind !== 'scalar' || b.kind !== 'scalar') {
+      this.fail(line, column, `不能对 ${typeName(a)} 和 ${typeName(b)} 做算术`);
+    }
+    if (a.scalar === 'float' || b.scalar === 'float') return { kind: 'scalar', scalar: 'float' };
+    if (a.scalar === 'uint' || b.scalar === 'uint') return { kind: 'scalar', scalar: 'uint' };
+    return { kind: 'scalar', scalar: 'int' };
+  }
+
+  private convert(value: Value, target: CudaType, line: number): Value {
+    const from = irTypeOf(value.type);
+    const to = irTypeOf(target);
+    if (from === to) return { reg: value.reg, type: target };
+    const dst = this.alloc();
+    this.emit({ op: 'cvt', dst, a: value.reg, from, to }, line);
+    return { reg: dst, type: target };
+  }
+
+  /**
+   * 不生成代码，只算出一个表达式的静态类型。
+   *
+   * 三目运算需要它：两个分支要转成同一个类型再写进同一个寄存器，
+   * 而 `then` 分支的代码必须在知道目标类型之后才能生成 —— 否则就得先生成、
+   * 再回过头改指令流，那条路试过，脆得多。
+   */
+  private staticTypeOf(node: Expr): CudaType {
+    switch (node.kind) {
+      case 'intLit': case 'boolLit':
+        return { kind: 'scalar', scalar: 'int' };
+      case 'floatLit':
+        return { kind: 'scalar', scalar: 'float' };
+      case 'builtin':
+        return { kind: 'scalar', scalar: 'uint' };
+      case 'name': {
+        const binding = this.lookup(node.name);
+        if (!binding) this.fail(node.span.line, node.span.column, `没有声明过 \`${node.name}\``);
+        return binding.type;
+      }
+      case 'unary':
+        return node.op === '!'
+          ? { kind: 'scalar', scalar: 'int' }
+          : this.staticTypeOf(node.operand);
+      case 'binary': {
+        if (COMPARISONS.has(node.op) || node.op === '&&' || node.op === '||') {
+          return { kind: 'scalar', scalar: 'int' };
+        }
+        const left = this.staticTypeOf(node.left);
+        const right = this.staticTypeOf(node.right);
+        if (isPointer(left)) return left;
+        if (isPointer(right)) return right;
+        return this.unify(left, right, node.span.line, node.span.column);
+      }
+      case 'ternary':
+        return this.unify(
+          this.staticTypeOf(node.then), this.staticTypeOf(node.otherwise),
+          node.span.line, node.span.column
+        );
+      case 'cast':
+        return node.to;
+      case 'subscript': {
+        const base = this.staticTypeOf(node.array);
+        const element = elementOf(base);
+        if (!element) this.fail(node.span.line, node.span.column, `${typeName(base)} 不能取下标`);
+        return element;
+      }
+      case 'deref': {
+        const pointer = this.staticTypeOf(node.pointer);
+        if (!isPointer(pointer)) this.fail(node.span.line, node.span.column, `${typeName(pointer)} 不是指针`);
+        return pointer.to;
+      }
+      case 'call': {
+        const spec = BUILTIN_FNS[node.callee];
+        if (!spec) this.fail(node.span.line, node.span.column, `暂不支持函数 \`${node.callee}\``);
+        return spec.ty === 'f32'
+          ? { kind: 'scalar', scalar: 'float' }
+          : { kind: 'scalar', scalar: 'int' };
+      }
+      case 'assign':
+        return this.staticTypeOf(node.target);
+      case 'incdec':
+        return this.staticTypeOf(node.target);
+    }
+  }
+
+  /* ---------------- 表达式 ---------------- */
+
+  private expr(node: Expr): Value {
+    switch (node.kind) {
+      case 'intLit':
+        return { reg: this.constant(node.value | 0, 'i32', node.span.line), type: { kind: 'scalar', scalar: 'int' } };
+
+      case 'floatLit':
+        return { reg: this.constant(node.value, 'f32', node.span.line), type: { kind: 'scalar', scalar: 'float' } };
+
+      case 'boolLit':
+        return { reg: this.constant(node.value ? 1 : 0, 'i32', node.span.line), type: { kind: 'scalar', scalar: 'int' } };
+
+      case 'builtin': {
+        const dst = this.alloc();
+        const map: Record<string, string> = {
+          'threadIdx.x': 'tid.x', 'threadIdx.y': 'tid.y', 'threadIdx.z': 'tid.z',
+          'blockIdx.x': 'ctaid.x', 'blockIdx.y': 'ctaid.y', 'blockIdx.z': 'ctaid.z',
+          'blockDim.x': 'ntid.x', 'blockDim.y': 'ntid.y', 'blockDim.z': 'ntid.z',
+          'gridDim.x': 'nctaid.x', 'gridDim.y': 'nctaid.y', 'gridDim.z': 'nctaid.z',
+          warpSize: 'warpsize',
+        };
+        this.emit({ op: 'sreg', dst, which: map[node.which] as never }, node.span.line);
+        // 内建变量在 CUDA 里是 unsigned
+        return { reg: dst, type: { kind: 'scalar', scalar: 'uint' } };
+      }
+
+      case 'name': {
+        const binding = this.lookup(node.name);
+        if (!binding) this.fail(node.span.line, node.span.column, `没有声明过 \`${node.name}\``);
+        if (binding.where === 'shared') {
+          const dst = this.alloc();
+          this.emit({ op: 'sharedbase', dst, offset: binding.offset }, node.span.line);
+          return { reg: dst, type: binding.type };
+        }
+        return { reg: binding.reg, type: binding.type };
+      }
+
+      case 'unary': {
+        const operand = this.expr(node.operand);
+        if (node.op === '+') return operand;
+        const ty = irTypeOf(operand.type);
+        const dst = this.alloc();
+        const kind = node.op === '-' ? 'neg' : node.op === '!' ? 'not' : 'bnot';
+        if (node.op !== '-' && ty === 'f32') {
+          this.fail(node.span.line, node.span.column, `\`${node.op}\` 不能用在 float 上`);
+        }
+        this.emit({ op: 'un', dst, a: operand.reg, kind, ty }, node.span.line);
+        return {
+          reg: dst,
+          type: node.op === '!' ? { kind: 'scalar', scalar: 'int' } : operand.type,
+        };
+      }
+
+      case 'binary':
+        return this.binary(node);
+
+      case 'ternary': {
+        // 用分歧区实现：两边都可能有 lane 走到，而且**只在自己的 lane 上求值** ——
+        // 三目里带访存时这一点是有意义的，`i < n ? a[i] : 0.0f` 不该越界读。
+        const type = this.unify(
+          this.staticTypeOf(node.then),
+          this.staticTypeOf(node.otherwise),
+          node.span.line, node.span.column
+        );
+        const result = this.alloc();
+        const cond = this.expr(node.cond);
+        const pushAt = this.emit(
+          { op: 'push', cond: cond.reg, elsePc: -1, joinPc: -1, line: node.span.line },
+          node.span.line
+        );
+        const thenValue = this.convert(this.expr(node.then), type, node.span.line);
+        this.emit({ op: 'mov', dst: result, src: thenValue.reg }, node.span.line);
+        const swapAt = this.here();
+        this.emit({ op: 'swap', joinPc: -1 }, node.span.line);
+        const elseValue = this.convert(this.expr(node.otherwise), type, node.span.line);
+        this.emit({ op: 'mov', dst: result, src: elseValue.reg }, node.span.line);
+        const joinAt = this.here();
+        this.emit({ op: 'pop' }, node.span.line);
+        this.patchPush(pushAt, swapAt, joinAt);
+        this.patchSwap(swapAt, joinAt);
+        return { reg: result, type };
+      }
+
+      case 'cast': {
+        const operand = this.expr(node.operand);
+        if (node.to.kind === 'pointer') {
+          return { reg: operand.reg, type: node.to };
+        }
+        return this.convert(operand, node.to, node.span.line);
+      }
+
+      case 'subscript': {
+        const address = this.addressOf(node);
+        return this.loadFrom(address, node.span.line);
+      }
+
+      case 'deref': {
+        const address = this.addressOf(node);
+        return this.loadFrom(address, node.span.line);
+      }
+
+      case 'call':
+        return this.call(node);
+
+      case 'assign':
+        return this.assign(node);
+
+      case 'incdec': {
+        const before = this.expr(node.target);
+        const one = this.constant(node.delta, irTypeOf(before.type) === 'f32' ? 'f32' : 'i32', node.span.line);
+        const oneValue: Value = {
+          reg: one,
+          type: irTypeOf(before.type) === 'f32'
+            ? { kind: 'scalar', scalar: 'float' }
+            : { kind: 'scalar', scalar: 'int' },
+        };
+        const sum = this.arith(before, oneValue, '+', node.span.line, node.span.column);
+        this.storeInto(node.target, sum, node.span.line, node.span.column);
+        if (!node.postfix) return sum;
+        // 后缀要的是旧值，而旧值的寄存器可能已经被覆写，复制一份
+        const saved = this.alloc();
+        this.emit({ op: 'mov', dst: saved, src: before.reg }, node.span.line);
+        return { reg: saved, type: before.type };
+      }
+    }
+  }
+
+  private patchPush(at: number, elsePc: number, joinPc: number): void {
+    const inst = this.insts[at];
+    if (inst.op !== 'push') throw new Error('内部错误：patchPush 指向的不是 push');
+    inst.elsePc = elsePc;
+    inst.joinPc = joinPc;
+  }
+
+  private patchSwap(at: number, joinPc: number): void {
+    const inst = this.insts[at];
+    if (inst.op !== 'swap') throw new Error('内部错误：patchSwap 指向的不是 swap');
+    inst.joinPc = joinPc;
+  }
+
+  private binary(node: Expr & { kind: 'binary' }): Value {
+    const { op, span } = node;
+
+    // && 与 || 在 C 里短路。SIMT 里「短路」的意思是：右边只在左边为真的
+    // lane 上求值 —— 用分歧区表达，副作用与真硬件一致。
+    if (op === '&&' || op === '||') {
+      return this.shortCircuit(node);
+    }
+
+    const left = this.expr(node.left);
+    const right = this.expr(node.right);
+    return this.arith(left, right, op, span.line, span.column);
+  }
+
+  private shortCircuit(node: Expr & { kind: 'binary' }): Value {
+    const line = node.span.line;
+    const result = this.alloc();
+
+    const left = this.toBool(this.expr(node.left), line);
+    this.emit({ op: 'mov', dst: result, src: left.reg }, line);
+
+    // && 时右边只在「左为真」的 lane 上算；|| 时只在「左为假」的 lane 上算。
+    // 这就是 SIMT 里的短路：不是跳过，是掩码掉。
+    let guard = left.reg;
+    if (node.op === '||') {
+      guard = this.alloc();
+      this.emit({ op: 'un', dst: guard, a: left.reg, kind: 'not', ty: 'i32' }, line);
+    }
+
+    const pushAt = this.emit({ op: 'push', cond: guard, elsePc: -1, joinPc: -1, line }, line);
+    const right = this.toBool(this.expr(node.right), line);
+    this.emit({ op: 'mov', dst: result, src: right.reg }, line);
+    const joinAt = this.here();
+    this.emit({ op: 'pop' }, line);
+    // 没有 else 分支：push 直接跳到 pop
+    this.patchPush(pushAt, joinAt, joinAt);
+
+    return { reg: result, type: { kind: 'scalar', scalar: 'int' } };
+  }
+
+  /** 把任意标量变成 0/1 */
+  private toBool(value: Value, line: number): Value {
+    const zero = this.constant(0, irTypeOf(value.type), line);
+    const dst = this.alloc();
+    this.emit({ op: 'bin', dst, a: value.reg, b: zero, kind: 'ne', ty: irTypeOf(value.type) }, line);
+    return { reg: dst, type: { kind: 'scalar', scalar: 'int' } };
+  }
+
+  private arith(left: Value, right: Value, op: BinaryOp, line: number, column: number): Value {
+    const kind = BIN_KIND[op];
+    if (!kind) this.fail(line, column, `暂不支持运算符 \`${op}\``);
+
+    // 指针算术：p + i 走元素步长
+    if (isPointer(left.type) || isPointer(right.type)) {
+      if (op !== '+' && op !== '-' && !COMPARISONS.has(op)) {
+        this.fail(line, column, `指针不能做 \`${op}\``);
+      }
+      if (COMPARISONS.has(op)) {
+        const dst = this.alloc();
+        this.emit({ op: 'bin', dst, a: left.reg, b: right.reg, kind, ty: 'u32' }, line);
+        return { reg: dst, type: { kind: 'scalar', scalar: 'int' } };
+      }
+      const pointer = isPointer(left.type) ? left : right;
+      const offset = isPointer(left.type) ? right : left;
+      const elementBytes = sizeOf((pointer.type as { to: CudaType }).to);
+      const scaled = this.alloc();
+      const bytes = this.constant(elementBytes, 'i32', line);
+      this.emit({ op: 'bin', dst: scaled, a: offset.reg, b: bytes, kind: 'mul', ty: 'i32' }, line);
+      const dst = this.alloc();
+      this.emit({ op: 'bin', dst, a: pointer.reg, b: scaled, kind, ty: 'u32' }, line);
+      return { reg: dst, type: pointer.type };
+    }
+
+    const unified = this.unify(left.type, right.type, line, column);
+    const ty = irTypeOf(unified);
+    if (ty === 'f32' && (op === '%' || op === '<<' || op === '>>' || op === '&' || op === '|' || op === '^')) {
+      this.fail(line, column, `\`${op}\` 不能用在 float 上`);
+    }
+
+    const a = this.convert(left, unified, line);
+    const b = this.convert(right, unified, line);
+    const dst = this.alloc();
+    this.emit({ op: 'bin', dst, a: a.reg, b: b.reg, kind, ty }, line);
+
+    return {
+      reg: dst,
+      type: COMPARISONS.has(op) ? { kind: 'scalar', scalar: 'int' } : unified,
+    };
+  }
+
+  private call(node: Expr & { kind: 'call' }): Value {
+    const spec = BUILTIN_FNS[node.callee];
+    if (!spec) {
+      this.fail(
+        node.span.line, node.span.column,
+        `暂不支持函数 \`${node.callee}\` —— 内建的只有 ${Object.keys(BUILTIN_FNS).join(' / ')}`
+      );
+    }
+    if (node.args.length !== spec.arity) {
+      this.fail(node.span.line, node.span.column, `${node.callee} 需要 ${spec.arity} 个参数，给了 ${node.args.length} 个`);
+    }
+    const target: CudaType = spec.ty === 'f32'
+      ? { kind: 'scalar', scalar: 'float' }
+      : { kind: 'scalar', scalar: 'int' };
+    const args = node.args.map((arg) => this.convert(this.expr(arg), target, node.span.line).reg);
+    const dst = this.alloc();
+    this.emit({ op: 'call', dst, fn: spec.fn, args, ty: spec.ty }, node.span.line);
+    return { reg: dst, type: target };
+  }
+
+  /* ---------------- 地址与访存 ---------------- */
+
+  /**
+   * 算出一个左值的地址。
+   *
+   * 返回地址寄存器、地址空间、以及元素类型。共享内存与全局内存的地址是两套
+   * 独立的偏移，所以 space 必须一路带着走。
+   */
+  private addressOf(node: Expr): { reg: number; space: Space; type: CudaType } {
+    switch (node.kind) {
+      case 'subscript': {
+        const base = this.addressBase(node.array);
+        const index = this.expr(node.index);
+        const elementType = elementOf(base.type);
+        if (!elementType) {
+          this.fail(node.span.line, node.span.column, `${typeName(base.type)} 不能取下标`);
+        }
+        const elementBytes = sizeOf(elementType);
+        const asInt = this.convert(index, { kind: 'scalar', scalar: 'int' }, node.span.line);
+        const scaled = this.alloc();
+        const bytes = this.constant(elementBytes, 'i32', node.span.line);
+        this.emit({ op: 'bin', dst: scaled, a: asInt.reg, b: bytes, kind: 'mul', ty: 'i32' }, node.span.line);
+        const addr = this.alloc();
+        this.emit({ op: 'bin', dst: addr, a: base.reg, b: scaled, kind: 'add', ty: 'u32' }, node.span.line);
+        return { reg: addr, space: base.space, type: elementType };
+      }
+
+      case 'deref': {
+        const pointer = this.expr(node.pointer);
+        if (!isPointer(pointer.type)) {
+          this.fail(node.span.line, node.span.column, `${typeName(pointer.type)} 不是指针，不能解引用`);
+        }
+        return { reg: pointer.reg, space: 'global', type: pointer.type.to };
+      }
+
+      default:
+        this.fail(
+          (node as Expr).span.line, (node as Expr).span.column,
+          '这个表达式不能作为左值'
+        );
+    }
+  }
+
+  /** 下标的基址：可能是共享数组、指针参数、或者又一层下标 */
+  private addressBase(node: Expr): { reg: number; space: Space; type: CudaType } {
+    if (node.kind === 'name') {
+      const binding = this.lookup(node.name);
+      if (!binding) this.fail(node.span.line, node.span.column, `没有声明过 \`${node.name}\``);
+      if (binding.where === 'shared') {
+        const reg = this.alloc();
+        this.emit({ op: 'sharedbase', dst: reg, offset: binding.offset }, node.span.line);
+        return { reg, space: 'shared', type: binding.type };
+      }
+      return { reg: binding.reg, space: 'global', type: binding.type };
+    }
+    if (node.kind === 'subscript') {
+      // 多维数组的中间一层：地址算出来，类型降一维
+      const inner = this.addressOf(node);
+      return inner;
+    }
+    const value = this.expr(node);
+    return { reg: value.reg, space: 'global', type: value.type };
+  }
+
+  private loadFrom(address: { reg: number; space: Space; type: CudaType }, line: number): Value {
+    if (address.type.kind === 'array') {
+      // `t[3]` 里 t 是二维数组时，取到的还是一段地址，不是值
+      return { reg: address.reg, type: address.type };
+    }
+    const dst = this.alloc();
+    this.emit(
+      { op: 'load', dst, addr: address.reg, space: address.space, ty: irTypeOf(address.type), line },
+      line
+    );
+    return { reg: dst, type: address.type };
+  }
+
+  private assign(node: Expr & { kind: 'assign' }): Value {
+    let value: Value;
+    if (node.op) {
+      const current = this.expr(node.target);
+      const operand = this.expr(node.value);
+      value = this.arith(current, operand, node.op, node.span.line, node.span.column);
+    } else {
+      value = this.expr(node.value);
+    }
+    return this.storeInto(node.target, value, node.span.line, node.span.column);
+  }
+
+  private storeInto(target: Expr, value: Value, line: number, column: number): Value {
+    if (target.kind === 'name') {
+      const binding = this.lookup(target.name);
+      if (!binding) this.fail(line, column, `没有声明过 \`${target.name}\``);
+      if (binding.where === 'shared') this.fail(line, column, `不能给共享数组 \`${target.name}\` 整体赋值`);
+      const converted = this.convert(value, binding.type, line);
+      this.emit({ op: 'mov', dst: binding.reg, src: converted.reg }, line);
+      return { reg: binding.reg, type: binding.type };
+    }
+
+    if (target.kind === 'subscript' || target.kind === 'deref') {
+      const address = this.addressOf(target);
+      if (address.type.kind === 'array') this.fail(line, column, '不能给整个数组赋值');
+      const converted = this.convert(value, address.type, line);
+      this.emit(
+        { op: 'store', addr: address.reg, src: converted.reg, space: address.space, ty: irTypeOf(address.type), line },
+        line
+      );
+      return converted;
+    }
+
+    this.fail(line, column, '这个表达式不能被赋值');
+  }
+
+  /* ---------------- 语句 ---------------- */
+
+  private stmt(node: Stmt): void {
+    switch (node.kind) {
+      case 'block':
+        this.pushScope();
+        node.body.forEach((child) => this.stmt(child));
+        this.popScope();
+        break;
+
+      case 'expr':
+        this.expr(node.expr);
+        break;
+
+      case 'decl':
+        node.decls.forEach((decl) => this.declare(decl));
+        break;
+
+      case 'if': {
+        const cond = this.expr(node.cond);
+        const pushAt = this.emit(
+          { op: 'push', cond: cond.reg, elsePc: -1, joinPc: -1, line: node.span.line },
+          node.span.line
+        );
+        this.stmt(node.then);
+        const swapAt = this.here();
+        this.emit({ op: 'swap', joinPc: -1 }, node.span.line);
+        if (node.otherwise) this.stmt(node.otherwise);
+        const joinAt = this.here();
+        this.emit({ op: 'pop' }, node.span.line);
+        this.patchPush(pushAt, swapAt, joinAt);
+        this.patchSwap(swapAt, joinAt);
+        break;
+      }
+
+      case 'while': {
+        const loopAt = this.emit({ op: 'loop', exitPc: -1 }, node.span.line);
+        const condAt = this.here();
+        const cond = this.expr(node.cond);
+        const lcondAt = this.emit({ op: 'lcond', cond: cond.reg, exitPc: -1 }, node.span.line);
+        this.stmt(node.body);
+        this.emit({ op: 'jmp', target: condAt }, node.span.line);
+        const exitAt = this.here();
+        this.emit({ op: 'pop' }, node.span.line);
+        (this.insts[loopAt] as { exitPc: number }).exitPc = exitAt;
+        (this.insts[lcondAt] as { exitPc: number }).exitPc = exitAt;
+        break;
+      }
+
+      case 'for': {
+        this.pushScope();
+        if (node.init) this.stmt(node.init);
+        const loopAt = this.emit({ op: 'loop', exitPc: -1 }, node.span.line);
+        const condAt = this.here();
+        let lcondAt = -1;
+        if (node.cond) {
+          const cond = this.expr(node.cond);
+          lcondAt = this.emit({ op: 'lcond', cond: cond.reg, exitPc: -1 }, node.span.line);
+        }
+        this.stmt(node.body);
+        if (node.step) this.expr(node.step);
+        this.emit({ op: 'jmp', target: condAt }, node.span.line);
+        const exitAt = this.here();
+        this.emit({ op: 'pop' }, node.span.line);
+        (this.insts[loopAt] as { exitPc: number }).exitPc = exitAt;
+        if (lcondAt >= 0) (this.insts[lcondAt] as { exitPc: number }).exitPc = exitAt;
+        this.popScope();
+        break;
+      }
+
+      case 'syncthreads':
+        this.emit({ op: 'bar', line: node.span.line }, node.span.line);
+        break;
+
+      case 'return':
+        if (node.value) this.fail(node.span.line, node.span.column, 'kernel 是 void，return 不能带值');
+        // 提前 return 会让部分 lane 退出，那是发散的一种。当前子集里只允许
+        // 出现在 kernel 末尾 —— 别处的 return 需要一条「退出掩码」，
+        // 和 break 是同一件事，一起等后续实现。
+        this.emit({ op: 'ret' }, node.span.line);
+        break;
+    }
+  }
+
+  private declare(decl: VarDecl): void {
+    if (decl.shared) {
+      if (decl.init) {
+        this.fail(decl.span.line, decl.span.column, '__shared__ 变量不能有初始值 —— 共享内存的内容在 kernel 启动时是未定义的');
+      }
+      const bytes = sizeOf(decl.type);
+      const align = 4;
+      this.sharedBytes = Math.ceil(this.sharedBytes / align) * align;
+      const offset = this.sharedBytes;
+      this.sharedBytes += bytes;
+      this.sharedVars.push({ name: decl.name, offset, bytes });
+      this.bind(decl.name, { where: 'shared', offset, type: decl.type });
+      return;
+    }
+
+    if (decl.type.kind === 'array') {
+      this.fail(
+        decl.span.line, decl.span.column,
+        '暂不支持线程私有的数组 —— 真卡上它会落到 local memory（那正是第 6 关的内容），先用标量'
+      );
+    }
+
+    const reg = this.alloc();
+    this.bind(decl.name, { where: 'reg', reg, type: decl.type });
+    if (decl.init) {
+      const value = this.convert(this.expr(decl.init), decl.type, decl.span.line);
+      this.emit({ op: 'mov', dst: reg, src: value.reg }, decl.span.line);
+    } else {
+      // 未初始化的变量在真卡上是垃圾值。我们给 0，但这是**已知的分叉**：
+      // 靠未初始化值出错的程序在这里不会暴露。
+      this.emit({ op: 'const', dst: reg, value: 0, ty: irTypeOf(decl.type) }, decl.span.line);
+    }
+  }
+}
+
+/** 数组或指针的元素类型 */
+function elementOf(type: CudaType): CudaType | null {
+  if (type.kind === 'array') return type.of;
+  if (type.kind === 'pointer') return type.to;
+  return null;
+}
+
+export function compileKernel(kernel: KernelDecl): CompiledKernel {
+  return new Compiler(kernel).compile();
+}
+
+export { isFloat };

--- a/src/lib/gpulab/ir/program.ts
+++ b/src/lib/gpulab/ir/program.ts
@@ -1,0 +1,229 @@
+/**
+ * 可执行程序：把 `Inst[]` 编码成扁平的定长记录
+ *
+ * 为什么不直接解释 `Inst[]`：`Inst` 是十八种不同形状的联合类型，于是
+ * `inst.dst` / `inst.a` 这些属性访问全是 megamorphic 的，V8 的内联缓存完全
+ * 失效；`switch (inst.op)` 也是字符串比较而不是跳转表。编成 `Int32Array`
+ * 之后取操作数是定址访问、分派是数值跳转表，两个问题一起没了。
+ *
+ * `Inst[]` 仍然是编译器的输出形式（可读、好测、将来的反汇编面板要用它），
+ * 只是在交给执行器之前过一道编码。
+ *
+ * **一个诚实的说明**：改成扁平编码之后在 jest 里量不出差别 —— 后来发现
+ * jest 自己就吃掉了 5–7 倍（SWC 转译 + 模块注册表 + vm 上下文）。
+ * 纯 node 下实测 **13.5M warp 指令/秒**（N=256 的朴素 GEMM 783ms），
+ * 而 jest 里同一段代码只有 2.0M/s。所以：
+ *   - 关卡规模按 13M/s 这个**生产数字**设计，不是按测试里看到的；
+ *   - 测试里的吞吐断言只能当回归哨兵用，不能当性能指标。
+ * 这一版没有单独隔离出扁平编码本身贡献了多少 —— 它是标准做法，
+ * 保留的理由是架构而不是一个测出来的加速比。
+ */
+import type { BinKind, BuiltinFn, CompiledKernel, Inst, IrType, Space, SpecialReg, UnKind } from './types';
+
+/** 每条指令占几个 int32 槽。取 2 的幂，`pc * SLOTS` 才能编译成移位。 */
+export const SLOTS = 8;
+
+export const OP = {
+  CONST: 0,
+  MOV: 1,
+  BIN: 2,
+  UN: 3,
+  CVT: 4,
+  SREG: 5,
+  PARAM: 6,
+  SHAREDBASE: 7,
+  LOAD: 8,
+  STORE: 9,
+  JMP: 10,
+  PUSH: 11,
+  SWAP: 12,
+  POP: 13,
+  LOOP: 14,
+  LCOND: 15,
+  BAR: 16,
+  CALL: 17,
+  RET: 18,
+} as const;
+
+export const TY = { F32: 0, I32: 1, U32: 2 } as const;
+export const SPACE = { GLOBAL: 0, SHARED: 1 } as const;
+
+export const BIN = {
+  add: 0, sub: 1, mul: 2, div: 3, rem: 4,
+  shl: 5, shr: 6, and: 7, or: 8, xor: 9,
+  lt: 10, le: 11, gt: 12, ge: 13, eq: 14, ne: 15,
+} as const;
+
+export const UN = { neg: 0, not: 1, bnot: 2 } as const;
+
+export const FN = {
+  fmaf: 0, fabsf: 1, fminf: 2, fmaxf: 3, sqrtf: 4, rsqrtf: 5,
+  expf: 6, logf: 7, tanhf: 8, powf: 9,
+  __expf: 10, __logf: 11, __fdividef: 12,
+  min: 13, max: 14, abs: 15,
+} as const;
+
+export const SREG = {
+  'tid.x': 0, 'tid.y': 1, 'tid.z': 2,
+  'ctaid.x': 3, 'ctaid.y': 4, 'ctaid.z': 5,
+  'ntid.x': 6, 'ntid.y': 7, 'ntid.z': 8,
+  'nctaid.x': 9, 'nctaid.y': 10, 'nctaid.z': 11,
+  warpsize: 12,
+} as const;
+
+function tyCode(ty: IrType): number {
+  return ty === 'f32' ? TY.F32 : ty === 'i32' ? TY.I32 : TY.U32;
+}
+
+export interface Program {
+  /** 指令流，每条 SLOTS 个槽 */
+  code: Int32Array;
+  /** 立即数常量池 —— float 放不进 Int32Array，用下标引用 */
+  pool: Float64Array;
+  /** 指令条数 */
+  count: number;
+  /** 指令下标 → 源码行号 */
+  lines: Int32Array;
+}
+
+export interface ExecutableKernel extends CompiledKernel {
+  program: Program;
+  /** 参数的类型码，避免执行时再查一遍 */
+  paramTypes: Int32Array;
+}
+
+export function encode(kernel: CompiledKernel): ExecutableKernel {
+  const count = kernel.insts.length;
+  const code = new Int32Array(count * SLOTS);
+  const lines = new Int32Array(count);
+  const pool: number[] = [];
+
+  const constant = (value: number): number => {
+    // 常量很多是重复的（下标步长、0、1），去重能让池小一个量级
+    const found = pool.indexOf(value);
+    if (found >= 0) return found;
+    pool.push(value);
+    return pool.length - 1;
+  };
+
+  for (let i = 0; i < count; i += 1) {
+    const inst = kernel.insts[i];
+    const at = i * SLOTS;
+    lines[i] = kernel.lines[i] ?? 0;
+
+    switch (inst.op) {
+      case 'const':
+        code[at] = OP.CONST;
+        code[at + 1] = inst.dst;
+        code[at + 2] = constant(inst.value);
+        code[at + 3] = tyCode(inst.ty);
+        break;
+      case 'mov':
+        code[at] = OP.MOV;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.src;
+        break;
+      case 'bin':
+        code[at] = OP.BIN;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.a;
+        code[at + 3] = inst.b;
+        code[at + 4] = BIN[inst.kind as BinKind];
+        code[at + 5] = tyCode(inst.ty);
+        break;
+      case 'un':
+        code[at] = OP.UN;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.a;
+        code[at + 3] = UN[inst.kind as UnKind];
+        code[at + 4] = tyCode(inst.ty);
+        break;
+      case 'cvt':
+        code[at] = OP.CVT;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.a;
+        code[at + 3] = tyCode(inst.from);
+        code[at + 4] = tyCode(inst.to);
+        break;
+      case 'sreg':
+        code[at] = OP.SREG;
+        code[at + 1] = inst.dst;
+        code[at + 2] = SREG[inst.which as SpecialReg];
+        break;
+      case 'param':
+        code[at] = OP.PARAM;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.index;
+        code[at + 3] = tyCode(inst.ty);
+        break;
+      case 'sharedbase':
+        code[at] = OP.SHAREDBASE;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.offset;
+        break;
+      case 'load':
+        code[at] = OP.LOAD;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.addr;
+        code[at + 3] = inst.space === 'global' ? SPACE.GLOBAL : SPACE.SHARED;
+        code[at + 4] = tyCode(inst.ty);
+        break;
+      case 'store':
+        code[at] = OP.STORE;
+        code[at + 1] = inst.addr;
+        code[at + 2] = inst.src;
+        code[at + 3] = inst.space === 'global' ? SPACE.GLOBAL : SPACE.SHARED;
+        code[at + 4] = tyCode(inst.ty);
+        break;
+      case 'jmp':
+        code[at] = OP.JMP;
+        code[at + 1] = inst.target;
+        break;
+      case 'push':
+        code[at] = OP.PUSH;
+        code[at + 1] = inst.cond;
+        code[at + 2] = inst.elsePc;
+        code[at + 3] = inst.joinPc;
+        break;
+      case 'swap':
+        code[at] = OP.SWAP;
+        code[at + 1] = inst.joinPc;
+        break;
+      case 'pop':
+        code[at] = OP.POP;
+        break;
+      case 'loop':
+        code[at] = OP.LOOP;
+        code[at + 1] = inst.exitPc;
+        break;
+      case 'lcond':
+        code[at] = OP.LCOND;
+        code[at + 1] = inst.cond;
+        code[at + 2] = inst.exitPc;
+        break;
+      case 'bar':
+        code[at] = OP.BAR;
+        break;
+      case 'call':
+        code[at] = OP.CALL;
+        code[at + 1] = inst.dst;
+        code[at + 2] = FN[inst.fn as BuiltinFn];
+        code[at + 3] = tyCode(inst.ty);
+        code[at + 4] = inst.args[0] ?? 0;
+        code[at + 5] = inst.args[1] ?? 0;
+        code[at + 6] = inst.args[2] ?? 0;
+        break;
+      case 'ret':
+        code[at] = OP.RET;
+        break;
+    }
+  }
+
+  return {
+    ...kernel,
+    program: { code, pool: Float64Array.from(pool), count, lines },
+    paramTypes: Int32Array.from(kernel.params.map((param) => tyCode(param.ty))),
+  };
+}
+
+export type { Space };

--- a/src/lib/gpulab/ir/types.ts
+++ b/src/lib/gpulab/ir/types.ts
@@ -1,0 +1,109 @@
+/**
+ * 扁平 IR
+ *
+ * 为什么是扁平的、带程序计数器的指令数组，而不是直接在 AST 上递归求值：
+ * **`__syncthreads()` 要能把一个 warp 挂起、去跑同一个 block 里的别的 warp。**
+ * 递归求值的话得靠生成器或 CPS 才能挂起，两者都比一个 pc 慢得多也难得多。
+ *
+ * 每条指令都是 **warp 级**的：执行器拿到一条指令，对 32 个 lane 各做一遍。
+ * 指令派发的开销就这样被摊薄了 32 倍 —— 这是整个执行模型能跑得动的原因
+ * （实测约 2000 万条 warp 指令/秒，见 design/gpulab.md）。
+ *
+ * 发散用经典的 SIMT 重汇聚栈。因为 C 的控制流是结构化的，编译期就能算出
+ * 重汇聚点，不需要在运行时求 IPDOM。
+ */
+
+/** 值在寄存器里怎么存 —— 决定算术怎么做、访存按几字节 */
+export type IrType = 'i32' | 'u32' | 'f32';
+
+/** 地址空间。决定访存走哪套计量。 */
+export type Space = 'global' | 'shared';
+
+export type BinKind =
+  | 'add' | 'sub' | 'mul' | 'div' | 'rem'
+  | 'shl' | 'shr' | 'and' | 'or' | 'xor'
+  | 'lt' | 'le' | 'gt' | 'ge' | 'eq' | 'ne';
+
+export type UnKind = 'neg' | 'not' | 'bnot';
+
+/** 内建数学函数。`__` 开头的是 fast-math 变体，精度低但快。 */
+export type BuiltinFn =
+  | 'fmaf' | 'fabsf' | 'fminf' | 'fmaxf' | 'sqrtf' | 'rsqrtf'
+  | 'expf' | 'logf' | 'tanhf' | 'powf'
+  | '__expf' | '__logf' | '__fdividef'
+  | 'min' | 'max' | 'abs';
+
+export type SpecialReg =
+  | 'tid.x' | 'tid.y' | 'tid.z'
+  | 'ctaid.x' | 'ctaid.y' | 'ctaid.z'
+  | 'ntid.x' | 'ntid.y' | 'ntid.z'
+  | 'nctaid.x' | 'nctaid.y' | 'nctaid.z'
+  | 'warpsize';
+
+export type Inst =
+  /** 立即数 */
+  | { op: 'const'; dst: number; value: number; ty: IrType }
+  | { op: 'mov'; dst: number; src: number }
+  | { op: 'bin'; dst: number; a: number; b: number; kind: BinKind; ty: IrType }
+  | { op: 'un'; dst: number; a: number; kind: UnKind; ty: IrType }
+  /** 类型转换。整数与浮点之间是真的按 C 的规则舍入。 */
+  | { op: 'cvt'; dst: number; a: number; from: IrType; to: IrType }
+  /** 内建变量 */
+  | { op: 'sreg'; dst: number; which: SpecialReg }
+  /** kernel 参数。标量直接进寄存器，指针进的是字节地址。 */
+  | { op: 'param'; dst: number; index: number; ty: IrType }
+  /** 共享内存里某个变量的基地址（block 内所有 lane 相同） */
+  | { op: 'sharedbase'; dst: number; offset: number }
+  | { op: 'load'; dst: number; addr: number; space: Space; ty: IrType; line: number }
+  | { op: 'store'; addr: number; src: number; space: Space; ty: IrType; line: number }
+  /** 无条件跳转 */
+  | { op: 'jmp'; target: number }
+  /**
+   * 进入一个分歧区。
+   *  active &= cond；把 (原 active, else 掩码, 汇合点) 压栈。
+   *  如果 cond 一个 lane 都没中，直接跳到 elsePc。
+   */
+  | { op: 'push'; cond: number; elsePc: number; joinPc: number; line: number }
+  /** then 分支结束：换成 else 掩码；else 也空就跳到汇合点 */
+  | { op: 'swap'; joinPc: number }
+  /** 汇合：弹栈，恢复进入前的 active */
+  | { op: 'pop' }
+  /**
+   * 进入一个循环。压栈保存进入前的 active，循环体里只会让 active 变小。
+   */
+  | { op: 'loop'; exitPc: number }
+  /** 循环条件：active &= cond；空了就跳出去 */
+  | { op: 'lcond'; cond: number; exitPc: number }
+  /** `__syncthreads()` —— 挂起本 warp，等同 block 的其它 warp */
+  | { op: 'bar'; line: number }
+  | { op: 'call'; dst: number; fn: BuiltinFn; args: number[]; ty: IrType }
+  | { op: 'ret' };
+
+export interface SharedVar {
+  name: string;
+  /** 共享内存里的字节偏移 */
+  offset: number;
+  bytes: number;
+}
+
+export interface KernelParam {
+  name: string;
+  ty: IrType;
+  /** 指针参数拿到的是一个字节地址，算术上就是 u32 */
+  isPointer: boolean;
+  /** 指向的元素占几字节，下标算地址要用 */
+  elementBytes: number;
+}
+
+export interface CompiledKernel {
+  name: string;
+  insts: Inst[];
+  params: KernelParam[];
+  /** 每个 lane 需要多少个寄存器槽 */
+  numRegs: number;
+  /** 静态共享内存总字节数 */
+  sharedBytes: number;
+  sharedVars: SharedVar[];
+  /** 指令下标 → 源码行号，报错与剖析要用 */
+  lines: number[];
+}

--- a/src/lib/gpulab/metrics.ts
+++ b/src/lib/gpulab/metrics.ts
@@ -1,0 +1,132 @@
+/**
+ * 指标
+ *
+ * 门槛读的就是这棵树。命名**对齐 Nsight Compute**（见 design/gpulab.md
+ * 第七节的对照表）—— 既是「接口真实」的一部分，也让学员拿这个名字去搜
+ * 能搜到真东西。
+ *
+ * 这里只做一件事：把 VM 的原始计数器整理成带派生量的一棵树。
+ * 派生量（比如 sectorsPerRequest）单独算，因为门槛写的是它而不是分子分母。
+ */
+import type { GpuCounters } from './vm/vm';
+import { SECTOR_BYTES, WARP_SIZE } from './vm/memory';
+
+export interface GpuMetrics {
+  global: {
+    loadRequests: number;
+    storeRequests: number;
+    loadSectors: number;
+    storeSectors: number;
+    /**
+     * 每次 warp 级访存平均打到几个 32B 扇区。
+     *
+     * 对齐 ncu 的
+     * `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`。
+     * 完全合并 = 4.0（32 个 lane × 4 字节 = 128 字节 = 4 个扇区），
+     * 完全发散 = 32.0。这是第 2 关门槛的那个数。
+     */
+    sectorsPerRequest: number;
+  };
+  /**
+   * L1 之下看到的字节数。
+   *
+   * **口径要说清楚**：这是扇区数 × 32，也就是「如果每次都打到 DRAM」的字节数。
+   * 还没有 L2 / L1 的命中模型，所以它是上界而不是 ncu 的 `dram__bytes_read.sum`。
+   * 缓存模型落地之前，门槛只用它来比「同一份数据被读了几遍」，
+   * 那个用途下缓存的影响是次要的。
+   */
+  memory: {
+    readBytes: number;
+    writeBytes: number;
+  };
+  shared: {
+    loadRequests: number;
+    storeRequests: number;
+    /**
+     * 冲突路数，对齐 ncu 的
+     * `l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_{ld,st}.sum`。
+     * 无冲突时是 0。
+     */
+    bankConflicts: number;
+  };
+  warp: {
+    /** 一条分支上 lane 分成两拨的次数 */
+    divergentBranches: number;
+    /** 活跃 lane 占比，0~1。全程不发散就是 1。 */
+    activeLaneRatio: number;
+  };
+  inst: {
+    /** warp 级指令条数 —— 执行预算看这个 */
+    warpExecuted: number;
+    /** 展开到 lane 的指令条数，对齐 ncu 的 `smsp__thread_inst_executed` */
+    laneExecuted: number;
+    fma: number;
+    ldst: number;
+  };
+  launch: {
+    blocks: number;
+    warps: number;
+    barriers: number;
+  };
+}
+
+export function toMetrics(counters: GpuCounters): GpuMetrics {
+  const globalRequests = counters.globalLoadRequests + counters.globalStoreRequests;
+  const globalSectors = counters.globalLoadSectors + counters.globalStoreSectors;
+
+  return {
+    global: {
+      loadRequests: counters.globalLoadRequests,
+      storeRequests: counters.globalStoreRequests,
+      loadSectors: counters.globalLoadSectors,
+      storeSectors: counters.globalStoreSectors,
+      sectorsPerRequest: globalRequests === 0 ? 0 : globalSectors / globalRequests,
+    },
+    memory: {
+      readBytes: counters.globalLoadSectors * SECTOR_BYTES,
+      writeBytes: counters.globalStoreSectors * SECTOR_BYTES,
+    },
+    shared: {
+      loadRequests: counters.sharedLoadRequests,
+      storeRequests: counters.sharedStoreRequests,
+      bankConflicts: counters.sharedBankConflicts,
+    },
+    warp: {
+      divergentBranches: counters.divergentBranches,
+      activeLaneRatio:
+        counters.warpInsts === 0 ? 0 : counters.laneInsts / (counters.warpInsts * WARP_SIZE),
+    },
+    inst: {
+      warpExecuted: counters.warpInsts,
+      laneExecuted: counters.laneInsts,
+      fma: counters.instFma,
+      ldst: counters.instLdSt,
+    },
+    launch: {
+      blocks: counters.blocksLaunched,
+      warps: counters.warpsLaunched,
+      barriers: counters.barriers,
+    },
+  };
+}
+
+/**
+ * 把指标摊平成 `gpu.` 前缀的路径，喂给现有的 MetricGate。
+ *
+ * `MetricGate.metric` 是 LabMetrics 上的一条路径，所以门槛写起来是
+ * `{ metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5 }`。
+ */
+export function flattenMetrics(metrics: GpuMetrics): Record<string, number> {
+  const out: Record<string, number> = {};
+  const walk = (prefix: string, value: unknown): void => {
+    if (typeof value === 'number') {
+      out[prefix] = value;
+      return;
+    }
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      walk(prefix ? `${prefix}.${key}` : key, child);
+    }
+  };
+  walk('gpu', metrics);
+  return out;
+}

--- a/src/lib/gpulab/vm/float.ts
+++ b/src/lib/gpulab/vm/float.ts
@@ -42,23 +42,6 @@ export function floatToU32Bits(value: number): number {
   return bitsU32[0];
 }
 
-/**
- * 两个 fp32 之间差多少个 ulp。
- *
- * 数值判定用它而不是相对误差：相对误差在接近 0 的地方会炸，
- * 而 ulp 在整个范围上都是同一把尺子。
- */
-export function ulpDistance(a: number, b: number): number {
-  if (Number.isNaN(a) || Number.isNaN(b)) return Number.POSITIVE_INFINITY;
-  if (a === b) return 0;
-  const toOrdered = (value: number): number => {
-    const bits = floatToBits(value);
-    // 负数的位模式是反的，翻成一条单调的整数轴
-    return bits < 0 ? 0x80000000 - bits : bits;
-  };
-  return Math.abs(toOrdered(a) - toOrdered(b));
-}
-
 /* ------------------------------------------------------------------ */
 /* 基本算术                                                            */
 /* ------------------------------------------------------------------ */
@@ -151,7 +134,6 @@ export function expF32(x: number): number {
   const r = (x - k * LN2_HI) - k * LN2_LO;
 
   // e^r ≈ 1 + r + r²/2 + r³/6 + r⁴/24 + r⁵/120 + r⁶/720
-  const r2 = r * r;
   const poly =
     1 + r * (1 + r * (0.5 + r * (1 / 6 + r * (1 / 24 + r * (1 / 120 + r / 720)))));
 
@@ -257,14 +239,6 @@ function truncateMantissa(value: number, bits: number): number {
 /* ------------------------------------------------------------------ */
 /* 整数                                                               */
 /* ------------------------------------------------------------------ */
-
-export function toI32(value: number): number {
-  return value | 0;
-}
-
-export function toU32(value: number): number {
-  return value >>> 0;
-}
 
 /** C 的 float → int 是截断（朝零取整），不是四舍五入 */
 export function floatToInt(value: number): number {

--- a/src/lib/gpulab/vm/float.ts
+++ b/src/lib/gpulab/vm/float.ts
@@ -1,0 +1,278 @@
+/**
+ * fp32 语义
+ *
+ * JS 的 Number 是 float64，CUDA 的 float 是 float32。每一步运算都要
+ * `Math.fround` 回 fp32，否则中间结果的精度比真卡高，学员在这里看不到
+ * 该看到的误差 —— 而「误差是怎么攒起来的」正是规约与 FlashAttention 那几关的内容。
+ *
+ * **超越函数一律自己实现，不用 JS 的 `Math.exp` / `Math.log` / `Math.tanh`。**
+ * 理由是硬的：ECMAScript 不要求这些函数逐位可复现，V8 与 JavaScriptCore
+ * 的结果就不一样。用了它们，「同一份代码跑两遍逐位相同」这条门槛在
+ * 换个浏览器之后就不成立了，整套判定跟着塌。
+ *
+ * 顺带白拿一件事：CUDA 有 `expf`（精确）与 `__expf`（快但不准）两套，
+ * 我们自己实现就能把这个区别做出来，而不是在 primer 里说一句了事。
+ */
+
+const f32 = Math.fround;
+
+export { f32 };
+
+/* ------------------------------------------------------------------ */
+/* 位级转换                                                            */
+/* ------------------------------------------------------------------ */
+
+const bitsBuffer = new ArrayBuffer(4);
+const bitsF32 = new Float32Array(bitsBuffer);
+const bitsI32 = new Int32Array(bitsBuffer);
+const bitsU32 = new Uint32Array(bitsBuffer);
+
+export function floatToBits(value: number): number {
+  bitsF32[0] = value;
+  return bitsI32[0];
+}
+
+export function bitsToFloat(bits: number): number {
+  bitsI32[0] = bits | 0;
+  return bitsF32[0];
+}
+
+export function floatToU32Bits(value: number): number {
+  bitsF32[0] = value;
+  return bitsU32[0];
+}
+
+/**
+ * 两个 fp32 之间差多少个 ulp。
+ *
+ * 数值判定用它而不是相对误差：相对误差在接近 0 的地方会炸，
+ * 而 ulp 在整个范围上都是同一把尺子。
+ */
+export function ulpDistance(a: number, b: number): number {
+  if (Number.isNaN(a) || Number.isNaN(b)) return Number.POSITIVE_INFINITY;
+  if (a === b) return 0;
+  const toOrdered = (value: number): number => {
+    const bits = floatToBits(value);
+    // 负数的位模式是反的，翻成一条单调的整数轴
+    return bits < 0 ? 0x80000000 - bits : bits;
+  };
+  return Math.abs(toOrdered(a) - toOrdered(b));
+}
+
+/* ------------------------------------------------------------------ */
+/* 基本算术                                                            */
+/* ------------------------------------------------------------------ */
+
+export function addF32(a: number, b: number): number {
+  return f32(a + b);
+}
+
+export function subF32(a: number, b: number): number {
+  return f32(a - b);
+}
+
+export function mulF32(a: number, b: number): number {
+  return f32(a * b);
+}
+
+export function divF32(a: number, b: number): number {
+  return f32(a / b);
+}
+
+/**
+ * 融合乘加：一次舍入。
+ *
+ * `a * b` 对两个 fp32 来说在 float64 里是**精确**的（24+24 = 48 位尾数，
+ * float64 有 53 位），所以 `a * b + c` 在 float64 里只舍入一次，再 fround
+ * 到 fp32 又舍入一次 —— 这是双重舍入，极少数情况下与真硬件的单次舍入差 1 ulp。
+ *
+ * 这是一处**已知分叉**，写在这里而不是藏着：它是确定的（同一输入永远同一输出），
+ * 只是不保证与真卡逐位一致。做到完全一致需要 two-sum 展开，等有关卡真的
+ * 卡在这 1 ulp 上再补。
+ */
+export function fmaF32(a: number, b: number, c: number): number {
+  return f32(a * b + c);
+}
+
+export function minF32(a: number, b: number): number {
+  // CUDA 的 fminf：有一个是 NaN 就返回另一个
+  if (Number.isNaN(a)) return b;
+  if (Number.isNaN(b)) return a;
+  return a < b ? a : b;
+}
+
+export function maxF32(a: number, b: number): number {
+  if (Number.isNaN(a)) return b;
+  if (Number.isNaN(b)) return a;
+  return a > b ? a : b;
+}
+
+export function sqrtF32(a: number): number {
+  return f32(Math.sqrt(a));
+}
+
+export function rsqrtF32(a: number): number {
+  return f32(1 / Math.sqrt(a));
+}
+
+/* ------------------------------------------------------------------ */
+/* 超越函数：自己实现                                                   */
+/* ------------------------------------------------------------------ */
+
+const LOG2E = 1.4426950408889634;
+const LN2_HI = 0.6931471824645996;   // ln2 的高位部分，fp32 可精确表示
+const LN2_LO = -1.904654323148236e-9; // 余项
+
+/**
+ * 2^n，n 为整数。用位运算直接构造指数，不走 Math.pow。
+ */
+function ldexpF32(mantissa: number, exponent: number): number {
+  if (exponent > 127) return mantissa > 0 ? Infinity : -Infinity;
+  if (exponent < -126) {
+    // 次正规数：分两步缩，避免一次性下溢
+    return f32(f32(mantissa * Math.pow(2, -126)) * Math.pow(2, exponent + 126));
+  }
+  return f32(mantissa * Math.pow(2, exponent));
+}
+
+/**
+ * expf：先把 x 化到 [-ln2/2, ln2/2]，再用 minimax 多项式，最后乘回 2^k。
+ *
+ * 这是 libm 的标准做法，系数取自对 e^r 在该区间上的截断泰勒展开
+ * （7 项，fp32 精度下足够 —— 误差目标 < 1 ulp）。
+ */
+export function expF32(x: number): number {
+  if (Number.isNaN(x)) return NaN;
+  if (x > 88.72283935546875) return Infinity;   // fp32 能表示的最大 exp 输入
+  if (x < -103.97208404541016) return 0;        // 再小就下溢到 0
+
+  const k = Math.round(x * LOG2E);
+  // 用高低位拆分减小舍入误差
+  const r = (x - k * LN2_HI) - k * LN2_LO;
+
+  // e^r ≈ 1 + r + r²/2 + r³/6 + r⁴/24 + r⁵/120 + r⁶/720
+  const r2 = r * r;
+  const poly =
+    1 + r * (1 + r * (0.5 + r * (1 / 6 + r * (1 / 24 + r * (1 / 120 + r / 720)))));
+
+  return ldexpF32(f32(poly), k);
+}
+
+/**
+ * logf：把 x 拆成 m * 2^k（m 在 [√2/2, √2)），再用 atanh 级数算 ln(m)。
+ */
+export function logF32(x: number): number {
+  if (Number.isNaN(x)) return NaN;
+  if (x < 0) return NaN;
+  if (x === 0) return -Infinity;
+  if (!Number.isFinite(x)) return Infinity;
+
+  // 从位模式里取指数与尾数，不用 Math.log2
+  let bits = floatToU32Bits(f32(x));
+  let exponent = ((bits >>> 23) & 0xff) - 127;
+  if (exponent === -127) {
+    // 次正规数：先放大再补回来
+    const scaled = f32(x * 16777216); // 2^24
+    bits = floatToU32Bits(scaled);
+    exponent = ((bits >>> 23) & 0xff) - 127 - 24;
+  }
+  // 尾数归一到 [1, 2)
+  const mantissaBits = (bits & 0x007fffff) | 0x3f800000;
+  let m = bitsToFloat(mantissaBits | 0);
+
+  // 再把 m 挪到 [√2/2, √2)，级数收敛更快
+  if (m > 1.4142135623730951) {
+    m = f32(m / 2);
+    exponent += 1;
+  }
+
+  // ln(m) = 2 * atanh(s)，s = (m-1)/(m+1)
+  const s = (m - 1) / (m + 1);
+  const s2 = s * s;
+  const atanh = s * (1 + s2 * (1 / 3 + s2 * (1 / 5 + s2 * (1 / 7 + s2 * (1 / 9 + s2 / 11)))));
+
+  return f32(2 * atanh + exponent * (LN2_HI + LN2_LO));
+}
+
+export function tanhF32(x: number): number {
+  if (Number.isNaN(x)) return NaN;
+  const ax = Math.abs(x);
+  if (ax > 9) return x > 0 ? 1 : -1;   // fp32 下已经饱和
+  if (ax < 1e-4) return f32(x);        // 小量直接返回，避免 0/0
+  const e = expF32(f32(2 * ax));
+  const result = (e - 1) / (e + 1);
+  return f32(x > 0 ? result : -result);
+}
+
+export function powF32(a: number, b: number): number {
+  if (b === 0) return 1;
+  if (a === 0) return b > 0 ? 0 : Infinity;
+  if (Number.isInteger(b) && Math.abs(b) <= 64) {
+    // 整数幂走平方乘，比走 exp(log) 准得多，也是 libm 的做法
+    let result = 1;
+    let base = f32(a);
+    let n = Math.abs(b);
+    while (n > 0) {
+      if (n & 1) result = f32(result * base);
+      base = f32(base * base);
+      n >>= 1;
+    }
+    return b > 0 ? result : f32(1 / result);
+  }
+  if (a < 0) return NaN;
+  return expF32(f32(b * logF32(a)));
+}
+
+/* ------------------------------------------------------------------ */
+/* fast-math 变体                                                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * `__expf`：真卡上走 SFU 的 `ex2.approx.f32`，约 22 位有效精度、单周期吞吐。
+ *
+ * 我们的模拟方式是**故意把精度砍掉**：算完之后把尾数低位抹掉，
+ * 留下和硬件近似指令相当的有效位数。这样「快但不准」在这里是真的不准，
+ * 学员在 softmax 那一关会看到它对结果的影响，而不是读到一句说明。
+ */
+export function fastExpF32(x: number): number {
+  return truncateMantissa(expF32(x), 10);
+}
+
+export function fastLogF32(x: number): number {
+  return truncateMantissa(logF32(x), 10);
+}
+
+export function fastDivF32(a: number, b: number): number {
+  return truncateMantissa(f32(a / b), 10);
+}
+
+/** 抹掉尾数低 bits 位，模拟近似指令的有效精度 */
+function truncateMantissa(value: number, bits: number): number {
+  if (!Number.isFinite(value) || value === 0) return value;
+  const raw = floatToBits(value);
+  const mask = ~((1 << bits) - 1);
+  return bitsToFloat(raw & mask);
+}
+
+/* ------------------------------------------------------------------ */
+/* 整数                                                               */
+/* ------------------------------------------------------------------ */
+
+export function toI32(value: number): number {
+  return value | 0;
+}
+
+export function toU32(value: number): number {
+  return value >>> 0;
+}
+
+/** C 的 float → int 是截断（朝零取整），不是四舍五入 */
+export function floatToInt(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.trunc(value) | 0;
+}
+
+export function floatToUint(value: number): number {
+  if (Number.isNaN(value) || value < 0) return 0;
+  return Math.trunc(value) >>> 0;
+}

--- a/src/lib/gpulab/vm/memory.ts
+++ b/src/lib/gpulab/vm/memory.ts
@@ -1,0 +1,232 @@
+/**
+ * 内存与访存计量
+ *
+ * 这个文件是整个项目的判定地基。design/gpulab.md 里立的规矩是
+ * **门槛只建立在结构性计量上** —— 而结构性计量几乎全部在这里产生：
+ * 一次 warp 访存打到多少个 32B 扇区、共享内存有几路 bank 冲突。
+ *
+ * 这两个数不是估的，是按真硬件的规则一条条数出来的，
+ * 所以它们换到真卡上一个不差。也正因如此，这里的规则必须写对。
+ */
+
+/** 全局访存的最小传输单位。ncu 的 dram__bytes 就是扇区数 × 32。 */
+export const SECTOR_BYTES = 32;
+
+/** 共享内存有 32 个 bank，每个 bank 4 字节宽 */
+export const SHARED_BANKS = 32;
+export const SHARED_BANK_BYTES = 4;
+
+export const WARP_SIZE = 32;
+
+export class MemoryFault extends Error {
+  address: number;
+  size: number;
+  space: 'global' | 'shared';
+  constructor(space: 'global' | 'shared', address: number, size: number, limit: number) {
+    super(
+      `invalid __${space}__ ${size === 4 ? 'read/write' : 'access'} of size ${size} bytes ` +
+      `at 0x${(address >>> 0).toString(16)} —— 越界了（这块空间只有 ${limit} 字节）`
+    );
+    this.name = 'MemoryFault';
+    this.address = address;
+    this.size = size;
+    this.space = space;
+  }
+}
+
+/**
+ * 一块线性内存。
+ *
+ * 地址就是字节偏移，从 1 开始分配 —— 0 留给空指针，这样解引用空指针
+ * 会真的报越界，而不是悄悄读到第一个变量。
+ */
+export class LinearMemory {
+  readonly bytes: ArrayBuffer;
+  private readonly i32: Int32Array;
+  private readonly u32: Uint32Array;
+  private readonly f32: Float32Array;
+  private cursor = 16;
+
+  constructor(readonly capacity: number, private readonly space: 'global' | 'shared') {
+    this.bytes = new ArrayBuffer(capacity);
+    this.i32 = new Int32Array(this.bytes);
+    this.u32 = new Uint32Array(this.bytes);
+    this.f32 = new Float32Array(this.bytes);
+  }
+
+  /** 分配一段，返回起始地址。按 256 字节对齐 —— 真 cudaMalloc 也是这样。 */
+  allocate(bytes: number): number {
+    const aligned = Math.ceil(this.cursor / 256) * 256;
+    if (aligned + bytes > this.capacity) {
+      throw new Error(
+        `out of memory：想要 ${bytes} 字节，只剩 ${this.capacity - aligned} 字节`
+      );
+    }
+    this.cursor = aligned + bytes;
+    return aligned;
+  }
+
+  get used(): number {
+    return this.cursor;
+  }
+
+  reset(): void {
+    this.cursor = 16;
+    new Uint8Array(this.bytes).fill(0);
+  }
+
+  private check(address: number, size: number): void {
+    if (address < 0 || address + size > this.capacity || (address & 3) !== 0) {
+      throw new MemoryFault(this.space, address, size, this.capacity);
+    }
+  }
+
+  readI32(address: number): number {
+    this.check(address, 4);
+    return this.i32[address >> 2];
+  }
+
+  readU32(address: number): number {
+    this.check(address, 4);
+    return this.u32[address >> 2];
+  }
+
+  readF32(address: number): number {
+    this.check(address, 4);
+    return this.f32[address >> 2];
+  }
+
+  writeI32(address: number, value: number): void {
+    this.check(address, 4);
+    this.i32[address >> 2] = value | 0;
+  }
+
+  writeU32(address: number, value: number): void {
+    this.check(address, 4);
+    this.u32[address >> 2] = value >>> 0;
+  }
+
+  writeF32(address: number, value: number): void {
+    this.check(address, 4);
+    this.f32[address >> 2] = value;
+  }
+
+  /** 把一段 float 拷进去（宿主侧的 cudaMemcpy） */
+  writeFloats(address: number, values: ArrayLike<number>): void {
+    this.check(address, values.length * 4);
+    this.f32.set(values as never, address >> 2);
+  }
+
+  readFloats(address: number, count: number): Float32Array {
+    this.check(address, count * 4);
+    return this.f32.slice(address >> 2, (address >> 2) + count);
+  }
+
+  writeInts(address: number, values: ArrayLike<number>): void {
+    this.check(address, values.length * 4);
+    this.i32.set(values as never, address >> 2);
+  }
+
+  readInts(address: number, count: number): Int32Array {
+    this.check(address, count * 4);
+    return this.i32.slice(address >> 2, (address >> 2) + count);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 合并访问分析                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 一条 warp 级全局访存打到多少个不同的 32B 扇区。
+ *
+ * 真硬件的规则：一个 warp 的 32 个 lane 的地址被归并成对 L1 的扇区请求，
+ * 落在同一个 32 字节扇区里的 lane 合并成一次传输。所以
+ *
+ *   - 完全合并（32 个 lane 读连续的 32 个 float = 128 字节）→ **4 个扇区**
+ *   - 完全发散（每个 lane 隔得足够远）→ **32 个扇区**，也就是 8 倍的传输量
+ *
+ * 第 2 关的门槛 `sectorsPerRequest ≤ 4.5` 就是照着这条算的。
+ *
+ * 实现上用固定长度的插入排序去重：warp 里的地址通常已经是升序
+ * （lane 顺着下标走），插入排序在近似有序的数据上是 O(n)，比开 Set 快得多，
+ * 而且不产生垃圾 —— 这个函数每条访存指令都要调一次。
+ */
+// 多一格：插入排序在插入时会先把元素往后挪一位，n=31 时会摸到下标 31，
+// 留出余量比推理边界安全（越界写在 TypedArray 上是静默丢弃，出了错查不出来）
+const sectorScratch = new Int32Array(WARP_SIZE + 1);
+
+export function countSectors(addresses: Int32Array, activeMask: number): number {
+  let n = 0;
+  for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+    if ((activeMask & (1 << lane)) === 0) continue;
+    const sector = addresses[lane] >> 5; // / SECTOR_BYTES
+    // 插入排序，顺带丢掉重复的
+    let i = n;
+    while (i > 0 && sectorScratch[i - 1] > sector) {
+      sectorScratch[i] = sectorScratch[i - 1];
+      i -= 1;
+    }
+    if (i > 0 && sectorScratch[i - 1] === sector) {
+      // 已经有了，把刚才挪出来的位置填回去
+      for (let j = i; j < n; j += 1) sectorScratch[j] = sectorScratch[j + 1];
+      continue;
+    }
+    sectorScratch[i] = sector;
+    n += 1;
+  }
+  return n;
+}
+
+/**
+ * 一条 warp 级共享内存访存要发几路。
+ *
+ * 真硬件的规则，三条都要对：
+ *  1. 共享内存分成 32 个 bank，bank 号 = (字节地址 / 4) % 32；
+ *  2. 同一个 bank 的**不同**地址会串行化 —— n 个不同地址就是 n 路，冲突数 n-1；
+ *  3. 同一个 bank 的**相同**地址是广播，**不算冲突**。
+ *
+ * 第 3 条是最容易做错也最容易被忽略的：`s[threadIdx.x / 2]` 这种一半 lane
+ * 读同一个地址的写法，真卡上一点都不慢。做错了会误伤正确的实现。
+ *
+ * 返回「冲突路数」，也就是 ncu 的
+ * `l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_*` 的口径：
+ * 完美无冲突时是 0。
+ */
+// bank 冲突分析的暂存。**复用**而不是每次分配 —— 这个函数每条共享内存
+// 访存都要调一次，每次 new 32 个数组的话垃圾回收会吃掉一半的执行预算。
+const bankAddresses = new Int32Array(SHARED_BANKS * WARP_SIZE);
+const bankCounts = new Int32Array(SHARED_BANKS);
+const touchedBanks = new Int32Array(SHARED_BANKS);
+
+export function countBankConflicts(addresses: Int32Array, activeMask: number): number {
+  let touched = 0;
+
+  for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+    if ((activeMask & (1 << lane)) === 0) continue;
+    const address = addresses[lane];
+    const bank = (address >> 2) & (SHARED_BANKS - 1);
+    const count = bankCounts[bank];
+    if (count === 0) {
+      touchedBanks[touched] = bank;
+      touched += 1;
+    }
+    // 同一个 bank 上的相同地址是广播，不算一路
+    const base = bank * WARP_SIZE;
+    let seen = false;
+    for (let i = 0; i < count; i += 1) {
+      if (bankAddresses[base + i] === address) { seen = true; break; }
+    }
+    if (seen) continue;
+    bankAddresses[base + count] = address;
+    bankCounts[bank] = count + 1;
+  }
+
+  let conflicts = 0;
+  for (let i = 0; i < touched; i += 1) {
+    const bank = touchedBanks[i];
+    if (bankCounts[bank] > 1) conflicts += bankCounts[bank] - 1;
+    bankCounts[bank] = 0; // 清干净，下次直接用
+  }
+  return conflicts;
+}

--- a/src/lib/gpulab/vm/memory.ts
+++ b/src/lib/gpulab/vm/memory.ts
@@ -12,9 +12,8 @@
 /** 全局访存的最小传输单位。ncu 的 dram__bytes 就是扇区数 × 32。 */
 export const SECTOR_BYTES = 32;
 
-/** 共享内存有 32 个 bank，每个 bank 4 字节宽 */
+/** 共享内存有 32 个 bank，每个 bank 4 字节宽 —— bank 号 = (字节地址 / 4) % 32 */
 export const SHARED_BANKS = 32;
-export const SHARED_BANK_BYTES = 4;
 
 export const WARP_SIZE = 32;
 

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -1,0 +1,701 @@
+/**
+ * warp 锁步执行器
+ *
+ * 核心：**一条指令派发一次，内部对 32 个 lane 循环**。指令派发的开销因此
+ * 被摊薄 32 倍，这是整个执行模型跑得动的原因。
+ *
+ * 三件事在这里是「真的」而不是估的：
+ *  - 发散：活跃掩码 + 结构化重汇聚栈，和真硬件对结构化控制流的处理一致；
+ *  - 屏障：`__syncthreads()` 真的把 warp 挂起，等同 block 的其它 warp 到齐；
+ *  - 访存计量：每条访存指令算 32 个地址，做扇区归并 / bank 冲突分析。
+ *
+ * 执行顺序完全确定（block 按 id、warp 按编号轮转），所以同一份代码跑两遍
+ * 逐位相同 —— 这是判定门槛之一。**代价是竞态不会自己暴露**，得靠单独的
+ * racecheck 主动检测。
+ *
+ * 性能纪律（生产环境实测约 1350 万条 warp 指令/秒，见 ir/program.ts 的说明）：
+ *  1. 指令流是 `Int32Array`，不是对象数组；
+ *  2. **热路径上不分配内存** —— `countSectors` / `countBankConflicts` 都用
+ *     复用的暂存数组，计数器在循环里用局部变量攒着，退出时再写回；
+ *  3. 收尾**不要用闭包**：闭包一旦捕获可变局部，V8 会把它们挪进堆上的
+ *     context 对象，每条指令多出好几次堆访问。
+ */
+import { encode, type ExecutableKernel, type Program, BIN, FN, OP, SLOTS, SPACE, SREG, TY, UN } from '../ir/program';
+import type { CompiledKernel } from '../ir/types';
+import {
+  addF32, divF32, expF32, fastDivF32, fastExpF32, fastLogF32, floatToInt, floatToUint,
+  fmaF32, logF32, maxF32, minF32, mulF32, powF32, rsqrtF32, sqrtF32, subF32, tanhF32,
+} from './float';
+import {
+  LinearMemory, MemoryFault, SECTOR_BYTES, WARP_SIZE,
+  countBankConflicts, countSectors,
+} from './memory';
+
+export interface Dim3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export function dim3(x: number, y = 1, z = 1): Dim3 {
+  return { x, y, z };
+}
+
+export interface LaunchConfig {
+  grid: Dim3;
+  block: Dim3;
+}
+
+/** kernel 实参：指针是地址（number），标量按声明的类型 */
+export type KernelArg = number;
+
+export interface GpuCounters {
+  warpInsts: number;
+  laneInsts: number;
+  instFma: number;
+  instLdSt: number;
+  globalLoadRequests: number;
+  globalStoreRequests: number;
+  globalLoadSectors: number;
+  globalStoreSectors: number;
+  sharedLoadRequests: number;
+  sharedStoreRequests: number;
+  sharedBankConflicts: number;
+  divergentBranches: number;
+  activeLanes: number;
+  barriers: number;
+  blocksLaunched: number;
+  warpsLaunched: number;
+}
+
+export function emptyCounters(): GpuCounters {
+  return {
+    warpInsts: 0, laneInsts: 0, instFma: 0, instLdSt: 0,
+    globalLoadRequests: 0, globalStoreRequests: 0,
+    globalLoadSectors: 0, globalStoreSectors: 0,
+    sharedLoadRequests: 0, sharedStoreRequests: 0, sharedBankConflicts: 0,
+    divergentBranches: 0, activeLanes: 0,
+    barriers: 0, blocksLaunched: 0, warpsLaunched: 0,
+  };
+}
+
+export class KernelError extends Error {
+  line: number;
+  constructor(message: string, line: number) {
+    super(line > 0 ? `第 ${line} 行：${message}` : message);
+    this.name = 'KernelError';
+    this.line = line;
+  }
+}
+
+/** 重汇聚栈的一项 */
+interface MaskFrame {
+  origin: number;
+  otherwise: number;
+}
+
+class Warp {
+  pc = 0;
+  active: number;
+  readonly present: number;
+  stack: MaskFrame[] = [];
+  atBarrier = false;
+  done = false;
+  readonly regs: Float64Array;
+
+  constructor(readonly index: number, present: number, numRegs: number) {
+    this.present = present;
+    this.active = present;
+    this.regs = new Float64Array(Math.max(1, numRegs) * WARP_SIZE);
+  }
+}
+
+export interface RunResult {
+  counters: GpuCounters;
+}
+
+export interface RunOptions {
+  memory: LinearMemory;
+  sharedCapacity?: number;
+  maxWarpInsts?: number;
+}
+
+const DEFAULT_MAX_WARP_INSTS = 200_000_000;
+
+export function launchKernel(
+  kernel: CompiledKernel | ExecutableKernel,
+  config: LaunchConfig,
+  args: KernelArg[],
+  options: RunOptions
+): RunResult {
+  const executable = 'program' in kernel ? kernel : encode(kernel);
+  const counters = emptyCounters();
+  new Executor(executable, config, args, options, counters).run();
+  return { counters };
+}
+
+class Executor {
+  private readonly shared: LinearMemory;
+  private readonly addresses = new Int32Array(WARP_SIZE);
+  private readonly maxWarpInsts: number;
+  private readonly blockThreads: number;
+  private readonly warpsPerBlock: number;
+  private readonly program: Program;
+  /** 参数值按类型规整过，避免每次 param 指令都判一遍 */
+  private readonly argValues: Float64Array;
+
+  constructor(
+    private readonly kernel: ExecutableKernel,
+    private readonly config: LaunchConfig,
+    args: KernelArg[],
+    private readonly options: RunOptions,
+    private readonly counters: GpuCounters
+  ) {
+    this.program = kernel.program;
+    const capacity = options.sharedCapacity ?? 48 * 1024;
+    if (kernel.sharedBytes > capacity) {
+      throw new KernelError(
+        `这个 kernel 要 ${kernel.sharedBytes} 字节共享内存，超过了每个 block 的上限 ${capacity} 字节`,
+        0
+      );
+    }
+    this.shared = new LinearMemory(Math.max(4, kernel.sharedBytes), 'shared');
+    this.maxWarpInsts = options.maxWarpInsts ?? DEFAULT_MAX_WARP_INSTS;
+    this.blockThreads = config.block.x * config.block.y * config.block.z;
+    if (this.blockThreads === 0) throw new KernelError('blockDim 不能是 0', 0);
+    if (this.blockThreads > 1024) {
+      throw new KernelError(`一个 block 最多 1024 个线程，这里是 ${this.blockThreads}`, 0);
+    }
+    this.warpsPerBlock = Math.ceil(this.blockThreads / WARP_SIZE);
+    if (args.length !== kernel.params.length) {
+      throw new KernelError(
+        `${kernel.name} 需要 ${kernel.params.length} 个参数，给了 ${args.length} 个`, 0
+      );
+    }
+    this.argValues = new Float64Array(args.length);
+    for (let i = 0; i < args.length; i += 1) {
+      const ty = kernel.paramTypes[i];
+      this.argValues[i] =
+        ty === TY.F32 ? Math.fround(args[i]) : ty === TY.U32 ? args[i] >>> 0 : args[i] | 0;
+    }
+  }
+
+  run(): void {
+    const { grid } = this.config;
+    for (let bz = 0; bz < grid.z; bz += 1) {
+      for (let by = 0; by < grid.y; by += 1) {
+        for (let bx = 0; bx < grid.x; bx += 1) {
+          this.runBlock(bx, by, bz);
+        }
+      }
+    }
+  }
+
+  private runBlock(bx: number, by: number, bz: number): void {
+    this.counters.blocksLaunched += 1;
+    // 共享内存在 block 之间不保留内容。真卡上它是脏的；我们清零是为了确定性，
+    // 这是一处已知分叉 —— 靠未初始化共享内存出错的程序在这里不会暴露。
+    this.shared.reset();
+
+    const warps: Warp[] = [];
+    for (let w = 0; w < this.warpsPerBlock; w += 1) {
+      const first = w * WARP_SIZE;
+      const count = Math.min(WARP_SIZE, this.blockThreads - first);
+      const present = count === WARP_SIZE ? -1 : (1 << count) - 1;
+      warps.push(new Warp(w, present, this.kernel.numRegs));
+      this.counters.warpsLaunched += 1;
+    }
+
+    let cursor = 0;
+    while (true) {
+      let live = 0;
+      let waiting = 0;
+      for (const warp of warps) {
+        if (warp.done) continue;
+        live += 1;
+        if (warp.atBarrier) waiting += 1;
+      }
+      if (live === 0) break;
+
+      if (waiting === live) {
+        // 全到齐了，一起放行
+        this.counters.barriers += 1;
+        for (const warp of warps) warp.atBarrier = false;
+      } else if (waiting > 0) {
+        // 有 warp 在等，还有 warp 活着 —— 先让活着的跑。但如果活着的
+        // 全都跑完退出了，等的那些就永远等不到人了。
+        let runnable = false;
+        for (const warp of warps) if (!warp.done && !warp.atBarrier) { runnable = true; break; }
+        if (!runnable) {
+          throw new KernelError(
+            '__syncthreads() 卡住了：block 里有 warp 已经退出，剩下的还在等它。' +
+            '屏障必须让整个 block 都到达',
+            0
+          );
+        }
+      }
+
+      const warp = warps[cursor % warps.length];
+      cursor += 1;
+      if (warp.done || warp.atBarrier) continue;
+      this.runWarp(warp, bx, by, bz);
+    }
+  }
+
+  /**
+   * 跑一个 warp，直到它到达屏障或者结束。
+   *
+   * 计数器在这里用局部变量攒 —— 每条指令碰一次 `this.counters.x` 的话，
+   * 光属性访问就能吃掉三成吞吐。
+   */
+  private runWarp(warp: Warp, bx: number, by: number, bz: number): void {
+    const code = this.program.code;
+    const pool = this.program.pool;
+    const lines = this.program.lines;
+    const regs = warp.regs;
+    const addresses = this.addresses;
+    const globalMemory = this.options.memory;
+    const sharedMemory = this.shared;
+    const block = this.config.block;
+    const grid = this.config.grid;
+    const argValues = this.argValues;
+    const counters = this.counters;
+    const warpBase = warp.index * WARP_SIZE;
+
+    // 计数器用局部变量攒着，出口再写回（理由见文件头第 3 条）
+    let warpInsts = 0;
+    let laneInsts = 0;
+    let instFma = 0;
+    let instLdSt = 0;
+    let divergent = 0;
+
+    let pc = warp.pc;
+
+    try {
+      while (true) {
+        if (pc < 0 || pc >= this.program.count) {
+          warp.done = true;
+          counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
+          counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.divergentBranches += divergent;
+          return;
+        }
+
+        warpInsts += 1;
+        if (counters.warpInsts + warpInsts > this.maxWarpInsts) {
+          counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
+          counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.divergentBranches += divergent;
+          throw new KernelError(
+            `执行预算用光了（${this.maxWarpInsts} 条 warp 指令）—— 多半是循环没退出`,
+            lines[pc]
+          );
+        }
+
+        const at = pc * SLOTS;
+        const op = code[at];
+        const active = warp.active;
+        const lanes = popcount(active);
+        laneInsts += lanes;
+
+        switch (op) {
+          case OP.CONST: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const ty = code[at + 3];
+            const raw = pool[code[at + 2]];
+            const value = ty === TY.F32 ? Math.fround(raw) : ty === TY.U32 ? raw >>> 0 : raw | 0;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) regs[dst + lane] = value;
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.MOV: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const src = code[at + 2] * WARP_SIZE;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) regs[dst + lane] = regs[src + lane];
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.BIN: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const a = code[at + 2] * WARP_SIZE;
+            const b = code[at + 3] * WARP_SIZE;
+            const kind = code[at + 4];
+            const ty = code[at + 5];
+            if (ty === TY.F32) this.binF32(regs, dst, a, b, kind, active, lines[pc]);
+            else this.binInt(regs, dst, a, b, kind, ty === TY.U32, active, lines[pc]);
+            pc += 1;
+            break;
+          }
+
+          case OP.UN: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const a = code[at + 2] * WARP_SIZE;
+            const kind = code[at + 3];
+            const ty = code[at + 4];
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const value = regs[a + lane];
+              regs[dst + lane] =
+                kind === UN.neg ? (ty === TY.F32 ? Math.fround(-value) : normalize(-value, ty))
+                : kind === UN.not ? (value === 0 ? 1 : 0)
+                : normalize(~value, ty);
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.CVT: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const a = code[at + 2] * WARP_SIZE;
+            const from = code[at + 3];
+            const to = code[at + 4];
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              regs[dst + lane] = convert(regs[a + lane], from, to);
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.SREG: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const which = code[at + 2];
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const tid = warpBase + lane;
+              let value: number;
+              switch (which) {
+                case SREG['tid.x']: value = tid % block.x; break;
+                case SREG['tid.y']: value = ((tid / block.x) | 0) % block.y; break;
+                case SREG['tid.z']: value = (tid / (block.x * block.y)) | 0; break;
+                case SREG['ctaid.x']: value = bx; break;
+                case SREG['ctaid.y']: value = by; break;
+                case SREG['ctaid.z']: value = bz; break;
+                case SREG['ntid.x']: value = block.x; break;
+                case SREG['ntid.y']: value = block.y; break;
+                case SREG['ntid.z']: value = block.z; break;
+                case SREG['nctaid.x']: value = grid.x; break;
+                case SREG['nctaid.y']: value = grid.y; break;
+                case SREG['nctaid.z']: value = grid.z; break;
+                default: value = WARP_SIZE; break;
+              }
+              regs[dst + lane] = value;
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.PARAM: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const value = argValues[code[at + 2]];
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) regs[dst + lane] = value;
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.SHAREDBASE: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const offset = code[at + 2];
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) regs[dst + lane] = offset;
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.LOAD: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const addr = code[at + 2] * WARP_SIZE;
+            const isGlobal = code[at + 3] === SPACE.GLOBAL;
+            const ty = code[at + 4];
+            const memory = isGlobal ? globalMemory : sharedMemory;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const address = regs[addr + lane] | 0;
+              addresses[lane] = address;
+              regs[dst + lane] =
+                ty === TY.F32 ? memory.readF32(address)
+                : ty === TY.U32 ? memory.readU32(address)
+                : memory.readI32(address);
+            }
+            if (isGlobal) {
+              counters.globalLoadRequests += 1;
+              counters.globalLoadSectors += countSectors(addresses, active);
+            } else {
+              counters.sharedLoadRequests += 1;
+              counters.sharedBankConflicts += countBankConflicts(addresses, active);
+            }
+            instLdSt += lanes;
+            pc += 1;
+            break;
+          }
+
+          case OP.STORE: {
+            const addr = code[at + 1] * WARP_SIZE;
+            const src = code[at + 2] * WARP_SIZE;
+            const isGlobal = code[at + 3] === SPACE.GLOBAL;
+            const ty = code[at + 4];
+            const memory = isGlobal ? globalMemory : sharedMemory;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const address = regs[addr + lane] | 0;
+              addresses[lane] = address;
+              const value = regs[src + lane];
+              if (ty === TY.F32) memory.writeF32(address, value);
+              else if (ty === TY.U32) memory.writeU32(address, value);
+              else memory.writeI32(address, value);
+            }
+            if (isGlobal) {
+              counters.globalStoreRequests += 1;
+              counters.globalStoreSectors += countSectors(addresses, active);
+            } else {
+              counters.sharedStoreRequests += 1;
+              counters.sharedBankConflicts += countBankConflicts(addresses, active);
+            }
+            instLdSt += lanes;
+            pc += 1;
+            break;
+          }
+
+          case OP.JMP:
+            pc = code[at + 1];
+            break;
+
+          case OP.PUSH: {
+            const cond = code[at + 1] * WARP_SIZE;
+            let taken = 0;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              if (regs[cond + lane] !== 0) taken |= 1 << lane;
+            }
+            const otherwise = active & ~taken;
+            if (taken !== 0 && otherwise !== 0) divergent += 1;
+            warp.stack.push({ origin: active, otherwise });
+            warp.active = taken;
+            pc = taken === 0 ? code[at + 2] : pc + 1;
+            break;
+          }
+
+          case OP.SWAP: {
+            const frame = warp.stack[warp.stack.length - 1];
+            if (!frame) throw new KernelError('内部错误：swap 时重汇聚栈是空的', lines[pc]);
+            warp.active = frame.otherwise;
+            frame.otherwise = 0;
+            pc = warp.active === 0 ? code[at + 1] : pc + 1;
+            break;
+          }
+
+          case OP.POP: {
+            const frame = warp.stack.pop();
+            if (!frame) throw new KernelError('内部错误：pop 时重汇聚栈是空的', lines[pc]);
+            warp.active = frame.origin;
+            pc += 1;
+            break;
+          }
+
+          case OP.LOOP:
+            warp.stack.push({ origin: active, otherwise: 0 });
+            pc += 1;
+            break;
+
+          case OP.LCOND: {
+            const cond = code[at + 1] * WARP_SIZE;
+            let taken = 0;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              if (regs[cond + lane] !== 0) taken |= 1 << lane;
+            }
+            if (taken !== 0 && taken !== active) divergent += 1;
+            warp.active = taken;
+            pc = taken === 0 ? code[at + 2] : pc + 1;
+            break;
+          }
+
+          case OP.BAR: {
+            // 屏障必须由整个 block 到达。一个 warp 在分歧区里到达屏障，
+            // 真卡上是未定义行为（多半挂死）—— 明确报错，不放过去。
+            if (warp.active !== warp.present) {
+              throw new KernelError(
+                '__syncthreads() 出现在发散的分支里：这个 warp 只有一部分 lane 到达了屏障。' +
+                '真卡上这是未定义行为，通常直接挂死。把屏障挪到所有线程都会执行到的地方',
+                lines[pc]
+              );
+            }
+            warp.atBarrier = true;
+            warp.pc = pc + 1;
+            counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
+            counters.instFma += instFma; counters.instLdSt += instLdSt;
+            counters.divergentBranches += divergent;
+            return;
+          }
+
+          case OP.CALL: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const fn = code[at + 2];
+            const a0 = code[at + 4] * WARP_SIZE;
+            const a1 = code[at + 5] * WARP_SIZE;
+            const a2 = code[at + 6] * WARP_SIZE;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const x = regs[a0 + lane];
+              const y = regs[a1 + lane];
+              const z = regs[a2 + lane];
+              let out: number;
+              switch (fn) {
+                case FN.fmaf: out = fmaF32(x, y, z); break;
+                case FN.fabsf: out = Math.fround(Math.abs(x)); break;
+                case FN.fminf: out = minF32(x, y); break;
+                case FN.fmaxf: out = maxF32(x, y); break;
+                case FN.sqrtf: out = sqrtF32(x); break;
+                case FN.rsqrtf: out = rsqrtF32(x); break;
+                case FN.expf: out = expF32(x); break;
+                case FN.logf: out = logF32(x); break;
+                case FN.tanhf: out = tanhF32(x); break;
+                case FN.powf: out = powF32(x, y); break;
+                case FN.__expf: out = fastExpF32(x); break;
+                case FN.__logf: out = fastLogF32(x); break;
+                case FN.__fdividef: out = fastDivF32(x, y); break;
+                case FN.min: out = Math.min(x | 0, y | 0) | 0; break;
+                case FN.max: out = Math.max(x | 0, y | 0) | 0; break;
+                default: out = Math.abs(x | 0) | 0; break;
+              }
+              regs[dst + lane] = out;
+            }
+            if (fn === FN.fmaf) instFma += lanes;
+            pc += 1;
+            break;
+          }
+
+          case OP.RET:
+            warp.done = true;
+            counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
+            counters.instFma += instFma; counters.instLdSt += instLdSt;
+            counters.divergentBranches += divergent;
+            return;
+
+          default:
+            throw new KernelError(`内部错误：不认识的操作码 ${op}`, lines[pc]);
+        }
+      }
+    } catch (error) {
+      counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
+      counters.instFma += instFma; counters.instLdSt += instLdSt;
+      counters.divergentBranches += divergent;
+      if (error instanceof MemoryFault) throw new KernelError(error.message, lines[Math.min(pc, this.program.count - 1)]);
+      if (error instanceof KernelError) throw error;
+      throw new KernelError(String((error as Error)?.message ?? error), lines[Math.min(pc, this.program.count - 1)]);
+    }
+  }
+
+  private binF32(
+    regs: Float64Array, dst: number, a: number, b: number,
+    kind: number, active: number, line: number
+  ): void {
+    switch (kind) {
+      case BIN.add:
+        for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+          if (active & (1 << lane)) regs[dst + lane] = addF32(regs[a + lane], regs[b + lane]);
+        }
+        return;
+      case BIN.sub:
+        for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+          if (active & (1 << lane)) regs[dst + lane] = subF32(regs[a + lane], regs[b + lane]);
+        }
+        return;
+      case BIN.mul:
+        for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+          if (active & (1 << lane)) regs[dst + lane] = mulF32(regs[a + lane], regs[b + lane]);
+        }
+        return;
+      case BIN.div:
+        for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+          if (active & (1 << lane)) regs[dst + lane] = divF32(regs[a + lane], regs[b + lane]);
+        }
+        return;
+      default:
+        break;
+    }
+    for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+      if ((active & (1 << lane)) === 0) continue;
+      const x = regs[a + lane];
+      const y = regs[b + lane];
+      let out: number;
+      switch (kind) {
+        case BIN.lt: out = x < y ? 1 : 0; break;
+        case BIN.le: out = x <= y ? 1 : 0; break;
+        case BIN.gt: out = x > y ? 1 : 0; break;
+        case BIN.ge: out = x >= y ? 1 : 0; break;
+        case BIN.eq: out = x === y ? 1 : 0; break;
+        case BIN.ne: out = x !== y ? 1 : 0; break;
+        default: throw new KernelError('这个运算符不能用在 float 上', line);
+      }
+      regs[dst + lane] = out;
+    }
+  }
+
+  private binInt(
+    regs: Float64Array, dst: number, a: number, b: number,
+    kind: number, unsigned: boolean, active: number, line: number
+  ): void {
+    for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+      if ((active & (1 << lane)) === 0) continue;
+      const xi = unsigned ? regs[a + lane] >>> 0 : regs[a + lane] | 0;
+      const yi = unsigned ? regs[b + lane] >>> 0 : regs[b + lane] | 0;
+      let out: number;
+      switch (kind) {
+        case BIN.add: out = unsigned ? (xi + yi) >>> 0 : (xi + yi) | 0; break;
+        case BIN.sub: out = unsigned ? (xi - yi) >>> 0 : (xi - yi) | 0; break;
+        case BIN.mul: out = unsigned ? Math.imul(xi, yi) >>> 0 : Math.imul(xi, yi); break;
+        case BIN.div:
+          if (yi === 0) throw new KernelError('整数除以 0', line);
+          out = unsigned ? Math.trunc(xi / yi) >>> 0 : Math.trunc(xi / yi) | 0;
+          break;
+        case BIN.rem:
+          if (yi === 0) throw new KernelError('整数取模 0', line);
+          out = unsigned ? (xi % yi) >>> 0 : (xi % yi) | 0;
+          break;
+        case BIN.shl: out = unsigned ? (xi << (yi & 31)) >>> 0 : xi << (yi & 31); break;
+        case BIN.shr: out = unsigned ? xi >>> (yi & 31) : xi >> (yi & 31); break;
+        case BIN.and: out = unsigned ? (xi & yi) >>> 0 : xi & yi; break;
+        case BIN.or: out = unsigned ? (xi | yi) >>> 0 : xi | yi; break;
+        case BIN.xor: out = unsigned ? (xi ^ yi) >>> 0 : xi ^ yi; break;
+        case BIN.lt: out = xi < yi ? 1 : 0; break;
+        case BIN.le: out = xi <= yi ? 1 : 0; break;
+        case BIN.gt: out = xi > yi ? 1 : 0; break;
+        case BIN.ge: out = xi >= yi ? 1 : 0; break;
+        case BIN.eq: out = xi === yi ? 1 : 0; break;
+        default: out = xi !== yi ? 1 : 0; break;
+      }
+      regs[dst + lane] = out;
+    }
+  }
+}
+
+function normalize(value: number, ty: number): number {
+  return ty === TY.F32 ? Math.fround(value) : ty === TY.U32 ? value >>> 0 : value | 0;
+}
+
+function convert(value: number, from: number, to: number): number {
+  if (from === to) return value;
+  if (to === TY.F32) return Math.fround(from === TY.U32 ? value >>> 0 : value | 0);
+  if (from === TY.F32) return to === TY.U32 ? floatToUint(value) : floatToInt(value);
+  return to === TY.U32 ? value >>> 0 : value | 0;
+}
+
+function popcount(mask: number): number {
+  let n = mask - ((mask >> 1) & 0x55555555);
+  n = (n & 0x33333333) + ((n >> 2) & 0x33333333);
+  n = (n + (n >> 4)) & 0x0f0f0f0f;
+  return (n * 0x01010101) >> 24;
+}
+
+export { SECTOR_BYTES, WARP_SIZE, LinearMemory, encode };
+export type { ExecutableKernel };

--- a/src/lib/labkit/machine/shell/parser.ts
+++ b/src/lib/labkit/machine/shell/parser.ts
@@ -14,6 +14,8 @@
  * 「看起来跑了但语义不对」—— 那种失败最难查。
  */
 
+import { createTreeSitterParser, isBrowser } from '../../treesitter';
+
 export type Redirect =
   /** `< file` */
   | { kind: 'in'; source: string }
@@ -169,34 +171,16 @@ export interface ShellParserOptions {
 /** tree-sitter 的运行时与语法都是 WASM，加载一次复用 */
 export async function loadShellParser(options: ShellParserOptions = {}): Promise<TsParser> {
   if (parserPromise) return parserPromise;
-  parserPromise = (async () => {
-    const treeSitter: any = await import('web-tree-sitter');
-    const Parser = treeSitter.Parser ?? treeSitter.default?.Parser;
-    const Language = treeSitter.Language ?? treeSitter.default?.Language;
-
-    const runtimeUrl = options.runtimeWasmUrl ?? (isBrowser() ? '/labkit/web-tree-sitter.wasm' : undefined);
-    await Parser.init(runtimeUrl ? { locateFile: () => runtimeUrl } : undefined);
-
-    const grammar = options.grammar ?? defaultGrammarPath();
-    // 自己把字节读出来再交给 Language.load。它自带的按路径加载会走动态
-    // import()，在 jest 的 CJS 环境里直接抛 —— 而且浏览器里那条路也走不通。
-    const language = await Language.load(
-      typeof grammar === 'string' ? await readWasm(grammar) : grammar
-    );
-    const parser = new Parser();
-    parser.setLanguage(language);
-    return parser as TsParser;
-  })();
+  parserPromise = createTreeSitterParser<TsParser>({
+    runtimeWasmUrl: options.runtimeWasmUrl,
+    grammar: options.grammar ?? defaultGrammarPath(),
+  });
   return parserPromise;
 }
 
 /** 测试之间要能换 wasm 路径重来 */
 export function resetShellParser(): void {
   parserPromise = null;
-}
-
-function isBrowser(): boolean {
-  return typeof window !== 'undefined' && typeof document !== 'undefined';
 }
 
 /**
@@ -209,17 +193,6 @@ function defaultGrammarPath(): string {
   return isBrowser()
     ? '/labkit/tree-sitter-bash.wasm'
     : 'node_modules/tree-sitter-bash/tree-sitter-bash.wasm';
-}
-
-async function readWasm(location: string): Promise<Uint8Array> {
-  if (isBrowser()) {
-    const response = await fetch(location);
-    if (!response.ok) throw new Error(`failed to fetch ${location}: ${response.status}`);
-    return new Uint8Array(await response.arrayBuffer());
-  }
-  // Node 专用分支。用 eval 拿 require，免得打包器把 fs 打进浏览器包。
-  const nodeRequire = eval('require') as (id: string) => any;
-  return new Uint8Array(nodeRequire('fs').readFileSync(location));
 }
 
 const literal = (text: string): Word => ({ parts: [{ kind: 'literal', text }], quoted: 'none' });

--- a/src/lib/labkit/treesitter.ts
+++ b/src/lib/labkit/treesitter.ts
@@ -1,0 +1,67 @@
+/**
+ * tree-sitter 的加载
+ *
+ * 两个实验台都要用：opslab 的 shell 用 bash 语法，gpulab 的 nvcc 用 CUDA 语法。
+ * 抽出来的原因不是「看起来该抽」，而是这里面有一处**必须记住的坑**，
+ * 抄两份的话早晚有一份会退化：
+ *
+ * **不能把路径交给 `Language.load`。** 它内部按路径加载时会走动态 `import()`，
+ * 在 jest 的 CJS 环境里直接抛「A dynamic import callback was invoked without
+ * --experimental-vm-modules」，而浏览器里那条路同样走不通。
+ * 正确做法是自己把字节读出来，再把 `Uint8Array` 交给它。
+ */
+
+/** tree-sitter 的 Parser，只暴露我们用得到的部分 */
+export interface TsParserLike {
+  parse(source: string): { rootNode: unknown };
+}
+
+export function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+/**
+ * 读一个 wasm 文件的字节。
+ *
+ * 浏览器里走 fetch（构建脚本已经把文件拷到 public/ 下），
+ * Node 里走 fs —— 用 eval 拿 require，免得打包器把 fs 打进浏览器包。
+ */
+export async function readWasmBytes(location: string): Promise<Uint8Array> {
+  if (isBrowser()) {
+    const response = await fetch(location);
+    if (!response.ok) throw new Error(`failed to fetch ${location}: ${response.status}`);
+    return new Uint8Array(await response.arrayBuffer());
+  }
+  const nodeRequire = eval('require') as (id: string) => { readFileSync(path: string): Buffer };
+  return new Uint8Array(nodeRequire('fs').readFileSync(location));
+}
+
+export interface GrammarLoadOptions {
+  /** web-tree-sitter 运行时 wasm 的地址。Node 里不用给。 */
+  runtimeWasmUrl?: string;
+  /** 语法：给地址或者直接给字节 */
+  grammar: string | Uint8Array;
+}
+
+/**
+ * 装好运行时与一门语法，返回一个 Parser。
+ *
+ * 调用方自己负责缓存 —— 每个语法各缓存一份，互不影响。
+ */
+export async function createTreeSitterParser<T>(options: GrammarLoadOptions): Promise<T> {
+  const treeSitter: any = await import('web-tree-sitter');
+  const Parser = treeSitter.Parser ?? treeSitter.default?.Parser;
+  const Language = treeSitter.Language ?? treeSitter.default?.Language;
+
+  const runtimeUrl = options.runtimeWasmUrl ?? (isBrowser() ? '/labkit/web-tree-sitter.wasm' : undefined);
+  await Parser.init(runtimeUrl ? { locateFile: () => runtimeUrl } : undefined);
+
+  const bytes = typeof options.grammar === 'string'
+    ? await readWasmBytes(options.grammar)
+    : options.grammar;
+
+  const language = await Language.load(bytes);
+  const parser = new Parser();
+  parser.setLanguage(language);
+  return parser as T;
+}

--- a/tests/gpulab/vm.test.ts
+++ b/tests/gpulab/vm.test.ts
@@ -1,0 +1,531 @@
+/**
+ * CUDA 前端 + warp 锁步 VM
+ *
+ * 这一套用例要回答三个问题，第三个是整个方案的命门：
+ *  1. 真 CUDA 语法能不能编、能不能算对；
+ *  2. 发散、屏障、共享内存的语义对不对；
+ *  3. **访存计量能不能证明「优化真的生效」** —— 也就是同一段逻辑换个下标，
+ *     扇区数是不是真的塌下去。门槛全建立在这上面。
+ */
+import {
+  CudaCompileError, CudaSyntaxError, GpuDevice, KernelError,
+  compileSource, dim3,
+} from '../../src/lib/gpulab';
+
+jest.setTimeout(120_000);
+
+/** 每关的规模都小，一台 4MB 的设备足够，建起来也快 */
+function device(): GpuDevice {
+  return new GpuDevice({ globalBytes: 4 * 1024 * 1024 });
+}
+
+async function compileOne(source: string, name: string) {
+  const kernels = await compileSource(source);
+  const kernel = kernels.get(name);
+  if (!kernel) throw new Error(`没编出 ${name}，只有 ${[...kernels.keys()].join(', ')}`);
+  return kernel;
+}
+
+describe('CUDA 前端', () => {
+  it('解析真实写法的 kernel：限定符、共享内存、内建变量、启动配置', async () => {
+    const kernels = await compileSource(`
+      __global__ void saxpy(const float* __restrict__ x, float* y, float a, int n) {
+        int i = blockIdx.x * blockDim.x + threadIdx.x;
+        if (i < n) {
+          y[i] = fmaf(a, x[i], y[i]);
+        }
+      }
+    `);
+    expect([...kernels.keys()]).toEqual(['saxpy']);
+    const kernel = kernels.get('saxpy')!;
+    expect(kernel.params.map((p) => p.name)).toEqual(['x', 'y', 'a', 'n']);
+    expect(kernel.params[0].isPointer).toBe(true);
+    expect(kernel.params[2].isPointer).toBe(false);
+  });
+
+  it('语法错误报在出错的那一行，而不是让它悄悄编过去', async () => {
+    await expect(compileSource(`
+      __global__ void k(float* a) {
+        a[0] = 1.0f
+      }
+    `)).rejects.toThrow(CudaSyntaxError);
+  });
+
+  it('子集之外的语法明确报「暂不支持」，并说清替代做法', async () => {
+    const cases: Array<[string, RegExp]> = [
+      ['__global__ void k(float* a) { struct P { int x; }; }', /暂不支持|struct/],
+      ['__global__ void k(float* a) { double d = 1.0; }', /double/],
+      ['__global__ void k(float* a) { for (int i=0;i<4;++i) { break; } }', /break/],
+      ['__device__ float f(float x) { return x; }', /__device__/],
+      ['__global__ void k(float* a) { extern __shared__ float s[]; }', /extern|动态共享内存/],
+      ['__global__ void k(float* a) { float t[8]; t[0] = 1.0f; }', /local memory|私有的数组/],
+    ];
+    for (const [source, pattern] of cases) {
+      await expect(compileSource(source)).rejects.toThrow(pattern);
+    }
+  });
+
+  it('调用没实现的函数会列出有哪些内建函数可用', async () => {
+    await expect(compileSource(`
+      __global__ void k(float* a) { a[0] = __shfl_xor_sync(0xffffffff, a[0], 1); }
+    `)).rejects.toThrow(CudaCompileError);
+  });
+});
+
+describe('算术与控制流', () => {
+  it('saxpy 算对，且尾块不越界', async () => {
+    const kernel = await compileOne(`
+      __global__ void saxpy(const float* x, float* y, float a, int n) {
+        int i = blockIdx.x * blockDim.x + threadIdx.x;
+        if (i < n) y[i] = a * x[i] + y[i];
+      }
+    `, 'saxpy');
+
+    const n = 100; // 故意不是 32 的整数倍
+    const gpu = device();
+    const dx = gpu.malloc(n * 4);
+    const dy = gpu.malloc(n * 4);
+    const x = Float32Array.from({ length: n }, (_, i) => i * 0.5);
+    const y = Float32Array.from({ length: n }, (_, i) => i * 0.25);
+    gpu.copyIn(dx, x);
+    gpu.copyIn(dy, y);
+
+    gpu.launch(kernel, { grid: dim3(4), block: dim3(32) }, [dx, dy, 2.0, n]);
+
+    const out = gpu.copyOut(dy, n);
+    for (let i = 0; i < n; i += 1) {
+      expect(out[i]).toBeCloseTo(2.0 * x[i] + y[i], 5);
+    }
+  });
+
+  it('fp32 的舍入是真的 —— 结果和 float64 不一样', async () => {
+    const kernel = await compileOne(`
+      __global__ void acc(float* out, int n) {
+        float sum = 0.0f;
+        for (int i = 0; i < n; ++i) sum += 0.1f;
+        out[0] = sum;
+      }
+    `, 'acc');
+
+    const gpu = device();
+    const out = gpu.malloc(4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(1) }, [out, 1000]);
+    const value = gpu.copyOut(out, 1)[0];
+
+    // fp32 累加 1000 个 0.1f 会明显偏离 100
+    expect(value).not.toBe(100);
+    expect(Math.abs(value - 100)).toBeGreaterThan(1e-4);
+    // 但仍然在合理范围内 —— 不是算错了，是精度就这样
+    expect(value).toBeCloseTo(100, 1);
+  });
+
+  it('循环里 lane 陆续退出，各自停在自己的迭代次数上', async () => {
+    const kernel = await compileOne(`
+      __global__ void tri(int* out) {
+        int t = threadIdx.x;
+        int c = 0;
+        for (int i = 0; i < t; ++i) c += 1;
+        out[t] = c;
+      }
+    `, 'tri');
+
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    for (let i = 0; i < 32; i += 1) expect(values[i]).toBe(i);
+  });
+
+  it('三目与短路：右边只在该走的 lane 上求值，不会越界读', async () => {
+    const kernel = await compileOne(`
+      __global__ void guard(const float* a, float* out, int n) {
+        int i = threadIdx.x;
+        // i >= n 时不许去读 a[i] —— 短路必须是真的
+        out[i] = (i < n && a[i] > 0.0f) ? a[i] : -1.0f;
+      }
+    `, 'guard');
+
+    const gpu = device();
+    const n = 8;
+    const da = gpu.malloc(n * 4);           // 只分配 8 个
+    const out = gpu.malloc(32 * 4);
+    gpu.copyIn(da, Float32Array.from({ length: n }, (_, i) => i + 1));
+
+    // 32 个线程里有 24 个 i >= n。短路不生效的话这里会越界读并抛 KernelError。
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [da, out, n]);
+
+    const values = gpu.copyOut(out, 32);
+    for (let i = 0; i < 32; i += 1) {
+      expect(values[i]).toBeCloseTo(i < n ? i + 1 : -1, 5);
+    }
+  });
+
+  it('越界访问被抓住，报的是 compute-sanitizer 那样的话', async () => {
+    const kernel = await compileOne(`
+      __global__ void oob(float* a) { a[threadIdx.x + 1000000] = 1.0f; }
+    `, 'oob');
+    const gpu = new GpuDevice({ globalBytes: 64 * 1024 });
+    const a = gpu.malloc(128);
+    expect(() => gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [a]))
+      .toThrow(/invalid __global__|越界/);
+  });
+
+  it('死循环撞到执行预算，而不是把页面卡死', async () => {
+    const kernel = await compileOne(`
+      __global__ void spin(int* out) {
+        int i = 0;
+        while (i >= 0) i += 1;
+        out[0] = i;
+      }
+    `, 'spin');
+    // 用一个小预算，报错要快 —— 学员写错死循环时等十秒是很糟的体验
+    const gpu = new GpuDevice({ globalBytes: 64 * 1024, maxWarpInsts: 100_000 });
+    const out = gpu.malloc(4);
+    expect(() => gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]))
+      .toThrow(/执行预算/);
+  });
+});
+
+describe('共享内存与屏障', () => {
+  it('block 内经共享内存交换数据，__syncthreads() 之后读得到', async () => {
+    const kernel = await compileOne(`
+      __global__ void reverse(const float* in, float* out) {
+        __shared__ float s[64];
+        int t = threadIdx.x;
+        s[t] = in[t];
+        __syncthreads();
+        out[t] = s[63 - t];
+      }
+    `, 'reverse');
+
+    const gpu = device();
+    const din = gpu.malloc(64 * 4);
+    const dout = gpu.malloc(64 * 4);
+    gpu.copyIn(din, Float32Array.from({ length: 64 }, (_, i) => i));
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(64) }, [din, dout]);
+
+    const out = gpu.copyOut(dout, 64);
+    for (let i = 0; i < 64; i += 1) expect(out[i]).toBe(63 - i);
+    // 两个 warp、一次屏障
+    expect(gpu.metrics().launch.barriers).toBe(1);
+  });
+
+  it('发散分支里的 __syncthreads() 明确报错，而不是装作没事', async () => {
+    const kernel = await compileOne(`
+      __global__ void bad(float* out) {
+        __shared__ float s[32];
+        int t = threadIdx.x;
+        if (t < 16) {
+          s[t] = 1.0f;
+          __syncthreads();
+        }
+        out[t] = s[t];
+      }
+    `, 'bad');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    expect(() => gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]))
+      .toThrow(/发散|__syncthreads/);
+  });
+
+  it('共享内存超过每 block 上限，在启动前就报错', async () => {
+    const kernel = await compileOne(`
+      __global__ void hog(float* out) {
+        __shared__ float s[16384];
+        s[threadIdx.x] = 1.0f;
+        out[threadIdx.x] = s[threadIdx.x];
+      }
+    `, 'hog');
+    const gpu = new GpuDevice({ globalBytes: 1024 * 1024, sharedBytesPerBlock: 48 * 1024 });
+    const out = gpu.malloc(128);
+    expect(() => gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]))
+      .toThrow(/共享内存|上限/);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 计量 —— 门槛的地基                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('全局访存合并计量', () => {
+  const COPY = `
+    __global__ void copy(const float* in, float* out, int stride) {
+      int i = (blockIdx.x * blockDim.x + threadIdx.x) * stride;
+      out[i] = in[i];
+    }
+  `;
+
+  it('完全合并时每次请求恰好 4 个扇区', async () => {
+    const kernel = await compileOne(COPY, 'copy');
+    const gpu = device();
+    const n = 1024;
+    const din = gpu.malloc(n * 4);
+    const dout = gpu.malloc(n * 4);
+    gpu.copyIn(din, new Float32Array(n));
+
+    gpu.launch(kernel, { grid: dim3(n / 32), block: dim3(32) }, [din, dout, 1]);
+
+    const metrics = gpu.metrics();
+    // 32 lane × 4 字节 = 128 字节 = 4 个 32B 扇区
+    expect(metrics.global.sectorsPerRequest).toBe(4);
+    expect(metrics.global.loadSectors).toBe((n / 32) * 4);
+    expect(metrics.memory.readBytes).toBe(n * 4);
+  });
+
+  it('stride=8 时每个 lane 落在不同扇区 —— 32 个，也就是 8 倍的传输量', async () => {
+    const kernel = await compileOne(COPY, 'copy');
+    const gpu = device();
+    const n = 256;
+    const din = gpu.malloc(n * 8 * 4);
+    const dout = gpu.malloc(n * 8 * 4);
+    gpu.copyIn(din, new Float32Array(n * 8));
+
+    gpu.launch(kernel, { grid: dim3(n / 32), block: dim3(32) }, [din, dout, 8]);
+
+    const metrics = gpu.metrics();
+    expect(metrics.global.sectorsPerRequest).toBe(32);
+  });
+
+  it('「优化真的生效」是能被证明的：同一段逻辑换个下标，DRAM 字节掉 8 倍', async () => {
+    const kernel = await compileOne(COPY, 'copy');
+    const n = 1024;
+
+    const measure = (stride: number) => {
+      const gpu = device();
+      const din = gpu.malloc(n * stride * 4);
+      const dout = gpu.malloc(n * stride * 4);
+      gpu.copyIn(din, new Float32Array(n * stride));
+      gpu.launch(kernel, { grid: dim3(n / 32), block: dim3(32) }, [din, dout, stride]);
+      return gpu.metrics();
+    };
+
+    const bad = measure(8);
+    const good = measure(1);
+
+    // 指令数一模一样 —— 学员没有「少做事」，只是访存变整齐了
+    expect(good.inst.laneExecuted).toBe(bad.inst.laneExecuted);
+    // 但传输量差 8 倍。这就是第 2 关的门槛能成立的原因。
+    expect(bad.memory.readBytes / good.memory.readBytes).toBe(8);
+    expect(good.global.sectorsPerRequest).toBe(4);
+    expect(bad.global.sectorsPerRequest).toBe(32);
+  });
+});
+
+describe('共享内存 bank 冲突计量', () => {
+  const TRANSPOSE = (pad: number) => `
+    __global__ void transpose(const float* in, float* out) {
+      __shared__ float tile[32][${32 + pad}];
+      int x = threadIdx.x;
+      int y = threadIdx.y;
+      tile[y][x] = in[y * 32 + x];
+      __syncthreads();
+      out[y * 32 + x] = tile[x][y];
+    }
+  `;
+
+  async function run(pad: number) {
+    const kernel = await compileOne(TRANSPOSE(pad), 'transpose');
+    const gpu = device();
+    const din = gpu.malloc(32 * 32 * 4);
+    const dout = gpu.malloc(32 * 32 * 4);
+    gpu.copyIn(din, Float32Array.from({ length: 32 * 32 }, (_, i) => i));
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32, 32) }, [din, dout]);
+    return { gpu, out: gpu.copyOut(dout, 32 * 32) };
+  }
+
+  it('不加 padding 时列访问 32 路冲突；加一列之后归零', async () => {
+    const without = await run(0);
+    const withPad = await run(1);
+
+    // 两边算的结果必须一样 —— padding 是纯优化，不改语义
+    expect(Array.from(withPad.out)).toEqual(Array.from(without.out));
+
+    const a = without.gpu.metrics().shared.bankConflicts;
+    const b = withPad.gpu.metrics().shared.bankConflicts;
+    expect(a).toBeGreaterThan(0);
+    expect(b).toBe(0);
+  });
+
+  it('转置结果本身是对的', async () => {
+    const { out } = await run(1);
+    for (let y = 0; y < 32; y += 1) {
+      for (let x = 0; x < 32; x += 1) {
+        expect(out[y * 32 + x]).toBe(x * 32 + y);
+      }
+    }
+  });
+
+  it('同一个 bank 上读同一个地址是广播，不算冲突', async () => {
+    const kernel = await compileOne(`
+      __global__ void broadcast(float* out) {
+        __shared__ float s[32];
+        int t = threadIdx.x;
+        s[t] = (float)t;
+        __syncthreads();
+        out[t] = s[0];
+      }
+    `, 'broadcast');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    expect(gpu.metrics().shared.bankConflicts).toBe(0);
+  });
+});
+
+describe('发散计量', () => {
+  it('warp 内分岔算一次发散，整个 warp 走同一边不算', async () => {
+    const source = `
+      __global__ void branch(int* out, int mode) {
+        int t = blockIdx.x * blockDim.x + threadIdx.x;
+        int v = 0;
+        // mode=0：按 lane 分岔；mode=1：按 warp 分岔
+        int c = (mode == 0) ? (t % 2) : ((t / 32) % 2);
+        if (c == 0) v = 1; else v = 2;
+        out[t] = v;
+      }
+    `;
+    const kernel = await compileOne(source, 'branch');
+
+    const measure = (mode: number) => {
+      const gpu = device();
+      const out = gpu.malloc(128 * 4);
+      gpu.launch(kernel, { grid: dim3(4), block: dim3(32) }, [out, mode]);
+      return gpu.metrics().warp;
+    };
+
+    const perLane = measure(0);
+    const perWarp = measure(1);
+
+    expect(perLane.divergentBranches).toBe(4);  // 四个 warp 各发散一次
+    expect(perWarp.divergentBranches).toBe(0);  // 整个 warp 走同一边
+    expect(perLane.activeLaneRatio).toBeLessThan(perWarp.activeLaneRatio);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 确定性 —— 判定的前提                                                 */
+/* ------------------------------------------------------------------ */
+
+describe('确定性', () => {
+  /**
+   * 同一份代码跑很多遍，结果与**全部计数器**都必须逐位相同。
+   *
+   * 这不是锦上添花：门槛判定、参考解重放、进度恢复全都建立在它上面。
+   * opslab 那边的教训是这条要进 CI 当门禁，所以放在这里而不是手工验一次。
+   */
+  it('1000 次重放，输出与全部指标逐位一致', async () => {
+    const kernel = await compileOne(`
+      __global__ void mix(const float* in, float* out, int n) {
+        __shared__ float s[64];
+        int t = threadIdx.x;
+        int i = blockIdx.x * blockDim.x + t;
+        s[t] = (i < n) ? in[i] : 0.0f;
+        __syncthreads();
+        float acc = 0.0f;
+        for (int k = 0; k < 8; ++k) {
+          acc = fmaf(s[(t + k) % 64], 1.5f, acc);
+          if ((t & 1) == 0) acc = acc * 0.5f; else acc = acc - 0.25f;
+        }
+        if (i < n) out[i] = acc + expf(s[t] * 0.01f);
+      }
+    `, 'mix');
+
+    const n = 256;
+    const input = Float32Array.from({ length: n }, (_, i) => Math.sin(i) * 10);
+
+    const once = () => {
+      const gpu = device();
+      const din = gpu.malloc(n * 4);
+      const dout = gpu.malloc(n * 4);
+      gpu.copyIn(din, input);
+      gpu.launch(kernel, { grid: dim3(4), block: dim3(64) }, [din, dout, n]);
+      return {
+        // 用位模式比较，而不是数值 —— NaN 与 -0 也要一致
+        bits: Array.from(new Int32Array(gpu.copyOut(dout, n).buffer)),
+        metrics: gpu.flatMetrics(),
+      };
+    };
+
+    const first = once();
+    const reference = JSON.stringify(first);
+    for (let run = 1; run < 1000; run += 1) {
+      expect(JSON.stringify(once())).toBe(reference);
+    }
+    // 确实跑了真东西，不是空转
+    expect(first.metrics['gpu.inst.laneExecuted']).toBeGreaterThan(10_000);
+  });
+
+  it('超越函数不走 JS 的 Math.* —— 换个引擎结果也一样', async () => {
+    // expf/logf/tanhf 自己实现的直接后果：这些值是我们定死的，
+    // 不随宿主 JS 引擎的 libm 变。这里钉住几个点，实现改了会立刻报。
+    const kernel = await compileOne(`
+      __global__ void trans(float* out) {
+        out[0] = expf(1.0f);
+        out[1] = logf(10.0f);
+        out[2] = tanhf(0.5f);
+        out[3] = __expf(1.0f);
+      }
+    `, 'trans');
+    const gpu = device();
+    const out = gpu.malloc(16);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(1) }, [out]);
+    const values = gpu.copyOut(out, 4);
+
+    expect(values[0]).toBeCloseTo(Math.E, 5);
+    expect(values[1]).toBeCloseTo(Math.log(10), 5);
+    expect(values[2]).toBeCloseTo(Math.tanh(0.5), 5);
+    // 快速版精度更低，但和精确版方向一致 —— 「快但不准」在这里是真的
+    expect(values[3]).toBeCloseTo(Math.E, 2);
+    expect(values[3]).not.toBe(values[0]);
+  });
+});
+
+describe('执行预算', () => {
+  it('朴素 GEMM 在 N=128 时跑得动，指令量在设计预算内', async () => {
+    const kernel = await compileOne(`
+      __global__ void sgemm(const float* A, const float* B, float* C, int n) {
+        int row = blockIdx.y * blockDim.y + threadIdx.y;
+        int col = blockIdx.x * blockDim.x + threadIdx.x;
+        if (row < n && col < n) {
+          float acc = 0.0f;
+          for (int k = 0; k < n; ++k) acc = fmaf(A[row * n + k], B[k * n + col], acc);
+          C[row * n + col] = acc;
+        }
+      }
+    `, 'sgemm');
+
+    const n = 128;
+    const gpu = device();
+    const dA = gpu.malloc(n * n * 4);
+    const dB = gpu.malloc(n * n * 4);
+    const dC = gpu.malloc(n * n * 4);
+    const A = Float32Array.from({ length: n * n }, (_, i) => ((i % 7) - 3) * 0.25);
+    const B = Float32Array.from({ length: n * n }, (_, i) => ((i % 5) - 2) * 0.5);
+    gpu.copyIn(dA, A);
+    gpu.copyIn(dB, B);
+
+    const startedAt = Date.now();
+    gpu.launch(kernel, { grid: dim3(n / 16, n / 16), block: dim3(16, 16) }, [dA, dB, dC, n]);
+    const elapsed = Date.now() - startedAt;
+
+    // 结果对着 float64 的参考实现比，用相对误差界
+    const C = gpu.copyOut(dC, n * n);
+    for (let row = 0; row < n; row += 8) {
+      for (let col = 0; col < n; col += 8) {
+        let expected = 0;
+        for (let k = 0; k < n; k += 1) expected += A[row * n + k] * B[k * n + col];
+        const scale = Math.max(1, Math.abs(expected));
+        expect(Math.abs(C[row * n + col] - expected) / scale).toBeLessThan(2e-5);
+      }
+    }
+
+    // 这是**回归哨兵，不是性能指标**。
+    //
+    // jest 自己就吃掉 5–7 倍（SWC 转译 + 模块注册表 + vm 上下文）：同一段代码
+    // 纯 node 下是 13.5M warp 指令/秒，这里只有约 2M。关卡规模按前一个数设计。
+    // 这条断言的作用是「有人往热路径里加了会分配内存的东西」时能立刻发现。
+    const metrics = gpu.metrics();
+    const warpInstsPerSecond = metrics.inst.warpExecuted / Math.max(1, elapsed) * 1000;
+    expect(warpInstsPerSecond).toBeGreaterThan(700_000);
+  });
+});


### PR DESCRIPTION
[设计方案](../blob/main/design/gpulab.md)里那条命门的第一段实现：**一段真 CUDA 源码进去，跑完之后内存里是对的结果，指标里是能证明优化生效的结构性计量。**

链路：`tree-sitter-cuda` 解析 → 我们的 AST → 扁平 IR → 定长字节码 → warp 锁步执行。

## 三件事是真的，不是估的

**发散** —— 活跃掩码 + 结构化重汇聚栈。C 的控制流是结构化的，重汇聚点编译期就能算出来，不用运行时求 IPDOM。

**屏障** —— `__syncthreads()` 真的把 warp 挂起、等同 block 的其它 warp 到齐。这也正是选「扁平 IR + pc」而不是在 AST 上递归求值的原因：递归要挂起得靠生成器或 CPS。发散分支里的屏障明确报错（等价 `synccheck`），有 warp 已退出而别的还在等也报错。

**访存计量** —— 每条 warp 访存算 32 个地址，做 32B 扇区归并与 bank 冲突分析。规则按真硬件写，包括最容易漏的第三条：*同 bank 不同地址才冲突，同地址是广播不算冲突*。漏了它会误伤 `s[threadIdx.x / 2]` 这类真卡上本来就不慢的写法。

## 立论有一条用例直接证明

同一个 copy kernel 换个 stride：

| | lane 指令数 | DRAM 字节 | sectorsPerRequest |
| --- | ---: | ---: | ---: |
| stride=8 | 相同 | 8× | **32.0** |
| stride=1 | 相同 | 1× | **4.0** |

**指令数一模一样** —— 学员没有「少做事」，只是访存变整齐了，但传输量差 8 倍。第 2 关的门槛就建立在这上面。

## 浮点：超越函数自己实现

每步过 `Math.fround`；`expf` / `logf` / `tanhf` / `powf` **全部自己写，不用 JS 的 `Math.*`**。

理由是硬的：ECMAScript 不要求这些函数逐位可复现，V8 与 JavaScriptCore 的结果就不一样。用了它们，「同一份代码跑两遍逐位相同」这条门槛换个浏览器就不成立，整套判定跟着塌。

自己实现顺带白拿一件事：`__expf` 这类 fast-math 变体可以**真的把尾数低位抹掉**，于是「快但不准」在这里是真的不准，而不是 primer 里的一句说明。

**确定性**：1000 次重放，输出位模式与全部指标逐位一致（604ms）。

## 性能：记一笔免得后人重走弯路

改成扁平字节码之后在 jest 里**量不出任何差别**。查下去发现 —— **jest 自己就吃掉 5–7 倍**（SWC 转译 + 模块注册表 + vm 上下文）：

| N=256 朴素 GEMM | 耗时 | 吞吐 |
| --- | ---: | ---: |
| jest | 5.5 s | 2.0M warp-inst/s |
| **纯 node** | **783 ms** | **13.5M warp-inst/s** |

所以：**关卡规模按 13M/s 这个生产数字设计**，不是按测试里看到的；测试里那条吞吐断言只能当回归哨兵（"有人往热路径里加了会分配内存的东西"），不能当性能指标。两处都写进了注释。

我原先在注释里把这 10× 归因于扁平编码，那是错的，已改正 —— 也没有单独隔离出扁平编码本身的贡献，保留它的理由是架构（标准做法、避免 megamorphic 访问、将来反汇编面板要用），不是一个测出来的加速比。

## 子集之外一律明确报错

`struct` / `double` / `break` / 自己写的 `__device__` 函数 / `extern __shared__` / 线程私有数组 —— 每一条都给出替代做法，绝不悄悄降级成「看起来跑了但语义不对」。模拟器最怕的就是这个。

## 顺带抽了一小块到 labkit

`labkit/treesitter.ts`：第二个消费者到了，而且里面有一处**必须记住的坑** —— 不能把路径交给 `Language.load`，它内部走动态 `import()`，在 jest 的 CJS 环境里直接抛。抄两份的话早晚有一份会退化。

## 验证

| | |
| --- | --- |
| `npx tsc --noEmit` | 干净 |
| `npm test` | **10/10 套件**，新增 `Gpulab CUDA VM` 23/23 |
| `npm run projects:verify` | 全绿 |
| `npm run electron:pack` | 真实产物里 `public/gpulab/tree-sitter-cuda.wasm` 在 asar 中且 asarUnpack 解出 |

打包白名单（`files` 与 `asarUnpack`）与 `copy-lab-assets.js` 一起改了；`release.yml` 不用动 —— 这个 wasm 来自 node_modules，由 `prebuild` 拷贝。

## 下一片

竞态检测（racecheck）。**在确定性模拟器里，漏写 `__syncthreads()` 的 kernel 会正常出结果** —— 不做这个，「在这里学会的换到真卡上成立」就不成立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)