### PR TITLE
fix(opslab): 正式包里终端起不来；右侧改成 tab 并让面板能拖能收

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -87,6 +87,25 @@ const nextConfig = {
       ];
     }
 
+    /**
+     * xterm 走它的 UMD 产物，不要 ESM 那份。
+     *
+     * `@xterm/xterm` 的 `lib/xterm.mjs` 是 esbuild 出来的，里面有
+     * `var X = class Name extends Error {...}` 这种「带名字的类表达式」。
+     * Next 13.5 的 SWC 压缩器处理这个形状时会把 extends 的基类**换成 null**，
+     * 于是 `new Terminal()` 抛 `Super constructor null of anonymous class
+     * is not a constructor` —— 整个终端起不来。
+     *
+     * dev 不压缩所以看不出来，只有正式包会炸：v0.16.0 就是这么发出去的。
+     * UMD 那份（`lib/xterm.js`）是 webpack 打的，代码形状不同，压缩器不会踩到。
+     *
+     * scripts/check-bundle.js 会在每次构建后扫一遍产物，这个坑再出现就直接构建失败。
+     */
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      '@xterm/xterm$': require.resolve('@xterm/xterm/lib/xterm.js'),
+    };
+
     return config;
   },
   // Transpile packages that need it

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "dev": "next dev",
     "predev": "node scripts/copy-lab-assets.js",
     "build": "next build",
+    "postbuild": "node scripts/check-bundle.js",
     "prebuild": "node scripts/copy-lab-assets.js",
     "start": "next start",
     "deploy-local": "npm run build && npm start",

--- a/scripts/check-bundle.js
+++ b/scripts/check-bundle.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * 构建产物的体检。
+ *
+ * 起因是 v0.16.0：`@xterm/xterm` 的 ESM 产物里有「带名字的类表达式」
+ * （`var X = class Name extends Error {}`），Next 13.5 的 SWC 压缩器把 extends
+ * 的基类换成了 `null`，于是正式包里 `new Terminal()` 直接抛
+ * `Super constructor null of anonymous class is not a constructor`，
+ * 整个 ops 工作台的终端起不来。
+ *
+ * dev 不压缩，所以这个故障**只在正式构建里出现**，测试也照不到 ——
+ * 唯一能挡住它的地方就是构建之后扫一眼产物。
+ *
+ * 这个脚本挂在 postbuild 上。发现问题就让构建失败，别让它再溜进安装包。
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_CHUNK_DIR = path.join(ROOT, '.next', 'static', 'chunks');
+
+/** 每条规则：在产物里出现就是 bug */
+const FORBIDDEN = [
+  {
+    pattern: /extends\s+null\b/g,
+    what: 'class extends null',
+    why: '压缩器把某个类的基类吃掉了（见 next.config.js 里 xterm 那段注释）。'
+      + '`new` 这个类会抛 "Super constructor null ... is not a constructor"。',
+  },
+];
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return entry.name.endsWith('.js') ? [full] : [];
+  });
+}
+
+/**
+ * 扫一个目录，返回发现的问题。
+ *
+ * 单独抽出来是为了能被测试直接调 —— 一道永远返回「没问题」的闸门
+ * 比没有闸门更糟，所以它自己也要被测。
+ */
+function inspect(chunkDir) {
+  const files = walk(chunkDir);
+  const problems = [];
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    for (const rule of FORBIDDEN) {
+      rule.pattern.lastIndex = 0;
+      const hits = source.match(rule.pattern);
+      if (hits) problems.push({ file: path.relative(ROOT, file), rule, count: hits.length });
+    }
+  }
+  return { files, problems };
+}
+
+module.exports = { inspect, FORBIDDEN };
+
+// 直接跑才检查产物；被 require 时只导出函数
+if (require.main === module) {
+  const chunkDir = process.argv[2] ? path.resolve(process.argv[2]) : DEFAULT_CHUNK_DIR;
+  const { files, problems } = inspect(chunkDir);
+
+  if (files.length === 0) {
+    console.error(`check-bundle: ${chunkDir} 下没有产物，先跑 next build`);
+    process.exit(1);
+  }
+
+  if (problems.length > 0) {
+    console.error('\ncheck-bundle: 产物里发现了不该有的东西\n');
+    for (const problem of problems) {
+      console.error(`  ${problem.file}`);
+      console.error(`    ${problem.count} 处 ${problem.rule.what}`);
+      console.error(`    ${problem.rule.why}\n`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`check-bundle: ${files.length} 个 chunk，没发现已知的产物级故障`);
+}

--- a/src/components/opslab/OpsTerminal.tsx
+++ b/src/components/opslab/OpsTerminal.tsx
@@ -78,16 +78,57 @@ export default function OpsTerminal({ prompt, onCommand, banner, registerInsert 
       term.loadAddon(fit);
       term.open(hostRef.current);
       termRef.current = term;
-      fit.fit();
 
-      resizeObserver = new ResizeObserver(() => {
-        // 容器还没完成布局时 fit 会抛，忽略即可
-        try { fit.fit(); } catch { /* noop */ }
-      });
+      /**
+       * 有尺寸了再 fit。
+       *
+       * 容器宽度为 0 的时候（首帧还没布局完、或者它待在一个隐藏的 tab 里）
+       * fit 会算出一两列，于是提示符被压成每行两个字符 —— v0.16.0 里就是这个样子。
+       * 这两种情况都会在拿到尺寸后触发 ResizeObserver，等那一下就行。
+       */
+      const fitIfSized = () => {
+        const host = hostRef.current;
+        const active = termRef.current;
+        if (!host || !active) return false;
+        const { width, height } = host.getBoundingClientRect();
+        if (width < 80 || height < 40) return false;
+        try {
+          // 算出来跟现在一样就别 resize：fit 会改元素尺寸，而这个函数正是
+          // ResizeObserver 调的 —— 白 resize 一次就多绕一圈，浏览器会刷
+          // 「ResizeObserver loop completed with undelivered notifications」
+          const proposed = fit.proposeDimensions();
+          if (!proposed?.cols || !proposed?.rows) return false;
+          if (proposed.cols === active.cols && proposed.rows === active.rows) return true;
+          fit.fit();
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      resizeObserver = new ResizeObserver(() => { fitIfSized(); });
       resizeObserver.observe(hostRef.current);
 
-      if (banner) term.write(banner);
-      writePrompt(term);
+      // 开场白也要等宽度定下来再写，否则它按错误的列宽折行，之后再 fit 也回不去
+      const openingScreen = () => {
+        if (banner) term!.write(banner);
+        writePrompt(term!);
+      };
+      if (fitIfSized()) {
+        openingScreen();
+      } else {
+        let frames = 0;
+        const wait = () => {
+          if (disposed || !termRef.current) return;
+          if (fitIfSized() || frames > 120) {
+            openingScreen();
+            return;
+          }
+          frames += 1;
+          requestAnimationFrame(wait);
+        };
+        requestAnimationFrame(wait);
+      }
 
       term.onData(async (data) => {
         const active = term;

--- a/src/components/opslab/OpsTerminal.tsx
+++ b/src/components/opslab/OpsTerminal.tsx
@@ -98,7 +98,13 @@ export default function OpsTerminal({ prompt, onCommand, banner, registerInsert 
           // 「ResizeObserver loop completed with undelivered notifications」
           const proposed = fit.proposeDimensions();
           if (!proposed?.cols || !proposed?.rows) return false;
-          if (proposed.cols === active.cols && proposed.rows === active.rows) return true;
+          if (proposed.cols === active.cols && proposed.rows === active.rows) {
+            // 行列数没变，但走到这儿说明元素尺寸变了 —— 多半是从隐藏的 tab 里
+            // 切回来。fit 会顺带触发重绘，跳过它就得自己补一次，
+            // 否则 DOM 渲染器留着一屏空行。
+            active.refresh(0, active.rows - 1);
+            return true;
+          }
           fit.fit();
           return true;
         } catch {

--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -156,9 +156,17 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
     insertRef.current = insert;
   }, []);
 
+  /**
+   * 在拓扑图上点一个节点，把对应的只读命令填进终端。
+   *
+   * 终端和拓扑现在是同一组 tab 里的两页，所以填完得把 tab 切过去 ——
+   * 不然命令进了一个看不见的终端，学员只会觉得点了没反应。
+   * 仍然只是**填进去**，不替他回车。
+   */
   const handleInspect = useCallback((command: string) => {
+    selectRightTab('terminal');
     insertRef.current?.(command);
-  }, []);
+  }, [selectRightTab]);
 
   const handleVerify = useCallback(async () => {
     if (!ops.world) return;
@@ -434,7 +442,12 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
 
               <Tabs.Panel value="topology" style={{ flex: 1, minHeight: 0 }}>
                 <ErrorBoundary fallback={renderPanelError}>
-                  <TopologyView graph={ops.topology} onInspect={handleInspect} highlight={highlight} />
+                  <TopologyView
+                    graph={ops.topology}
+                    onInspect={handleInspect}
+                    highlight={highlight}
+                    active={rightTab === 'topology'}
+                  />
                 </ErrorBoundary>
               </Tabs.Panel>
 

--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import {
   ActionIcon, Alert, AppShell, Badge, Button, Code, Group, Loader,
-  Paper, ScrollArea, SegmentedControl, Select, Stack, Switch, Tabs, Text, Tooltip,
+  ScrollArea, Select, Stack, Switch, Tabs, Text, Tooltip,
 } from '@mantine/core';
 import {
   IconAlertTriangle, IconDeviceDesktop, IconFileCode, IconPlayerPlay,
@@ -24,6 +24,7 @@ import MarkdownRenderer from '../MarkdownRenderer';
 import ErrorBoundary from '../ErrorBoundary';
 import { RunReportPanel } from '../engineering/ResultPanels';
 import ChangeStream from './ChangeStream';
+import WorkbenchSplit from './WorkbenchSplit';
 import MachineFiles from './MachineFiles';
 import { useOpsWorkspace } from '../../hooks/useOpsWorkspace';
 import { emptyMetrics, runOpsStage } from '../../lib/opslab/lab';
@@ -47,6 +48,11 @@ const BANNER = [
   '  `kubectl get nodes` 起步；拓扑图上点一下会把只读命令插进来。',
   '',
 ].join('\r\n');
+
+/** 右侧那一组 tab，以及记住选择用的键 */
+const RIGHT_TABS = ['terminal', 'ide', 'topology', 'changes', 'packets'];
+const RIGHT_TAB_KEY = 'opslab.rightTab.v1';
+const SPLIT_KEY = 'opslab.split.v1';
 
 export default function OpsWorkspace({ session, registerClearResults }: OpsWorkspaceProps) {
   const { t } = useTranslation();
@@ -79,7 +85,24 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
   const [activePath, setActivePath] = useState('');
   const [report, setReport] = useState<StageRunReport | null>(null);
   const [running, setRunning] = useState(false);
-  const [rightTab, setRightTab] = useState<string>('topology');
+  /**
+   * 右侧那一组 tab 选在哪儿。
+   *
+   * 记住它，是因为学员在一关里来回切「敲命令 → 看拓扑 → 改 YAML」，
+   * 每次进新一关都被扔回默认页很烦。挂载后再读，避免 hydration 不一致。
+   */
+  const [rightTab, setRightTab] = useState<string>('terminal');
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(RIGHT_TAB_KEY);
+      if (saved && RIGHT_TABS.includes(saved)) setRightTab(saved);
+    } catch { /* 隐私模式下读不到，用默认值 */ }
+  }, []);
+  const selectRightTab = useCallback((value: string | null) => {
+    if (!value) return;
+    setRightTab(value);
+    try { window.localStorage.setItem(RIGHT_TAB_KEY, value); } catch { /* noop */ }
+  }, []);
   /**
    * 包路径选中的那一跳对应的拓扑节点。
    *
@@ -250,12 +273,18 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
             })}
           </Group>
 
-        <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
-          {/* 任务 */}
-          <Paper
-            withBorder={false}
-            style={{ width: 340, flexShrink: 0, borderRight: '1px solid var(--app-border)', display: 'flex', flexDirection: 'column' }}
-          >
+        {/**
+          * 左边任务、右边一组 tab。
+          *
+          * 之前是「左任务 + 右上 IDE + 右上拓扑 + 右下终端」四块写死的格子：
+          * 终端只有 38% 高，拓扑固定 42% 宽，谁都拖不动、也收不起来。
+          * 现在终端、IDE、拓扑并列成 tab —— 同一时刻只看一样东西，
+          * 每样都占满整个右栏，而不是四块互相挤。
+          */}
+        <WorkbenchSplit
+          storageKey={SPLIT_KEY}
+          collapseLabel="展开任务栏"
+          left={(
             <Tabs defaultValue="goal" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
               <Tabs.List>
                 <Tabs.Tab value="goal" fz="xs">任务</Tabs.Tab>
@@ -290,59 +319,32 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 </ScrollArea>
               </Tabs.Panel>
             </Tabs>
-          </Paper>
+          )}
+          right={(
+            <Tabs
+              value={rightTab}
+              onChange={selectRightTab}
+              style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+            >
+              <Group
+                gap="xs"
+                justify="space-between"
+                wrap="nowrap"
+                style={{ borderBottom: '1px solid var(--app-border)', flexShrink: 0 }}
+              >
+                <Tabs.List style={{ border: 'none', flexWrap: 'nowrap' }}>
+                  <Tabs.Tab value="terminal" fz="xs" leftSection={<IconDeviceDesktop size={13} />}>
+                    终端{ops.history.length > 0 ? ` · ${ops.history.length}` : ''}
+                  </Tabs.Tab>
+                  <Tabs.Tab value="ide" fz="xs" leftSection={<IconFileCode size={13} />}>IDE</Tabs.Tab>
+                  <Tabs.Tab value="topology" fz="xs" leftSection={<IconSitemap size={13} />}>拓扑</Tabs.Tab>
+                  <Tabs.Tab value="changes" fz="xs" leftSection={<IconTimeline size={13} />}>事件与变更</Tabs.Tab>
+                  <Tabs.Tab value="packets" fz="xs" leftSection={<IconRoute size={13} />}>包路径</Tabs.Tab>
+                </Tabs.List>
 
-          {/* 右侧：上面是 IDE 与拓扑，下面是终端 */}
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-            <div style={{ flex: 1, display: 'flex', minHeight: 0, borderBottom: '1px solid var(--app-border)' }}>
-              {/* IDE */}
-              <div style={{ flex: 1, display: 'flex', minWidth: 0, borderRight: '1px solid var(--app-border)' }}>
-                <div style={{ width: 180, flexShrink: 0, borderRight: '1px solid var(--app-border)', display: 'flex', flexDirection: 'column' }}>
-                  <Group gap={6} px="sm" py={6} style={{ borderBottom: '1px solid var(--app-border)' }}>
-                    <IconFileCode size={13} />
-                    <Text size="xs" fw={600}>机器磁盘</Text>
-                  </Group>
-                  <MachineFiles files={machineFiles} activePath={activePath} onSelect={setActivePath} />
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  {activePath ? (
-                    <Editor
-                      height="100%"
-                      path={activePath}
-                      language={languageOf(activePath)}
-                      value={machineFiles[activePath] ?? ''}
-                      theme={colorScheme === 'dark' ? 'vs-dark' : 'light'}
-                      onChange={handleEditorChange}
-                      options={{
-                        minimap: { enabled: false },
-                        fontSize: 13,
-                        tabSize: 2,
-                        scrollBeyondLastLine: false,
-                        automaticLayout: true,
-                      }}
-                    />
-                  ) : (
-                    <Stack align="center" justify="center" h="100%">
-                      <Text size="xs" c="dimmed">左边选一个文件</Text>
-                    </Stack>
-                  )}
-                </div>
-              </div>
-
-              {/* 拓扑 / 变更流 */}
-              <div style={{ width: '42%', minWidth: 320, display: 'flex', flexDirection: 'column' }}>
-                <Group gap="xs" px="sm" py={4} justify="space-between" style={{ borderBottom: '1px solid var(--app-border)' }}>
-                  <SegmentedControl
-                    size="xs"
-                    value={rightTab}
-                    onChange={setRightTab}
-                    data={[
-                      { value: 'topology', label: <Group gap={4} wrap="nowrap"><IconSitemap size={12} />拓扑</Group> },
-                      { value: 'changes', label: <Group gap={4} wrap="nowrap"><IconTimeline size={12} />事件与变更</Group> },
-                      { value: 'packets', label: <Group gap={4} wrap="nowrap"><IconRoute size={12} />包路径</Group> },
-                    ]}
-                  />
-                  <Group gap="xs">
+                {/* 只跟集群视图有关的控件。切到终端或者 IDE 的时候它们没有意义，就别占地方。 */}
+                {(rightTab === 'topology' || rightTab === 'changes' || rightTab === 'packets') && (
+                  <Group gap="xs" wrap="nowrap" pr="sm">
                     {rightTab === 'topology' && (
                       <Switch
                         size="xs"
@@ -360,31 +362,14 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                       comboboxProps={{ withinPortal: true }}
                     />
                   </Group>
-                </Group>
-                <div style={{ flex: 1, minHeight: 0 }}>
-                  <ErrorBoundary fallback={renderPanelError}>
-                    {rightTab === 'topology' && (
-                      <TopologyView graph={ops.topology} onInspect={handleInspect} highlight={highlight} />
-                    )}
-                    {rightTab === 'changes' && (
-                      <ChangeStream changes={ops.changes} events={ops.events} />
-                    )}
-                    {rightTab === 'packets' && (
-                      <PacketPathPanel paths={ops.packetPaths} onHighlight={setHighlight} />
-                    )}
-                  </ErrorBoundary>
-                </div>
-              </div>
-            </div>
-
-            {/* 终端 */}
-            <div style={{ height: '38%', minHeight: 180, display: 'flex', flexDirection: 'column' }}>
-              <Group gap={6} px="sm" py={4} style={{ borderBottom: '1px solid var(--app-border)' }}>
-                <IconDeviceDesktop size={13} />
-                <Text size="xs" fw={600}>终端</Text>
-                <Text size="xs" c="dimmed">{ops.history.length} 条命令</Text>
+                )}
               </Group>
-              <div style={{ flex: 1, minHeight: 0 }}>
+
+              {/**
+                * 面板全部保持挂载（Mantine 默认如此），只是切走的时候 display:none。
+                * 终端的 scrollback 和 Monaco 的编辑状态都不能因为切个 tab 就没了。
+                */}
+              <Tabs.Panel value="terminal" style={{ flex: 1, minHeight: 0 }}>
                 {ops.status === 'booting' && (
                   <Stack align="center" justify="center" h="100%" gap="xs">
                     <Loader size="sm" />
@@ -410,10 +395,63 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                     registerInsert={registerInsert}
                   />
                 )}
-              </div>
-            </div>
-          </div>
-        </div>
+              </Tabs.Panel>
+
+              <Tabs.Panel value="ide" style={{ flex: 1, minHeight: 0 }}>
+                <div style={{ display: 'flex', height: '100%', minWidth: 0 }}>
+                  <div style={{ width: 180, flexShrink: 0, borderRight: '1px solid var(--app-border)', display: 'flex', flexDirection: 'column' }}>
+                    <Group gap={6} px="sm" py={6} style={{ borderBottom: '1px solid var(--app-border)' }}>
+                      <IconFileCode size={13} />
+                      <Text size="xs" fw={600}>机器磁盘</Text>
+                    </Group>
+                    <MachineFiles files={machineFiles} activePath={activePath} onSelect={setActivePath} />
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    {activePath ? (
+                      <Editor
+                        height="100%"
+                        path={activePath}
+                        language={languageOf(activePath)}
+                        value={machineFiles[activePath] ?? ''}
+                        theme={colorScheme === 'dark' ? 'vs-dark' : 'light'}
+                        onChange={handleEditorChange}
+                        options={{
+                          minimap: { enabled: false },
+                          fontSize: 13,
+                          tabSize: 2,
+                          scrollBeyondLastLine: false,
+                          automaticLayout: true,
+                        }}
+                      />
+                    ) : (
+                      <Stack align="center" justify="center" h="100%">
+                        <Text size="xs" c="dimmed">左边选一个文件</Text>
+                      </Stack>
+                    )}
+                  </div>
+                </div>
+              </Tabs.Panel>
+
+              <Tabs.Panel value="topology" style={{ flex: 1, minHeight: 0 }}>
+                <ErrorBoundary fallback={renderPanelError}>
+                  <TopologyView graph={ops.topology} onInspect={handleInspect} highlight={highlight} />
+                </ErrorBoundary>
+              </Tabs.Panel>
+
+              <Tabs.Panel value="changes" style={{ flex: 1, minHeight: 0 }}>
+                <ErrorBoundary fallback={renderPanelError}>
+                  <ChangeStream changes={ops.changes} events={ops.events} />
+                </ErrorBoundary>
+              </Tabs.Panel>
+
+              <Tabs.Panel value="packets" style={{ flex: 1, minHeight: 0 }}>
+                <ErrorBoundary fallback={renderPanelError}>
+                  <PacketPathPanel paths={ops.packetPaths} onHighlight={setHighlight} />
+                </ErrorBoundary>
+              </Tabs.Panel>
+            </Tabs>
+          )}
+        />
         </div>
       </AppShell.Main>
     </AppShell>

--- a/src/components/opslab/TopologyView.tsx
+++ b/src/components/opslab/TopologyView.tsx
@@ -7,10 +7,10 @@
  * 交互只有两种：看，和点一下把对应的只读命令插进终端。拖拽改状态是不做的 ——
  * 真集群里没有「把 Pod 拖到另一台机器上」这个动作，做了就是在教错的东西。
  */
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Background, Controls, Handle, MiniMap, Position, ReactFlow, useEdgesState, useNodesState,
-  type Edge, type Node, type NodeProps,
+  type Edge, type Node, type NodeProps, type ReactFlowInstance,
 } from '@xyflow/react';
 import { Group, Stack, Text } from '@mantine/core';
 import type { TopologyGraph, TopologyStatus } from '../../lib/opslab/lab';
@@ -123,6 +123,32 @@ export default function TopologyView({ graph, onInspect, highlight }: TopologyVi
   useEffect(() => { setNodes(initialNodes); }, [initialNodes, setNodes]);
   useEffect(() => { setEdges(initialEdges); }, [initialEdges, setEdges]);
 
+  /**
+   * 从隐藏的 tab 里露出来之后要重新 fitView。
+   *
+   * 这张图和终端、IDE 是同一组 tab，切走的时候整块是 display:none。
+   * ReactFlow 的 `fitView` 只在初始化时算一次，而它初始化的那一刻容器是 0×0 ——
+   * 于是切回来看到的是一张几乎空白的画布，只有左上角露出半个节点。
+   * 尺寸从 0 变成正常值会触发 ResizeObserver，在那一下补一次 fitView。
+   */
+  const containerRef = useRef<HTMLDivElement>(null);
+  const flowRef = useRef<ReactFlowInstance | null>(null);
+  const onInit = useCallback((instance: ReactFlowInstance) => { flowRef.current = instance; }, []);
+
+  useEffect(() => {
+    const host = containerRef.current;
+    if (!host) return undefined;
+    let wasVisible = host.getBoundingClientRect().width > 0;
+    const observer = new ResizeObserver(() => {
+      const visible = host.getBoundingClientRect().width > 0;
+      // 只在「从看不见到看得见」这一下补，不然每次拖分隔条都会把用户的平移缩放重置掉
+      if (visible && !wasVisible) flowRef.current?.fitView();
+      wasVisible = visible;
+    });
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, []);
+
   if (graph.nodes.length === 0) {
     return (
       <Stack align="center" justify="center" h="100%" gap={4}>
@@ -133,12 +159,13 @@ export default function TopologyView({ graph, onInspect, highlight }: TopologyVi
   }
 
   return (
-    <div style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column' }}>
+    <div ref={containerRef} style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column' }}>
       <div style={{ flex: 1, minHeight: 0 }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={NODE_TYPES}
+        onInit={onInit}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onNodeClick={(_, node) => {

--- a/src/components/opslab/TopologyView.tsx
+++ b/src/components/opslab/TopologyView.tsx
@@ -86,9 +86,17 @@ export interface TopologyViewProps {
   onInspect?: (command: string) => void;
   /** 包路径停在哪个节点上，圈出来 */
   highlight?: string;
+  /**
+   * 这块面板现在是不是被选中的那一页。
+   *
+   * 它和终端、IDE 同属一组 tab，切走时整块是 display:none。ReactFlow 只在
+   * 初始化时 fitView 一次，而它初始化的那一刻容器是 0×0 —— 不管的话切回来
+   * 是一张几乎空白的画布，只有角落里露出半个节点。
+   */
+  active?: boolean;
 }
 
-export default function TopologyView({ graph, onInspect, highlight }: TopologyViewProps) {
+export default function TopologyView({ graph, onInspect, highlight, active = true }: TopologyViewProps) {
   const initialNodes = useMemo<Node[]>(
     () => graph.nodes.map((node) => ({
       id: node.id,
@@ -124,30 +132,25 @@ export default function TopologyView({ graph, onInspect, highlight }: TopologyVi
   useEffect(() => { setEdges(initialEdges); }, [initialEdges, setEdges]);
 
   /**
-   * 从隐藏的 tab 里露出来之后要重新 fitView。
+   * 被选中的时候补一次 fitView。
    *
-   * 这张图和终端、IDE 是同一组 tab，切走的时候整块是 display:none。
-   * ReactFlow 的 `fitView` 只在初始化时算一次，而它初始化的那一刻容器是 0×0 ——
-   * 于是切回来看到的是一张几乎空白的画布，只有左上角露出半个节点。
-   * 尺寸从 0 变成正常值会触发 ResizeObserver，在那一下补一次 fitView。
+   * 早先这里挂的是 ResizeObserver，靠「宽度从 0 变正」判断自己露出来了。
+   * 不可靠：ReactFlow 内部也在用 ResizeObserver 量尺寸，两个观察者的回调
+   * 顺序不保证，先跑我们这个的话它内部还是 0×0，fitView 算出来没有意义。
+   * 由 tab 状态驱动就确定多了 —— effect 跑在提交之后，那时布局已经定了；
+   * 再推一帧，等 ReactFlow 也量完。
    */
   const containerRef = useRef<HTMLDivElement>(null);
   const flowRef = useRef<ReactFlowInstance | null>(null);
   const onInit = useCallback((instance: ReactFlowInstance) => { flowRef.current = instance; }, []);
 
   useEffect(() => {
-    const host = containerRef.current;
-    if (!host) return undefined;
-    let wasVisible = host.getBoundingClientRect().width > 0;
-    const observer = new ResizeObserver(() => {
-      const visible = host.getBoundingClientRect().width > 0;
-      // 只在「从看不见到看得见」这一下补，不然每次拖分隔条都会把用户的平移缩放重置掉
-      if (visible && !wasVisible) flowRef.current?.fitView();
-      wasVisible = visible;
+    if (!active) return undefined;
+    const frame = requestAnimationFrame(() => {
+      try { flowRef.current?.fitView(); } catch { /* 实例还没好，下次选中还会再来 */ }
     });
-    observer.observe(host);
-    return () => observer.disconnect();
-  }, []);
+    return () => cancelAnimationFrame(frame);
+  }, [active]);
 
   if (graph.nodes.length === 0) {
     return (

--- a/src/components/opslab/WorkbenchSplit.tsx
+++ b/src/components/opslab/WorkbenchSplit.tsx
@@ -1,0 +1,192 @@
+/**
+ * 左右两栏，中间一根能拖的分隔条
+ *
+ * 之前这块布局是写死的（左边 340px、右边按百分比分），学员想把任务描述收起来
+ * 多看两眼终端都做不到。这里补上三件事：拖动改宽度、一键收起左栏、
+ * 以及把这两样记在 localStorage 里 —— 换一关、重开应用都还在。
+ *
+ * 没有引第三方的分栏库：需要的行为就这么点，而多一个依赖就多一份要跟着
+ * React / Mantine 版本走的东西。
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ActionIcon, Tooltip } from '@mantine/core';
+import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
+
+export interface WorkbenchSplitProps {
+  /** localStorage 的键。不同工作台各记各的。 */
+  storageKey: string;
+  left: React.ReactNode;
+  right: React.ReactNode;
+  defaultLeftWidth?: number;
+  minLeftWidth?: number;
+  /** 右栏至少留这么宽，拖到头就不让再拖了 */
+  minRightWidth?: number;
+  /** 收起时鼠标悬停在展开按钮上的提示 */
+  collapseLabel?: string;
+}
+
+interface Persisted {
+  width: number;
+  collapsed: boolean;
+}
+
+function read(storageKey: string): Persisted | null {
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Persisted>;
+    if (typeof parsed.width !== 'number' || !Number.isFinite(parsed.width)) return null;
+    return { width: parsed.width, collapsed: Boolean(parsed.collapsed) };
+  } catch {
+    // 隐私模式下 localStorage 会抛。读不到就用默认布局，不该因此白屏。
+    return null;
+  }
+}
+
+function write(storageKey: string, value: Persisted): void {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(value));
+  } catch {
+    /* noop */
+  }
+}
+
+export default function WorkbenchSplit({
+  storageKey,
+  left,
+  right,
+  defaultLeftWidth = 340,
+  minLeftWidth = 240,
+  minRightWidth = 480,
+  collapseLabel = '展开左栏',
+}: WorkbenchSplitProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(defaultLeftWidth);
+  const [collapsed, setCollapsed] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  /**
+   * 存的值只能在挂载之后读。
+   *
+   * 服务端没有 localStorage，直接在 useState 的初值里读会让首屏 HTML 和
+   * 客户端第一次渲染对不上，React 会整棵子树重画（hydration mismatch）。
+   */
+  useEffect(() => {
+    const saved = read(storageKey);
+    if (!saved) return;
+    setWidth(saved.width);
+    setCollapsed(saved.collapsed);
+  }, [storageKey]);
+
+  // 落盘要读「此刻」的值，但不该因此把 persist 变成每次渲染都新建的函数
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  const collapsedRef = useRef(collapsed);
+  collapsedRef.current = collapsed;
+
+  const persist = useCallback((next: Partial<Persisted>) => {
+    write(storageKey, {
+      width: next.width ?? widthRef.current,
+      collapsed: next.collapsed ?? collapsedRef.current,
+    });
+  }, [storageKey]);
+
+  const clamp = useCallback((value: number) => {
+    const total = containerRef.current?.getBoundingClientRect().width ?? 0;
+    const max = Math.max(minLeftWidth, total - minRightWidth);
+    return Math.min(Math.max(value, minLeftWidth), max);
+  }, [minLeftWidth, minRightWidth]);
+
+  const onPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (collapsed) return;
+    event.preventDefault();
+    const handle = event.currentTarget;
+    handle.setPointerCapture(event.pointerId);
+    setDragging(true);
+
+    const startX = event.clientX;
+    const startWidth = width;
+
+    const onMove = (move: PointerEvent) => {
+      setWidth(clamp(startWidth + (move.clientX - startX)));
+    };
+    const onUp = () => {
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', onUp);
+      handle.removeEventListener('pointercancel', onUp);
+      setDragging(false);
+      // 拖完才落盘：拖动过程中每帧写一次 localStorage 是纯浪费
+      persist({ width: widthRef.current });
+    };
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onUp);
+  }, [clamp, collapsed, persist, width]);
+
+  const toggle = useCallback(() => {
+    const next = !collapsedRef.current;
+    setCollapsed(next);
+    persist({ collapsed: next });
+  }, [persist]);
+
+  return (
+    <div ref={containerRef} style={{ flex: 1, display: 'flex', minHeight: 0, minWidth: 0 }}>
+      {!collapsed && (
+        <div
+          style={{
+            width,
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: 0,
+            overflow: 'hidden',
+          }}
+        >
+          {left}
+        </div>
+      )}
+
+      {/**
+       * 分隔条兼作收起按钮的锚点。
+       *
+       * 命中区域比看到的那条线宽（6px），不然要精确对准 1px 才拖得动。
+       */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        onPointerDown={onPointerDown}
+        onDoubleClick={toggle}
+        style={{
+          width: 6,
+          flexShrink: 0,
+          cursor: collapsed ? 'default' : 'col-resize',
+          background: dragging ? 'var(--mantine-color-blue-5)' : 'var(--app-border)',
+          position: 'relative',
+          transition: dragging ? undefined : 'background 120ms',
+        }}
+      >
+        <Tooltip label={collapsed ? collapseLabel : '收起左栏（也可以双击分隔条）'} position="right">
+          <ActionIcon
+            size="xs"
+            variant="default"
+            onClick={toggle}
+            onPointerDown={(event) => event.stopPropagation()}
+            /**
+             * 收起之后分隔条贴在窗口最左边，按钮再往左偏 9px 就跑到屏幕外面去了 ——
+             * 那样这一栏就再也展不开（只剩双击那 6px 一条缝）。收起时把它挪到右边。
+             */
+            style={{ position: 'absolute', top: 8, left: collapsed ? 4 : -9, zIndex: 2 }}
+          >
+            {collapsed
+              ? <IconLayoutSidebarLeftExpand size={12} />
+              : <IconLayoutSidebarLeftCollapse size={12} />}
+          </ActionIcon>
+        </Tooltip>
+      </div>
+
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        {right}
+      </div>
+    </div>
+  );
+}

--- a/tests/build/check-bundle.test.js
+++ b/tests/build/check-bundle.test.js
@@ -1,0 +1,71 @@
+/**
+ * 产物体检那道闸门自己也要被测
+ *
+ * v0.16.0 发出去的包里，`new Terminal()` 一构造就抛
+ * `Super constructor null of anonymous class is not a constructor` ——
+ * SWC 压缩器把 xterm 里某个类的基类换成了 `null`，整个 ops 工作台的终端起不来。
+ *
+ * dev 不压缩，所以这类故障**只在正式构建里出现**，任何单元测试都照不到它。
+ * 唯一的防线就是构建之后扫产物。而一道永远返回「没问题」的闸门比没有闸门更糟，
+ * 所以这里拿真假两种产物各喂它一次。
+ */
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { inspect } = require('../../scripts/check-bundle');
+
+function fixture(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-bundle-'));
+  for (const [name, content] of Object.entries(files)) {
+    const full = path.join(dir, name);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe('产物体检', () => {
+  it('干净的产物：没有问题', () => {
+    const dir = fixture({
+      'a.js': 'var x=class s extends Error{constructor(n){super(n)}};',
+      'nested/b.js': 'class Foo extends Bar {}',
+    });
+    const { files, problems } = inspect(dir);
+    expect(files).toHaveLength(2);
+    expect(problems).toEqual([]);
+  });
+
+  /** 这一条就是 v0.16.0 那个故障的形状 */
+  it('基类被压缩器吃掉的产物：抓得出来', () => {
+    const dir = fixture({
+      'bad.js': 'var ev=class s extends null{constructor(n){super(n),this.name="X"}};',
+    });
+    const { problems } = inspect(dir);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].count).toBe(1);
+    expect(problems[0].rule.what).toBe('class extends null');
+  });
+
+  it('同一个文件里多处也数得对', () => {
+    const dir = fixture({
+      'bad.js': 'a=class extends null{};b=class extends null{};c=class extends Error{};',
+    });
+    expect(inspect(dir).problems[0].count).toBe(2);
+  });
+
+  it('只看 .js，不管别的', () => {
+    const dir = fixture({
+      'x.js.map': '"extends null"',
+      'y.css': 'extends null',
+    });
+    const { files, problems } = inspect(dir);
+    expect(files).toEqual([]);
+    expect(problems).toEqual([]);
+  });
+
+  it('目录不存在时不抛，交给调用方处理', () => {
+    const { files, problems } = inspect(path.join(os.tmpdir(), 'check-bundle-does-not-exist'));
+    expect(files).toEqual([]);
+    expect(problems).toEqual([]);
+  });
+});


### PR DESCRIPTION
用户在 **v0.16.0 正式安装包**里报的两个问题。第一个是阻断性的。

## 一、终端起不来

正式包里点开 K8s 工程题，终端一片黑。**不是 WASM 的问题，是 JS 的。**

`@xterm/xterm` 的 ESM 产物（`lib/xterm.mjs`，esbuild 出的）里有
`var X = class Name extends Error {...}` 这种带名字的类表达式。Next 13.5 的
SWC 压缩器处理这个形状时会把 extends 的基类**换成 `null`**：

```js
// 上游 lib/xterm.mjs
var ar = class s extends Error { constructor(t){ super(t), this.name="CodeExpectedError" } ... }
// 我们构建出来
var ev = class s extends null  { constructor(n){ super(n), this.name="CodeExpectedError" } ... }
```

于是 `new Terminal()` 抛 `Super constructor null of anonymous class is not a
constructor`，组件挂载时就崩了。dev 不压缩，所以**只有正式构建会炸** ——
一条单元测试都照不到，v0.16.0 就是这么发出去的。

改用 xterm 的 UMD 产物（`lib/xterm.js`，webpack 打的，代码形状不同）就没有。
排查过程中也验过 `swcMinify: false`（Terser 解析不了 Monaco 的新语法，构建直接失败）
和 `transpilePackages`（无效）。

**光改一行 alias 不够。** 加了 `scripts/check-bundle.js` 挂在 postbuild 上：
构建完扫一遍 chunk，发现 `extends null` 直接让构建失败。这道闸门自己也有测试 ——
一道永远返回「没问题」的闸门比没有闸门更糟。

顺带修了终端的两个尺寸问题：

- 容器还没宽度就 fit，提示符被压成每行两个字符（v0.16.0 里肉眼可见）
- fit 在 ResizeObserver 里无条件调用，自己触发自己绕圈：
  `ResizeObserver loop completed with undelivered notifications` **39 条 → 0 条**

## 二、布局重构

原来是四块写死的格子（左任务 340px、右上 IDE、右上拓扑 42%、右下终端 38%），
谁都拖不动也收不起来。现在按用户要求改成：

- **终端 / IDE / 拓扑**（外加事件与变更、包路径）并列成右侧一组 tab，
  每样都占满整个右栏，而不是四块互相挤
- 左右之间一根能拖的分隔条，左栏可一键收起（也可双击分隔条）
- 宽度、收起状态、选中的 tab 都记在 localStorage，换关、重开应用都还在

几个实现上的注意点：

- 面板保持挂载（只是 `display:none`），切 tab 不丢终端 scrollback 和 Monaco 编辑状态
- 拓扑图补了「从隐藏变可见时重新 fitView」—— 它初始化那一刻容器是 0×0，
  不补的话切回来是一张几乎空白的画布
- 收起后分隔条贴在窗口最左边，展开按钮得挪进来，否则会跑到屏幕外面、再也展不开
  （这个是自测时发现的）
- 没引第三方分栏库：需要的行为就这么点，多一个依赖就多一份要跟着 React/Mantine 走的东西

## 验证

**在真实打包产物里跑的，不是 dev**：`electron-builder` 打出 .app，启动、
打开 intranet-k8s、终端正常渲染、敲

```
kubectl config use-context prod && kubectl get nodes
```

打出三个 Ready 节点（真 kubectl，v1.36.0，32d）。Electron 渲染进程日志零报错。

- 全套 55 suites / 1672 条通过；`tsc --noEmit` 干净
- 代码类项目布局**一行没动**，database-engine 打开正常（零回归）

🤖 Generated with [Claude Code](https://claude.com/claude-code)