### PR TITLE
feat(opslab): 给 ops 工作台补上 AI 对话与复盘

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -624,6 +624,38 @@
       "note": "Recorded across the whole acceptance run. Steps carry the file they came from, so the view follows execution across files."
     }
   },
+  "opslab": {
+    "chat": {
+      "tab": "AI assistant",
+      "title": "On-call buddy",
+      "empty": "I can see what you just ran in the terminal, which objects in the cluster are unhealthy, and which verification checks did not pass. Ask when you are stuck and I will give you the next command to run — you type it, I never touch this cluster.",
+      "placeholder": "Ask about this stage… (Enter to send, Shift+Enter for a newline)",
+      "prompts": {
+        "lastError": "Why did that last command fail?",
+        "whyFailing": "What is the failing check actually asserting?",
+        "whereToLook": "Where should I look next?",
+        "explainStage": "What is this stage asking me to do?"
+      }
+    },
+    "review": {
+      "title": "AI review",
+      "subtitle": "Judges how you operated, not whether the checks passed",
+      "request": "Review my run",
+      "running": "Reviewing…",
+      "empty": "Come here after you finish a stage — or when you are stuck. The AI walks back through the commands you ran: whether the path made sense, whether the cluster is actually correct now, and whether you took a shortcut that would not fly on a real cluster.",
+      "issues": "Worth fixing",
+      "strengths": "Done well",
+      "nextSteps": "Next steps",
+      "noWorld": "The cluster is not up yet — wait for the terminal to be ready.",
+      "dimensions": {
+        "diagnosis": "Diagnosis",
+        "outcome": "Outcome",
+        "safety": "Safety",
+        "efficiency": "Efficiency",
+        "understanding": "Understanding"
+      }
+    }
+  },
   "editor": {
     "toggleWrap": "Word wrap",
     "toggleMinimap": "Minimap",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -624,6 +624,38 @@
       "note": "录的是整轮验收。每一步都带所属文件，跨文件调用时视图会跟着切过去。"
     }
   },
+  "opslab": {
+    "chat": {
+      "tab": "AI 助手",
+      "title": "现场助手",
+      "empty": "我看得到你终端里最近敲了什么、集群里哪些东西不正常、以及上一次验收没过的是哪条。卡住了就问，我给你下一条该敲的命令 —— 命令由你自己敲，我不碰这个集群。",
+      "placeholder": "问一个关于当前这一关的问题…（Enter 发送，Shift+Enter 换行）",
+      "prompts": {
+        "lastError": "上一条命令为什么报错？",
+        "whyFailing": "验收没过的那条在检查什么？",
+        "whereToLook": "现在该从哪儿查起？",
+        "explainStage": "这一关到底要我做什么？"
+      }
+    },
+    "review": {
+      "title": "AI 复盘",
+      "subtitle": "评的是你怎么操作的，不是验收过没过",
+      "request": "让 AI 复盘",
+      "running": "复盘中…",
+      "empty": "跑完一关（或者卡住了）之后来这里。AI 会顺着你敲过的命令看一遍：排查路径合不合理、集群现在是不是真的对了、有没有为了通关走了在生产上不能走的捷径。",
+      "issues": "值得改的地方",
+      "strengths": "做得好的地方",
+      "nextSteps": "下一步",
+      "noWorld": "集群还没起来，先等终端就绪再复盘。",
+      "dimensions": {
+        "diagnosis": "排查路径",
+        "outcome": "结果正确性",
+        "safety": "操作安全",
+        "efficiency": "效率",
+        "understanding": "机制理解"
+      }
+    }
+  },
   "editor": {
     "toggleWrap": "自动换行",
     "toggleMinimap": "缩略图",

--- a/pages/api/ops-chat.ts
+++ b/pages/api/ops-chat.ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  abortSignalFor,
+  AIProviderConfig,
+  ChatMessage,
+  NoProviderError,
+  streamAI,
+  statusForError,
+} from '../../src/lib/server/aiProvider';
+import { buildOpsContext, OpsContext } from '../../src/lib/server/opsPrompt';
+
+/*
+ * 请求体上限。
+ *
+ * ops 的上下文已经在客户端压成定长摘要了（src/lib/opslab/lab/aicontext.ts），
+ * 正常一条请求几十 KB。这里仍然把上限抬到 8mb，和工程对话保持一致 ——
+ * 工程对话当年就是撞在 Next 默认的 1mb 上，一个中等项目直接 413。
+ * responseLimit 关掉是因为回答是流式的。
+ */
+export const config = {
+  api: {
+    responseLimit: false,
+    bodyParser: { sizeLimit: '8mb' },
+  },
+};
+
+interface OpsChatRequest {
+  messages: ChatMessage[];
+  context: OpsContext;
+  language: 'en' | 'zh';
+  config?: AIProviderConfig;
+}
+
+/**
+ * 只读，而且明说。
+ *
+ * 这个助手不能改集群 —— 不只是因为「代劳会毁掉教学目的」，还因为判定读的就是
+ * 世界状态：能改集群的助手等于能替学员通关，进度这件事本身就没意义了。
+ * 所以提示词里把它定位成「坐在旁边看着同一块屏幕的人」：能读，能给命令，
+ * 但手是学员的。
+ */
+function systemPrompt(language: 'en' | 'zh'): string {
+  if (language === 'zh') {
+    return `你是一位资深的 SRE / 平台工程师，正坐在用户旁边，看着同一台跳板机的屏幕，陪他做一个内网 Kubernetes 实战关卡。
+
+你能看到的东西都在下面的上下文里：关卡要求、他终端里最近敲的命令与输出、集群里那些状态不正常的对象、最近的事件、他打开的 manifest、以及上一次验收的结果。
+
+**你没有手。** 你不能执行任何命令，也不能改集群 —— 手是用户的。你要做的是让他自己敲出那条对的命令。
+
+规则：
+1. **先读上下文再回答。** 尤其是终端里最近那几条命令：他卡住的原因八成就在某条报错里。不要泛泛地讲 Kubernetes 概念。
+2. **不要直接把整关的答案给出来**，除非他明确要。优先给出「下一步该查什么」，并给出**具体可敲的命令**。
+3. 给命令时用独立的 \`\`\`bash 代码块，一次给一到两条，并说清楚「你要从输出里看什么」。他会自己敲，然后把结果贴回来。
+4. 上下文里的集群状态是**裁剪过的摘要**，不是全量。需要更多细节时，让他敲 kubectl 去查，而不是猜。
+5. 分清「集群里客观是什么」和「你的推测」。前者引用上下文里的原文，后者要说明这是推测、以及怎么验证。
+6. 验收没过时，先解释那条用例在检查什么、为什么现在不满足，再给最小的下一步。
+7. 用 Markdown，用中文回答。`;
+  }
+
+  return `You are a senior SRE / platform engineer sitting next to the user, looking at the same jump-host screen, working through a hands-on intranet Kubernetes stage with them.
+
+Everything you can see is in the context below: the stage requirements, the commands they recently ran and their output, the objects in the cluster that are not healthy, recent events, the manifests they have open, and the result of the last verification run.
+
+**You have no hands.** You cannot run commands or change the cluster — the hands are theirs. Your job is to get them to type the right command themselves.
+
+Rules:
+1. **Read the context before answering**, especially the recent terminal output: the reason they are stuck is usually in one of those errors. Do not lecture about Kubernetes in general.
+2. **Do not hand over the whole stage solution** unless they explicitly ask. Prefer "here is what to look at next", with a **concrete command to run**.
+3. Put commands in their own \`\`\`bash block, one or two at a time, and say what to look for in the output. They will run it and paste the result back.
+4. The cluster state in context is a **trimmed summary**, not everything. When you need more, ask them to run kubectl rather than guessing.
+5. Separate what the cluster objectively shows from what you suspect. Quote the context for the former; label the latter as a hypothesis and say how to confirm it.
+6. When verification fails, first explain what that check is asserting and why it does not hold yet, then give the smallest next step.
+7. Use Markdown. Answer in English.`;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // aiConfig 而不是 config：模块顶上那个 export const config 是路由配置
+    const { messages, context, language = 'zh', config: aiConfig } = req.body as OpsChatRequest;
+
+    if (!Array.isArray(messages)) {
+      return res.status(400).json({ error: 'Messages array is required' });
+    }
+    if (!context || typeof context !== 'object') {
+      return res.status(400).json({ error: 'Ops context is required' });
+    }
+
+    const fullMessages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt(language) },
+      { role: 'system', content: buildOpsContext(context, language) },
+      ...messages,
+    ];
+
+    await streamAI(res, fullMessages, aiConfig, {
+      temperature: 0.5,
+      maxTokens: 2500,
+      format: 'sse',
+      signal: abortSignalFor(res),
+    });
+  } catch (error) {
+    console.error('Ops chat error:', error);
+    const message =
+      error instanceof NoProviderError ? error.message : (error as Error).message || 'Failed to get AI response';
+    if (!res.headersSent) return res.status(statusForError(error)).json({ error: message });
+    res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+    res.end();
+  }
+}

--- a/pages/api/ops-chat.ts
+++ b/pages/api/ops-chat.ts
@@ -12,15 +12,16 @@ import { buildOpsContext, OpsContext } from '../../src/lib/server/opsPrompt';
 /*
  * 请求体上限。
  *
- * ops 的上下文已经在客户端压成定长摘要了（src/lib/opslab/lab/aicontext.ts），
- * 正常一条请求几十 KB。这里仍然把上限抬到 8mb，和工程对话保持一致 ——
- * 工程对话当年就是撞在 Next 默认的 1mb 上，一个中等项目直接 413。
+ * 不照抄工程对话那个 8mb：那边发的是整个工作区，大小由项目决定，所以撞过
+ * Next 默认的 1mb（一个中等项目直接 413）。这边不一样 —— 上下文在客户端就被
+ * 压成了定长摘要（src/lib/opslab/lab/aicontext.ts），实测几十 KB，测试盯着
+ * 200KB 这条线。给到 2mb 是十倍余量，再往上只是白开一个更大的解析面。
  * responseLimit 关掉是因为回答是流式的。
  */
 export const config = {
   api: {
     responseLimit: false,
-    bodyParser: { sizeLimit: '8mb' },
+    bodyParser: { sizeLimit: '2mb' },
   },
 };
 

--- a/pages/api/ops-review.ts
+++ b/pages/api/ops-review.ts
@@ -1,0 +1,170 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  abortSignalFor,
+  AIProviderConfig,
+  ChatMessage,
+  extractJson,
+  NoProviderError,
+  streamStructured,
+  statusForError,
+} from '../../src/lib/server/aiProvider';
+import { buildOpsContext, OpsContext, REVIEW_MAX_CHARS } from '../../src/lib/server/opsPrompt';
+import { OPS_DIMENSION_KEYS } from '../../src/lib/engineering/types';
+import type { OpsReview } from '../../src/lib/engineering/types';
+
+/*
+ * 上下文已经在客户端压成定长摘要了（src/lib/opslab/lab/aicontext.ts），复盘比对话
+ * 多带一整条排查路径，量级仍在几十 KB。上限和其它 AI 路由保持一致的 8mb ——
+ * 工程评审当年就是撞在 Next 默认的 1mb 上，一个中等项目直接 413。
+ */
+export const config = {
+  api: {
+    responseLimit: false,
+    bodyParser: { sizeLimit: '8mb' },
+  },
+};
+
+interface OpsReviewRequest {
+  context: OpsContext;
+  language: 'en' | 'zh';
+  config?: AIProviderConfig;
+}
+
+const REVIEW_SCHEMA = `{
+  "summary": "2-4 sentences: how did they operate this stage, and would you hand them the on-call pager",
+  "dimensions": [
+    { "key": "diagnosis|outcome|safety|efficiency|understanding", "score": 0-100, "comment": "one concrete sentence" }
+  ],
+  "issues": [
+    {
+      "title": "short problem statement",
+      "severity": "blocker|major|minor|nit",
+      "where": "the command, object or file this is about",
+      "detail": "why this would hurt on a real cluster, not just here",
+      "suggestion": "the smallest concrete change, as a command or an edit"
+    }
+  ],
+  "strengths": ["what they genuinely did well"],
+  "nextSteps": ["what to do before calling this stage done"]
+}`;
+
+/**
+ * 复盘评的是操作，不是代码。
+ *
+ * 学员在这一关里没有写程序，他敲了一串命令、改了几个 manifest，把集群从坏改到好。
+ * 所以能评的东西是：他怎么缩小范围的、集群现在到底对不对、有没有为了通关走危险
+ * 的旁路（--force / delete 重建 / 直接改 status）、多少步走到答案、以及从命令的
+ * 选择上看得出他是理解了机制还是在照抄。
+ *
+ * 「验收过了」不等于操作是对的：判定只查关键点，把 replicas 调成 0 也能让
+ * CrashLoopBackOff 消失。提示词里把这一条写死。
+ */
+function systemPrompt(language: 'en' | 'zh'): string {
+  const shared = `You are a senior SRE doing a post-incident review with an engineer who has just worked through a hands-on Kubernetes stage on a jump host. You can see the stage requirements, the commands they ran in order, the current cluster state, the manifests they touched, and the verification result.
+
+Judge how they operated, in order of importance:
+1. **diagnosis** — the path they took to find the problem. Did each command narrow the search, or were they guessing? Did they read the error before reacting to it? Did they check the obvious cheap thing first (events, describe, logs) before the expensive one?
+2. **outcome** — is the cluster actually correct now, not just passing. Look at the objects, not only the verification result.
+3. **safety** — anything they did that would be dangerous on a production cluster: --force, deleting and recreating instead of fixing, editing status, scaling to zero to silence a crash loop, disabling a probe rather than fixing what it caught, changes made imperatively that are not in any manifest.
+4. **efficiency** — how many steps it took, repeated commands that told them nothing new, long detours.
+5. **understanding** — does the sequence of commands read like someone who knows the mechanism, or like someone pattern-matching a runbook?
+
+Hard rules:
+- **A passing verification does NOT mean they operated well.** The checks only assert key facts; a shortcut can satisfy them. If they got there by a route that would be unacceptable on a real cluster, say so and score safety accordingly, even when everything is green.
+- Judge what is actually in the context. Never invent commands they did not run or objects that are not there.
+- The cluster state and command history are a **trimmed summary**. If something is absent, do not assume they never did it — say what you would need to see.
+- Every issue must point at something concrete in the context: quote the command or name the object in "where".
+- Prefer a few findings that matter over a list of nitpicks. Severity reflects blast radius on a real cluster.
+- Scores are calibrated: 90+ means you would be happy to see this from a colleague on-call, 70 means it works but you would coach them, below 50 means something is actually wrong with how they did it.
+- Return ONLY valid JSON matching the schema. No markdown fences, no commentary outside the JSON.`;
+
+  const localised =
+    language === 'zh'
+      ? '\n\nAll human-readable text inside the JSON (summary, comment, title, where, detail, suggestion, strengths, nextSteps) MUST be written in Chinese.'
+      : '\n\nAll human-readable text inside the JSON must be written in English.';
+
+  return shared + localised;
+}
+
+function normalise(review: any, language: 'en' | 'zh'): OpsReview {
+  const allowedSeverity = ['blocker', 'major', 'minor', 'nit'];
+
+  const dimensions = Array.isArray(review?.dimensions)
+    ? review.dimensions
+        .filter((item: any) => (OPS_DIMENSION_KEYS as readonly string[]).includes(item?.key))
+        .map((item: any) => ({
+          key: item.key,
+          score: Math.max(0, Math.min(100, Math.round(Number(item.score) || 0))),
+          comment: String(item.comment || ''),
+        }))
+    : [];
+
+  const issues = Array.isArray(review?.issues)
+    ? review.issues.slice(0, 12).map((item: any) => ({
+        title: String(item?.title || 'Issue'),
+        severity: allowedSeverity.includes(item?.severity) ? item.severity : 'minor',
+        where: item?.where ? String(item.where) : undefined,
+        detail: String(item?.detail || ''),
+        suggestion: item?.suggestion ? String(item.suggestion) : undefined,
+      }))
+    : [];
+
+  return {
+    summary: String(review?.summary || (language === 'zh' ? '（模型没有给出总结）' : '(no summary returned)')),
+    dimensions,
+    issues,
+    strengths: Array.isArray(review?.strengths) ? review.strengths.slice(0, 8).map(String) : [],
+    nextSteps: Array.isArray(review?.nextSteps) ? review.nextSteps.slice(0, 8).map(String) : [],
+  };
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // aiConfig 而不是 config：模块顶上那个 export const config 是路由配置
+    const { context, language = 'zh', config: aiConfig } = req.body as OpsReviewRequest;
+
+    if (!context || typeof context !== 'object') {
+      return res.status(400).json({ error: 'Ops context is required' });
+    }
+    if (!context.snapshot) {
+      return res.status(400).json({ error: 'A cluster snapshot is required to review an ops stage' });
+    }
+
+    const userContent = [
+      buildOpsContext(context, language, REVIEW_MAX_CHARS),
+      '',
+      language === 'zh'
+        ? '请按上面的标准复盘这一关的操作过程，并严格按下面的 JSON 结构返回：'
+        : 'Review how this stage was operated and return exactly this JSON structure:',
+      REVIEW_SCHEMA,
+    ].join('\n\n');
+
+    const messages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt(language) },
+      { role: 'user', content: userContent },
+    ];
+
+    // 复盘是给人读的长文，没有理由攒到最后一次性甩出来
+    await streamStructured(res, messages, aiConfig, {
+      temperature: 0.3,
+      maxTokens: 4000,
+      signal: abortSignalFor(res),
+      onComplete: (raw) => ({ review: normalise(extractJson<any>(raw), language) }),
+    });
+  } catch (error) {
+    console.error('Ops review error:', error);
+    const message =
+      error instanceof NoProviderError ? error.message : (error as Error).message || 'Failed to generate review';
+    if (res.headersSent) {
+      res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);
+      res.end();
+      return;
+    }
+    return res.status(statusForError(error)).json({ error: message });
+  }
+}

--- a/pages/api/ops-review.ts
+++ b/pages/api/ops-review.ts
@@ -13,14 +13,14 @@ import { OPS_DIMENSION_KEYS } from '../../src/lib/engineering/types';
 import type { OpsReview } from '../../src/lib/engineering/types';
 
 /*
- * 上下文已经在客户端压成定长摘要了（src/lib/opslab/lab/aicontext.ts），复盘比对话
- * 多带一整条排查路径，量级仍在几十 KB。上限和其它 AI 路由保持一致的 8mb ——
- * 工程评审当年就是撞在 Next 默认的 1mb 上，一个中等项目直接 413。
+ * 请求体上限，理由同 ops-chat：上下文是客户端压出来的定长摘要，复盘比对话多带
+ * 一整条排查路径，实测也就几十 KB。2mb 是十倍余量，不用照抄工程评审那个 8mb ——
+ * 那个数是为「整个工作区」留的。responseLimit 关掉是因为回答是流式的。
  */
 export const config = {
   api: {
     responseLimit: false,
-    bodyParser: { sizeLimit: '8mb' },
+    bodyParser: { sizeLimit: '2mb' },
   },
 };
 
@@ -130,7 +130,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!context || typeof context !== 'object') {
       return res.status(400).json({ error: 'Ops context is required' });
     }
-    if (!context.snapshot) {
+    // 查到字段一级：只判 snapshot 存在的话，一个 {} 会在排版时抛出去变成 500
+    const snapshot = context.snapshot as Partial<typeof context.snapshot> | undefined;
+    if (!snapshot || !Array.isArray(snapshot.problems) || !Array.isArray(snapshot.commands)) {
       return res.status(400).json({ error: 'A cluster snapshot is required to review an ops stage' });
     }
 

--- a/src/components/engineering/ReviewPanel.tsx
+++ b/src/components/engineering/ReviewPanel.tsx
@@ -3,7 +3,7 @@ import { IconBulb, IconCheck, IconSparkles, IconThumbUp } from '@tabler/icons-re
 import { useTranslation } from '../../contexts/I18nContext';
 import MarkdownRenderer from '../MarkdownRenderer';
 import { scoreColor } from './ResultPanels';
-import type { AiReview, DimensionKey } from '../../lib/engineering/types';
+import type { DimensionKey } from '../../lib/engineering/types';
 
 const SEVERITY_COLOR: Record<string, string> = {
   blocker: 'red',
@@ -12,17 +12,65 @@ const SEVERITY_COLOR: Record<string, string> = {
   nit: 'gray',
 };
 
+/**
+ * 面板认的是形状，不是某一种评审。
+ *
+ * ops 工作台的复盘（OpsReview）维度不一样、定位字段也不叫 file，但排版是同一套：
+ * 总结 + 维度分 + 问题列表 + 亮点 + 下一步。与其抄一份，不如把这里放宽到结构，
+ * 由调用方把自己的评审映射进来。AiReview 天然满足这个形状。
+ */
+export interface ReviewPanelData {
+  summary: string;
+  dimensions: Array<{ key: string; score: number; comment: string }>;
+  issues: Array<{
+    title: string;
+    severity: string;
+    /** 右上角那行小字：代码形态是文件名，ops 是命令或对象 */
+    file?: string;
+    detail: string;
+    suggestion?: string;
+  }>;
+  strengths: string[];
+  nextSteps: string[];
+}
+
+/** 面板上的文案。不传就按代码形态的来，代码工作台因此完全不用改。 */
+export interface ReviewPanelStrings {
+  title: string;
+  subtitle: string;
+  request: string;
+  running: string;
+  empty: string;
+  issues: string;
+  strengths: string;
+  nextSteps: string;
+  dimensionLabel: (key: string) => string;
+}
+
 interface ReviewPanelProps {
-  review: AiReview | null;
+  review: ReviewPanelData | null;
   loading: boolean;
   error: string | null;
   onRequest: () => void;
   /** 评审生成中的原文。有它就不用对着一个转圈猜进度。 */
   draft?: string;
+  strings?: ReviewPanelStrings;
 }
 
-export default function ReviewPanel({ review, loading, error, onRequest, draft }: ReviewPanelProps) {
+export default function ReviewPanel({ review, loading, error, onRequest, draft, strings }: ReviewPanelProps) {
   const { t } = useTranslation();
+
+  const text: ReviewPanelStrings = strings ?? {
+    title: t('engineering.review.title'),
+    subtitle: t('engineering.review.subtitle'),
+    request: t('engineering.review.request'),
+    running: t('engineering.review.running'),
+    empty: t('engineering.review.empty'),
+    issues: t('engineering.review.issues'),
+    strengths: t('engineering.review.strengths'),
+    nextSteps: t('engineering.review.nextSteps'),
+    dimensionLabel: (key) => t(`engineering.dimensions.${key as DimensionKey}` as const),
+  };
 
   return (
     <Stack gap="md">
@@ -30,10 +78,10 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
         <Group justify="space-between" wrap="nowrap">
           <Stack gap={2} style={{ minWidth: 0 }}>
             <Text size="sm" fw={600}>
-              {t('engineering.review.title')}
+              {text.title}
             </Text>
             <Text size="xs" c="dimmed">
-              {t('engineering.review.subtitle')}
+              {text.subtitle}
             </Text>
           </Stack>
           <Button
@@ -44,7 +92,7 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
             onClick={onRequest}
             disabled={loading}
           >
-            {loading ? t('engineering.review.running') : t('engineering.review.request')}
+            {loading ? text.running : text.request}
           </Button>
         </Group>
       </Card>
@@ -76,7 +124,7 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
       {!review && !loading && !error && (
         <Group justify="center" py="xl">
           <Text size="sm" c="dimmed" ta="center" maw={360}>
-            {t('engineering.review.empty')}
+            {text.empty}
           </Text>
         </Group>
       )}
@@ -93,7 +141,7 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
                 <Card key={dimension.key} withBorder radius="md" padding="sm" style={{ flex: '1 1 160px' }}>
                   <Group justify="space-between" mb={2}>
                     <Text size="xs" fw={600}>
-                      {t(`engineering.dimensions.${dimension.key as DimensionKey}` as const)}
+                      {text.dimensionLabel(dimension.key)}
                     </Text>
                     <Text size="sm" fw={700} c={scoreColor(dimension.score)}>
                       {dimension.score}
@@ -110,7 +158,7 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
           {review.issues.length > 0 && (
             <Stack gap={8}>
               <Text size="sm" fw={600}>
-                {t('engineering.review.issues')}
+                {text.issues}
               </Text>
               {review.issues.map((issue, index) => (
                 <Card key={index} withBorder radius="md" padding="sm">
@@ -150,7 +198,7 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
               <Group gap={6} mb={6}>
                 <IconThumbUp size={14} />
                 <Text size="sm" fw={600}>
-                  {t('engineering.review.strengths')}
+                  {text.strengths}
                 </Text>
               </Group>
               <List size="xs" spacing={4} icon={<IconCheck size={12} color="var(--mantine-color-teal-filled)" />}>
@@ -164,7 +212,7 @@ export default function ReviewPanel({ review, loading, error, onRequest, draft }
           {review.nextSteps.length > 0 && (
             <Card withBorder radius="md" padding="sm">
               <Text size="sm" fw={600} mb={6}>
-                {t('engineering.review.nextSteps')}
+                {text.nextSteps}
               </Text>
               <List size="xs" spacing={4} type="ordered">
                 {review.nextSteps.map((item, index) => (

--- a/src/components/opslab/OpsChat.tsx
+++ b/src/components/opslab/OpsChat.tsx
@@ -1,0 +1,115 @@
+/**
+ * ops 工作台里的 AI 助手
+ *
+ * 和代码形态那个浮动按钮 + 弹窗不一样：这里它是右侧那组 tab 里的一页，
+ * 和终端、IDE、拓扑并列。原因是 ops 的问答几乎总是「看着报错问」——
+ * 一个盖住半个屏幕的弹窗会把学员要问的那段输出挡住。
+ *
+ * 上下文在**每次发送时**现取：集群一直在动，敲一条命令世界就变了，
+ * 缓存下来的快照第二个问题就已经过期了。
+ */
+import { useCallback, useMemo } from 'react';
+import { Text } from '@mantine/core';
+import { IconRobot } from '@tabler/icons-react';
+import { useI18n, useTranslation } from '../../contexts/I18nContext';
+import { useAiConfig } from '../../hooks/useAiConfig';
+import { useChatStream, StreamMessage } from '../../hooks/useChatStream';
+import ChatPanel from '../chat/ChatPanel';
+import { buildOpsSnapshot, summarizeReport } from '../../lib/opslab/lab';
+import type { OpsWorld } from '../../lib/opslab/lab';
+import type { CommandRecord } from '../../lib/labkit/machine';
+import type { LocalizedText, StageRunReport } from '../../lib/engineering/types';
+
+export interface OpsChatProps {
+  projectTitle: LocalizedText;
+  projectSummary: LocalizedText;
+  stageTitle: LocalizedText;
+  stageGoal: LocalizedText;
+  stageIndex: number;
+  stageCount: number;
+  checklist?: LocalizedText[];
+  world: OpsWorld | null;
+  history: CommandRecord[];
+  namespace: string;
+  /** IDE 里打开的文件（这一关涉及的那些） */
+  files: Record<string, string>;
+  report: StageRunReport | null;
+}
+
+export default function OpsChat(props: OpsChatProps) {
+  const { t } = useTranslation();
+  const { locale } = useI18n();
+  const { config } = useAiConfig();
+
+  const {
+    world, history, namespace, files, report,
+    projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+  } = props;
+
+  const buildBody = useCallback(
+    (chatHistory: StreamMessage[], input: string) => ({
+      messages: [...chatHistory, { role: 'user' as const, content: input }].map((message) => ({
+        role: message.role,
+        content: message.content,
+      })),
+      language: locale,
+      config,
+      context: {
+        projectTitle,
+        projectSummary,
+        stageIndex,
+        stageCount,
+        stageTitle,
+        stageGoal,
+        checklist,
+        // 世界还没起来时只发关卡信息 —— 总比整个面板不能用强
+        snapshot: world ? buildOpsSnapshot(world, { files, history, namespace }) : undefined,
+        report: summarizeReport(report),
+      },
+    }),
+    [
+      config, locale, world, files, history, namespace, report,
+      projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+    ]
+  );
+
+  const chat = useChatStream({ url: '/api/ops-chat', body: buildBody });
+
+  /**
+   * 快捷提问跟着现场走。
+   *
+   * 上一条命令挂了就先问它 —— 那通常就是学员想问的；验收没过就问没过的那条。
+   */
+  const quickPrompts = useMemo(() => {
+    const prompts: string[] = [];
+    const last = history[history.length - 1];
+    if (last && last.code !== 0) prompts.push(t('opslab.chat.prompts.lastError'));
+    if (report && report.status !== 'passed') prompts.push(t('opslab.chat.prompts.whyFailing'));
+    prompts.push(t('opslab.chat.prompts.whereToLook'));
+    prompts.push(t('opslab.chat.prompts.explainStage'));
+    return prompts;
+  }, [history, report, t]);
+
+  return (
+    <ChatPanel
+      messages={chat.messages}
+      isStreaming={chat.isStreaming}
+      error={chat.error}
+      onSend={chat.send}
+      onStop={chat.stop}
+      onClear={chat.clear}
+      onRetry={chat.retry}
+      onDismissError={() => chat.setError(null)}
+      quickPrompts={quickPrompts}
+      placeholder={t('opslab.chat.placeholder')}
+      emptyState={
+        <>
+          <IconRobot size={44} opacity={0.35} />
+          <Text size="sm" c="dimmed" ta="center" maw={420}>
+            {t('opslab.chat.empty')}
+          </Text>
+        </>
+      }
+    />
+  );
+}

--- a/src/components/opslab/OpsReview.tsx
+++ b/src/components/opslab/OpsReview.tsx
@@ -1,0 +1,133 @@
+/**
+ * ops 工作台的 AI 复盘
+ *
+ * 和代码形态的评审并列，但评的东西完全不同：那边评「这段代码能不能合」，
+ * 这边评「这一关他是怎么操作过来的」—— 学员没写代码，他敲了一串命令、
+ * 改了几个 manifest，把集群从坏改到好。
+ *
+ * 它放在左栏「验收」旁边而不是右栏：右栏是干活的地方（终端、IDE、拓扑），
+ * 左栏是读长文的地方，而复盘正是一篇要从头读到尾的长文。
+ *
+ * 排版直接复用代码形态那个 ReviewPanel —— 总结 + 维度分 + 问题 + 亮点 + 下一步
+ * 是同一套结构，只是维度和文案换了一套。
+ */
+import { useCallback, useMemo, useState } from 'react';
+import { useI18n, useTranslation } from '../../contexts/I18nContext';
+import { useAiConfig } from '../../hooks/useAiConfig';
+import { requestStructuredStream } from '../../lib/streamRequest';
+import ReviewPanel from '../engineering/ReviewPanel';
+import type { ReviewPanelData, ReviewPanelStrings } from '../engineering/ReviewPanel';
+import { buildOpsSnapshot, summarizeReport, SNAPSHOT_LIMITS } from '../../lib/opslab/lab';
+import type { OpsWorld } from '../../lib/opslab/lab';
+import type { CommandRecord } from '../../lib/labkit/machine';
+import type { LocalizedText, OpsReview as OpsReviewData, StageRunReport } from '../../lib/engineering/types';
+
+export interface OpsReviewProps {
+  projectTitle: LocalizedText;
+  projectSummary: LocalizedText;
+  stageTitle: LocalizedText;
+  stageGoal: LocalizedText;
+  stageIndex: number;
+  stageCount: number;
+  checklist?: LocalizedText[];
+  world: OpsWorld | null;
+  history: CommandRecord[];
+  namespace: string;
+  files: Record<string, string>;
+  report: StageRunReport | null;
+}
+
+export default function OpsReview(props: OpsReviewProps) {
+  const { t } = useTranslation();
+  const { locale } = useI18n();
+  const { config } = useAiConfig();
+
+  const [review, setReview] = useState<OpsReviewData | null>(null);
+  const [draft, setDraft] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    world, history, namespace, files, report,
+    projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+  } = props;
+
+  const handleRequest = useCallback(async () => {
+    if (!world) {
+      setError(t('opslab.review.noWorld'));
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setDraft('');
+
+    try {
+      const data = await requestStructuredStream<{ review: OpsReviewData }>(
+        '/api/ops-review',
+        {
+          language: locale,
+          config,
+          context: {
+            projectTitle,
+            projectSummary,
+            stageIndex,
+            stageCount,
+            stageTitle,
+            stageGoal,
+            checklist,
+            // 复盘要看整条排查路径，不是最近几条 —— 命令的顺序本身就是被评的东西
+            snapshot: buildOpsSnapshot(world, {
+              files, history, namespace, limits: SNAPSHOT_LIMITS.review,
+            }),
+            report: summarizeReport(report),
+          },
+        },
+        { onDelta: (_chunk, full) => setDraft(full) }
+      );
+      setReview(data.review);
+    } catch (requestError) {
+      setError((requestError as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    config, locale, world, files, history, namespace, report, t,
+    projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+  ]);
+
+  const strings = useMemo<ReviewPanelStrings>(
+    () => ({
+      title: t('opslab.review.title'),
+      subtitle: t('opslab.review.subtitle'),
+      request: t('opslab.review.request'),
+      running: t('opslab.review.running'),
+      empty: t('opslab.review.empty'),
+      issues: t('opslab.review.issues'),
+      strengths: t('opslab.review.strengths'),
+      nextSteps: t('opslab.review.nextSteps'),
+      dimensionLabel: (key) => t(`opslab.review.dimensions.${key}`),
+    }),
+    [t]
+  );
+
+  // where -> file：面板右上角那行小字，代码形态放文件名，这里放命令或对象
+  const data = useMemo<ReviewPanelData | null>(
+    () =>
+      review
+        ? { ...review, issues: review.issues.map((issue) => ({ ...issue, file: issue.where })) }
+        : null,
+    [review]
+  );
+
+  return (
+    <ReviewPanel
+      review={data}
+      loading={loading}
+      error={error}
+      draft={draft}
+      onRequest={handleRequest}
+      strings={strings}
+    />
+  );
+}

--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mantine/core';
 import {
   IconAlertTriangle, IconDeviceDesktop, IconFileCode, IconPlayerPlay,
-  IconRefresh, IconRoute, IconSitemap, IconTimeline,
+  IconRefresh, IconRobot, IconRoute, IconSitemap, IconTimeline,
 } from '@tabler/icons-react';
 import { useMantineColorScheme } from '@mantine/core';
 import Editor from '@monaco-editor/react';
@@ -35,6 +35,8 @@ import type { StageRunReport } from '../../lib/engineering/types';
 const OpsTerminal = dynamic(() => import('./OpsTerminal'), { ssr: false });
 const TopologyView = dynamic(() => import('./TopologyView'), { ssr: false });
 const PacketPathPanel = dynamic(() => import('./PacketPathPanel'), { ssr: false });
+const OpsChat = dynamic(() => import('./OpsChat'), { ssr: false });
+const OpsReview = dynamic(() => import('./OpsReview'), { ssr: false });
 
 export interface OpsWorkspaceProps {
   session: ProjectSession;
@@ -50,7 +52,7 @@ const BANNER = [
 ].join('\r\n');
 
 /** 右侧那一组 tab，以及记住选择用的键 */
-const RIGHT_TABS = ['terminal', 'ide', 'topology', 'changes', 'packets'];
+const RIGHT_TABS = ['terminal', 'ide', 'topology', 'changes', 'packets', 'chat'];
 const RIGHT_TAB_KEY = 'opslab.rightTab.v1';
 const SPLIT_KEY = 'opslab.split.v1';
 
@@ -300,6 +302,7 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 <Tabs.Tab value="result" fz="xs">
                   验收{report ? ` · ${report.totals.passed}/${report.totals.total}` : ''}
                 </Tabs.Tab>
+                <Tabs.Tab value="review" fz="xs">复盘</Tabs.Tab>
               </Tabs.List>
               <Tabs.Panel value="goal" style={{ flex: 1, minHeight: 0 }}>
                 <ScrollArea h="100%" type="auto" p="sm">
@@ -326,6 +329,30 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                     : <Text size="xs" c="dimmed">还没跑过验收</Text>}
                 </ScrollArea>
               </Tabs.Panel>
+              {/**
+                * 复盘。评的是操作过程，不是验收结果 —— 验收只查关键点，
+                * 把 replicas 调成 0 也能让 CrashLoopBackOff 消失。
+                */}
+              <Tabs.Panel value="review" style={{ flex: 1, minHeight: 0 }}>
+                <ScrollArea h="100%" type="auto" p="sm">
+                  <ErrorBoundary fallback={renderPanelError}>
+                    <OpsReview
+                      projectTitle={project.title}
+                      projectSummary={project.summary}
+                      stageTitle={stage.title}
+                      stageGoal={stage.goal}
+                      stageIndex={stageIndex}
+                      stageCount={project.stages.length}
+                      checklist={stage.checklist}
+                      world={ops.world}
+                      history={ops.history}
+                      namespace={ops.namespace}
+                      files={machineFiles}
+                      report={report}
+                    />
+                  </ErrorBoundary>
+                </ScrollArea>
+              </Tabs.Panel>
             </Tabs>
           )}
           right={(
@@ -348,6 +375,9 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                   <Tabs.Tab value="topology" fz="xs" leftSection={<IconSitemap size={13} />}>拓扑</Tabs.Tab>
                   <Tabs.Tab value="changes" fz="xs" leftSection={<IconTimeline size={13} />}>事件与变更</Tabs.Tab>
                   <Tabs.Tab value="packets" fz="xs" leftSection={<IconRoute size={13} />}>包路径</Tabs.Tab>
+                  <Tabs.Tab value="chat" fz="xs" leftSection={<IconRobot size={13} />}>
+                    {t('opslab.chat.tab')}
+                  </Tabs.Tab>
                 </Tabs.List>
 
                 {/* 只跟集群视图有关的控件。切到终端或者 IDE 的时候它们没有意义，就别占地方。 */}
@@ -466,6 +496,31 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
               <Tabs.Panel value="packets" style={{ flex: 1, minHeight: 0 }}>
                 <ErrorBoundary fallback={renderPanelError}>
                   <PacketPathPanel paths={ops.packetPaths} onHighlight={setHighlight} />
+                </ErrorBoundary>
+              </Tabs.Panel>
+
+              {/**
+                * AI 助手。
+                *
+                * 保持挂载：对话历史不能因为切去看一眼拓扑就没了。
+                * 它只读世界，不执行任何命令 —— 建议的命令由学员自己敲进终端。
+                */}
+              <Tabs.Panel value="chat" style={{ flex: 1, minHeight: 0 }}>
+                <ErrorBoundary fallback={renderPanelError}>
+                  <OpsChat
+                    projectTitle={project.title}
+                    projectSummary={project.summary}
+                    stageTitle={stage.title}
+                    stageGoal={stage.goal}
+                    stageIndex={stageIndex}
+                    stageCount={project.stages.length}
+                    checklist={stage.checklist}
+                    world={ops.world}
+                    history={ops.history}
+                    namespace={ops.namespace}
+                    files={machineFiles}
+                    report={report}
+                  />
                 </ErrorBoundary>
               </Tabs.Panel>
             </Tabs>

--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -121,6 +121,16 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
   }, [registerClearResults]);
 
   /**
+   * 复盘的结论只对「这一关的这个世界」成立。
+   *
+   * OpsWorkspace 换关卡时不重挂（关卡在 session 里），复盘的结果又是它自己的
+   * 局部状态 —— 不管的话，学员翻到下一关，看到的还是上一关的评分和问题列表，
+   * 而且被当成这一关的。「重置世界」同理：结论挂在一个已经不存在的世界上。
+   * 用 key 把这两件事一起解决。
+   */
+  const reviewKey = `${stage?.id ?? 'none'}:${ops.generation}`;
+
+  /**
    * 自测入口，只在开发构建里挂。
    *
    * 终端的输入走的是真键盘事件（xterm 自己解析），自动化环境很难可靠地
@@ -337,6 +347,7 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 <ScrollArea h="100%" type="auto" p="sm">
                   <ErrorBoundary fallback={renderPanelError}>
                     <OpsReview
+                      key={reviewKey}
                       projectTitle={project.title}
                       projectSummary={project.summary}
                       stageTitle={stage.title}

--- a/src/hooks/useOpsWorkspace.ts
+++ b/src/hooks/useOpsWorkspace.ts
@@ -55,6 +55,8 @@ export interface OpsWorkspaceState {
   prompt: string;
   /** 从头再来 */
   reboot(): void;
+  /** 重置过几次。世界被推倒重来之后，挂在旧世界上的结论（比如 AI 复盘）就该作废 */
+  generation: number;
   /** 拓扑图要不要展开 ReplicaSet */
   showReplicaSets: boolean;
   setShowReplicaSets(value: boolean): void;
@@ -193,6 +195,7 @@ export function useOpsWorkspace(options: UseOpsWorkspaceOptions): OpsWorkspaceSt
     writeFile,
     prompt: world?.machine.prompt() ?? '$ ',
     reboot: () => setGeneration((value) => value + 1),
+    generation,
     showReplicaSets,
     setShowReplicaSets,
     namespace,

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -637,3 +637,32 @@ export interface AiReview {
   strengths: string[];
   nextSteps: string[];
 }
+
+/* ------------------------------------------------------------------ *
+ * ops 工作台的 AI 复盘
+ *
+ * 和代码形态的 AiReview 是两回事：那边评的是「这段代码能不能合」，这边评的是
+ * 「这一关他是怎么操作过来的」—— 学员没写代码，他敲了一串命令、改了几个
+ * manifest，把集群从坏改成好。所以维度也不一样，判分看的是排查路径本身。
+ * ------------------------------------------------------------------ */
+
+export const OPS_DIMENSION_KEYS = ['diagnosis', 'outcome', 'safety', 'efficiency', 'understanding'] as const;
+
+export type OpsDimensionKey = (typeof OPS_DIMENSION_KEYS)[number];
+
+export interface OpsReviewIssue {
+  title: string;
+  severity: 'blocker' | 'major' | 'minor' | 'nit';
+  /** 出问题的地方：一条命令、一个集群对象，或者一个文件 */
+  where?: string;
+  detail: string;
+  suggestion?: string;
+}
+
+export interface OpsReview {
+  summary: string;
+  dimensions: Array<{ key: OpsDimensionKey; score: number; comment: string }>;
+  issues: OpsReviewIssue[];
+  strengths: string[];
+  nextSteps: string[];
+}

--- a/src/lib/opslab/lab/aicontext.ts
+++ b/src/lib/opslab/lab/aicontext.ts
@@ -18,8 +18,14 @@ import type { StageRunReport } from '../../engineering/types';
 import { describe as describeObject } from './view';
 import type { OpsWorld } from './world';
 
-/** 最多带几个命名空间的常规对象（异常对象不受这个限制） */
-const MAX_NAMESPACES = 8;
+/**
+ * 最多带几个命名空间的常规对象（异常对象不受这个限制）。
+ *
+ * 得盖得住整个工程：intranet-k8s 有 15 个命名空间，之前这里是 8，按字母序
+ * 砍掉的正好是 istio-system、monitoring、velero 这些**关卡本身要讲的**那几个。
+ * 真正约束体积的是 MAX_WORKLOADS，这个数放宽不会把请求体撑起来。
+ */
+const MAX_NAMESPACES = 24;
 /** 常规工作负载最多带多少条 */
 const MAX_WORKLOADS = 40;
 /** 异常对象最多带多少条 */
@@ -51,6 +57,12 @@ const MAX_FILE_CHARS = 4000;
 const MAX_FILES_TOTAL = 10000;
 /** 失败用例最多带几条 */
 const MAX_FAILING_CASES = 6;
+/** 节点最多带多少个（自动伸缩那几关能把节点数拉起来） */
+const MAX_NODES = 20;
+/** 单条命令本身截到多少字符：粘一段 PEM 进终端也不该整段发出去 */
+const MAX_COMMAND_TEXT = 300;
+/** 单条失败用例的报错截到多少字符 */
+const MAX_CASE_ERROR = 800;
 
 /** 这些类型是「工作负载」，值得逐个列出来 */
 const WORKLOAD_KINDS = new Set([
@@ -89,7 +101,7 @@ export interface SnapshotCommand {
 }
 
 export interface OpsSnapshot {
-  /** kubeconfig 的 current-context 指着哪个命名空间 */
+  /** 学员正在看的那个命名空间（拓扑上那个下拉框选的，未必等于 kubeconfig 里的） */
   namespace: string;
   nodes: SnapshotObject[];
   workloads: SnapshotObject[];
@@ -98,8 +110,14 @@ export interface OpsSnapshot {
   events: SnapshotEvent[];
   commands: SnapshotCommand[];
   files: Array<{ path: string; content: string }>;
-  /** 被裁掉了多少东西，让模型知道自己看到的不是全部 */
-  omitted: { objects: number; namespaces: number; commands: number };
+  /**
+   * 被裁掉了多少东西，让模型知道自己看到的不是全部。
+   *
+   * `objects` 和 `problems` 必须分开报：前者是「健康、故意不列」，后者是
+   * 「不健康、但超出上限被砍了」。混在一起报成「省略了 N 个健康对象」，
+   * 等于跟模型撒谎说问题列表是全的。
+   */
+  omitted: { objects: number; problems: number; namespaces: number; commands: number; files: number };
 }
 
 function truncate(text: string, limit: number): string {
@@ -125,7 +143,7 @@ function toSnapshot(object: KubeObject): SnapshotObject {
 }
 
 export interface OpsSnapshotOptions {
-  /** IDE 里打开的、以及这一关自带的文件 */
+  /** 跳板机磁盘上的文件（整块盘，下面会挑和裁） */
   files?: Record<string, string>;
   /** 终端历史 */
   history?: CommandRecord[];
@@ -159,7 +177,11 @@ export function buildOpsSnapshot(world: OpsWorld, options: OpsSnapshotOptions = 
   const allNamespaces = cluster.registry
     .list(cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'namespaces' })).items
     .map((item) => item.metadata.name!)
-    .sort((a, b) => (a === namespace ? -1 : b === namespace ? 1 : a < b ? -1 : 1));
+    .sort((a, b) => {
+      if (a === namespace) return b === namespace ? 0 : -1;
+      if (b === namespace) return 1;
+      return a === b ? 0 : a < b ? -1 : 1;
+    });
   const detailed = new Set(allNamespaces.slice(0, MAX_NAMESPACES));
 
   for (const definition of cluster.scheme.list()) {
@@ -174,10 +196,15 @@ export function buildOpsSnapshot(world: OpsWorld, options: OpsSnapshotOptions = 
         continue;
       }
 
-      const unhealthy = summary.status === 'error' || summary.status === 'warn';
-      if (unhealthy) {
-        if (problems.length < MAX_PROBLEMS) problems.push(summary);
-        else omittedObjects += 1;
+      /**
+       * 不是 ok 就算异常 —— pending 也要算。
+       *
+       * 之前只收 error 和 warn，于是一个卡在 Pending 的裸 Pod（ops 关卡里
+       * 最常见的症状）会一路掉到下面的 else 里被当成「健康对象」省掉，
+       * 模型收到的是「状态不正常的对象：没有」。
+       */
+      if (summary.status !== 'ok') {
+        problems.push(summary);
         continue;
       }
 
@@ -195,6 +222,21 @@ export function buildOpsSnapshot(world: OpsWorld, options: OpsSnapshotOptions = 
     }
   }
 
+  /**
+   * 异常对象先排序再砍，不能按遍历顺序先到先得。
+   *
+   * 注册表的遍历顺序是按资源类型来的，Pod 排在 Deployment 前面 —— 先到先得
+   * 的话，别处命名空间的一堆 Pod 能把 25 个名额占满，而学员正在问的那个
+   * 对象根本进不了请求。排序键：先当前命名空间，再按坏的程度。
+   */
+  const severity: Record<string, number> = { error: 0, warn: 1, pending: 2, ok: 3 };
+  problems.sort((a, b) => {
+    const mine = (item: SnapshotObject) => (item.namespace === namespace ? 0 : 1);
+    return mine(a) - mine(b) || severity[a.status] - severity[b.status];
+  });
+  const omittedProblems = Math.max(0, problems.length - MAX_PROBLEMS);
+  problems.length = Math.min(problems.length, MAX_PROBLEMS);
+
   const eventDefinition = cluster.scheme.get({ group: '', version: 'v1', resource: 'events' });
   if (eventDefinition) {
     const all = cluster.registry.list(eventDefinition).items;
@@ -203,7 +245,11 @@ export function buildOpsSnapshot(world: OpsWorld, options: OpsSnapshotOptions = 
       const warn = (item: KubeObject) => ((item as Record<string, unknown>).type === 'Warning' ? 0 : 1);
       const byType = warn(a) - warn(b);
       if (byType !== 0) return byType;
-      return (b.metadata.creationTimestamp ?? '') < (a.metadata.creationTimestamp ?? '') ? -1 : 1;
+      // 并列时必须返回 0：模拟时钟会让一批事件共用同一个时间戳，
+      // 恒返回 1 的比较器在这种情况下顺序是未定义的
+      const left = a.metadata.creationTimestamp ?? '';
+      const right = b.metadata.creationTimestamp ?? '';
+      return left === right ? 0 : left < right ? 1 : -1;
     });
     for (const event of sorted.slice(0, MAX_EVENTS)) {
       const raw = event as unknown as Record<string, any>;
@@ -220,32 +266,55 @@ export function buildOpsSnapshot(world: OpsWorld, options: OpsSnapshotOptions = 
   const history = options.history ?? [];
   const recent = history.slice(-limits.commands);
   const commands: SnapshotCommand[] = recent.map((record) => ({
-    command: record.command,
+    // 命令本身也截：往终端里粘一段 PEM 或者 base64 的 secret 是真会发生的
+    command: truncate(record.command, MAX_COMMAND_TEXT),
     code: record.code,
     output: outputOf(record, limits.commandOutput),
   }));
 
+  /**
+   * 文件。收到的是**整块磁盘**，不是「IDE 里打开的那几个」。
+   *
+   * 所以顺序很要紧：磁盘是按路径排序的，照单全收的话预算会被排在最前面的
+   * 点文件吃掉（`/root/.kube/config` 永远第一个），而学员正在改的
+   * `/root/infra/*.yaml` 反倒挤不进去；`git clone` 之后 `.git/objects/**`
+   * 更是能塞满整个预算。所以先把这类噪音排掉，再按「像不像学员在编辑的东西」
+   * 排序。裁掉了几个也要报出来，别让模型以为它看到的是全部。
+   */
+  const NOISE = /(^|\/)\.git\/|(^|\/)node_modules\/|\.(lock|log)$/;
+  const INTERESTING = /\.(ya?ml|json|conf|md|sh|toml|ini)$/;
+  const candidates = Object.entries(options.files ?? {})
+    .filter(([path]) => !NOISE.test(path))
+    .sort(([a], [b]) => {
+      const rank = (path: string) => (INTERESTING.test(path) ? 0 : 1);
+      return rank(a) - rank(b) || (a === b ? 0 : a < b ? -1 : 1);
+    });
+
   let filesBudget = MAX_FILES_TOTAL;
   const files: Array<{ path: string; content: string }> = [];
-  for (const [path, content] of Object.entries(options.files ?? {})) {
-    if (filesBudget <= 0) break;
+  let omittedFiles = 0;
+  for (const [path, content] of candidates) {
+    if (filesBudget <= 0) { omittedFiles += 1; continue; }
     const body = truncate(content, Math.min(MAX_FILE_CHARS, filesBudget));
     filesBudget -= body.length;
     files.push({ path, content: body });
   }
+  omittedFiles += Object.keys(options.files ?? {}).length - candidates.length;
 
   return {
     namespace,
-    nodes,
+    nodes: nodes.slice(0, MAX_NODES),
     workloads,
     problems,
     events,
     commands,
     files,
     omitted: {
-      objects: omittedObjects,
+      objects: omittedObjects + Math.max(0, nodes.length - MAX_NODES),
+      problems: omittedProblems,
       namespaces: Math.max(0, allNamespaces.length - detailed.size),
       commands: Math.max(0, history.length - recent.length),
+      files: omittedFiles,
     },
   };
 }
@@ -260,8 +329,12 @@ export function summarizeReport(report: StageRunReport | null): OpsReportSummary
     failing: report.cases
       .filter((item) => !item.passed)
       .slice(0, MAX_FAILING_CASES)
-      .map((item) => ({ name: [item.suite, item.name].filter(Boolean).join(' > '), error: item.error ?? '' })),
-    error: report.error,
+      .map((item) => ({
+        name: [item.suite, item.name].filter(Boolean).join(' > '),
+        // 断言在命令输出上的用例，报错里会带着整段输出
+        error: truncate(item.error ?? '', MAX_CASE_ERROR),
+      })),
+    error: report.error ? truncate(report.error, MAX_CASE_ERROR) : undefined,
   };
 }
 

--- a/src/lib/opslab/lab/aicontext.ts
+++ b/src/lib/opslab/lab/aicontext.ts
@@ -1,0 +1,274 @@
+/**
+ * 把一个 ops 世界压成 AI 能吃下的快照
+ *
+ * 代码形态那边是把工作区的文件原样发上去，服务端再裁剪。ops 这边不能这么干：
+ * 一个集群几百个对象，每个对象的 YAML 都不小，原样发过去先撞 Next 的请求体上限
+ * （工程对话就撞过 413），撞不上也会把 token 烧光。
+ *
+ * 所以裁剪发生在**客户端**：这里把世界压成一份定长的结构化摘要，服务端只负责
+ * 排版。所有的上限都写在这个文件里，`tests/opslab/aicontext.test.ts` 盯着它们。
+ *
+ * 取舍：宁可少给对象，也要把**异常**和**最近的命令输出**给全 —— 学员卡住的时候，
+ * 十有八九答案就在上一条命令的报错里，而不在某个健康 Deployment 的 YAML 里。
+ */
+import type { KubeObject } from '../apiserver';
+import type { Cluster } from '../controllers';
+import type { CommandRecord } from '../../labkit/machine';
+import type { StageRunReport } from '../../engineering/types';
+import { describe as describeObject } from './view';
+import type { OpsWorld } from './world';
+
+/** 最多带几个命名空间的常规对象（异常对象不受这个限制） */
+const MAX_NAMESPACES = 8;
+/** 常规工作负载最多带多少条 */
+const MAX_WORKLOADS = 40;
+/** 异常对象最多带多少条 */
+const MAX_PROBLEMS = 25;
+/** 事件最多带多少条 */
+const MAX_EVENTS = 20;
+/**
+ * 终端历史的预算，两种用法差别很大，所以做成两套。
+ *
+ * 对话是「看着刚才那条报错问」：条数少，但每条的输出要给全 —— 答案通常就在
+ * 输出的某一行里。复盘反过来，问的是「这一关他是怎么走过来的」：**顺序**比
+ * 每条的细节重要，所以条数放宽、单条压短。
+ */
+export interface SnapshotLimits {
+  /** 终端历史最多带最近几条 */
+  commands: number;
+  /** 单条命令的输出截到多少字符 */
+  commandOutput: number;
+}
+
+const CHAT_LIMITS: SnapshotLimits = { commands: 8, commandOutput: 1200 };
+const REVIEW_LIMITS: SnapshotLimits = { commands: 50, commandOutput: 400 };
+
+/** 复盘要看完整的排查路径，对话只要最近几条 */
+export const SNAPSHOT_LIMITS = { chat: CHAT_LIMITS, review: REVIEW_LIMITS };
+/** 单个文件截到多少字符 */
+const MAX_FILE_CHARS = 4000;
+/** 所有文件加起来的预算 */
+const MAX_FILES_TOTAL = 10000;
+/** 失败用例最多带几条 */
+const MAX_FAILING_CASES = 6;
+
+/** 这些类型是「工作负载」，值得逐个列出来 */
+const WORKLOAD_KINDS = new Set([
+  'Deployment', 'StatefulSet', 'DaemonSet', 'Rollout', 'Job', 'CronJob', 'MachineDeployment',
+]);
+
+/**
+ * 这些类型即使一切正常也值得列出来：它们是「接线」，
+ * 而 ops 关卡里出问题的往往不是工作负载本身，是它前面那根线。
+ */
+const WIRING_KINDS = new Set([
+  'Service', 'Gateway', 'HTTPRoute', 'Ingress', 'NetworkPolicy',
+  'PersistentVolumeClaim', 'Certificate', 'ServiceMonitor',
+]);
+
+export interface SnapshotObject {
+  kind: string;
+  name: string;
+  namespace?: string;
+  /** 一行小字，和拓扑图上那行是同一个来源 */
+  detail: string;
+  status: 'ok' | 'pending' | 'warn' | 'error';
+}
+
+export interface SnapshotEvent {
+  type: string;
+  reason: string;
+  object: string;
+  message: string;
+}
+
+export interface SnapshotCommand {
+  command: string;
+  code: number;
+  output: string;
+}
+
+export interface OpsSnapshot {
+  /** kubeconfig 的 current-context 指着哪个命名空间 */
+  namespace: string;
+  nodes: SnapshotObject[];
+  workloads: SnapshotObject[];
+  /** 状态不是 ok 的对象，跨命名空间收集 —— 这些是最该给模型看的 */
+  problems: SnapshotObject[];
+  events: SnapshotEvent[];
+  commands: SnapshotCommand[];
+  files: Array<{ path: string; content: string }>;
+  /** 被裁掉了多少东西，让模型知道自己看到的不是全部 */
+  omitted: { objects: number; namespaces: number; commands: number };
+}
+
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n…（还有 ${text.length - limit} 个字符被截掉）`;
+}
+
+/** 命令的输出：stderr 比 stdout 重要，先给 stderr */
+function outputOf(record: CommandRecord, limit: number): string {
+  const parts = [record.stderr?.trim(), record.stdout?.trim()].filter(Boolean) as string[];
+  return truncate(parts.join('\n'), limit);
+}
+
+function toSnapshot(object: KubeObject): SnapshotObject {
+  const { detail, status } = describeObject(object);
+  return {
+    kind: object.kind,
+    name: object.metadata.name ?? '',
+    namespace: object.metadata.namespace,
+    detail,
+    status,
+  };
+}
+
+export interface OpsSnapshotOptions {
+  /** IDE 里打开的、以及这一关自带的文件 */
+  files?: Record<string, string>;
+  /** 终端历史 */
+  history?: CommandRecord[];
+  /** 当前命名空间 */
+  namespace?: string;
+  /** 终端历史的预算，默认按对话来（见 SNAPSHOT_LIMITS） */
+  limits?: Partial<SnapshotLimits>;
+}
+
+/**
+ * 走一遍集群，压成快照。
+ *
+ * 只读，不碰任何状态 —— 这个函数在学员每次发消息时都会跑一遍。
+ */
+export function buildOpsSnapshot(world: OpsWorld, options: OpsSnapshotOptions = {}): OpsSnapshot {
+  const cluster: Cluster = world.cluster;
+  const namespace = options.namespace ?? 'default';
+
+  const nodes: SnapshotObject[] = [];
+  const workloads: SnapshotObject[] = [];
+  const problems: SnapshotObject[] = [];
+  const events: SnapshotEvent[] = [];
+  let omittedObjects = 0;
+
+  /**
+   * 命名空间的取舍顺序：当前的排第一，其余按名字排。
+   *
+   * 超过上限的命名空间仍然会被扫**异常对象** —— 一个坏在别处的东西
+   * 不该因为它的命名空间排在后面就看不见了。
+   */
+  const allNamespaces = cluster.registry
+    .list(cluster.scheme.mustGet({ group: '', version: 'v1', resource: 'namespaces' })).items
+    .map((item) => item.metadata.name!)
+    .sort((a, b) => (a === namespace ? -1 : b === namespace ? 1 : a < b ? -1 : 1));
+  const detailed = new Set(allNamespaces.slice(0, MAX_NAMESPACES));
+
+  for (const definition of cluster.scheme.list()) {
+    // 事件单独收，不当成普通对象
+    if (definition.resource === 'events') continue;
+
+    for (const object of cluster.registry.list(definition).items) {
+      const summary = toSnapshot(object);
+
+      if (object.kind === 'Node') {
+        nodes.push(summary);
+        continue;
+      }
+
+      const unhealthy = summary.status === 'error' || summary.status === 'warn';
+      if (unhealthy) {
+        if (problems.length < MAX_PROBLEMS) problems.push(summary);
+        else omittedObjects += 1;
+        continue;
+      }
+
+      const ns = object.metadata.namespace;
+      if (ns && !detailed.has(ns)) { omittedObjects += 1; continue; }
+
+      if (WORKLOAD_KINDS.has(object.kind) || WIRING_KINDS.has(object.kind)) {
+        if (workloads.length < MAX_WORKLOADS) workloads.push(summary);
+        else omittedObjects += 1;
+      } else {
+        // Pod、ReplicaSet、ConfigMap 这些健康时不单独列：数量大而信息量低，
+        // 它们的状态已经体现在属主的 `3/3` 上了
+        omittedObjects += 1;
+      }
+    }
+  }
+
+  const eventDefinition = cluster.scheme.get({ group: '', version: 'v1', resource: 'events' });
+  if (eventDefinition) {
+    const all = cluster.registry.list(eventDefinition).items;
+    // Warning 优先，然后按新到旧 —— 事件表最有用的永远是「最近出的问题」
+    const sorted = [...all].sort((a, b) => {
+      const warn = (item: KubeObject) => ((item as Record<string, unknown>).type === 'Warning' ? 0 : 1);
+      const byType = warn(a) - warn(b);
+      if (byType !== 0) return byType;
+      return (b.metadata.creationTimestamp ?? '') < (a.metadata.creationTimestamp ?? '') ? -1 : 1;
+    });
+    for (const event of sorted.slice(0, MAX_EVENTS)) {
+      const raw = event as unknown as Record<string, any>;
+      events.push({
+        type: String(raw.type ?? 'Normal'),
+        reason: String(raw.reason ?? ''),
+        object: `${raw.involvedObject?.kind ?? ''}/${raw.involvedObject?.name ?? ''}`,
+        message: truncate(String(raw.message ?? ''), 300),
+      });
+    }
+  }
+
+  const limits = { ...CHAT_LIMITS, ...options.limits };
+  const history = options.history ?? [];
+  const recent = history.slice(-limits.commands);
+  const commands: SnapshotCommand[] = recent.map((record) => ({
+    command: record.command,
+    code: record.code,
+    output: outputOf(record, limits.commandOutput),
+  }));
+
+  let filesBudget = MAX_FILES_TOTAL;
+  const files: Array<{ path: string; content: string }> = [];
+  for (const [path, content] of Object.entries(options.files ?? {})) {
+    if (filesBudget <= 0) break;
+    const body = truncate(content, Math.min(MAX_FILE_CHARS, filesBudget));
+    filesBudget -= body.length;
+    files.push({ path, content: body });
+  }
+
+  return {
+    namespace,
+    nodes,
+    workloads,
+    problems,
+    events,
+    commands,
+    files,
+    omitted: {
+      objects: omittedObjects,
+      namespaces: Math.max(0, allNamespaces.length - detailed.size),
+      commands: Math.max(0, history.length - recent.length),
+    },
+  };
+}
+
+/** 判定结果也要压一压：整份报告里对模型有用的只有失败的那几条 */
+export function summarizeReport(report: StageRunReport | null): OpsReportSummary | null {
+  if (!report) return null;
+  return {
+    status: report.status,
+    passed: report.totals.passed,
+    total: report.totals.total,
+    failing: report.cases
+      .filter((item) => !item.passed)
+      .slice(0, MAX_FAILING_CASES)
+      .map((item) => ({ name: [item.suite, item.name].filter(Boolean).join(' > '), error: item.error ?? '' })),
+    error: report.error,
+  };
+}
+
+export interface OpsReportSummary {
+  status: string;
+  passed: number;
+  total: number;
+  failing: Array<{ name: string; error: string }>;
+  error?: string;
+}

--- a/src/lib/opslab/lab/index.ts
+++ b/src/lib/opslab/lab/index.ts
@@ -12,5 +12,10 @@ export {
 
 export { toolchainFor, baseImageOf, type ToolchainName } from './toolchains';
 export { createExecHandler, normalizeCommand } from './podshell';
-export { buildPacketPath, buildPacketPaths } from './view';
+export { buildPacketPath, buildPacketPaths, describe } from './view';
+export { buildOpsSnapshot, summarizeReport, SNAPSHOT_LIMITS } from './aicontext';
+export type {
+  OpsSnapshot, OpsSnapshotOptions, OpsReportSummary, SnapshotObject, SnapshotEvent, SnapshotCommand,
+  SnapshotLimits,
+} from './aicontext';
 export type { PacketPath, PacketStep } from './view';

--- a/src/lib/opslab/lab/view.ts
+++ b/src/lib/opslab/lab/view.ts
@@ -210,6 +210,30 @@ export function describe(object: KubeObject): { detail: string; status: Topology
           : phase === 'Failed' ? 'error' : 'pending',
       };
     }
+    /** DaemonSet 没有 replicas：它的「期望」是能调度到几个节点上 */
+    case 'DaemonSet': {
+      const ready = Number(status.numberReady ?? 0);
+      const desired = Number(status.desiredNumberScheduled ?? 0);
+      return {
+        detail: `${ready}/${desired}`,
+        status: desired === 0 ? 'pending' : ready === desired ? 'ok' : ready === 0 ? 'error' : 'warn',
+      };
+    }
+    case 'MachineDeployment': {
+      const ready = Number(status.readyReplicas ?? 0);
+      const desired = Number(spec.replicas ?? 0);
+      return {
+        detail: `${ready}/${desired}`,
+        status: desired === 0 ? 'pending' : ready === desired ? 'ok' : ready === 0 ? 'error' : 'warn',
+      };
+    }
+    case 'Job': {
+      const succeeded = Number(status.succeeded ?? 0);
+      const failed = Number(status.failed ?? 0);
+      const wanted = Number(spec.completions ?? 1);
+      if (failed > 0) return { detail: `${succeeded}/${wanted}，失败 ${failed}`, status: 'error' };
+      return { detail: `${succeeded}/${wanted}`, status: succeeded >= wanted ? 'ok' : 'pending' };
+    }
     case 'Service': {
       const type = String(spec.type ?? 'ClusterIP');
       return { detail: type, status: 'ok' };
@@ -224,8 +248,49 @@ export function describe(object: KubeObject): { detail: string; status: Topology
       };
     }
     default:
-      return { detail: object.kind, status: 'ok' };
+      return describeGeneric(object, status);
   }
+}
+
+/**
+ * 没写进上面 switch 的类型，按 Kubernetes 的通用写法读。
+ *
+ * 这里原来直接 `return { status: 'ok' }` —— 于是 PVC、Ingress、Gateway、
+ * Certificate、ServiceMonitor 这些类型**坏成什么样都是绿的**，拓扑图上看不出来，
+ * 喂给模型的快照还会明说「状态不正常的对象：没有」。助手于是信心十足地
+ * 让学员去别处找，而问题就在那个被判成健康的对象上。
+ *
+ * 「好没好」在 Kubernetes 里就两种写法：一个 True/False 的 condition，
+ * 或者一个 phase。照着这两种读，读不出来才退回 ok。
+ */
+const HEALTHY_CONDITIONS = new Set([
+  'Ready', 'Available', 'Accepted', 'Programmed', 'Established', 'Synced', 'Approved', 'Bound',
+]);
+const HEALTHY_PHASES = new Set(['Bound', 'Active', 'Available', 'Succeeded', 'Running', 'Completed']);
+const BROKEN_PHASES = new Set(['Failed', 'Lost']);
+
+function describeGeneric(object: KubeObject, status: Record<string, unknown>) {
+  const conditions = (status.conditions ?? []) as Array<{ type?: string; status?: string; reason?: string }>;
+  const known = conditions.filter((item) => item.type && HEALTHY_CONDITIONS.has(item.type));
+
+  const bad = known.find((item) => item.status !== 'True');
+  if (bad) {
+    return {
+      detail: `${bad.type}=${bad.status ?? 'Unknown'}${bad.reason ? `（${bad.reason}）` : ''}`,
+      // False 是明确的「不行」，Unknown 是「还不知道」
+      status: (bad.status === 'False' ? 'error' : 'pending') as TopologyStatus,
+    };
+  }
+
+  const phase = status.phase ? String(status.phase) : '';
+  if (phase) {
+    if (BROKEN_PHASES.has(phase)) return { detail: phase, status: 'error' as TopologyStatus };
+    return { detail: phase, status: (HEALTHY_PHASES.has(phase) ? 'ok' : 'pending') as TopologyStatus };
+  }
+
+  if (known.length) return { detail: `${known[0].type}=True`, status: 'ok' as TopologyStatus };
+  // 真的没有状态可读（ConfigMap、Secret、NetworkPolicy 这些本来就没有）
+  return { detail: object.kind, status: 'ok' as TopologyStatus };
 }
 
 /** 点一下拓扑上的节点，往终端里插这条命令 —— 只读检查，不改状态 */

--- a/src/lib/opslab/lab/view.ts
+++ b/src/lib/opslab/lab/view.ts
@@ -155,8 +155,13 @@ function toNode(object: KubeObject, index: number, y: number): TopologyNode {
   };
 }
 
-/** 节点上那行小字，抄的是 `kubectl get` 里最要紧的那一列 */
-function describe(object: KubeObject): { detail: string; status: TopologyStatus } {
+/**
+ * 节点上那行小字，抄的是 `kubectl get` 里最要紧的那一列，外加一个健康度。
+ *
+ * 导出是给 AI 上下文用的 —— 喂给模型的集群快照和拓扑图上看到的应该是
+ * 同一套判断，不然学员会问「它说我这个 Pod 没问题，可图上是红的」。
+ */
+export function describe(object: KubeObject): { detail: string; status: TopologyStatus } {
   const status = (object.status ?? {}) as Record<string, unknown>;
   const spec = (object.spec ?? {}) as Record<string, unknown>;
 

--- a/src/lib/server/opsPrompt.ts
+++ b/src/lib/server/opsPrompt.ts
@@ -54,7 +54,23 @@ export function buildOpsContext(
 ): string {
   const zh = language === 'zh';
   const sections: string[] = [];
-  const snapshot = context.snapshot;
+  /**
+   * 排版之前先把形状补齐。
+   *
+   * 这个函数是路由的最后一站，而请求体是外面来的 —— 一个缺了 problems 的
+   * snapshot 不该让路由 500，它顶多是「这块没内容」。
+   */
+  const raw = context.snapshot;
+  const snapshot: OpsSnapshot | undefined = raw && {
+    ...raw,
+    nodes: raw.nodes ?? [],
+    workloads: raw.workloads ?? [],
+    problems: raw.problems ?? [],
+    events: raw.events ?? [],
+    commands: raw.commands ?? [],
+    files: raw.files ?? [],
+    omitted: { ...{ objects: 0, problems: 0, namespaces: 0, commands: 0, files: 0 }, ...(raw.omitted ?? {}) },
+  };
 
   sections.push(
     [
@@ -102,6 +118,20 @@ export function buildOpsContext(
 
     if (snapshot.problems.length) {
       lines.push('', zh ? '### 状态不正常的对象' : '### Objects not healthy', ...snapshot.problems.map(objectLine));
+      /**
+       * 超上限被砍掉的异常对象必须单独说。
+       *
+       * 这一行以前和「省略了 N 个健康对象」混在一起报 —— 于是问题列表被砍了
+       * 一半，模型收到的却是「其余都是健康的」。宁可让它知道自己看不全，
+       * 也不能让它以为看全了。
+       */
+      if (snapshot.omitted.problems > 0) {
+        lines.push(zh
+          ? `（还有 ${snapshot.omitted.problems} 个状态不正常的对象没列出来 —— 这个列表**不是全的**，`
+            + `让用户敲 kubectl get -A 自己看。）`
+          : `(${snapshot.omitted.problems} more unhealthy objects were not listed — this list is NOT complete. `
+            + `Ask the user to run kubectl get -A.)`);
+      }
     } else {
       lines.push('', zh ? '### 状态不正常的对象：没有' : '### Objects not healthy: none');
     }
@@ -137,12 +167,16 @@ export function buildOpsContext(
   }
 
   if (snapshot?.files.length) {
-    sections.push(
-      [
-        zh ? '## 机器磁盘上打开的文件' : '## Files open on the jump host',
-        ...snapshot.files.map((file) => `### ${file.path}\n\`\`\`yaml\n${file.content}\n\`\`\``),
-      ].join('\n')
-    );
+    const lines = [
+      zh ? '## 跳板机磁盘上的文件' : '## Files on the jump host',
+      ...snapshot.files.map((file) => `### ${file.path}\n\`\`\`yaml\n${file.content}\n\`\`\``),
+    ];
+    if (snapshot.omitted.files > 0) {
+      lines.push(zh
+        ? `（另有 ${snapshot.omitted.files} 个文件没带上。需要哪个就让用户 cat 出来贴给你。）`
+        : `(${snapshot.omitted.files} more files were not included. Ask the user to cat the one you need.)`);
+    }
+    sections.push(lines.join('\n'));
   }
 
   const report = context.report;

--- a/src/lib/server/opsPrompt.ts
+++ b/src/lib/server/opsPrompt.ts
@@ -1,0 +1,168 @@
+/**
+ * 把 ops 世界的快照排成给模型看的上下文
+ *
+ * 裁剪已经在客户端做完了（见 src/lib/opslab/lab/aicontext.ts），这里只负责排版 ——
+ * 以及再兜一次总量：客户端是可以被绕过的，服务端不该假设请求体是善意的。
+ *
+ * 排版顺序就是重要性顺序：先关卡要求，再终端最近发生了什么，再集群哪儿不对，
+ * 最后才是清单式的资源列表。模型和人一样，读到后面注意力会散。
+ */
+import type { LocalizedText } from '../engineering/types';
+import type { OpsSnapshot, OpsReportSummary } from '../opslab/lab/aicontext';
+
+export interface OpsContext {
+  projectTitle?: LocalizedText;
+  projectSummary?: LocalizedText;
+  stageIndex?: number;
+  stageCount?: number;
+  stageTitle?: LocalizedText;
+  stageGoal?: LocalizedText;
+  checklist?: LocalizedText[];
+  snapshot?: OpsSnapshot;
+  report?: OpsReportSummary | null;
+}
+
+/**
+ * 服务端的兜底总量。客户端已经裁过一轮，这里防的是被构造的请求。
+ *
+ * 复盘的额度更高：它要看完整的排查路径，几十条命令本身就占掉对话的全部预算。
+ */
+const MAX_TOTAL_CHARS = 40000;
+export const REVIEW_MAX_CHARS = 60000;
+
+function pick(text: LocalizedText | undefined, language: 'en' | 'zh'): string {
+  if (!text) return '';
+  return text[language] || text.zh || text.en || '';
+}
+
+function statusMark(status: string): string {
+  if (status === 'error') return '✗';
+  if (status === 'warn') return '!';
+  if (status === 'pending') return '…';
+  return '✓';
+}
+
+function objectLine(item: { kind: string; namespace?: string; name: string; detail: string; status: string }): string {
+  const where = item.namespace ? `${item.namespace}/` : '';
+  return `  ${statusMark(item.status)} ${item.kind} ${where}${item.name} — ${item.detail}`;
+}
+
+export function buildOpsContext(
+  context: OpsContext,
+  language: 'en' | 'zh',
+  maxChars: number = MAX_TOTAL_CHARS
+): string {
+  const zh = language === 'zh';
+  const sections: string[] = [];
+  const snapshot = context.snapshot;
+
+  sections.push(
+    [
+      zh ? '## 当前工程' : '## Project',
+      `${pick(context.projectTitle, language)} — ${pick(context.projectSummary, language)}`,
+      '',
+      zh
+        ? `## 当前关卡（第 ${(context.stageIndex ?? 0) + 1} / ${context.stageCount ?? '?'} 关）`
+        : `## Current stage (${(context.stageIndex ?? 0) + 1} of ${context.stageCount ?? '?'})`,
+      pick(context.stageTitle, language),
+      '',
+      pick(context.stageGoal, language),
+    ].join('\n')
+  );
+
+  const checklist = (context.checklist ?? []).map((item) => `- ${pick(item, language)}`).filter((line) => line !== '- ');
+  if (checklist.length) {
+    sections.push([zh ? '## 通关标准' : '## Done when', ...checklist].join('\n'));
+  }
+
+  /**
+   * 终端历史排在集群状态前面。
+   *
+   * ops 场景里学员卡住，答案十有八九在上一条命令的报错里 —— 而不在某个
+   * 健康对象的字段上。把它放在模型注意力最好的位置。
+   */
+  if (snapshot?.commands.length) {
+    const lines = [zh ? '## 终端最近敲了什么' : '## Recent terminal activity'];
+    if (snapshot.omitted.commands > 0) {
+      lines.push(zh
+        ? `（更早的 ${snapshot.omitted.commands} 条没有带上）`
+        : `(${snapshot.omitted.commands} earlier commands omitted)`);
+    }
+    for (const entry of snapshot.commands) {
+      lines.push('', `$ ${entry.command}`, `# exit ${entry.code}`, entry.output || '(无输出)');
+    }
+    sections.push(lines.join('\n'));
+  }
+
+  if (snapshot) {
+    const lines = [
+      zh ? '## 集群现状' : '## Cluster state',
+      zh ? `当前命名空间：${snapshot.namespace}` : `Current namespace: ${snapshot.namespace}`,
+    ];
+
+    if (snapshot.problems.length) {
+      lines.push('', zh ? '### 状态不正常的对象' : '### Objects not healthy', ...snapshot.problems.map(objectLine));
+    } else {
+      lines.push('', zh ? '### 状态不正常的对象：没有' : '### Objects not healthy: none');
+    }
+
+    if (snapshot.nodes.length) {
+      lines.push('', zh ? '### 节点' : '### Nodes', ...snapshot.nodes.map(objectLine));
+    }
+    if (snapshot.workloads.length) {
+      lines.push('', zh ? '### 工作负载与接线' : '### Workloads and wiring', ...snapshot.workloads.map(objectLine));
+    }
+    if (snapshot.omitted.objects > 0 || snapshot.omitted.namespaces > 0) {
+      lines.push(
+        '',
+        zh
+          ? `（为控制体积，省略了 ${snapshot.omitted.objects} 个健康对象`
+            + `${snapshot.omitted.namespaces ? `、${snapshot.omitted.namespaces} 个命名空间的明细` : ''}。`
+            + `需要的话让用户自己敲 kubectl 查，然后把输出贴给你。）`
+          : `(${snapshot.omitted.objects} healthy objects`
+            + `${snapshot.omitted.namespaces ? ` and detail for ${snapshot.omitted.namespaces} namespaces` : ''}`
+            + ` were omitted to keep this small. Ask the user to run kubectl and paste the output.)`
+      );
+    }
+    sections.push(lines.join('\n'));
+  }
+
+  if (snapshot?.events.length) {
+    sections.push(
+      [
+        zh ? '## 最近的事件' : '## Recent events',
+        ...snapshot.events.map((event) => `  [${event.type}] ${event.reason} ${event.object}: ${event.message}`),
+      ].join('\n')
+    );
+  }
+
+  if (snapshot?.files.length) {
+    sections.push(
+      [
+        zh ? '## 机器磁盘上打开的文件' : '## Files open on the jump host',
+        ...snapshot.files.map((file) => `### ${file.path}\n\`\`\`yaml\n${file.content}\n\`\`\``),
+      ].join('\n')
+    );
+  }
+
+  const report = context.report;
+  if (report) {
+    const lines = [
+      zh ? '## 上一次验收' : '## Latest verification',
+      `status: ${report.status}, ${report.passed}/${report.total}`,
+    ];
+    if (report.failing.length) {
+      lines.push(
+        '',
+        zh ? '### 没过的用例' : '### Failing checks',
+        ...report.failing.map((item) => `  ✗ ${item.name}\n    ${item.error}`)
+      );
+    }
+    if (report.error) lines.push('', zh ? '### 运行错误' : '### Run error', report.error);
+    sections.push(lines.join('\n'));
+  }
+
+  const text = sections.join('\n\n');
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n…（上下文过长，后面被截断）`;
+}

--- a/tests/opslab/aicontext.test.ts
+++ b/tests/opslab/aicontext.test.ts
@@ -204,7 +204,7 @@ describe('排版给模型的上下文', () => {
       commands: Array.from({ length: 500 }, (_, i) => ({
         command: `c-${i}`, code: 0, output: 'q'.repeat(5000),
       })),
-      files: [], omitted: { objects: 0, namespaces: 0, commands: 0 },
+      files: [], omitted: { objects: 0, problems: 0, namespaces: 0, commands: 0, files: 0 },
     };
     const text = buildOpsContext({ snapshot }, 'zh');
     expect(text.length).toBeLessThan(41_000);
@@ -264,7 +264,7 @@ describe('复盘的上下文', () => {
       commands: Array.from({ length: 500 }, (_, i) => ({
         command: `c-${i}`, code: 0, output: 'q'.repeat(5000),
       })),
-      files: [], omitted: { objects: 0, namespaces: 0, commands: 0 },
+      files: [], omitted: { objects: 0, problems: 0, namespaces: 0, commands: 0, files: 0 },
     };
     const chat = buildOpsContext({ snapshot }, 'zh');
     const review = buildOpsContext({ snapshot }, 'zh', REVIEW_MAX_CHARS);
@@ -272,5 +272,130 @@ describe('复盘的上下文', () => {
     expect(review.length).toBeGreaterThan(chat.length);
     expect(review.length).toBeLessThan(REVIEW_MAX_CHARS + 100);
     expect(review).toContain('上下文过长');
+  });
+});
+
+/**
+ * 自审时抓出来的一组：快照把「不健康」报成了「健康」。
+ *
+ * 这比少给信息严重得多 —— 少给了模型至少知道自己看不全，报错了它会信心十足地
+ * 让学员去别处找。四个来源：describe() 对不认识的类型一律返回 ok；pending 不算
+ * 异常所以整个对象消失；被上限砍掉的异常对象被算进「省略的健康对象」；名额按
+ * 遍历顺序先到先得，学员正在问的那个反而挤不进去。
+ */
+describe('快照不能把不健康的说成健康的', () => {
+  it('describe() 不认识的类型，按通用的 condition / phase 判', async () => {
+    const world = await build({
+      namespaces: ['default'],
+      objects: [
+        {
+          apiVersion: 'v1', kind: 'PersistentVolumeClaim',
+          metadata: { name: 'data', namespace: 'default' },
+          spec: { storageClassName: 'nope' },
+          status: { phase: 'Pending' },
+        },
+        {
+          apiVersion: 'gateway.networking.k8s.io/v1', kind: 'Gateway',
+          metadata: { name: 'edge', namespace: 'default' },
+          spec: {},
+          status: { conditions: [{ type: 'Programmed', status: 'False', reason: 'NoListener' }] },
+        },
+      ] as never,
+    });
+    const snapshot = buildOpsSnapshot(world, { namespace: 'default' });
+
+    const pvc = snapshot.problems.find((item) => item.kind === 'PersistentVolumeClaim');
+    const gateway = snapshot.problems.find((item) => item.kind === 'Gateway');
+    expect(pvc?.status).toBe('pending');
+    expect(gateway?.status).toBe('error');
+    // detail 也不能再是干巴巴的类型名
+    expect(gateway?.detail).toContain('NoListener');
+  });
+
+  it('卡在 Pending 的裸 Pod 不能整个消失', async () => {
+    const world = await build({
+      namespaces: ['default'],
+      objects: [{
+        apiVersion: 'v1', kind: 'Pod',
+        metadata: { name: 'stuck', namespace: 'default' },
+        spec: { nodeSelector: { disk: 'nvme' }, containers: [{ name: 'app', image: APP_IMAGE }] },
+      }] as never,
+    });
+    const snapshot = buildOpsSnapshot(world, { namespace: 'default' });
+
+    expect(snapshot.problems.some((item) => item.name === 'stuck')).toBe(true);
+    expect(buildOpsContext({ snapshot }, 'zh')).toContain('stuck');
+  });
+
+  it('被砍掉的异常对象单独报，不混进「省略的健康对象」', async () => {
+    const world = await build(bigWorld(12, 10));
+    const snapshot = buildOpsSnapshot(world, { namespace: 'team-0' });
+    expect(snapshot.omitted.problems).toBeGreaterThan(0);
+
+    const text = buildOpsContext({ snapshot }, 'zh');
+    expect(text).toContain(`还有 ${snapshot.omitted.problems} 个状态不正常的对象没列出来`);
+    expect(text).toContain('不是全的');
+    // 健康那句报的数不许把异常的算进去
+    expect(text).toContain(`省略了 ${snapshot.omitted.objects} 个健康对象`);
+    expect(snapshot.omitted.objects).toBeLessThan(snapshot.omitted.problems + snapshot.omitted.objects);
+  });
+
+  it('异常名额先给当前命名空间，别处的噪音挤不掉学员正在问的那个', async () => {
+    const objects: unknown[] = [];
+    // 别处一堆坏的，数量足够占满 25 个名额
+    for (let i = 0; i < 40; i += 1) {
+      objects.push({
+        apiVersion: 'v1', kind: 'Pod',
+        metadata: { name: `noise-${i}`, namespace: 'kube-system' },
+        spec: { containers: [{ name: 'c', image: BAD_IMAGE }] },
+      });
+    }
+    objects.push({
+      apiVersion: 'v1', kind: 'Pod',
+      metadata: { name: 'portal', namespace: 'payments' },
+      spec: { containers: [{ name: 'c', image: BAD_IMAGE }] },
+    });
+    const world = await build({ namespaces: ['default', 'kube-system', 'payments'], objects: objects as never });
+
+    const snapshot = buildOpsSnapshot(world, { namespace: 'payments' });
+    expect(snapshot.problems).toHaveLength(25);
+    expect(snapshot.problems.some((item) => item.name === 'portal')).toBe(true);
+    // 而且排在最前面 —— 模型注意力最好的位置
+    expect(snapshot.problems[0].namespace).toBe('payments');
+  });
+});
+
+describe('文件挑选', () => {
+  it('.git 内部和 node_modules 不占预算，裁掉了几个要报出来', async () => {
+    const world = await build(bigWorld(1, 1));
+    const files: Record<string, string> = {
+      '/root/.git/objects/aa/bbccdd': 'x'.repeat(9000),
+      '/root/node_modules/foo/index.js': 'y'.repeat(9000),
+      '/root/infra/app.yaml': 'kind: Deployment',
+    };
+    const snapshot = buildOpsSnapshot(world, { files });
+
+    expect(snapshot.files.map((file) => file.path)).toEqual(['/root/infra/app.yaml']);
+    expect(snapshot.omitted.files).toBe(2);
+    expect(buildOpsContext({ snapshot }, 'zh')).toContain('另有 2 个文件没带上');
+  });
+
+  it('学员在改的 yaml 排在点文件前面，别被 .kube/config 吃掉预算', async () => {
+    const world = await build(bigWorld(1, 1));
+    const files: Record<string, string> = {
+      '/root/.bashrc': 'a'.repeat(6000),
+      '/root/.kube/config': 'b'.repeat(6000),
+      '/root/infra/app.yaml': 'kind: Deployment',
+    };
+    const snapshot = buildOpsSnapshot(world, { files });
+    expect(snapshot.files[0].path).toBe('/root/infra/app.yaml');
+  });
+});
+
+describe('排版是最后一站，请求体是外面来的', () => {
+  it('缺字段的 snapshot 不该抛，顶多是那块没内容', () => {
+    const broken = { namespace: 'default' } as never;
+    expect(() => buildOpsContext({ snapshot: broken }, 'zh')).not.toThrow();
+    expect(buildOpsContext({ snapshot: broken }, 'zh')).toContain('状态不正常的对象：没有');
   });
 });

--- a/tests/opslab/aicontext.test.ts
+++ b/tests/opslab/aicontext.test.ts
@@ -1,0 +1,276 @@
+/**
+ * 喂给 AI 的集群快照
+ *
+ * 这一组存在的理由是一个踩过的坑：工程对话把整个工作区发上去，撞在 Next 默认的
+ * 1mb 请求体上限上，中等项目直接 413 —— 功能不是变慢，是直接不可用。
+ *
+ * ops 的上下文比代码形态更容易失控（一个集群几百个对象，每个都有 YAML），
+ * 所以裁剪放在客户端，而这里盯着裁剪真的生效：**大集群下请求体必须远低于上限**。
+ */
+import { createOpsWorld } from '../../src/lib/opslab/lab';
+import { buildOpsSnapshot, summarizeReport, SNAPSHOT_LIMITS } from '../../src/lib/opslab/lab';
+import { buildOpsContext, REVIEW_MAX_CHARS } from '../../src/lib/server/opsPrompt';
+import type { OpsWorldSpec, StageRunReport } from '../../src/lib/engineering/types';
+import type { CommandRecord } from '../../src/lib/labkit/machine';
+
+const APP_IMAGE = 'registry.corp.internal/app:1.0';
+const BAD_IMAGE = 'registry.corp.internal/app:broken';
+
+/** 一个「大」集群：多命名空间、多工作负载，其中一部分是坏的 */
+function bigWorld(namespaceCount: number, perNamespace: number): OpsWorldSpec {
+  const namespaces = ['default', 'kube-system'];
+  for (let i = 0; i < namespaceCount; i += 1) namespaces.push(`team-${i}`);
+
+  const objects: unknown[] = [];
+  for (let i = 0; i < namespaceCount; i += 1) {
+    for (let j = 0; j < perNamespace; j += 1) {
+      const broken = j % 7 === 0;
+      const name = `svc-${j}`;
+      objects.push({
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name, namespace: `team-${i}` },
+        spec: {
+          replicas: 2,
+          selector: { matchLabels: { app: name } },
+          template: {
+            metadata: { labels: { app: name } },
+            spec: {
+              containers: [{
+                name: 'app',
+                image: broken ? BAD_IMAGE : APP_IMAGE,
+                // 塞一堆环境变量，模拟真实 manifest 的体积
+                env: Array.from({ length: 12 }, (_, k) => ({ name: `VAR_${k}`, value: 'x'.repeat(60) })),
+              }],
+            },
+          },
+        },
+      });
+      objects.push({
+        apiVersion: 'v1', kind: 'Service',
+        metadata: { name, namespace: `team-${i}` },
+        spec: { selector: { app: name }, ports: [{ port: 80, targetPort: 8080 }] },
+      });
+      objects.push({
+        apiVersion: 'v1', kind: 'ConfigMap',
+        metadata: { name: `${name}-config`, namespace: `team-${i}` },
+        data: { 'app.conf': 'y'.repeat(2000) },
+      });
+    }
+  }
+
+  return {
+    namespaces,
+    images: {
+      [APP_IMAGE]: { pullMs: 10, startupMs: 10, readyAfterMs: 10 },
+      // 坏镜像不在目录里 -> 拉不到 -> Pod 进 ImagePullBackOff
+    },
+    objects: objects as never,
+  };
+}
+
+async function build(spec: OpsWorldSpec) {
+  const world = await createOpsWorld({ world: spec });
+  await world.cluster.advanceBy(60_000);
+  return world;
+}
+
+const command = (text: string, code: number, out: string): CommandRecord => ({
+  command: text, cwd: '/root', at: 0, code, stdout: out, stderr: code === 0 ? '' : out,
+});
+
+describe('集群快照', () => {
+  it('状态不正常的对象优先带上，健康的可以省', async () => {
+    const world = await build(bigWorld(3, 7));
+    const snapshot = buildOpsSnapshot(world, { namespace: 'team-0' });
+
+    expect(snapshot.problems.length).toBeGreaterThan(0);
+    // 坏镜像那几个必须在
+    expect(snapshot.problems.some((item) => item.detail.includes('ImagePull') || item.status === 'error'))
+      .toBe(true);
+    // 省掉的东西要有个数，模型才知道自己看到的不是全部
+    expect(snapshot.omitted.objects).toBeGreaterThan(0);
+  });
+
+  it('各项都有上限', async () => {
+    const world = await build(bigWorld(12, 10));
+    const history = Array.from({ length: 30 }, (_, i) => command(`kubectl get pods # ${i}`, 0, 'x'.repeat(5000)));
+    const snapshot = buildOpsSnapshot(world, { namespace: 'team-0', history });
+
+    expect(snapshot.workloads.length).toBeLessThanOrEqual(40);
+    expect(snapshot.problems.length).toBeLessThanOrEqual(25);
+    expect(snapshot.events.length).toBeLessThanOrEqual(20);
+    expect(snapshot.commands.length).toBeLessThanOrEqual(8);
+    expect(snapshot.omitted.commands).toBe(22);
+    for (const entry of snapshot.commands) {
+      expect(entry.output.length).toBeLessThan(1400);
+    }
+  });
+
+  /**
+   * 这一条是这组测试存在的理由。
+   *
+   * 一个十二个命名空间、每个十套服务的集群，请求体必须远远低于 Next 的默认
+   * 1mb —— 就算将来有人把 sizeLimit 改回默认值，功能也不该挂。
+   */
+  it('大集群下请求体远低于 1mb', async () => {
+    const world = await build(bigWorld(12, 10));
+    const history = Array.from({ length: 40 }, (_, i) =>
+      command(`kubectl describe pod pod-${i}`, i % 3 === 0 ? 1 : 0, 'z'.repeat(20000)));
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 20; i += 1) files[`/root/infra/manifest-${i}.yaml`] = 'a'.repeat(30000);
+
+    const snapshot = buildOpsSnapshot(world, { namespace: 'team-0', history, files });
+    const payload = JSON.stringify({ messages: [{ role: 'user', content: '为什么起不来' }], context: { snapshot } });
+
+    // 原始素材是好几 MB（20 个 30KB 的文件 + 40 条 20KB 的输出 + 几百个对象）
+    expect(payload.length).toBeLessThan(200_000);
+    // 也不能压过头压成空壳
+    expect(snapshot.problems.length).toBeGreaterThan(0);
+    expect(snapshot.commands.length).toBe(8);
+    expect(snapshot.files.length).toBeGreaterThan(0);
+  });
+
+  it('文件有总预算，超了就不再带', async () => {
+    const world = await build(bigWorld(1, 1));
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 10; i += 1) files[`/root/f-${i}.yaml`] = 'b'.repeat(9000);
+    const snapshot = buildOpsSnapshot(world, { files });
+
+    const total = snapshot.files.reduce((sum, file) => sum + file.content.length, 0);
+    expect(total).toBeLessThanOrEqual(11000);
+    expect(snapshot.files.length).toBeLessThan(10);
+  });
+
+  it('命令输出里 stderr 排在 stdout 前面', async () => {
+    const world = await build(bigWorld(1, 1));
+    const record: CommandRecord = {
+      command: 'kubectl apply -f x.yaml', cwd: '/root', at: 0, code: 1,
+      stdout: 'STDOUT-PART', stderr: 'STDERR-PART',
+    };
+    const snapshot = buildOpsSnapshot(world, { history: [record] });
+    const output = snapshot.commands[0].output;
+    expect(output.indexOf('STDERR-PART')).toBeLessThan(output.indexOf('STDOUT-PART'));
+  });
+});
+
+describe('验收结果的摘要', () => {
+  it('只留没过的那几条', () => {
+    const report = {
+      status: 'failed',
+      totals: { total: 10, passed: 7, failed: 3 },
+      cases: Array.from({ length: 10 }, (_, i) => ({
+        suite: 'stage', name: `case-${i}`, passed: i > 2, durationMs: 1,
+        error: i > 2 ? undefined : `boom ${i}`,
+      })),
+      gates: [], metrics: {} as never, console: [], wallClockMs: 1,
+    } as unknown as StageRunReport;
+
+    const summary = summarizeReport(report)!;
+    expect(summary.passed).toBe(7);
+    expect(summary.failing).toHaveLength(3);
+    expect(summary.failing[0].error).toBe('boom 0');
+  });
+
+  it('没跑过就是 null', () => {
+    expect(summarizeReport(null)).toBeNull();
+  });
+});
+
+describe('排版给模型的上下文', () => {
+  it('终端历史排在集群状态前面', async () => {
+    const world = await build(bigWorld(2, 3));
+    const snapshot = buildOpsSnapshot(world, {
+      namespace: 'team-0',
+      history: [command('kubectl get pods', 1, 'ImagePullBackOff')],
+    });
+    const text = buildOpsContext(
+      { stageTitle: { zh: '关卡', en: 'stage' }, snapshot },
+      'zh'
+    );
+    expect(text.indexOf('终端最近敲了什么')).toBeLessThan(text.indexOf('集群现状'));
+    expect(text).toContain('ImagePullBackOff');
+  });
+
+  it('没有异常对象时明说「没有」，而不是留空让模型猜', async () => {
+    const world = await build({ namespaces: ['default'], objects: [] as never });
+    const snapshot = buildOpsSnapshot(world, {});
+    const text = buildOpsContext({ snapshot }, 'zh');
+    expect(text).toContain('状态不正常的对象：没有');
+  });
+
+  it('服务端兜底截断：构造一个超大 snapshot 也不会无限长', async () => {
+    const snapshot = {
+      namespace: 'default', nodes: [], workloads: [], problems: [], events: [],
+      commands: Array.from({ length: 500 }, (_, i) => ({
+        command: `c-${i}`, code: 0, output: 'q'.repeat(5000),
+      })),
+      files: [], omitted: { objects: 0, namespaces: 0, commands: 0 },
+    };
+    const text = buildOpsContext({ snapshot }, 'zh');
+    expect(text.length).toBeLessThan(41_000);
+    expect(text).toContain('上下文过长');
+  });
+});
+
+/**
+ * 复盘的预算和对话不一样，所以要单独盯一遍。
+ *
+ * 复盘问的是「这一关他是怎么走过来的」，命令的**顺序**本身就是被评的东西 ——
+ * 只给最近 8 条等于把排查路径砍掉了。所以条数放宽、单条压短，而放宽之后总量
+ * 仍然必须远低于请求体上限。
+ */
+describe('复盘的上下文', () => {
+  it('条数放宽到能看见整条排查路径，单条输出压短', async () => {
+    const world = await build(bigWorld(2, 3));
+    const history = Array.from({ length: 80 }, (_, i) =>
+      command(`kubectl describe pod pod-${i}`, i % 5 === 0 ? 1 : 0, 'z'.repeat(9000)));
+
+    const chat = buildOpsSnapshot(world, { history, limits: SNAPSHOT_LIMITS.chat });
+    const review = buildOpsSnapshot(world, { history, limits: SNAPSHOT_LIMITS.review });
+
+    expect(chat.commands).toHaveLength(8);
+    expect(review.commands).toHaveLength(50);
+    // 放宽的是条数，不是总量：单条反而更短
+    expect(review.commands[0].output.length).toBeLessThan(chat.commands[0].output.length);
+    expect(review.omitted.commands).toBe(30);
+  });
+
+  it('默认还是对话那套预算，调用方不传就不变', async () => {
+    const world = await build(bigWorld(1, 1));
+    const history = Array.from({ length: 20 }, (_, i) => command(`c-${i}`, 0, 'x'));
+    expect(buildOpsSnapshot(world, { history }).commands).toHaveLength(8);
+  });
+
+  it('复盘的请求体同样远低于 1mb', async () => {
+    const world = await build(bigWorld(12, 10));
+    const history = Array.from({ length: 200 }, (_, i) =>
+      command(`kubectl describe pod pod-${i}`, i % 3 === 0 ? 1 : 0, 'z'.repeat(20000)));
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 20; i += 1) files[`/root/infra/manifest-${i}.yaml`] = 'a'.repeat(30000);
+
+    const snapshot = buildOpsSnapshot(world, {
+      namespace: 'team-0', history, files, limits: SNAPSHOT_LIMITS.review,
+    });
+    const payload = JSON.stringify({ context: { snapshot } });
+
+    expect(payload.length).toBeLessThan(200_000);
+    expect(snapshot.commands).toHaveLength(50);
+    expect(snapshot.problems.length).toBeGreaterThan(0);
+  });
+
+  it('服务端给复盘的额度更高，但仍然有上限', async () => {
+    const snapshot = {
+      namespace: 'default', nodes: [], workloads: [], problems: [], events: [],
+      commands: Array.from({ length: 500 }, (_, i) => ({
+        command: `c-${i}`, code: 0, output: 'q'.repeat(5000),
+      })),
+      files: [], omitted: { objects: 0, namespaces: 0, commands: 0 },
+    };
+    const chat = buildOpsContext({ snapshot }, 'zh');
+    const review = buildOpsContext({ snapshot }, 'zh', REVIEW_MAX_CHARS);
+
+    expect(review.length).toBeGreaterThan(chat.length);
+    expect(review.length).toBeLessThan(REVIEW_MAX_CHARS + 100);
+    expect(review).toContain('上下文过长');
+  });
+});


### PR DESCRIPTION
代码形态的 9 个工程有 AI 对话和 AI 评审，ops 工作台两样都没有。查了一下**不是重构时掉的，是从来就没接过**：`engineering-chat` / `engineering-review` 收的都是「工作区文件数组」，而 ops 这边根本没有工作区，它有的是一个活的集群。所以不是接线问题，是要重做上下文。

两样一起补。

## 上下文怎么裁（这是这个 PR 的主要难点）

工程对话当年把整个工作区原样发上去，撞在 Next 默认的 1mb 请求体上限上，一个中等项目直接 413。ops 的素材比那更容易失控：一个集群几百个对象，每个都有 YAML。

裁剪放在**客户端**（`src/lib/opslab/lab/aicontext.ts`），把世界压成一份定长摘要，服务端只排版、再兜一次总量（客户端可以被绕过，服务端不该假设请求体是善意的）。

取舍：**宁可少给对象，也要把异常和最近的命令输出给全**。学员卡住的时候答案八成在上一条命令的报错里，而不在某个健康 Deployment 的字段上。所以：

- 健康的 Pod / ReplicaSet / ConfigMap 不单独列 —— 数量大、信息量低，状态已经体现在属主的 `3/3` 上
- 异常对象**跨命名空间**收集，不受命名空间上限约束（坏在别处的东西不该因为排序靠后就看不见）
- 命令输出里 **stderr 排在 stdout 前面**
- 每一项都有上限，且都记了「省掉了多少」，让模型知道自己看到的不是全部

排版顺序就是重要性顺序：关卡要求 → **终端最近敲了什么** → 集群哪儿不对 → 资源清单。

**对话和复盘用两套预算**，因为问的不是一件事：对话是「看着刚才那条报错问」，条数少（8）、每条输出给全（1200）；复盘问的是「这一关是怎么走过来的」，命令的顺序本身就是被评的东西，所以条数放宽（50）、单条压短（400）。

### 实测

| 场景 | 原始素材 | 请求体 |
|---|---|---|
| 12 命名空间 × 10 服务（240 Pod）+ 40 条 20KB 输出 + 20 个 30KB 文件 | 2.10 MB | **29.1 KB** |
| 真实第 1 关，7 条命令（对话） | — | **18.9 KB** |
| 同一份历史（复盘） | — | **19.8 KB** |

`tests/opslab/aicontext.test.ts` 盯着这条线，断言是 `< 200KB`——就算将来有人把 `sizeLimit` 改回默认值，功能也不该挂。

## 只读

助手**没有手**。它不执行命令、不改集群，只给出让学员自己敲的命令。除了「代劳会毁掉教学目的」，还有一条硬理由：**判定读的就是世界状态**，能改集群的助手等于能替学员通关，进度这件事本身就没意义了。提示词里把它定位成「坐在旁边看着同一块屏幕的人」。

## 复盘评的是操作，不是代码

学员在这一关里没写程序，他敲了一串命令、改了几个 manifest，把集群从坏改到好。所以维度换了一套：**排查路径 / 结果正确性 / 操作安全 / 效率 / 机制理解**。

提示词里写死了一条：**验收过了不等于操作是对的** —— 判定只查关键点，把 replicas 调成 0 也能让 CrashLoopBackOff 消失。安全维度专门盯 `--force`、删了重建、改 status、关探针这类在生产上不能走的捷径。

## 位置

- **对话**进右侧那组 tab，和终端 / IDE / 拓扑并列。ops 的问答几乎总是「看着报错问」，一个盖住半个屏幕的弹窗会把要问的那段输出挡住。保持挂载，切去看一眼拓扑不会丢对话历史。
- **复盘**进左栏，挨着「验收」。右栏是干活的地方，左栏是读长文的地方，而复盘正是一篇要从头读到尾的长文。

## 代码工作台零回归

`ReviewPanel` 放宽成认**结构**而不是认某一种评审，两边共用同一套排版。`strings` 不传就还是 `engineering.*` 那套文案，`CodeWorkspace` 一行没改。

## 验收

- `npx tsc --noEmit` 干净
- 全量 **57 suites / 1703 tests** 全绿（新增 14 条）
- zh / en 键完全对齐，新增 14 个键两边都有
- **真实打包产物**（`dist/mac-arm64/AlgoLocal.app`，asar 里确认有两条路由）里跑通了完整链路：走完第 1 关（7 条命令、验收 3/3），对话和复盘都拿到真实上下文；后端用本地 OpenAI 兼容 mock，录下的请求体逐段核对过——终端历史（含真实的 `no such host` 报错原文）、集群现状、节点、打开的文件、上一次验收全部在位
- 故意在 mock 里塞了一个不在白名单的维度，确认被 `normalise` 丢掉了
- `check-bundle` 通过（115 chunk，无 `extends null`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)