### PR TITLE
feat(gpulab): 设备运行时与 nvcc / ncu / compute-sanitizer

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -54,7 +54,7 @@ class TestRunner {
       {
         name: 'Gpulab CUDA VM',
         file: 'tests/gpulab',
-        description: 'The CUDA frontend, the warp-lockstep VM, coalescing and bank-conflict measurement, and byte-identical replay'
+        description: 'The CUDA frontend, the warp-lockstep VM, coalescing/bank-conflict measurement, racecheck, and the nvcc/ncu toolchain'
       },
       {
         name: 'Desktop Menus',

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -199,6 +199,19 @@ export class GpuDevice {
   resetMetrics(): void {
     this.counters = emptyCounters();
   }
+
+  /**
+   * 把设备恢复到刚开机的样子：显存清零、分配游标归零、指标清空。
+   *
+   * `./bench` 每次跑都要先做这个 —— 跑两遍必须得到同样的结果，
+   * 否则「重放一致」这条门槛就不成立了。
+   */
+  reset(): void {
+    this.memory.reset();
+    this.counters = emptyCounters();
+    this.lastSanitizer = { races: [], truncated: 0 };
+    this.lastStatic = null;
+  }
 }
 
 /** 每次 launch 的计数器累加到设备上 —— 一关可能 launch 很多次 */

--- a/src/lib/gpulab/lab/cli.ts
+++ b/src/lib/gpulab/lab/cli.ts
@@ -1,0 +1,369 @@
+/**
+ * 装在机器上的 CUDA 工具链：`nvcc` / `ncu` / `compute-sanitizer` / `nvidia-smi`
+ *
+ * 学员的循环和真机上一样：
+ *
+ *     nvcc -o bench kernel.cu
+ *     ./bench
+ *     ncu ./bench
+ *     compute-sanitizer --tool racecheck ./bench
+ *
+ * 命令名、常用 flag、输出的骨架都照真的来。报错文本做不到与 nvcc 逐字节
+ * 一致（那是闭源的），这是 design/gpulab.md 里写明的一处 S4 分叉 ——
+ * 但**位置、行号、以及「哪一行出错」是准的**。
+ */
+import type { CommandHandler, CommandResult } from '../../labkit/machine';
+import { compileSource } from '../index';
+import { CudaCompileError } from '../cuda/lower';
+import { CudaSyntaxError } from '../cuda/parser';
+import { KernelError } from '../vm/vm';
+import { formatRaceReports } from '../vm/sanitizer';
+import { formatNvidiaSmi, formatProfile } from './report';
+import { materialize, toDim3, type BenchSpec, type GpuWorld, type LaunchSpec } from './world';
+
+const CUDA_VERSION = '13.3';
+
+/** 把参数里的 flag 与位置参数分开 */
+function parseArgs(argv: string[]): { flags: Map<string, string | true>; positional: string[] } {
+  const flags = new Map<string, string | true>();
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('-')) { positional.push(arg); continue; }
+    const eq = arg.indexOf('=');
+    if (eq > 0) { flags.set(arg.slice(0, eq), arg.slice(eq + 1)); continue; }
+    // `-o bench` / `--tool racecheck` 这种把下一个参数吃掉
+    if ((arg === '-o' || arg === '--tool' || arg === '-arch' || arg === '--gpu-architecture')
+        && i + 1 < argv.length) {
+      flags.set(arg, argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    flags.set(arg, true);
+  }
+  return { flags, positional };
+}
+
+function resolve(cwd: string, path: string): string {
+  return path.startsWith('/') ? path : `${cwd.replace(/\/$/, '')}/${path}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* nvcc                                                                */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 编译。
+ *
+ * 报错格式贴 nvcc：`kernel.cu(12): error: ...`，下面把出错那一行原样打出来
+ * 并用 `^` 指位置，最后一行是 `N error detected in the compilation of "..."`。
+ * 学员在真机上见到的就是这个形状。
+ */
+export function createNvcc(world: GpuWorld): CommandHandler {
+  return async ({ argv, cwd, vfs }) => {
+    const { flags, positional } = parseArgs(argv);
+
+    if (flags.has('--version') || flags.has('-V')) {
+      return {
+        stdout: [
+          'nvcc: NVIDIA (R) Cuda compiler driver',
+          'Copyright (c) 2005-2026 NVIDIA Corporation',
+          `Cuda compilation tools, release ${CUDA_VERSION}`,
+          '',
+        ].join('\n'),
+      };
+    }
+
+    const sources = positional.filter((path) => path.endsWith('.cu'));
+    if (!sources.length) {
+      return { stderr: 'nvcc fatal   : No input files specified\n', code: 1 };
+    }
+
+    const output = typeof flags.get('-o') === 'string' ? (flags.get('-o') as string) : 'a.out';
+    const merged: string[] = [];
+
+    for (const source of sources) {
+      const path = resolve(cwd, source);
+      if (!vfs.exists(path)) {
+        return { stderr: `nvcc fatal   : Cannot open input file '${source}'\n`, code: 1 };
+      }
+      merged.push(vfs.readFile(path));
+    }
+
+    const text = merged.join('\n');
+    const displayName = sources[0].split('/').pop() ?? sources[0];
+
+    try {
+      const kernels = await compileSource(text);
+      world.artifacts.set(resolve(cwd, output), {
+        path: resolve(cwd, output),
+        kernels,
+        sources: sources.map((source) => resolve(cwd, source)),
+      });
+      // 磁盘上留一个真的文件，`ls` / `cat` 看得见
+      vfs.writeFile(resolve(cwd, output), `#!gpulab-binary\n${[...kernels.keys()].join('\n')}\n`);
+      // 让 `./bench` 能敲。
+      //
+      // labkit 的 shell 只按名字查已注册的命令，不会去磁盘上找可执行文件 ——
+      // 「执行 VFS 里的文件」是机器层该有的能力，但那是 labkit 的事，
+      // 不该在 gpulab 这一片顺手改共享代码。这里按学员实际会敲的两种写法
+      // 各注册一次，够用且不外溢。
+      const basename = output.replace(/^\.\//, '').split('/').pop() ?? output;
+      const runner = createBenchRunner(world, resolve(cwd, output));
+      world.machine.install(`./${basename}`, runner);
+      world.machine.install(basename, runner);
+      return { code: 0 };
+    } catch (error) {
+      return { stderr: diagnose(error, text, displayName), code: 1 };
+    }
+  };
+}
+
+function diagnose(error: unknown, source: string, fileName: string): string {
+  const lines = source.split('\n');
+  let line = 0;
+  let column = 1;
+  let message = String((error as Error)?.message ?? error);
+
+  if (error instanceof CudaCompileError || error instanceof CudaSyntaxError) {
+    line = error.line;
+    column = error.column;
+    // 类里已经把 `行:列: ` 拼进 message 了，打印时去掉免得重复
+    message = message.replace(/^\d+:\d+:\s*/, '');
+  }
+
+  const out: string[] = [];
+  if (line > 0) {
+    out.push(`${fileName}(${line}): error: ${message}`);
+    const text = lines[line - 1];
+    if (text !== undefined) {
+      out.push(`      ${text.trim()}`);
+      // `^` 对到 trim 之后的位置
+      const lead = text.length - text.trimStart().length;
+      out.push(`      ${' '.repeat(Math.max(0, column - 1 - lead))}^`);
+    }
+  } else {
+    out.push(`nvcc error   : ${message}`);
+  }
+  out.push('');
+  out.push(`1 error detected in the compilation of "${fileName}".`);
+  out.push('');
+  return out.join('\n');
+}
+
+/* ------------------------------------------------------------------ */
+/* 跑一个编出来的程序                                                   */
+/* ------------------------------------------------------------------ */
+
+export interface RunOptions {
+  /** 开着 racecheck 跑 */
+  racecheck?: boolean;
+}
+
+export class BenchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BenchError';
+  }
+}
+
+/**
+ * 跑 `./bench`：按世界里的声明分配缓冲区、填数据、依次起 kernel。
+ *
+ * 每次跑都从头分配与填充 —— 跑两遍必须得到同样的结果，
+ * 否则「重放一致」这条门槛就不成立了。
+ */
+export async function runBench(
+  world: GpuWorld,
+  binaryPath: string,
+  options: RunOptions = {}
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const artifact = world.artifacts.get(binaryPath);
+  if (!artifact) {
+    return { stdout: '', stderr: `${binaryPath}: 还没编译，先跑 nvcc\n`, code: 127 };
+  }
+  const bench = world.spec.bench;
+  if (!bench) {
+    return { stdout: '', stderr: '这一关没有声明 bench，无法运行\n', code: 1 };
+  }
+
+  // 重新建一台干净的设备：显存内容、分配游标、指标全部归零
+  world.gpu.reset();
+  world.buffers.clear();
+
+  const seed = world.spec.seed ?? 1;
+  for (const buffer of bench.buffers) {
+    const data = materialize(buffer, seed);
+    const address = world.gpu.malloc(buffer.length * 4);
+    if (buffer.type === 'int') world.gpu.copyInInts(address, data as Int32Array);
+    else world.gpu.copyIn(address, data as Float32Array);
+    world.buffers.set(buffer.name, {
+      address, length: buffer.length, type: buffer.type ?? 'float',
+    });
+  }
+
+  const startedAt = Date.now();
+  const out: string[] = [];
+
+  for (const launch of bench.launches) {
+    const kernel = artifact.kernels.get(launch.kernel);
+    if (!kernel) {
+      return {
+        stdout: out.join('\n'),
+        stderr: `找不到 kernel \`${launch.kernel}\` —— 编出来的有：${[...artifact.kernels.keys()].join(', ')}\n`,
+        code: 1,
+      };
+    }
+    const args = launch.args.map((arg) => {
+      if (typeof arg === 'number') return arg;
+      const buffer = world.buffers.get(arg);
+      if (!buffer) throw new BenchError(`bench 里引用了不存在的缓冲区 \`${arg}\``);
+      return buffer.address;
+    });
+
+    try {
+      if (options.racecheck) {
+        world.gpu.launchWithRacecheck(kernel, {
+          grid: toDim3(launch.grid), block: toDim3(launch.block),
+        }, args);
+      } else {
+        world.gpu.launch(kernel, {
+          grid: toDim3(launch.grid), block: toDim3(launch.block),
+        }, args);
+      }
+    } catch (error) {
+      const detail = error instanceof KernelError
+        ? `${launch.kernel}: ${error.message}`
+        : String((error as Error)?.message ?? error);
+      return { stdout: out.join('\n'), stderr: `${detail}\n`, code: 1 };
+    }
+  }
+
+  world.lastRun = { artifact, launches: bench.launches, wallClockMs: Date.now() - startedAt };
+  out.push(`launched ${bench.launches.length} kernel(s) on ${world.device.name}`);
+  return { stdout: `${out.join('\n')}\n`, stderr: '', code: 0 };
+}
+
+/** 从 argv 里认出「要跑哪个程序」 —— `./bench` / `bench` / 绝对路径都认 */
+function targetOf(cwd: string, positional: string[]): string | null {
+  const target = positional.find((arg) => !arg.startsWith('-'));
+  if (!target) return null;
+  return resolve(cwd, target.replace(/^\.\//, ''));
+}
+
+export function createBenchRunner(world: GpuWorld, binaryPath: string): CommandHandler {
+  return async () => runBench(world, binaryPath);
+}
+
+/* ------------------------------------------------------------------ */
+/* ncu                                                                 */
+/* ------------------------------------------------------------------ */
+
+export function createNcu(world: GpuWorld): CommandHandler {
+  return async ({ argv, cwd }): Promise<CommandResult> => {
+    const { positional } = parseArgs(argv);
+    const target = targetOf(cwd, positional);
+    if (!target) {
+      return { stderr: 'ncu: 要给一个可执行文件，比如 `ncu ./bench`\n', code: 1 };
+    }
+
+    const run = await runBench(world, target);
+    if (run.code !== 0) return run;
+
+    const artifact = world.artifacts.get(target)!;
+    const bench = world.spec.bench!;
+    const lines: string[] = [
+      '==PROF== Connected to process 1',
+    ];
+    for (const launch of bench.launches) {
+      lines.push(`==PROF== Profiling "${launch.kernel}" - 0: 0%....50%....100% - 1 pass`);
+    }
+    lines.push('==PROF== Disconnected from process 1');
+    lines.push(`[1] ${target.split('/').pop()}`);
+
+    const first = bench.launches[0];
+    const kernel = artifact.kernels.get(first.kernel)!;
+    lines.push(formatProfile({
+      kernelName: first.kernel,
+      signature: kernel.params.map((param) =>
+        `${param.isPointer ? `${param.ty === 'f32' ? 'float' : 'int'} *` : param.ty === 'f32' ? 'float' : 'int'}`
+      ).join(', '),
+      device: world.device,
+      metrics: world.gpu.metrics(),
+      stat: world.gpu.staticMetrics(),
+    }));
+    lines.push('');
+    return { stdout: `${lines.join('\n')}\n`, code: 0 };
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* compute-sanitizer                                                   */
+/* ------------------------------------------------------------------ */
+
+export function createComputeSanitizer(world: GpuWorld): CommandHandler {
+  return async ({ argv, cwd }): Promise<CommandResult> => {
+    const { flags, positional } = parseArgs(argv);
+    const tool = typeof flags.get('--tool') === 'string' ? (flags.get('--tool') as string) : 'memcheck';
+    const target = targetOf(cwd, positional);
+    if (!target) {
+      return {
+        stderr: 'compute-sanitizer: 要给一个可执行文件，比如 `compute-sanitizer --tool racecheck ./bench`\n',
+        code: 1,
+      };
+    }
+
+    if (tool !== 'racecheck' && tool !== 'memcheck' && tool !== 'synccheck') {
+      return { stderr: `compute-sanitizer: 暂不支持 --tool ${tool}（有 memcheck / racecheck / synccheck）\n`, code: 1 };
+    }
+
+    const run = await runBench(world, target, { racecheck: tool === 'racecheck' });
+
+    // memcheck 与 synccheck 的检查在 VM 里是常开的：越界会抛、发散屏障会抛。
+    // 所以跑挂了就是它们报出来的东西。
+    if (run.code !== 0) {
+      return {
+        stdout: '========= COMPUTE-SANITIZER\n',
+        stderr: `========= ${run.stderr.trim()}\n========= ERROR SUMMARY: 1 error\n`,
+        code: 1,
+      };
+    }
+
+    if (tool === 'racecheck') {
+      const kernelName = world.spec.bench?.launches[0]?.kernel ?? 'kernel';
+      const report = world.gpu.sanitizerReport();
+      const text = formatRaceReports(report, kernelName);
+      return {
+        stdout: `${text}\n`,
+        code: report.races.length ? 1 : 0,
+      };
+    }
+
+    return {
+      stdout: '========= COMPUTE-SANITIZER\n========= ERROR SUMMARY: 0 errors\n',
+      code: 0,
+    };
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* nvidia-smi                                                          */
+/* ------------------------------------------------------------------ */
+
+export function createNvidiaSmi(world: GpuWorld): CommandHandler {
+  return async () => ({
+    stdout: `${formatNvidiaSmi(world.device, world.gpu.usedBytes)}\n`,
+    code: 0,
+  });
+}
+
+/** 把整套工具链装到机器上 */
+export function installToolchain(world: GpuWorld): void {
+  world.machine.install('nvcc', createNvcc(world));
+  world.machine.install('ncu', createNcu(world));
+  world.machine.install('compute-sanitizer', createComputeSanitizer(world));
+  world.machine.install('nvidia-smi', createNvidiaSmi(world));
+  // `./bench` 走 shell 的「执行磁盘上的文件」路径，见 lab/index.ts
+}
+
+export type { BenchSpec, LaunchSpec };

--- a/src/lib/gpulab/lab/index.ts
+++ b/src/lib/gpulab/lab/index.ts
@@ -1,0 +1,21 @@
+/**
+ * 关卡运行时的门面
+ *
+ * 一句话建好一个世界：机器 + 设备 + 整套 CUDA 工具链。
+ */
+export { createGpuWorld, materialize, toDim3 } from './world';
+export type {
+  BenchSpec, BufferFill, BufferSpec, GpuWorld, GpuWorldSpec, LaunchSpec,
+} from './world';
+export { installToolchain, runBench } from './cli';
+export { formatProfile, formatNvidiaSmi, arithmeticIntensity } from './report';
+
+import { createGpuWorld, type GpuWorld, type GpuWorldSpec } from './world';
+import { installToolchain } from './cli';
+
+/** 建一个装好工具链、可以直接敲命令的世界 */
+export function buildWorld(spec: GpuWorldSpec): GpuWorld {
+  const world = createGpuWorld(spec);
+  installToolchain(world);
+  return world;
+}

--- a/src/lib/gpulab/lab/report.ts
+++ b/src/lib/gpulab/lab/report.ts
@@ -1,0 +1,193 @@
+/**
+ * Nsight Compute 样子的剖析报告
+ *
+ * 分节名与指标名**照抄 ncu**（见 design/gpulab.md 第七节的对照表）。
+ * 这不是装样子：学员拿 `dram__bytes_read.sum` 这个名字去搜，搜到的是
+ * NVIDIA 的文档而不是我们编的东西 —— 「接口真实」在剖析器上的具体含义
+ * 就是这个。
+ *
+ * 数值来自我们的计数器。哪些精确、哪些是模型值，metrics.ts 的注释里
+ * 逐条写了；这里只负责排版。
+ */
+import type { GpuMetrics, StaticMetrics } from '../metrics';
+import type { DeviceSpec } from '../device';
+
+interface Row {
+  metric: string;
+  unit: string;
+  value: string;
+}
+
+function table(rows: Row[]): string[] {
+  const widths = [
+    Math.max(11, ...rows.map((row) => row.metric.length)),
+    Math.max(11, ...rows.map((row) => row.unit.length)),
+    Math.max(12, ...rows.map((row) => row.value.length)),
+  ];
+  const rule = widths.map((width) => '-'.repeat(width)).join(' ');
+  const line = (a: string, b: string, c: string) =>
+    `    ${a.padEnd(widths[0])} ${b.padEnd(widths[1])} ${c.padStart(widths[2])}`;
+
+  return [
+    line('Metric Name', 'Metric Unit', 'Metric Value'),
+    `    ${rule}`,
+    ...rows.map((row) => line(row.metric, row.unit, row.value)),
+  ];
+}
+
+function num(value: number, digits = 2): string {
+  if (!Number.isFinite(value)) return '—';
+  if (Number.isInteger(value) && Math.abs(value) < 1e15) return value.toLocaleString('en-US');
+  return value.toFixed(digits);
+}
+
+/**
+ * 一次 kernel 的完整剖析。
+ *
+ * 分节顺序和 ncu 的默认报告一致：Speed Of Light → Memory Workload →
+ * Compute Workload → Occupancy → Warp State → Launch Statistics。
+ */
+export function formatProfile(input: {
+  kernelName: string;
+  signature: string;
+  device: DeviceSpec;
+  metrics: GpuMetrics;
+  stat: StaticMetrics | null;
+}): string {
+  const { kernelName, signature, device, metrics, stat } = input;
+  const lines: string[] = [];
+
+  lines.push(`  ${kernelName}(${signature})`);
+  lines.push(`    Section: GPU Speed Of Light Throughput`);
+  lines.push(...table([
+    { metric: 'DRAM Read Bytes', unit: 'byte', value: num(metrics.memory.readBytes) },
+    { metric: 'DRAM Write Bytes', unit: 'byte', value: num(metrics.memory.writeBytes) },
+    { metric: 'Arithmetic Intensity', unit: 'flop/byte', value: num(arithmeticIntensity(metrics)) },
+  ]));
+  lines.push('');
+
+  lines.push(`    Section: Memory Workload Analysis`);
+  lines.push(...table([
+    { metric: 'dram__bytes_read.sum', unit: 'byte', value: num(metrics.memory.readBytes) },
+    { metric: 'dram__bytes_write.sum', unit: 'byte', value: num(metrics.memory.writeBytes) },
+    {
+      metric: 'l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio',
+      unit: 'sector/req',
+      value: num(metrics.global.sectorsPerRequest, 2),
+    },
+    {
+      metric: 'l1tex__data_bank_conflicts_pipe_lsu_mem_shared.sum',
+      unit: '', value: num(metrics.shared.bankConflicts),
+    },
+    { metric: 'Local Memory Traffic', unit: 'byte', value: num(metrics.local.bytes) },
+  ]));
+  lines.push('');
+
+  lines.push(`    Section: Compute Workload Analysis`);
+  lines.push(...table([
+    { metric: 'smsp__thread_inst_executed.sum', unit: 'inst', value: num(metrics.inst.laneExecuted) },
+    { metric: 'sm__inst_executed.sum', unit: 'inst', value: num(metrics.inst.warpExecuted) },
+    { metric: 'FMA Instructions', unit: 'inst', value: num(metrics.inst.fma) },
+    { metric: 'Load/Store Instructions', unit: 'inst', value: num(metrics.inst.ldst) },
+    { metric: 'Atomic Operations', unit: 'op', value: num(metrics.atomics) },
+  ]));
+  lines.push('');
+
+  lines.push(`    Section: Occupancy`);
+  lines.push(...table([
+    {
+      metric: 'Theoretical Occupancy', unit: '%',
+      value: stat ? num(stat.occupancy.theoretical * 100, 1) : '—',
+    },
+    {
+      metric: 'Theoretical Active Warps per SM', unit: 'warp',
+      value: stat ? num(stat.occupancy.warpsPerSm) : '—',
+    },
+    {
+      metric: 'Block Limit', unit: 'block',
+      value: stat ? num(stat.occupancy.blocksPerSm) : '—',
+    },
+    {
+      metric: 'launch__registers_per_thread', unit: 'register/thread',
+      value: stat ? num(stat.registersPerThread) : '—',
+    },
+    {
+      metric: 'launch__shared_mem_per_block_static', unit: 'byte/block',
+      value: stat ? num(stat.sharedBytesPerBlock) : '—',
+    },
+  ]));
+  if (stat && stat.occupancy.limiter !== 'none' && stat.occupancy.limiter !== 'warps') {
+    lines.push('');
+    lines.push(`    OPT   占用率被 ${limiterText(stat.occupancy.limiter)} 卡住了。`);
+  }
+  lines.push('');
+
+  lines.push(`    Section: Warp State Statistics`);
+  lines.push(...table([
+    { metric: 'Warp Execution Efficiency', unit: '%', value: num(metrics.warp.activeLaneRatio * 100, 1) },
+    { metric: 'Divergent Branches', unit: '', value: num(metrics.warp.divergentBranches) },
+    { metric: 'Warp Shuffles', unit: 'inst', value: num(metrics.warp.shuffles) },
+    { metric: 'Barriers', unit: '', value: num(metrics.launch.barriers) },
+  ]));
+  lines.push('');
+
+  lines.push(`    Section: Launch Statistics`);
+  lines.push(...table([
+    { metric: 'Blocks Launched', unit: 'block', value: num(metrics.launch.blocks) },
+    { metric: 'Warps Launched', unit: 'warp', value: num(metrics.launch.warps) },
+    { metric: 'Device', unit: '', value: device.name },
+  ]));
+
+  return lines.join('\n');
+}
+
+function limiterText(limiter: StaticMetrics['occupancy']['limiter']): string {
+  switch (limiter) {
+    case 'registers': return '寄存器用量';
+    case 'shared': return '共享内存用量';
+    case 'blocks': return '每 SM 的 block 数上限';
+    default: return '';
+  }
+}
+
+/**
+ * 算术强度：每从 DRAM 搬一个字节，做了多少次浮点运算。
+ *
+ * roofline 的横坐标。分块、融合、寄存器分块这些优化的直接证据都是它涨了。
+ * 分母用「读 + 写」，和 roofline 的惯例一致。
+ */
+export function arithmeticIntensity(metrics: GpuMetrics): number {
+  const bytes = metrics.memory.readBytes + metrics.memory.writeBytes;
+  if (bytes === 0) return 0;
+  // FMA 算两次浮点运算，其余算一次
+  const flops = metrics.inst.fma * 2 + (metrics.inst.laneExecuted - metrics.inst.fma - metrics.inst.ldst);
+  return Math.max(0, flops) / bytes;
+}
+
+/** `nvidia-smi` 的样子 */
+export function formatNvidiaSmi(device: DeviceSpec, usedBytes: number): string {
+  const totalMiB = Math.round(device.memoryBytes / 1024 / 1024);
+  const usedMiB = Math.round(usedBytes / 1024 / 1024);
+  const name = device.name.replace('NVIDIA ', '').padEnd(20).slice(0, 20);
+  return [
+    '+-----------------------------------------------------------------------------------------+',
+    '| NVIDIA-SMI 580.65.06              Driver Version: 580.65.06      CUDA Version: 13.3     |',
+    '|-----------------------------------------+------------------------+----------------------+',
+    '| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |',
+    '| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |',
+    '|                                         |                        |               MIG M. |',
+    '|=========================================+========================+======================|',
+    `|   0  ${name} On  |   00000000:01:00.0 Off |                    0 |`,
+    `| N/A   32C    P0             71W /  700W |${String(`${usedMiB}MiB / ${totalMiB}MiB`).padStart(23)} |      0%      Default |`,
+    '|                                         |                        |             Disabled |',
+    '+-----------------------------------------+------------------------+----------------------+',
+    '',
+    '+-----------------------------------------------------------------------------------------+',
+    '| Processes:                                                                              |',
+    '|  GPU   GI   CI develop        PID   Type   Process name                      GPU Memory |',
+    '|        ID   ID                                                               Usage      |',
+    '|=========================================================================================|',
+    '|  No running processes found                                                             |',
+    '+-----------------------------------------------------------------------------------------+',
+  ].join('\n');
+}

--- a/src/lib/gpulab/lab/world.ts
+++ b/src/lib/gpulab/lab/world.ts
@@ -1,0 +1,185 @@
+/**
+ * 一关的世界
+ *
+ * 学员面前是一台装了 CUDA 工具链的机器：磁盘上有 `.cu` 文件，终端里能敲
+ * `nvcc` / `ncu` / `compute-sanitizer` / `nvidia-smi`。机器层直接复用
+ * labkit（VFS、shell、coreutils），我们只往上装几个命令。
+ *
+ * **这一版学员只写 kernel，宿主侧是平台给的只读样板。**
+ * design/gpulab.md 里定的是「宿主也用 CUDA C」，那需要一个 C 宿主解释器；
+ * 前 16 关一行宿主代码都不用学员写，所以那一片留到第 17 关之前再做。
+ * 现在宿主程序用**声明式**描述：缓冲区怎么填、kernel 怎么起、参数怎么传。
+ */
+import { createMachine, type Machine } from '../../labkit/machine';
+import { createRandom } from '../../labkit/kernel';
+import { GpuDevice, type DeviceOptions } from '../index';
+import { B200, H100, type DeviceSpec } from '../device';
+import type { ExecutableKernel } from '../ir/program';
+import type { Dim3 } from '../vm/vm';
+
+/** 缓冲区里一开始装什么。要能写进 JSON，所以是声明而不是函数。 */
+export type BufferFill =
+  | { kind: 'zeros' }
+  /** `value = offset + i * scale` */
+  | { kind: 'iota'; scale?: number; offset?: number }
+  | { kind: 'const'; value: number }
+  /** 种子固定，所以每次跑出来的数据一模一样 */
+  | { kind: 'random'; seed: number; min?: number; max?: number }
+  | { kind: 'values'; values: number[] };
+
+export interface BufferSpec {
+  name: string;
+  /** 元素个数 */
+  length: number;
+  /** 元素类型，默认 float */
+  type?: 'float' | 'int';
+  fill?: BufferFill;
+}
+
+/** 一次 kernel 启动 */
+export interface LaunchSpec {
+  kernel: string;
+  grid: [number, number?, number?];
+  block: [number, number?, number?];
+  /** 实参：字符串是缓冲区名，数字是标量 */
+  args: Array<string | number>;
+}
+
+/** `./bench` 跑起来是什么 */
+export interface BenchSpec {
+  /** 要编译的源文件，相对机器磁盘 */
+  sources: string[];
+  buffers: BufferSpec[];
+  launches: LaunchSpec[];
+}
+
+export interface GpuWorldSpec {
+  seed?: number;
+  device?: 'H100' | 'B200';
+  /** 显存大小，默认 64MB */
+  globalBytes?: number;
+  /** 每 block 共享内存上限，默认 48KB */
+  sharedBytesPerBlock?: number;
+  machine?: {
+    hostname?: string;
+    user?: string;
+    cwd?: string;
+    files?: Record<string, string>;
+  };
+  bench?: BenchSpec;
+}
+
+export interface CompiledArtifact {
+  /** 编出来的可执行文件路径 */
+  path: string;
+  /** 名字 → kernel */
+  kernels: Map<string, ExecutableKernel>;
+  /** 编译时用的源文件 */
+  sources: string[];
+}
+
+export interface GpuWorld {
+  machine: Machine;
+  gpu: GpuDevice;
+  spec: GpuWorldSpec;
+  device: DeviceSpec;
+  /** 已经 `nvcc -o` 出来的东西，按可执行文件名索引 */
+  artifacts: Map<string, CompiledArtifact>;
+  /** 缓冲区名 → 设备地址 */
+  buffers: Map<string, { address: number; length: number; type: 'float' | 'int' }>;
+  /** 最近一次 `./bench` 跑完的情况 */
+  lastRun: BenchRun | null;
+  run(command: string): Promise<{ stdout: string; stderr: string; code: number }>;
+}
+
+export interface BenchRun {
+  artifact: CompiledArtifact;
+  launches: LaunchSpec[];
+  /** 真实墙钟耗时，只用来给「跑了多久」一个感觉，不作判定 */
+  wallClockMs: number;
+}
+
+/** 按 fill 规格把一段数据造出来。种子固定 → 每次一模一样。 */
+export function materialize(spec: BufferSpec, seed: number): Float32Array | Int32Array {
+  const { length } = spec;
+  const isInt = spec.type === 'int';
+  const out = isInt ? new Int32Array(length) : new Float32Array(length);
+  const fill = spec.fill ?? { kind: 'zeros' as const };
+
+  switch (fill.kind) {
+    case 'zeros':
+      break;
+    case 'const':
+      out.fill(isInt ? fill.value | 0 : Math.fround(fill.value) as never);
+      break;
+    case 'iota': {
+      const scale = fill.scale ?? 1;
+      const offset = fill.offset ?? 0;
+      for (let i = 0; i < length; i += 1) {
+        out[i] = isInt ? (offset + i * scale) | 0 : Math.fround(offset + i * scale);
+      }
+      break;
+    }
+    case 'random': {
+      // 用 labkit 的种子 RNG —— 和 opslab 是同一套，重放一定一致
+      const random = createRandom(fill.seed ^ seed);
+      const min = fill.min ?? -1;
+      const max = fill.max ?? 1;
+      for (let i = 0; i < length; i += 1) {
+        const value = min + random.next() * (max - min);
+        out[i] = isInt ? Math.floor(value) | 0 : Math.fround(value);
+      }
+      break;
+    }
+    case 'values':
+      for (let i = 0; i < length; i += 1) {
+        const value = fill.values[i % fill.values.length] ?? 0;
+        out[i] = isInt ? value | 0 : Math.fround(value);
+      }
+      break;
+  }
+  return out;
+}
+
+export function toDim3(dims: [number, number?, number?]): Dim3 {
+  return { x: dims[0], y: dims[1] ?? 1, z: dims[2] ?? 1 };
+}
+
+/**
+ * 把世界搭起来。
+ *
+ * 装命令这一步由调用方做（见 lab/index.ts 的 buildWorld），
+ * 这样 world 不用认识 nvcc / ncu 具体是什么。
+ */
+export function createGpuWorld(spec: GpuWorldSpec): GpuWorld {
+  const deviceSpec = spec.device === 'B200' ? B200 : H100;
+
+  const options: DeviceOptions = {
+    globalBytes: spec.globalBytes ?? 64 * 1024 * 1024,
+    sharedBytesPerBlock: spec.sharedBytesPerBlock ?? 48 * 1024,
+    device: deviceSpec,
+  };
+
+  const machine = createMachine({
+    hostname: spec.machine?.hostname ?? 'gpu-01',
+    user: spec.machine?.user ?? 'root',
+    cwd: spec.machine?.cwd ?? '/root',
+    files: spec.machine?.files,
+  });
+
+  const world: GpuWorld = {
+    machine,
+    gpu: new GpuDevice(options),
+    spec,
+    device: deviceSpec,
+    artifacts: new Map(),
+    buffers: new Map(),
+    lastRun: null,
+    async run(command: string) {
+      const record = await machine.exec(command);
+      return { stdout: record.stdout, stderr: record.stderr, code: record.code };
+    },
+  };
+
+  return world;
+}

--- a/tests/gpulab/toolchain.test.ts
+++ b/tests/gpulab/toolchain.test.ts
@@ -1,0 +1,328 @@
+/**
+ * CUDA 工具链
+ *
+ * 学员在终端里的循环和真机上一样：
+ *
+ *     nvcc -o bench kernel.cu
+ *     ./bench
+ *     ncu ./bench
+ *     compute-sanitizer --tool racecheck ./bench
+ *
+ * 这套用例守两件事：**命令与 flag 是真的**（换到真机上原样能用），
+ * 以及**跑两遍结果一样**（判定的前提）。
+ */
+import { buildWorld, type GpuWorldSpec } from '../../src/lib/gpulab/lab';
+
+jest.setTimeout(120_000);
+
+const SAXPY = `
+__global__ void saxpy(const float* x, float* y, float a, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) y[i] = a * x[i] + y[i];
+}
+`;
+
+function spec(source = SAXPY): GpuWorldSpec {
+  return {
+    seed: 7,
+    globalBytes: 2 * 1024 * 1024,
+    machine: { files: { '/root/kernel.cu': source } },
+    bench: {
+      sources: ['/root/kernel.cu'],
+      buffers: [
+        { name: 'x', length: 256, fill: { kind: 'iota', scale: 0.5 } },
+        { name: 'y', length: 256, fill: { kind: 'const', value: 1 } },
+      ],
+      launches: [
+        { kernel: 'saxpy', grid: [8], block: [32], args: ['x', 'y', 2, 256] },
+      ],
+    },
+  };
+}
+
+describe('nvcc', () => {
+  it('编译成功之后磁盘上有产物，`./bench` 能敲', async () => {
+    const world = buildWorld(spec());
+    const compile = await world.run('nvcc -o bench kernel.cu');
+    expect(compile.code).toBe(0);
+    expect(compile.stderr).toBe('');
+
+    const ls = await world.run('ls');
+    expect(ls.stdout).toContain('bench');
+
+    const run = await world.run('./bench');
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain('launched 1 kernel');
+  });
+
+  it('`nvcc --version` 报的是钉住的那个版本', async () => {
+    const world = buildWorld(spec());
+    const result = await world.run('nvcc --version');
+    expect(result.stdout).toContain('Cuda compilation tools, release 13.3');
+  });
+
+  it('语法错误按 nvcc 的样子报：文件(行): error，并把那一行指出来', async () => {
+    const world = buildWorld(spec(`
+__global__ void broken(float* a) {
+  a[0] = 1.0f
+}
+`));
+    const result = await world.run('nvcc -o bench kernel.cu');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/^kernel\.cu\(\d+\): error:/m);
+    expect(result.stderr).toContain('^');
+    expect(result.stderr).toContain('1 error detected in the compilation of "kernel.cu".');
+  });
+
+  it('用了子集之外的语法，报错指到那一行并说清替代做法', async () => {
+    const world = buildWorld(spec(`
+__global__ void k(float* a) {
+  double d = 1.0;
+  a[0] = (float)d;
+}
+`));
+    const result = await world.run('nvcc -o bench kernel.cu');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('kernel.cu(3): error:');
+    expect(result.stderr).toContain('double');
+  });
+
+  it('文件不存在时报 nvcc 的原话', async () => {
+    const world = buildWorld(spec());
+    const result = await world.run('nvcc -o bench nope.cu');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("nvcc fatal   : Cannot open input file 'nope.cu'");
+  });
+
+  it('没编译就跑，报「先跑 nvcc」而不是莫名其妙地成功', async () => {
+    const world = buildWorld(spec());
+    const result = await world.run('./bench');
+    expect(result.code).not.toBe(0);
+  });
+});
+
+describe('./bench', () => {
+  it('算出来的结果是对的', async () => {
+    const world = buildWorld(spec());
+    await world.run('nvcc -o bench kernel.cu');
+    await world.run('./bench');
+
+    const y = world.buffers.get('y')!;
+    const out = world.gpu.copyOut(y.address, y.length);
+    for (let i = 0; i < 256; i += 1) {
+      expect(out[i]).toBeCloseTo(2 * (i * 0.5) + 1, 4);
+    }
+  });
+
+  it('跑两遍结果与指标完全一样 —— 每次都从干净的设备开始', async () => {
+    const world = buildWorld(spec());
+    await world.run('nvcc -o bench kernel.cu');
+
+    await world.run('./bench');
+    const first = {
+      y: Array.from(world.gpu.copyOut(world.buffers.get('y')!.address, 256)),
+      metrics: world.gpu.flatMetrics(),
+    };
+
+    await world.run('./bench');
+    const second = {
+      y: Array.from(world.gpu.copyOut(world.buffers.get('y')!.address, 256)),
+      metrics: world.gpu.flatMetrics(),
+    };
+
+    expect(second).toEqual(first);
+  });
+
+  it('kernel 跑挂了（越界）报到 stderr，退出码非 0', async () => {
+    const world = buildWorld({
+      ...spec(`
+__global__ void oob(float* y, int n) {
+  y[blockIdx.x * blockDim.x + threadIdx.x + 1000000] = 1.0f;
+}
+`),
+      bench: {
+        sources: ['/root/kernel.cu'],
+        buffers: [{ name: 'y', length: 64, fill: { kind: 'zeros' } }],
+        launches: [{ kernel: 'oob', grid: [2], block: [32], args: ['y', 64] }],
+      },
+    });
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('./bench');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/invalid __global__|越界/);
+  });
+});
+
+describe('ncu', () => {
+  it('分节名与指标名照抄 Nsight Compute', async () => {
+    const world = buildWorld(spec());
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('ncu ./bench');
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('==PROF== Connected to process');
+    expect(result.stdout).toContain('==PROF== Profiling "saxpy"');
+    for (const section of [
+      'Section: GPU Speed Of Light Throughput',
+      'Section: Memory Workload Analysis',
+      'Section: Compute Workload Analysis',
+      'Section: Occupancy',
+      'Section: Warp State Statistics',
+      'Section: Launch Statistics',
+    ]) {
+      expect(result.stdout).toContain(section);
+    }
+    // 真的 ncu 指标名，学员拿去搜能搜到 NVIDIA 的文档
+    expect(result.stdout).toContain('dram__bytes_read.sum');
+    expect(result.stdout).toContain('l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio');
+    expect(result.stdout).toContain('launch__registers_per_thread');
+  });
+
+  it('合并访问的数字是真的：saxpy 每次请求 4 个扇区', async () => {
+    const world = buildWorld(spec());
+    await world.run('nvcc -o bench kernel.cu');
+    await world.run('ncu ./bench');
+    expect(world.gpu.metrics().global.sectorsPerRequest).toBe(4);
+  });
+
+  it('占用率被什么卡住会直接写出来', async () => {
+    const world = buildWorld({
+      ...spec(`
+__global__ void hog(float* y) {
+  __shared__ float big[20000];
+  int t = threadIdx.x;
+  big[t] = (float)t;
+  __syncthreads();
+  y[t] = big[t];
+}
+`),
+      sharedBytesPerBlock: 96 * 1024,
+      bench: {
+        sources: ['/root/kernel.cu'],
+        buffers: [{ name: 'y', length: 64, fill: { kind: 'zeros' } }],
+        launches: [{ kernel: 'hog', grid: [1], block: [64], args: ['y'] }],
+      },
+    });
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('ncu ./bench');
+    expect(result.stdout).toContain('OPT');
+    expect(result.stdout).toContain('共享内存用量');
+  });
+});
+
+describe('compute-sanitizer', () => {
+  const RACY = `
+__global__ void ordered(float* out) {
+  __shared__ float s[64];
+  int t = threadIdx.x;
+  s[t] = (float)t;
+  out[t] = (t >= 32) ? s[t - 32] : s[t];
+}
+`;
+
+  function racySpec(source: string): GpuWorldSpec {
+    return {
+      globalBytes: 1024 * 1024,
+      machine: { files: { '/root/kernel.cu': source } },
+      bench: {
+        sources: ['/root/kernel.cu'],
+        buffers: [{ name: 'out', length: 64, fill: { kind: 'zeros' } }],
+        launches: [{ kernel: 'ordered', grid: [1], block: [64], args: ['out'] }],
+      },
+    };
+  }
+
+  it('racecheck 抓出竞态，退出码非 0', async () => {
+    const world = buildWorld(racySpec(RACY));
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('compute-sanitizer --tool racecheck ./bench');
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('========= COMPUTE-SANITIZER');
+    expect(result.stdout).toMatch(/ERROR: Race reported between/);
+    expect(result.stdout).toContain('RACECHECK SUMMARY');
+  });
+
+  it('加上屏障之后 0 hazards，退出码 0', async () => {
+    const world = buildWorld(racySpec(RACY.replace('  out[t]', '  __syncthreads();\n  out[t]')));
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('compute-sanitizer --tool racecheck ./bench');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('0 hazards displayed (0 errors, 0 warnings)');
+  });
+
+  it('memcheck 抓越界', async () => {
+    const world = buildWorld({
+      globalBytes: 512 * 1024,
+      machine: {
+        files: {
+          '/root/kernel.cu': `
+__global__ void oob(float* out) { out[threadIdx.x + 900000] = 1.0f; }
+`,
+        },
+      },
+      bench: {
+        sources: ['/root/kernel.cu'],
+        buffers: [{ name: 'out', length: 32, fill: { kind: 'zeros' } }],
+        launches: [{ kernel: 'oob', grid: [1], block: [32], args: ['out'] }],
+      },
+    });
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('compute-sanitizer --tool memcheck ./bench');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('ERROR SUMMARY');
+  });
+
+  it('不认识的 tool 会把有哪些列出来', async () => {
+    const world = buildWorld(racySpec(RACY));
+    await world.run('nvcc -o bench kernel.cu');
+    const result = await world.run('compute-sanitizer --tool initcheck ./bench');
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('racecheck');
+  });
+});
+
+describe('nvidia-smi', () => {
+  it('打出来是那张熟悉的表', async () => {
+    const world = buildWorld(spec());
+    const result = await world.run('nvidia-smi');
+    expect(result.stdout).toContain('NVIDIA-SMI');
+    expect(result.stdout).toContain('CUDA Version: 13.3');
+    expect(result.stdout).toContain('H100');
+    expect(result.stdout).toContain('MiB /');
+  });
+});
+
+describe('和 shell 的其它东西一起用', () => {
+  it('管道、重定向、&& 都照常', async () => {
+    const world = buildWorld(spec());
+    const result = await world.run('nvcc -o bench kernel.cu && ./bench > out.txt && cat out.txt | wc -l');
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe('1');
+  });
+
+  it('编译失败时 && 后面的不跑', async () => {
+    const world = buildWorld(spec('__global__ void k(float* a) { a[0] = }'));
+    const result = await world.run('nvcc -o bench kernel.cu && ./bench');
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).not.toContain('launched');
+  });
+
+  it('学员改了源码再编，跑的是新的', async () => {
+    const world = buildWorld(spec());
+    await world.run('nvcc -o bench kernel.cu && ./bench');
+    const before = world.gpu.copyOut(world.buffers.get('y')!.address, 4)[1];
+
+    // 把 a * x + y 改成 x + y
+    await world.run(`cat > kernel.cu <<'EOF'
+__global__ void saxpy(const float* x, float* y, float a, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) y[i] = x[i] + y[i];
+}
+EOF`);
+    await world.run('nvcc -o bench kernel.cu && ./bench');
+    const after = world.gpu.copyOut(world.buffers.get('y')!.address, 4)[1];
+
+    expect(before).toBeCloseTo(2 * 0.5 + 1, 5);
+    expect(after).toBeCloseTo(0.5 + 1, 5);
+  });
+});


### PR DESCRIPTION
学员在终端里的循环和真机上一样：

```bash
nvcc -o bench kernel.cu
./bench
ncu ./bench
compute-sanitizer --tool racecheck ./bench
```

机器层直接复用 labkit（VFS、shell、coreutils），只往上装四个命令。管道、重定向、`&&`、heredoc 全部照常 —— 有一条用例就是 `nvcc -o bench kernel.cu && ./bench > out.txt && cat out.txt | wc -l`。

## 这一版学员只写 kernel

设计文档定的是「宿主也用 CUDA C」，那需要一个 C 宿主解释器。**前 16 关一行宿主代码都不用学员写**，所以那一片留到第 17 关之前再做。现在宿主程序用声明式描述：缓冲区怎么填（`zeros`/`iota`/`const`/`random`/`values`，随机走 labkit 的种子 RNG）、kernel 怎么起、参数怎么传。

## nvcc 的报错贴真格式

```
kernel.cu(3): error: double 暂不支持 —— 这个工作台的算术全部在 fp32 上做
      double d = 1.0;
      ^

1 error detected in the compilation of "kernel.cu".
```

文本做不到与真 nvcc 逐字节一致（闭源），这是设计文档里写明的 S4 分叉；但**位置、行号、哪一行出错是准的**。

## ncu 的名字全是真的

分节名照抄：`GPU Speed Of Light Throughput` / `Memory Workload Analysis` / `Compute Workload Analysis` / `Occupancy` / `Warp State Statistics` / `Launch Statistics`。

指标名同理 —— `dram__bytes_read.sum`、`l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`、`launch__registers_per_thread`。**学员拿这些名字去搜，搜到的是 NVIDIA 的文档而不是我们编的东西**，这就是「接口真实」在剖析器上的具体含义。

占用率被谁卡住会直接写出来（`OPT 占用率被共享内存用量卡住了`），ncu 也是这么给的。

## 一处必须说明的取巧

labkit 的 shell 只按名字查已注册命令，不会去磁盘上找可执行文件。「执行 VFS 里的文件」是机器层该有的能力，但那是 labkit 的事，不该在这一片顺手改共享代码 —— 所以 `nvcc` 编完之后按学员会敲的两种写法（`bench` 与 `./bench`）各注册一次。注释里写清了来龙去脉。

## `reset()`：重放一致的前提

`./bench` 每次跑都从干净的设备开始（显存清零、分配游标归零、指标清空）。跑两遍结果与**全部指标**必须一样，否则重放门槛不成立 —— 用例钉住了。

## 验证

`tsc` 干净 · `npm test` 10/10（gpulab **94** 个用例，新增 20）· `projects:verify` 全绿 · `npm run build` 过 `check-bundle` 闸门（115 chunk）

🤖 Generated with [Claude Code](https://claude.com/claude-code)