### PR TITLE
fix(opslab): 拓扑页切走时卸载，修掉切回来一片空白

### DIFF
--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -440,15 +440,21 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 </div>
               </Tabs.Panel>
 
+              {/**
+                * 拓扑这一页切走就卸载，和别的页不一样。
+                *
+                * 它是世界的纯投影，没有自己的状态，卸载不丢任何东西；而留着的话
+                * 代价很实在：隐藏期间 ReactFlow 把每个节点量成 0×0，切回来时
+                * fitView 按错的包围盒算，缩放停在最小值 0.5，看着就是一张空白画布
+                * （要再切一次才正常）。重新挂载则是它最顺的那条路 —— 容器一开始
+                * 就有尺寸，`fitView` 属性自己就对了。
+                */}
               <Tabs.Panel value="topology" style={{ flex: 1, minHeight: 0 }}>
-                <ErrorBoundary fallback={renderPanelError}>
-                  <TopologyView
-                    graph={ops.topology}
-                    onInspect={handleInspect}
-                    highlight={highlight}
-                    active={rightTab === 'topology'}
-                  />
-                </ErrorBoundary>
+                {rightTab === 'topology' && (
+                  <ErrorBoundary fallback={renderPanelError}>
+                    <TopologyView graph={ops.topology} onInspect={handleInspect} highlight={highlight} />
+                  </ErrorBoundary>
+                )}
               </Tabs.Panel>
 
               <Tabs.Panel value="changes" style={{ flex: 1, minHeight: 0 }}>

--- a/src/components/opslab/TopologyView.tsx
+++ b/src/components/opslab/TopologyView.tsx
@@ -7,10 +7,10 @@
  * 交互只有两种：看，和点一下把对应的只读命令插进终端。拖拽改状态是不做的 ——
  * 真集群里没有「把 Pod 拖到另一台机器上」这个动作，做了就是在教错的东西。
  */
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   Background, Controls, Handle, MiniMap, Position, ReactFlow, useEdgesState, useNodesState,
-  type Edge, type Node, type NodeProps, type ReactFlowInstance,
+  type Edge, type Node, type NodeProps,
 } from '@xyflow/react';
 import { Group, Stack, Text } from '@mantine/core';
 import type { TopologyGraph, TopologyStatus } from '../../lib/opslab/lab';
@@ -86,17 +86,9 @@ export interface TopologyViewProps {
   onInspect?: (command: string) => void;
   /** 包路径停在哪个节点上，圈出来 */
   highlight?: string;
-  /**
-   * 这块面板现在是不是被选中的那一页。
-   *
-   * 它和终端、IDE 同属一组 tab，切走时整块是 display:none。ReactFlow 只在
-   * 初始化时 fitView 一次，而它初始化的那一刻容器是 0×0 —— 不管的话切回来
-   * 是一张几乎空白的画布，只有角落里露出半个节点。
-   */
-  active?: boolean;
 }
 
-export default function TopologyView({ graph, onInspect, highlight, active = true }: TopologyViewProps) {
+export default function TopologyView({ graph, onInspect, highlight }: TopologyViewProps) {
   const initialNodes = useMemo<Node[]>(
     () => graph.nodes.map((node) => ({
       id: node.id,
@@ -131,27 +123,6 @@ export default function TopologyView({ graph, onInspect, highlight, active = tru
   useEffect(() => { setNodes(initialNodes); }, [initialNodes, setNodes]);
   useEffect(() => { setEdges(initialEdges); }, [initialEdges, setEdges]);
 
-  /**
-   * 被选中的时候补一次 fitView。
-   *
-   * 早先这里挂的是 ResizeObserver，靠「宽度从 0 变正」判断自己露出来了。
-   * 不可靠：ReactFlow 内部也在用 ResizeObserver 量尺寸，两个观察者的回调
-   * 顺序不保证，先跑我们这个的话它内部还是 0×0，fitView 算出来没有意义。
-   * 由 tab 状态驱动就确定多了 —— effect 跑在提交之后，那时布局已经定了；
-   * 再推一帧，等 ReactFlow 也量完。
-   */
-  const containerRef = useRef<HTMLDivElement>(null);
-  const flowRef = useRef<ReactFlowInstance | null>(null);
-  const onInit = useCallback((instance: ReactFlowInstance) => { flowRef.current = instance; }, []);
-
-  useEffect(() => {
-    if (!active) return undefined;
-    const frame = requestAnimationFrame(() => {
-      try { flowRef.current?.fitView(); } catch { /* 实例还没好，下次选中还会再来 */ }
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [active]);
-
   if (graph.nodes.length === 0) {
     return (
       <Stack align="center" justify="center" h="100%" gap={4}>
@@ -162,13 +133,12 @@ export default function TopologyView({ graph, onInspect, highlight, active = tru
   }
 
   return (
-    <div ref={containerRef} style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column' }}>
       <div style={{ flex: 1, minHeight: 0 }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={NODE_TYPES}
-        onInit={onInit}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onNodeClick={(_, node) => {


### PR DESCRIPTION
v0.16.1 验收时发现的一个残留问题。不影响终端，属于新布局的小毛病。

## 现象

切走拓扑页，期间集群变了（比如 `kubectl config use-context` 换了命名空间），
再切回来是一张空白画布，只有角落露出半个节点；**再切一次才正常**。

## 原因

不在 fitView 的时机上 —— 推一帧、推两帧都试过，没用。量出来的是：

```
transform: translate(-152px, -196.75px) scale(0.5)     ← 坏的，最小缩放
transform: translate(-1.11594px, -325.933px) scale(1.53986)  ← 好的
```

`fitView` 确实跑了，但按一个巨大的包围盒算 —— 面板隐藏期间 ReactFlow 把每个
节点都量成了 0×0（`display:none` 下 ResizeObserver 报 0），fit 自然算不对。

## 改法

与其跟它的测量时机较劲，让这一页**切走就卸载**：拓扑是世界的纯投影，没有自己的
状态，卸载不丢任何东西；重新挂载反而是它最顺的那条路 —— 容器一开始就有尺寸，
`fitView` 属性自己就对了。

终端和 IDE 仍然保持挂载（scrollback 和编辑状态不能丢）。顺带删掉上一版为此
加的 `active` 属性和那段 ResizeObserver。

## 验证

在打包产物里走了出问题的那条完整路径：拓扑页 → 切到终端 → 敲
`kubectl config use-context staging` → 切回拓扑。**首次切入即正确 fit**
（`scale(1.53986)`，三个节点排布正常）。

全套 1689 条通过；`tsc --noEmit` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)