### PR TITLE
feat(gpulab): warp 原语与原子操作

### DIFF
--- a/src/lib/gpulab/cuda/ast.ts
+++ b/src/lib/gpulab/cuda/ast.ts
@@ -27,6 +27,14 @@ export interface ScalarType {
 export interface PointerType {
   kind: 'pointer';
   to: CudaType;
+  /**
+   * 指向哪个地址空间。
+   *
+   * 不带这一条的话 `float* p = &s[0]`（s 是 __shared__）会悄悄按全局内存
+   * 去读 —— 地址对不上，算出来的东西全是错的，而且不报任何错。
+   * 缺省是 global，只有从 `__shared__` 变量取地址时才是 shared。
+   */
+  space?: 'global' | 'shared';
 }
 
 /** 定长数组。共享内存的 `__shared__ float t[32][33]` 就是它。 */
@@ -114,6 +122,8 @@ export type Expr =
   | { kind: 'ternary'; cond: Expr; then: Expr; otherwise: Expr; span: SourceSpan }
   | { kind: 'subscript'; array: Expr; index: Expr; span: SourceSpan }
   | { kind: 'deref'; pointer: Expr; span: SourceSpan }
+  /** `&lvalue` —— 取地址。`atomicAdd(&hist[i], 1)` 这类写法要用。 */
+  | { kind: 'addressOf'; target: Expr; span: SourceSpan }
   | { kind: 'cast'; to: CudaType; operand: Expr; span: SourceSpan }
   | { kind: 'call'; callee: string; args: Expr[]; span: SourceSpan }
   | { kind: 'assign'; target: Expr; op: BinaryOp | null; value: Expr; span: SourceSpan }

--- a/src/lib/gpulab/cuda/ast.ts
+++ b/src/lib/gpulab/cuda/ast.ts
@@ -83,14 +83,6 @@ export function typeName(type: CudaType): string {
   }
 }
 
-export function sameType(a: CudaType, b: CudaType): boolean {
-  if (a.kind !== b.kind) return false;
-  if (a.kind === 'scalar' && b.kind === 'scalar') return a.scalar === b.scalar;
-  if (a.kind === 'pointer' && b.kind === 'pointer') return sameType(a.to, b.to);
-  if (a.kind === 'array' && b.kind === 'array') return a.length === b.length && sameType(a.of, b.of);
-  return false;
-}
-
 /* ------------------------------------------------------------------ */
 /* 表达式                                                              */
 /* ------------------------------------------------------------------ */

--- a/src/lib/gpulab/cuda/lower.ts
+++ b/src/lib/gpulab/cuda/lower.ts
@@ -330,7 +330,7 @@ function lowerExpr(node: TsNode): Expr {
     case 'pointer_expression': {
       const children = namedChildren(node);
       const op = operatorOf(node);
-      if (op === '&') fail(node, '暂不支持取地址运算符 `&`');
+      if (op === '&') return { kind: 'addressOf', target: lowerExpr(children[0]), span };
       return { kind: 'deref', pointer: lowerExpr(children[0]), span };
     }
 

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -14,7 +14,8 @@ import {
 } from '../cuda/ast';
 import { CudaCompileError } from '../cuda/lower';
 import type {
-  BinKind, BuiltinFn, CompiledKernel, Inst, IrType, KernelParam, SharedVar, Space,
+  AtomKind, BinKind, BuiltinFn, CompiledKernel, Inst, IrType,
+  KernelParam, SharedVar, ShflMode, Space,
 } from './types';
 
 /** 一个值：寄存器编号 + 它的 CUDA 类型 */
@@ -48,6 +49,30 @@ const BUILTIN_FNS: Record<string, { fn: BuiltinFn; arity: number; ty: IrType }> 
   min: { fn: 'min', arity: 2, ty: 'i32' },
   max: { fn: 'max', arity: 2, ty: 'i32' },
   abs: { fn: 'abs', arity: 1, ty: 'i32' },
+  __popc: { fn: '__popc', arity: 1, ty: 'i32' },
+  __clz: { fn: '__clz', arity: 1, ty: 'i32' },
+  __ffs: { fn: '__ffs', arity: 1, ty: 'i32' },
+};
+
+/** `__shfl_*_sync(mask, var, laneArg, width = warpSize)` */
+const SHFL_FNS: Record<string, ShflMode> = {
+  __shfl_sync: 'idx',
+  __shfl_up_sync: 'up',
+  __shfl_down_sync: 'down',
+  __shfl_xor_sync: 'xor',
+};
+
+/** `atomicXxx(addr, value)`；atomicCAS 多一个参数 */
+const ATOMIC_FNS: Record<string, { kind: AtomKind; arity: number }> = {
+  atomicAdd: { kind: 'add', arity: 2 },
+  atomicSub: { kind: 'sub', arity: 2 },
+  atomicExch: { kind: 'exch', arity: 2 },
+  atomicMin: { kind: 'min', arity: 2 },
+  atomicMax: { kind: 'max', arity: 2 },
+  atomicAnd: { kind: 'and', arity: 2 },
+  atomicOr: { kind: 'or', arity: 2 },
+  atomicXor: { kind: 'xor', arity: 2 },
+  atomicCAS: { kind: 'cas', arity: 3 },
 };
 
 const COMPARISONS = new Set<BinaryOp>(['<', '<=', '>', '>=', '==', '!=']);
@@ -235,16 +260,52 @@ class Compiler {
         return pointer.to;
       }
       case 'call': {
+        if (SHFL_FNS[node.callee]) return this.staticTypeOf(node.args[1]);
+        if (ATOMIC_FNS[node.callee]) {
+          const pointer = this.staticTypeOf(node.args[0]);
+          if (!isPointer(pointer)) this.fail(node.span.line, node.span.column, '原子操作的第一个参数得是指针');
+          return pointer.to;
+        }
+        if (node.callee === '__ballot_sync' || node.callee === '__activemask') {
+          return { kind: 'scalar', scalar: 'uint' };
+        }
+        if (node.callee === '__any_sync' || node.callee === '__all_sync' || node.callee === '__syncwarp') {
+          return { kind: 'scalar', scalar: 'int' };
+        }
         const spec = BUILTIN_FNS[node.callee];
         if (!spec) this.fail(node.span.line, node.span.column, `暂不支持函数 \`${node.callee}\``);
         return spec.ty === 'f32'
           ? { kind: 'scalar', scalar: 'float' }
           : { kind: 'scalar', scalar: 'int' };
       }
+      case 'addressOf': {
+        const target = this.staticTypeOf(node.target);
+        return { kind: 'pointer', to: target, space: this.spaceOfLvalue(node.target) };
+      }
       case 'assign':
         return this.staticTypeOf(node.target);
       case 'incdec':
         return this.staticTypeOf(node.target);
+    }
+  }
+
+  /** 一个左值静态上住在哪个地址空间 */
+  private spaceOfLvalue(node: Expr): Space {
+    switch (node.kind) {
+      case 'name': {
+        const binding = this.lookup(node.name);
+        if (binding?.where === 'shared') return 'shared';
+        if (binding && binding.type.kind === 'pointer') return binding.type.space ?? 'global';
+        return 'global';
+      }
+      case 'subscript':
+        return this.spaceOfLvalue(node.array);
+      case 'deref': {
+        const pointer = this.staticTypeOf(node.pointer);
+        return pointer.kind === 'pointer' ? pointer.space ?? 'global' : 'global';
+      }
+      default:
+        return 'global';
     }
   }
 
@@ -281,7 +342,11 @@ class Compiler {
         if (binding.where === 'shared') {
           const dst = this.alloc();
           this.emit({ op: 'sharedbase', dst, offset: binding.offset }, node.span.line);
-          return { reg: dst, type: binding.type };
+          // 数组名衰减成指针时把地址空间带上
+          const decayed: CudaType = binding.type.kind === 'array'
+            ? { kind: 'pointer', to: binding.type.of, space: 'shared' }
+            : binding.type;
+          return { reg: dst, type: decayed };
         }
         return { reg: binding.reg, type: binding.type };
       }
@@ -348,6 +413,11 @@ class Compiler {
       case 'deref': {
         const address = this.addressOf(node);
         return this.loadFrom(address, node.span.line);
+      }
+
+      case 'addressOf': {
+        const address = this.addressOf(node.target);
+        return { reg: address.reg, type: { kind: 'pointer', to: address.type, space: address.space } };
       }
 
       case 'call':
@@ -479,7 +549,133 @@ class Compiler {
     };
   }
 
+  /**
+   * `__shfl_*_sync` —— warp 内直接读别的 lane 的寄存器。
+   *
+   * `width` 必须是编译期常量（真代码里也总是），因为它决定 warp 被切成
+   * 几段，运行时才知道的话每个 lane 的段边界都要现算。
+   */
+  private shuffle(node: Expr & { kind: 'call' }): Value {
+    const mode = SHFL_FNS[node.callee];
+    const { line, column } = node.span;
+    if (node.args.length < 3 || node.args.length > 4) {
+      this.fail(line, column, `${node.callee} 需要 3 或 4 个参数（mask, var, lane[, width]）`);
+    }
+    const mask = this.convert(this.expr(node.args[0]), { kind: 'scalar', scalar: 'uint' }, line);
+    const value = this.expr(node.args[1]);
+    const lane = this.convert(this.expr(node.args[2]), { kind: 'scalar', scalar: 'int' }, line);
+
+    let width = 32;
+    if (node.args.length === 4) {
+      const literal = node.args[3];
+      if (literal.kind !== 'intLit') {
+        this.fail(line, column, `${node.callee} 的 width 必须是常量`);
+      }
+      width = literal.value;
+      if (width < 1 || width > 32 || (width & (width - 1)) !== 0) {
+        this.fail(line, column, 'width 必须是 1..32 之间的 2 的幂');
+      }
+    }
+
+    const dst = this.alloc();
+    this.emit({
+      op: 'shfl', dst, src: value.reg, lane: lane.reg, mask: mask.reg,
+      mode, width, ty: irTypeOf(value.type), line,
+    }, line);
+    return { reg: dst, type: value.type };
+  }
+
+  private ballot(node: Expr & { kind: 'call' }): Value {
+    const { line, column } = node.span;
+    if (node.args.length !== 2) this.fail(line, column, '__ballot_sync(mask, pred)');
+    const mask = this.convert(this.expr(node.args[0]), { kind: 'scalar', scalar: 'uint' }, line);
+    const pred = this.expr(node.args[1]);
+    const dst = this.alloc();
+    this.emit({ op: 'ballot', dst, pred: pred.reg, mask: mask.reg, line }, line);
+    return { reg: dst, type: { kind: 'scalar', scalar: 'uint' } };
+  }
+
+  /** `__any_sync` / `__all_sync` 就是 ballot 之后看掩码 */
+  private anyAll(node: Expr & { kind: 'call' }): Value {
+    const { line } = node.span;
+    const voted = this.ballot({ ...node, callee: '__ballot_sync' });
+    const dst = this.alloc();
+    if (node.callee === '__any_sync') {
+      const zero = this.constant(0, 'u32', line);
+      this.emit({ op: 'bin', dst, a: voted.reg, b: zero, kind: 'ne', ty: 'u32' }, line);
+    } else {
+      // all：投票掩码要覆盖参与的每一个 lane
+      const participants = this.convert(this.expr(node.args[0]), { kind: 'scalar', scalar: 'uint' }, line);
+      this.emit({ op: 'bin', dst, a: voted.reg, b: participants.reg, kind: 'eq', ty: 'u32' }, line);
+    }
+    return { reg: dst, type: { kind: 'scalar', scalar: 'int' } };
+  }
+
+  /**
+   * `atomicXxx(ptr, value)` —— 返回**旧值**，和真 API 一致。
+   *
+   * 第 5 关的门槛之一是 `atomics <= gridDim`：逼出 shuffle 规约而不是
+   * 每个线程都往同一个地址 atomicAdd。所以这条指令必须单独计数。
+   */
+  private atomic(node: Expr & { kind: 'call' }): Value {
+    const spec = ATOMIC_FNS[node.callee];
+    const { line, column } = node.span;
+    if (node.args.length !== spec.arity) {
+      this.fail(line, column, `${node.callee} 需要 ${spec.arity} 个参数`);
+    }
+
+    const pointer = this.expr(node.args[0]);
+    if (!isPointer(pointer.type)) {
+      this.fail(line, column, `${node.callee} 的第一个参数得是指针`);
+    }
+    const elementType = pointer.type.to;
+    // 共享内存上的原子操作要走共享地址空间 —— 地址是两套独立的偏移
+    const space: Space = pointer.type.space ?? 'global';
+
+    const value = this.convert(this.expr(node.args[1]), elementType, line);
+    let compare = value.reg;
+    if (spec.kind === 'cas') {
+      // atomicCAS(addr, compare, val)：参数顺序是「比较值」在前
+      const cmp = this.convert(this.expr(node.args[1]), elementType, line);
+      const desired = this.convert(this.expr(node.args[2]), elementType, line);
+      compare = cmp.reg;
+      const dst = this.alloc();
+      this.emit({
+        op: 'atom', dst, addr: pointer.reg, value: desired.reg, compare,
+        kind: 'cas', space, ty: irTypeOf(elementType), line,
+      }, line);
+      return { reg: dst, type: elementType };
+    }
+
+    const dst = this.alloc();
+    this.emit({
+      op: 'atom', dst, addr: pointer.reg, value: value.reg, compare,
+      kind: spec.kind, space, ty: irTypeOf(elementType), line,
+    }, line);
+    return { reg: dst, type: elementType };
+  }
+
   private call(node: Expr & { kind: 'call' }): Value {
+    if (SHFL_FNS[node.callee]) return this.shuffle(node);
+    if (ATOMIC_FNS[node.callee]) return this.atomic(node);
+    if (node.callee === '__ballot_sync') return this.ballot(node);
+    if (node.callee === '__any_sync' || node.callee === '__all_sync') return this.anyAll(node);
+    if (node.callee === '__syncwarp') {
+      const { line } = node.span;
+      const mask = node.args.length
+        ? this.convert(this.expr(node.args[0]), { kind: 'scalar', scalar: 'uint' }, line).reg
+        : this.constant(-1, 'u32', line);
+      this.emit({ op: 'syncwarp', mask, line }, line);
+      // 返回值没人用，给一个 0 占位
+      return { reg: this.constant(0, 'i32', line), type: { kind: 'scalar', scalar: 'int' } };
+    }
+    if (node.callee === '__activemask') {
+      if (node.args.length) this.fail(node.span.line, node.span.column, '__activemask() 不带参数');
+      const dst = this.alloc();
+      this.emit({ op: 'activemask', dst }, node.span.line);
+      return { reg: dst, type: { kind: 'scalar', scalar: 'uint' } };
+    }
+
     const spec = BUILTIN_FNS[node.callee];
     if (!spec) {
       this.fail(
@@ -531,7 +727,7 @@ class Compiler {
         if (!isPointer(pointer.type)) {
           this.fail(node.span.line, node.span.column, `${typeName(pointer.type)} 不是指针，不能解引用`);
         }
-        return { reg: pointer.reg, space: 'global', type: pointer.type.to };
+        return { reg: pointer.reg, space: pointer.type.space ?? 'global', type: pointer.type.to };
       }
 
       default:
@@ -552,7 +748,8 @@ class Compiler {
         this.emit({ op: 'sharedbase', dst: reg, offset: binding.offset }, node.span.line);
         return { reg, space: 'shared', type: binding.type };
       }
-      return { reg: binding.reg, space: 'global', type: binding.type };
+      const space = binding.type.kind === 'pointer' ? binding.type.space ?? 'global' : 'global';
+      return { reg: binding.reg, space, type: binding.type };
     }
     if (node.kind === 'subscript') {
       // 多维数组的中间一层：地址算出来，类型降一维
@@ -560,7 +757,8 @@ class Compiler {
       return inner;
     }
     const value = this.expr(node);
-    return { reg: value.reg, space: 'global', type: value.type };
+    const space = value.type.kind === 'pointer' ? value.type.space ?? 'global' : 'global';
+    return { reg: value.reg, space, type: value.type };
   }
 
   private loadFrom(address: { reg: number; space: Space; type: CudaType }, line: number): Value {
@@ -719,9 +917,18 @@ class Compiler {
     }
 
     const reg = this.alloc();
-    this.bind(decl.name, { where: 'reg', reg, type: decl.type });
+    let boundType = decl.type;
     if (decl.init) {
-      const value = this.convert(this.expr(decl.init), decl.type, decl.span.line);
+      // `float* p = &s[0]` —— 声明里写不出地址空间，从初始值继承过来。
+      // 不继承的话 p 会被当成全局指针，读到的是完全不相干的内存。
+      const initType = this.staticTypeOf(decl.init);
+      if (decl.type.kind === 'pointer' && initType.kind === 'pointer' && initType.space) {
+        boundType = { ...decl.type, space: initType.space };
+      }
+    }
+    this.bind(decl.name, { where: 'reg', reg, type: boundType });
+    if (decl.init) {
+      const value = this.convert(this.expr(decl.init), boundType, decl.span.line);
       this.emit({ op: 'mov', dst: reg, src: value.reg }, decl.span.line);
     } else {
       // 未初始化的变量在真卡上是垃圾值。我们给 0，但这是**已知的分叉**：

--- a/src/lib/gpulab/ir/program.ts
+++ b/src/lib/gpulab/ir/program.ts
@@ -18,7 +18,10 @@
  * 这一版没有单独隔离出扁平编码本身贡献了多少 —— 它是标准做法，
  * 保留的理由是架构而不是一个测出来的加速比。
  */
-import type { BinKind, BuiltinFn, CompiledKernel, Inst, IrType, Space, SpecialReg, UnKind } from './types';
+import type {
+  AtomKind, BinKind, BuiltinFn, CompiledKernel, Inst, IrType,
+  ShflMode, Space, SpecialReg, UnKind,
+} from './types';
 
 /** 每条指令占几个 int32 槽。取 2 的幂，`pc * SLOTS` 才能编译成移位。 */
 export const SLOTS = 8;
@@ -43,6 +46,17 @@ export const OP = {
   BAR: 16,
   CALL: 17,
   RET: 18,
+  SHFL: 19,
+  BALLOT: 20,
+  ACTIVEMASK: 21,
+  SYNCWARP: 22,
+  ATOM: 23,
+} as const;
+
+export const SHFL = { idx: 0, up: 1, down: 2, xor: 3 } as const;
+
+export const ATOM = {
+  add: 0, sub: 1, exch: 2, min: 3, max: 4, cas: 5, and: 6, or: 7, xor: 8,
 } as const;
 
 export const TY = { F32: 0, I32: 1, U32: 2 } as const;
@@ -61,6 +75,7 @@ export const FN = {
   expf: 6, logf: 7, tanhf: 8, powf: 9,
   __expf: 10, __logf: 11, __fdividef: 12,
   min: 13, max: 14, abs: 15,
+  __popc: 16, __clz: 17, __ffs: 18,
 } as const;
 
 export const SREG = {
@@ -212,6 +227,39 @@ export function encode(kernel: CompiledKernel): ExecutableKernel {
         code[at + 4] = inst.args[0] ?? 0;
         code[at + 5] = inst.args[1] ?? 0;
         code[at + 6] = inst.args[2] ?? 0;
+        break;
+      case 'shfl':
+        code[at] = OP.SHFL;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.src;
+        code[at + 3] = inst.lane;
+        code[at + 4] = inst.mask;
+        code[at + 5] = SHFL[inst.mode as ShflMode];
+        code[at + 6] = inst.width;
+        break;
+      case 'ballot':
+        code[at] = OP.BALLOT;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.pred;
+        code[at + 3] = inst.mask;
+        break;
+      case 'activemask':
+        code[at] = OP.ACTIVEMASK;
+        code[at + 1] = inst.dst;
+        break;
+      case 'syncwarp':
+        code[at] = OP.SYNCWARP;
+        code[at + 1] = inst.mask;
+        break;
+      case 'atom':
+        code[at] = OP.ATOM;
+        code[at + 1] = inst.dst;
+        code[at + 2] = inst.addr;
+        code[at + 3] = inst.value;
+        code[at + 4] = ATOM[inst.kind as AtomKind];
+        code[at + 5] = inst.space === 'global' ? SPACE.GLOBAL : SPACE.SHARED;
+        code[at + 6] = tyCode(inst.ty);
+        code[at + 7] = inst.compare;
         break;
       case 'ret':
         code[at] = OP.RET;

--- a/src/lib/gpulab/ir/types.ts
+++ b/src/lib/gpulab/ir/types.ts
@@ -31,7 +31,21 @@ export type BuiltinFn =
   | 'fmaf' | 'fabsf' | 'fminf' | 'fmaxf' | 'sqrtf' | 'rsqrtf'
   | 'expf' | 'logf' | 'tanhf' | 'powf'
   | '__expf' | '__logf' | '__fdividef'
-  | 'min' | 'max' | 'abs';
+  | 'min' | 'max' | 'abs'
+  /** 位操作 —— 和 __ballot_sync 配套用，数掩码里有几位、最低位在哪 */
+  | '__popc' | '__clz' | '__ffs';
+
+/**
+ * warp 内的数据交换方式。
+ *
+ * 真 CUDA 的 `__shfl_*_sync` 系列。它们是 warp 级原语 —— 一个 lane 直接读
+ * 另一个 lane 的寄存器，不经过内存。规约、前缀和、以及 FlashAttention 里
+ * 那些行内归并全靠它。
+ */
+export type ShflMode = 'idx' | 'up' | 'down' | 'xor';
+
+/** 原子操作。真卡上它们的完成顺序不定，这里的处理见 vm.ts 的说明。 */
+export type AtomKind = 'add' | 'sub' | 'exch' | 'min' | 'max' | 'cas' | 'and' | 'or' | 'xor';
 
 export type SpecialReg =
   | 'tid.x' | 'tid.y' | 'tid.z'
@@ -77,6 +91,19 @@ export type Inst =
   /** `__syncthreads()` —— 挂起本 warp，等同 block 的其它 warp */
   | { op: 'bar'; line: number }
   | { op: 'call'; dst: number; fn: BuiltinFn; args: number[]; ty: IrType }
+  /**
+   * warp 内交换：`dst` 拿到 `src` 在另一个 lane 上的值。
+   * `mask` 是参与线程掩码（真 API 的第一个参数），`width` 把 warp 切成段。
+   */
+  | { op: 'shfl'; dst: number; src: number; lane: number; mask: number; mode: ShflMode; width: number; ty: IrType; line: number }
+  /** `__ballot_sync`：把每个 lane 的谓词收成一个 32 位掩码 */
+  | { op: 'ballot'; dst: number; pred: number; mask: number; line: number }
+  /** `__activemask()` */
+  | { op: 'activemask'; dst: number }
+  /** `__syncwarp(mask)` */
+  | { op: 'syncwarp'; mask: number; line: number }
+  /** 原子读改写。返回**旧值**，和真 API 一致。 */
+  | { op: 'atom'; dst: number; addr: number; value: number; compare: number; kind: AtomKind; space: Space; ty: IrType; line: number }
   | { op: 'ret' };
 
 export interface SharedVar {

--- a/src/lib/gpulab/metrics.ts
+++ b/src/lib/gpulab/metrics.ts
@@ -54,7 +54,21 @@ export interface GpuMetrics {
     divergentBranches: number;
     /** 活跃 lane 占比，0~1。全程不发散就是 1。 */
     activeLaneRatio: number;
+    /** warp 级交换指令（`__shfl_*_sync`）条数 */
+    shuffles: number;
+    /**
+     * warp 同步原语用错的次数。
+     * 恒为 0 的硬门槛 —— 和 sanitizer 那几项一个性质。
+     */
+    syncErrors: number;
   };
+  /**
+   * 原子操作次数（按 lane 算）。
+   *
+   * 第 5 关的门槛读它：`atomics <= gridDim` 逼出 shuffle 规约，
+   * 而不是每个线程都往同一个地址 atomicAdd。
+   */
+  atomics: number;
   inst: {
     /** warp 级指令条数 —— 执行预算看这个 */
     warpExecuted: number;
@@ -95,7 +109,10 @@ export function toMetrics(counters: GpuCounters): GpuMetrics {
       divergentBranches: counters.divergentBranches,
       activeLaneRatio:
         counters.warpInsts === 0 ? 0 : counters.laneInsts / (counters.warpInsts * WARP_SIZE),
+      shuffles: counters.shuffles,
+      syncErrors: counters.warpSyncErrors,
     },
+    atomics: counters.atomics,
     inst: {
       warpExecuted: counters.warpInsts,
       laneExecuted: counters.laneInsts,

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -20,7 +20,7 @@
  *  3. 收尾**不要用闭包**：闭包一旦捕获可变局部，V8 会把它们挪进堆上的
  *     context 对象，每条指令多出好几次堆访问。
  */
-import { encode, type ExecutableKernel, type Program, BIN, FN, OP, SLOTS, SPACE, SREG, TY, UN } from '../ir/program';
+import { encode, type ExecutableKernel, type Program, ATOM, BIN, FN, OP, SHFL, SLOTS, SPACE, SREG, TY, UN } from '../ir/program';
 import type { CompiledKernel } from '../ir/types';
 import {
   addF32, divF32, expF32, fastDivF32, fastExpF32, fastLogF32, floatToInt, floatToUint,
@@ -64,6 +64,15 @@ export interface GpuCounters {
   sharedBankConflicts: number;
   divergentBranches: number;
   activeLanes: number;
+  /** 原子操作次数（按 lane 算）—— 第 5 关的门槛读它 */
+  atomics: number;
+  /** warp 级交换指令条数 */
+  shuffles: number;
+  /**
+   * warp 同步原语用错的次数：shuffle 读了一个不参与的 lane、
+   * 或者 __syncwarp 的掩码里有 lane 没到。真卡上这些是未定义行为。
+   */
+  warpSyncErrors: number;
   barriers: number;
   blocksLaunched: number;
   warpsLaunched: number;
@@ -76,6 +85,7 @@ export function emptyCounters(): GpuCounters {
     globalLoadSectors: 0, globalStoreSectors: 0,
     sharedLoadRequests: 0, sharedStoreRequests: 0, sharedBankConflicts: 0,
     divergentBranches: 0, activeLanes: 0,
+    atomics: 0, shuffles: 0, warpSyncErrors: 0,
     barriers: 0, blocksLaunched: 0, warpsLaunched: 0,
   };
 }
@@ -146,6 +156,8 @@ export function launchKernel(
 class Executor {
   private readonly shared: LinearMemory;
   private readonly addresses = new Int32Array(WARP_SIZE);
+  /** shuffle 要先把源值快照下来 —— dst 和 src 可能是同一个寄存器 */
+  private readonly shflScratch = new Float64Array(WARP_SIZE);
   private readonly maxWarpInsts: number;
   private readonly blockThreads: number;
   private readonly warpsPerBlock: number;
@@ -285,6 +297,9 @@ class Executor {
     let instFma = 0;
     let instLdSt = 0;
     let divergent = 0;
+    let atomics = 0;
+    let shuffles = 0;
+    let warpSyncErrors = 0;
 
     let pc = warp.pc;
 
@@ -295,6 +310,8 @@ class Executor {
           counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
           counters.instFma += instFma; counters.instLdSt += instLdSt;
           counters.divergentBranches += divergent;
+          counters.atomics += atomics; counters.shuffles += shuffles;
+          counters.warpSyncErrors += warpSyncErrors;
           return;
         }
 
@@ -303,6 +320,8 @@ class Executor {
           counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
           counters.instFma += instFma; counters.instLdSt += instLdSt;
           counters.divergentBranches += divergent;
+          counters.atomics += atomics; counters.shuffles += shuffles;
+          counters.warpSyncErrors += warpSyncErrors;
           throw new KernelError(
             `执行预算用光了（${this.maxWarpInsts} 条 warp 指令）—— 多半是循环没退出`,
             lines[pc]
@@ -569,6 +588,8 @@ class Executor {
             counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
             counters.instFma += instFma; counters.instLdSt += instLdSt;
             counters.divergentBranches += divergent;
+          counters.atomics += atomics; counters.shuffles += shuffles;
+          counters.warpSyncErrors += warpSyncErrors;
             return;
           }
 
@@ -600,11 +621,168 @@ class Executor {
                 case FN.__fdividef: out = fastDivF32(x, y); break;
                 case FN.min: out = Math.min(x | 0, y | 0) | 0; break;
                 case FN.max: out = Math.max(x | 0, y | 0) | 0; break;
-                default: out = Math.abs(x | 0) | 0; break;
+                case FN.abs: out = Math.abs(x | 0) | 0; break;
+                case FN.__popc: out = popcount(x | 0); break;
+                case FN.__clz: out = (x | 0) === 0 ? 32 : Math.clz32(x >>> 0); break;
+                // __ffs 是 1 起算的最低置位位号，0 表示没有置位
+                default: out = (x | 0) === 0 ? 0 : 32 - Math.clz32(((x | 0) & -(x | 0)) >>> 0); break;
               }
               regs[dst + lane] = out;
             }
             if (fn === FN.fmaf) instFma += lanes;
+            pc += 1;
+            break;
+          }
+
+          case OP.SHFL: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const src = code[at + 2] * WARP_SIZE;
+            const laneArg = code[at + 3] * WARP_SIZE;
+            const maskReg = code[at + 4] * WARP_SIZE;
+            const mode = code[at + 5];
+            const width = code[at + 6];
+            const scratch = this.shflScratch;
+
+            // 先快照：dst 有可能就是 src
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) scratch[lane] = regs[src + lane];
+
+            // 参与者 = 调用方给的掩码 ∩ 当前活跃的 lane
+            let participants = active;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) { participants = active & (regs[maskReg + lane] | 0); break; }
+            }
+
+            const segMask = width - 1;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const delta = regs[laneArg + lane] | 0;
+              const inSeg = lane & segMask;
+              let target: number;
+              switch (mode) {
+                case SHFL.idx: target = delta & segMask; break;
+                case SHFL.up: target = inSeg - delta; break;
+                case SHFL.down: target = inSeg + delta; break;
+                default: target = inSeg ^ delta; break;
+              }
+              // 越出本段就是「原地不动」，和真硬件一致
+              if (target < 0 || target >= width) target = inSeg;
+              const srcLane = (lane & ~segMask) | target;
+              if ((participants & (1 << srcLane)) === 0) {
+                // 真卡上这里是未定义值。给 0 并记一笔，好让 sanitizer 说得出话。
+                warpSyncErrors += 1;
+                regs[dst + lane] = 0;
+              } else {
+                regs[dst + lane] = scratch[srcLane];
+              }
+            }
+            shuffles += 1;
+            pc += 1;
+            break;
+          }
+
+          case OP.BALLOT: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const pred = code[at + 2] * WARP_SIZE;
+            const maskReg = code[at + 3] * WARP_SIZE;
+            let participants = active;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) { participants = active & (regs[maskReg + lane] | 0); break; }
+            }
+            let voted = 0;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((participants & (1 << lane)) === 0) continue;
+              if (regs[pred + lane] !== 0) voted |= 1 << lane;
+            }
+            const result = voted >>> 0;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) regs[dst + lane] = result;
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.ACTIVEMASK: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const value = active >>> 0;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) regs[dst + lane] = value;
+            }
+            pc += 1;
+            break;
+          }
+
+          case OP.SYNCWARP: {
+            // 我们的 lane 本来就是锁步的，所以这条指令语义上是空操作。
+            // 但它是一个**检查点**：掩码里点了名却没到的 lane，
+            // 在真卡上会让这条指令行为未定义。
+            const maskReg = code[at + 1] * WARP_SIZE;
+            let requested = active;
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if (active & (1 << lane)) { requested = regs[maskReg + lane] | 0; break; }
+            }
+            if ((requested & warp.present & ~active) !== 0) warpSyncErrors += 1;
+            pc += 1;
+            break;
+          }
+
+          case OP.ATOM: {
+            const dst = code[at + 1] * WARP_SIZE;
+            const addr = code[at + 2] * WARP_SIZE;
+            const value = code[at + 3] * WARP_SIZE;
+            const kind = code[at + 4];
+            const isGlobal = code[at + 5] === SPACE.GLOBAL;
+            const ty = code[at + 6];
+            const compare = code[at + 7] * WARP_SIZE;
+            const memory = isGlobal ? globalMemory : sharedMemory;
+
+            // **按 lane 号从小到大依次执行。**
+            // 真卡上原子操作的完成顺序是不定的，这正是「同样的种子、同样的
+            // 数据，loss 曲线对不上」的常见来源。我们必须给一个确定的顺序
+            // （否则重放门槛不成立），所以这里是一处**已知分叉**，
+            // primer 里要专门讲。
+            for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+              if ((active & (1 << lane)) === 0) continue;
+              const address = regs[addr + lane] | 0;
+              const operand = regs[value + lane];
+              const old = ty === TY.F32 ? memory.readF32(address)
+                : ty === TY.U32 ? memory.readU32(address) : memory.readI32(address);
+              let next: number;
+              if (ty === TY.F32) {
+                switch (kind) {
+                  case ATOM.add: next = Math.fround(old + operand); break;
+                  case ATOM.sub: next = Math.fround(old - operand); break;
+                  case ATOM.exch: next = operand; break;
+                  case ATOM.min: next = old < operand ? old : operand; break;
+                  case ATOM.max: next = old > operand ? old : operand; break;
+                  case ATOM.cas: next = old === regs[compare + lane] ? operand : old; break;
+                  default:
+                    throw new KernelError('位运算的原子操作不能用在 float 上', lines[pc]);
+                }
+                memory.writeF32(address, next);
+              } else {
+                const o = ty === TY.U32 ? old >>> 0 : old | 0;
+                const v = ty === TY.U32 ? operand >>> 0 : operand | 0;
+                switch (kind) {
+                  case ATOM.add: next = o + v; break;
+                  case ATOM.sub: next = o - v; break;
+                  case ATOM.exch: next = v; break;
+                  case ATOM.min: next = o < v ? o : v; break;
+                  case ATOM.max: next = o > v ? o : v; break;
+                  case ATOM.and: next = o & v; break;
+                  case ATOM.or: next = o | v; break;
+                  case ATOM.xor: next = o ^ v; break;
+                  default: next = o === (regs[compare + lane] | 0) ? v : o; break;
+                }
+                next = ty === TY.U32 ? next >>> 0 : next | 0;
+                if (ty === TY.U32) memory.writeU32(address, next);
+                else memory.writeI32(address, next);
+              }
+              regs[dst + lane] = old;
+              atomics += 1;
+            }
+            // 原子操作是并发更新的**正确**做法，不该被 racecheck 报成竞态 ——
+            // 真的 racecheck 也不报它们。所以这里不喂给检测器。
+            instLdSt += lanes;
             pc += 1;
             break;
           }
@@ -614,6 +792,8 @@ class Executor {
             counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
             counters.instFma += instFma; counters.instLdSt += instLdSt;
             counters.divergentBranches += divergent;
+          counters.atomics += atomics; counters.shuffles += shuffles;
+          counters.warpSyncErrors += warpSyncErrors;
             return;
 
           default:
@@ -624,6 +804,8 @@ class Executor {
       counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
       counters.instFma += instFma; counters.instLdSt += instLdSt;
       counters.divergentBranches += divergent;
+          counters.atomics += atomics; counters.shuffles += shuffles;
+          counters.warpSyncErrors += warpSyncErrors;
       if (error instanceof MemoryFault) throw new KernelError(error.message, lines[Math.min(pc, this.program.count - 1)]);
       if (error instanceof KernelError) throw error;
       throw new KernelError(String((error as Error)?.message ?? error), lines[Math.min(pc, this.program.count - 1)]);

--- a/tests/gpulab/vm.test.ts
+++ b/tests/gpulab/vm.test.ts
@@ -66,8 +66,9 @@ describe('CUDA 前端', () => {
   });
 
   it('调用没实现的函数会列出有哪些内建函数可用', async () => {
+    // __ldg 是只读缓存加载，还没做（等缓存模型那一片）
     await expect(compileSource(`
-      __global__ void k(float* a) { a[0] = __shfl_xor_sync(0xffffffff, a[0], 1); }
+      __global__ void k(const float* a, float* out) { out[0] = __ldg(&a[0]); }
     `)).rejects.toThrow(CudaCompileError);
   });
 });

--- a/tests/gpulab/warp.test.ts
+++ b/tests/gpulab/warp.test.ts
@@ -1,0 +1,373 @@
+/**
+ * warp 原语与原子操作
+ *
+ * 第 5 关（发散与 warp 原语）直接建立在这上面，后面 softmax、LayerNorm、
+ * FlashAttention 的行内归并也全靠它。
+ *
+ * 用例分两类：**语义对不对**（shuffle 的段边界、ballot 的参与者）、
+ * 以及**门槛能不能成立**（shuffle 规约与 atomic 规约算出同样的结果，
+ * 但 `gpu.atomics` 差两个数量级）。
+ */
+import { GpuDevice, compileSource, dim3 } from '../../src/lib/gpulab';
+
+jest.setTimeout(120_000);
+
+function device(): GpuDevice {
+  return new GpuDevice({ globalBytes: 2 * 1024 * 1024 });
+}
+
+async function compileOne(source: string, name: string) {
+  return (await compileSource(source)).get(name)!;
+}
+
+describe('__shfl_*_sync', () => {
+  it('xor：蝶形交换，段内按位异或取源 lane', async () => {
+    const kernel = await compileOne(`
+      __global__ void butterfly(int* out, int delta) {
+        int t = threadIdx.x;
+        int v = t * 10;
+        out[t] = __shfl_xor_sync(0xffffffff, v, delta);
+      }
+    `, 'butterfly');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    for (const delta of [1, 2, 4, 16]) {
+      gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out, delta]);
+      const values = gpu.copyOutInts(out, 32);
+      for (let t = 0; t < 32; t += 1) expect(values[t]).toBe((t ^ delta) * 10);
+    }
+  });
+
+  it('down：往上取，越出 warp 就原地不动', async () => {
+    const kernel = await compileOne(`
+      __global__ void down(int* out) {
+        int t = threadIdx.x;
+        out[t] = __shfl_down_sync(0xffffffff, t * 10, 4);
+      }
+    `, 'down');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    for (let t = 0; t < 32; t += 1) {
+      // t + 4 越界的那几个 lane 拿回自己的值，和真硬件一致
+      expect(values[t]).toBe(t + 4 < 32 ? (t + 4) * 10 : t * 10);
+    }
+  });
+
+  it('up：往下取，越出就原地不动', async () => {
+    const kernel = await compileOne(`
+      __global__ void up(int* out) {
+        int t = threadIdx.x;
+        out[t] = __shfl_up_sync(0xffffffff, t * 10, 3);
+      }
+    `, 'up');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    for (let t = 0; t < 32; t += 1) {
+      expect(values[t]).toBe(t - 3 >= 0 ? (t - 3) * 10 : t * 10);
+    }
+  });
+
+  it('idx：广播 —— 所有 lane 取同一个源', async () => {
+    const kernel = await compileOne(`
+      __global__ void bcast(int* out) {
+        int t = threadIdx.x;
+        out[t] = __shfl_sync(0xffffffff, t * 10, 7);
+      }
+    `, 'bcast');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    for (let t = 0; t < 32; t += 1) expect(values[t]).toBe(70);
+  });
+
+  it('width 把 warp 切成段，段之间互不串门', async () => {
+    const kernel = await compileOne(`
+      __global__ void seg(int* out) {
+        int t = threadIdx.x;
+        // width=8：0..7 一段、8..15 一段，以此类推
+        out[t] = __shfl_sync(0xffffffff, t, 0, 8);
+      }
+    `, 'seg');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    for (let t = 0; t < 32; t += 1) expect(values[t]).toBe((t >> 3) << 3);
+  });
+
+  it('dst 和 src 是同一个变量也不会互相踩', async () => {
+    const kernel = await compileOne(`
+      __global__ void inplace(int* out) {
+        int v = threadIdx.x;
+        v = __shfl_xor_sync(0xffffffff, v, 1);
+        out[threadIdx.x] = v;
+      }
+    `, 'inplace');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    for (let t = 0; t < 32; t += 1) expect(values[t]).toBe(t ^ 1);
+  });
+
+  it('float 也能交换，位模式原样过去', async () => {
+    const kernel = await compileOne(`
+      __global__ void f(float* out) {
+        int t = threadIdx.x;
+        float v = (float)t * 0.25f;
+        out[t] = __shfl_xor_sync(0xffffffff, v, 1);
+      }
+    `, 'f');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOut(out, 32);
+    for (let t = 0; t < 32; t += 1) expect(values[t]).toBe((t ^ 1) * 0.25);
+  });
+
+  it('读一个不参与的 lane 会被记成 warp 同步错误', async () => {
+    const kernel = await compileOne(`
+      __global__ void bad(int* out) {
+        int t = threadIdx.x;
+        // 掩码只点了低 16 个 lane，却让每个 lane 都去读 t+16
+        out[t] = __shfl_sync(0x0000ffff, t, t + 16);
+      }
+    `, 'bad');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    expect(gpu.metrics().warp.syncErrors).toBeGreaterThan(0);
+  });
+});
+
+describe('__ballot_sync / __any_sync / __all_sync / __activemask', () => {
+  it('ballot 把谓词收成掩码', async () => {
+    const kernel = await compileOne(`
+      __global__ void vote(unsigned* out) {
+        int t = threadIdx.x;
+        out[t] = __ballot_sync(0xffffffff, (t % 3) == 0);
+      }
+    `, 'vote');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    let expected = 0;
+    for (let t = 0; t < 32; t += 1) if (t % 3 === 0) expected |= 1 << t;
+    const values = gpu.copyOutInts(out, 32);
+    for (let t = 0; t < 32; t += 1) expect(values[t] >>> 0).toBe(expected >>> 0);
+  });
+
+  it('__popc 数出投票里有几个 —— 和 ballot 配套用', async () => {
+    const kernel = await compileOne(`
+      __global__ void count(int* out) {
+        int t = threadIdx.x;
+        unsigned m = __ballot_sync(0xffffffff, (t & 1) == 0);
+        out[t] = __popc(m);
+      }
+    `, 'count');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    expect(Array.from(gpu.copyOutInts(out, 32))).toEqual(new Array(32).fill(16));
+  });
+
+  it('any / all', async () => {
+    const kernel = await compileOne(`
+      __global__ void votes(int* out) {
+        int t = threadIdx.x;
+        out[t] = __any_sync(0xffffffff, t == 7) * 10 + __all_sync(0xffffffff, t < 32);
+      }
+    `, 'votes');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    expect(Array.from(gpu.copyOutInts(out, 32))).toEqual(new Array(32).fill(11));
+  });
+
+  it('__activemask 在分歧区里只报当前这一拨', async () => {
+    const kernel = await compileOne(`
+      __global__ void mask(unsigned* out) {
+        int t = threadIdx.x;
+        unsigned m = 0;
+        if (t < 8) { m = __activemask(); } else { m = __activemask(); }
+        out[t] = m;
+      }
+    `, 'mask');
+    const gpu = device();
+    const out = gpu.malloc(32 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const values = gpu.copyOutInts(out, 32);
+    expect(values[0] >>> 0).toBe(0x000000ff);
+    expect(values[10] >>> 0).toBe(0xffffff00);
+  });
+});
+
+describe('原子操作', () => {
+  it('atomicAdd 返回旧值，累加结果正确', async () => {
+    const kernel = await compileOne(`
+      __global__ void bump(int* counter, int* olds) {
+        int t = blockIdx.x * blockDim.x + threadIdx.x;
+        olds[t] = atomicAdd(counter, 1);
+      }
+    `, 'bump');
+    const gpu = device();
+    const counter = gpu.malloc(4);
+    const olds = gpu.malloc(128 * 4);
+    gpu.copyInInts(counter, [0]);
+    gpu.launch(kernel, { grid: dim3(4), block: dim3(32) }, [counter, olds]);
+    expect(gpu.copyOutInts(counter, 1)[0]).toBe(128);
+    // 128 个旧值恰好是 0..127 的一个排列
+    expect(Array.from(gpu.copyOutInts(olds, 128)).sort((a, b) => a - b))
+      .toEqual(Array.from({ length: 128 }, (_, i) => i));
+  });
+
+  it('atomicMax / atomicCAS', async () => {
+    const kernel = await compileOne(`
+      __global__ void ops(int* mx, int* slot) {
+        int t = threadIdx.x;
+        atomicMax(mx, t * 3);
+        // 只有第一个把 0 换成自己 tid 的线程会成功
+        atomicCAS(slot, 0, t + 1);
+      }
+    `, 'ops');
+    const gpu = device();
+    const mx = gpu.malloc(4);
+    const slot = gpu.malloc(4);
+    gpu.copyInInts(mx, [0]);
+    gpu.copyInInts(slot, [0]);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [mx, slot]);
+    expect(gpu.copyOutInts(mx, 1)[0]).toBe(93);
+    expect(gpu.copyOutInts(slot, 1)[0]).toBe(1);
+  });
+
+  it('float 的 atomicAdd 走 fp32 累加', async () => {
+    const kernel = await compileOne(`
+      __global__ void fadd(float* total) {
+        atomicAdd(total, 0.5f);
+      }
+    `, 'fadd');
+    const gpu = device();
+    const total = gpu.malloc(4);
+    gpu.copyIn(total, [0]);
+    gpu.launch(kernel, { grid: dim3(2), block: dim3(32) }, [total]);
+    expect(gpu.copyOut(total, 1)[0]).toBe(32);
+  });
+
+  it('共享内存上的原子操作打到共享地址空间', async () => {
+    const kernel = await compileOne(`
+      __global__ void shmem(int* out) {
+        __shared__ int hist[4];
+        int t = threadIdx.x;
+        if (t < 4) hist[t] = 0;
+        __syncthreads();
+        atomicAdd(&hist[t % 4], 1);
+        __syncthreads();
+        if (t < 4) out[t] = hist[t];
+      }
+    `, 'shmem');
+    const gpu = device();
+    const out = gpu.malloc(4 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(64) }, [out]);
+    expect(Array.from(gpu.copyOutInts(out, 4))).toEqual([16, 16, 16, 16]);
+  });
+
+  it('**原子操作不该被 racecheck 报成竞态** —— 它本来就是并发更新的正确做法', async () => {
+    const kernel = await compileOne(`
+      __global__ void safe(int* counter) {
+        atomicAdd(counter, 1);
+      }
+    `, 'safe');
+    const gpu = device();
+    const counter = gpu.malloc(4);
+    gpu.copyInInts(counter, [0]);
+    const report = gpu.launchWithRacecheck(kernel, { grid: dim3(4), block: dim3(32) }, [counter]);
+    expect(report.races.length).toBe(0);
+  });
+});
+
+describe('规约：门槛能不能证明「换了做法」', () => {
+  const ATOMIC_REDUCE = `
+    __global__ void reduce(const float* in, float* out) {
+      int t = blockIdx.x * blockDim.x + threadIdx.x;
+      atomicAdd(out, in[t]);
+    }
+  `;
+
+  const SHUFFLE_REDUCE = `
+    __global__ void reduce(const float* in, float* out) {
+      int t = blockIdx.x * blockDim.x + threadIdx.x;
+      float v = in[t];
+      // warp 内蝶形规约：5 步把 32 个值收成 1 个
+      v += __shfl_xor_sync(0xffffffff, v, 16);
+      v += __shfl_xor_sync(0xffffffff, v, 8);
+      v += __shfl_xor_sync(0xffffffff, v, 4);
+      v += __shfl_xor_sync(0xffffffff, v, 2);
+      v += __shfl_xor_sync(0xffffffff, v, 1);
+      // 每个 warp 只出一次 atomic
+      if ((threadIdx.x & 31) == 0) atomicAdd(out, v);
+    }
+  `;
+
+  async function run(source: string) {
+    const kernel = await compileOne(source, 'reduce');
+    const gpu = device();
+    const n = 1024;
+    const din = gpu.malloc(n * 4);
+    const dout = gpu.malloc(4);
+    gpu.copyIn(din, Float32Array.from({ length: n }, () => 0.5));
+    gpu.copyIn(dout, [0]);
+    gpu.launch(kernel, { grid: dim3(n / 128), block: dim3(128) }, [din, dout]);
+    return { total: gpu.copyOut(dout, 1)[0], metrics: gpu.metrics() };
+  }
+
+  it('两种做法算出同一个和，但原子操作次数差两个数量级', async () => {
+    const naive = await run(ATOMIC_REDUCE);
+    const fast = await run(SHUFFLE_REDUCE);
+
+    expect(naive.total).toBe(512);
+    expect(fast.total).toBe(512);
+
+    // 1024 个线程各来一次 vs 每个 warp 一次
+    expect(naive.metrics.atomics).toBe(1024);
+    expect(fast.metrics.atomics).toBe(1024 / 32);
+    expect(fast.metrics.warp.shuffles).toBeGreaterThan(0);
+  });
+
+  it('shuffle 版一次共享内存都不用', async () => {
+    const fast = await run(SHUFFLE_REDUCE);
+    expect(fast.metrics.shared.loadRequests).toBe(0);
+    expect(fast.metrics.shared.storeRequests).toBe(0);
+  });
+});
+
+describe('确定性', () => {
+  it('原子操作的顺序是定死的 —— 重放两次逐位相同', async () => {
+    // 真卡上 atomicAdd(float*) 的完成顺序不定，同样的输入会给出不同的位模式。
+    // 我们按 lane 号定序，因此可复现 —— 这是一处**已知分叉**，
+    // primer 里要专门讲，否则学员学不到「为什么 loss 曲线对不上」。
+    const kernel = await compileOne(`
+      __global__ void acc(const float* in, float* out) {
+        int t = blockIdx.x * blockDim.x + threadIdx.x;
+        atomicAdd(out, in[t]);
+      }
+    `, 'acc');
+    const n = 256;
+    const input = Float32Array.from({ length: n }, (_, i) => Math.sin(i) * 1e6);
+    const once = () => {
+      const gpu = device();
+      const din = gpu.malloc(n * 4);
+      const dout = gpu.malloc(4);
+      gpu.copyIn(din, input);
+      gpu.copyIn(dout, [0]);
+      gpu.launch(kernel, { grid: dim3(n / 64), block: dim3(64) }, [din, dout]);
+      return new Int32Array(gpu.copyOut(dout, 1).buffer)[0];
+    };
+    const first = once();
+    for (let i = 0; i < 50; i += 1) expect(once()).toBe(first);
+  });
+});


### PR DESCRIPTION
第 5 关（发散与 warp 原语）的前置，后面 softmax / LayerNorm / FlashAttention 的行内归并也全靠它。

## 新增

`__shfl_sync` / `__shfl_up_sync` / `__shfl_down_sync` / `__shfl_xor_sync` · `__ballot_sync` / `__any_sync` / `__all_sync` / `__activemask` / `__syncwarp` · `__popc` / `__clz` / `__ffs` · `atomicAdd/Sub/Exch/Min/Max/And/Or/Xor/CAS`（int / unsigned / float，全局与共享）

## 三处照真硬件写，不是想当然

- **shuffle 的 `width` 把 warp 切成段**，越出本段是「原地不动」而不是取到邻段去；`dst` 与 `src` 可能是同一个寄存器，所以源值先快照。
- **掩码里没点到的 lane 被读时**，真卡上是未定义值。我们给 0 并记一笔 `warp.syncErrors` —— 恒为 0 的硬门槛，和 sanitizer 那几项一个性质。
- **原子操作不喂给 racecheck**。它本来就是并发更新的正确做法，真的 racecheck 也不报它们。

## 顺手补上一个会静默算错的洞

`atomicAdd(&hist[i], 1)`（`hist` 是 `__shared__`）这个最常见的写法之前被直接拒掉。放开 `&` 之后立刻发现更深的问题：**指针原本不带地址空间**，于是

```cuda
__shared__ float s[64];
float* p = &s[0];   // p 被当成全局指针
*p = 1.0f;          // 写到完全不相干的内存，一个错都不报
```

现在 `PointerType` 带 `space`，取地址、数组名衰减、以及「声明时从初始值继承」三条路径都把它带着走。

## 门槛立得住

同一个规约的两种写法：

| | 结果 | `gpu.atomics` | 共享内存访问 |
| --- | ---: | ---: | ---: |
| 每线程 atomicAdd | 512 | **1024** | 0 |
| warp 蝶形 + 每 warp 一次 atomic | 512 | **32** | 0 |

算出同一个和，但原子操作差一个 warp 的量级。第 5 关的 `atomics ≤ gridDim` 就是照这个设的。

## 一处已知分叉

原子操作按 lane 号定序执行，所以可复现（50 次重放位模式一致）。**真卡上完成顺序不定** —— 这正是「同样的种子、同样的数据，loss 曲线对不上」的常见来源。写进了注释，primer 里要专门讲。

## 验证

`tsc` 干净 · `npm test` 10/10（gpulab **60** 个用例，新增 20）· `projects:verify` 全绿 · `npm run build` 过 `check-bundle` 闸门

🤖 Generated with [Claude Code](https://claude.com/claude-code)