### PR TITLE
feat(gpulab): workspace.kind='gpu' 与判定接入

### DIFF
--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -134,6 +134,8 @@ export interface ProjectStage {
   lab?: LabNetworkConfig;
   /** ops 形态的关卡增量（workspace.kind === 'ops' 时才有意义） */
   ops?: OpsStageSpec;
+  /** gpu 形态的关卡增量（workspace.kind === 'gpu' 时才有意义） */
+  gpu?: GpuStageSpec;
   /** 本关重点考察的维度，用于 AI 评审聚焦 */
   focus?: DimensionKey[];
   /**
@@ -159,7 +161,7 @@ export interface ProjectStage {
  * 这里声明的是**形态**而不是布局坐标：面板怎么摆是代码的事，
  * 题目只回答「这是哪一类实验台」。
  */
-export type WorkspaceKind = 'code' | 'ops';
+export type WorkspaceKind = 'code' | 'ops' | 'gpu';
 
 /** 现有形态：多文件工作区 + 隐藏用例 + 指标门槛 */
 export interface CodeWorkspaceSpec {
@@ -431,7 +433,43 @@ export interface OpsStageSpec {
   };
 }
 
-export type WorkspaceSpec = CodeWorkspaceSpec | OpsWorkspaceSpec;
+/**
+ * GPU 形态：任务 + 终端 + IDE + 剖析 + 访存（+ 后半程的集群）。
+ *
+ * 世界（这是一台什么卡、磁盘上有什么、`./bench` 跑什么）放在项目上，
+ * 每一关只写自己的增量 —— 和 ops 形态一个路子。
+ */
+export interface GpuWorkspaceSpec {
+  kind: 'gpu';
+  world?: import('../gpulab/lab').GpuWorldSpec;
+}
+
+/**
+ * 一关在 GPU 世界上加的增量。
+ *
+ * 判定仍然走隐藏用例（`stage.specs`），只是那些 TS 里 import 的是
+ * `@gpu/lab`。
+ */
+export interface GpuStageSpec {
+  /** 进入本关时往机器磁盘上放的文件（一般就是那个 .cu） */
+  files?: Record<string, string>;
+  /** 这一关的 `./bench` 跑什么。不写就沿用世界里的。 */
+  bench?: import('../gpulab/lab').BenchSpec;
+  /** 每 block 共享内存上限的覆盖（比如需要 96KB 的关卡） */
+  sharedBytesPerBlock?: number;
+  /** 进入本关时先替学员跑一遍的命令 */
+  setupCommands?: string[];
+  /**
+   * 参考解：把这一关做对的那份 kernel 源码。
+   *
+   * 反向验证靠它 —— 用参考解跑，用例与门槛必须全绿；用起始代码跑，必须挂。
+   */
+  referenceFiles?: Record<string, string>;
+  /** 参考解顺带要敲的命令 */
+  referenceCommands?: string[];
+}
+
+export type WorkspaceSpec = CodeWorkspaceSpec | OpsWorkspaceSpec | GpuWorkspaceSpec;
 
 export interface EngineeringProject {
   id: string;
@@ -541,6 +579,14 @@ export interface LabMetrics {
   samples: RequestSample[];
   /** 用户通过 @lab/metrics 打的自定义计数 */
   counters: Record<string, number>;
+  /**
+   * GPU 关卡的指标树。
+   *
+   * 门槛直接写路径，比如
+   * `{ metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5 }` ——
+   * `getMetricValue` 本来就会一层层走下去，不用改解析。
+   */
+  gpu?: Record<string, unknown>;
 }
 
 export interface GateResult {

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -141,6 +141,10 @@ export class GpuDevice {
     config: LaunchConfig,
     args: KernelArg[]
   ): SanitizerReport {
+    // 静态指标和普通 launch 是同一份（同一个 kernel、同一个配置），
+    // 也要填上 —— 否则 racecheck 跑完之后占用率与寄存器数会变成空的
+    const threadsPerBlock = config.block.x * config.block.y * config.block.z;
+    this.lastStatic = staticMetricsOf(this.device, kernel, threadsPerBlock);
     const detector = new RaceDetector({
       // 只盯已经分配出去的那部分显存，影子内存跟着题目规模走
       globalBytes: this.memory.used,
@@ -201,6 +205,20 @@ export class GpuDevice {
   }
 
   /**
+   * 存 / 取一份计数器快照。
+   *
+   * 给 racecheck 那一遍用：它要在干净的设备上重跑一次，但**不能把
+   * 真实那一遍的指标冲掉** —— 门槛读的是真实那一遍。
+   */
+  snapshotCounters(): GpuCounters {
+    return { ...this.counters };
+  }
+
+  restoreCounters(snapshot: GpuCounters): void {
+    this.counters = { ...snapshot };
+  }
+
+  /**
    * 把设备恢复到刚开机的样子：显存清零、分配游标归零、指标清空。
    *
    * `./bench` 每次跑都要先做这个 —— 跑两遍必须得到同样的结果，
@@ -209,7 +227,6 @@ export class GpuDevice {
   reset(): void {
     this.memory.reset();
     this.counters = emptyCounters();
-    this.lastSanitizer = { races: [], truncated: 0 };
     this.lastStatic = null;
   }
 }

--- a/src/lib/gpulab/lab/cli.ts
+++ b/src/lib/gpulab/lab/cli.ts
@@ -187,6 +187,10 @@ export async function runBench(
     return { stdout: '', stderr: '这一关没有声明 bench，无法运行\n', code: 1 };
   }
 
+  // racecheck 是**额外**跑的一遍，不能把真实那一遍的指标冲掉 ——
+  // 门槛读的是真实那一遍。先存住，跑完再放回去。
+  const preserved = options.racecheck ? world.gpu.snapshotCounters() : null;
+
   // 重新建一台干净的设备：显存内容、分配游标、指标全部归零
   world.gpu.reset();
   world.buffers.clear();
@@ -239,6 +243,7 @@ export async function runBench(
     }
   }
 
+  if (preserved) world.gpu.restoreCounters(preserved);
   world.lastRun = { artifact, launches: bench.launches, wallClockMs: Date.now() - startedAt };
   out.push(`launched ${bench.launches.length} kernel(s) on ${world.device.name}`);
   return { stdout: `${out.join('\n')}\n`, stderr: '', code: 0 };

--- a/src/lib/gpulab/lab/index.ts
+++ b/src/lib/gpulab/lab/index.ts
@@ -9,6 +9,11 @@ export type {
 } from './world';
 export { installToolchain, runBench } from './cli';
 export { formatProfile, formatNvidiaSmi, arithmeticIntensity } from './report';
+export { createGpuLabApi, createGpuLabModules, GpuLabError } from './modules';
+export type { GpuLabApi, Deviation } from './modules';
+export { ulpDistanceOf, accumulationTolerance } from './numeric';
+export { runGpuStage, gpuMetricTree } from './runner';
+export type { RunGpuStageOptions } from './runner';
 
 import { createGpuWorld, type GpuWorld, type GpuWorldSpec } from './world';
 import { installToolchain } from './cli';

--- a/src/lib/gpulab/lab/modules.ts
+++ b/src/lib/gpulab/lab/modules.ts
@@ -1,0 +1,169 @@
+/**
+ * `@gpu/lab` —— GPU 关卡的隐藏用例能拿到的东西
+ *
+ * 和 `@ops/lab` 一个路子：判定读的是**工作台里那个世界**，不是另起一个
+ * 干净的设备。学员在终端里编过、跑过的东西必须算数。
+ *
+ * 判定的三个证据来源：
+ *  1. **终态** —— `buffer()` 把显存里的结果读回来；
+ *  2. **行为探测** —— `sh()` / `build()` / `run()` 由平台自己跑，学员改不了；
+ *  3. **过程指标** —— `metrics()`，也就是门槛读的那棵树。
+ */
+import type { GpuMetrics, StaticMetrics } from '../metrics';
+import type { SanitizerReport } from '../vm/sanitizer';
+import type { CommandRecord } from '../../labkit/machine';
+import { ulpDistanceOf } from './numeric';
+import { runBench } from './cli';
+import type { GpuWorld } from './world';
+
+export interface ShellResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** 一组数和参考值差多少 */
+export interface Deviation {
+  /** 最大绝对误差 */
+  maxAbs: number;
+  /**
+   * 最大相对误差。分母用 `max(1, |expected|)`，
+   * 避免参考值接近 0 时相对误差炸掉。
+   */
+  maxRel: number;
+  /** 最大 ulp 距离 —— 在整个数值范围上是同一把尺子 */
+  maxUlp: number;
+  /** 第一个超出容差的下标，全在容差内就是 -1 */
+  firstBadIndex: number;
+  /** 有没有 NaN 或 Inf */
+  hasNonFinite: boolean;
+}
+
+export interface GpuLabApi {
+  /** 敲一条命令（平台身份） */
+  sh(command: string): Promise<ShellResult>;
+  /** `nvcc -o bench <世界里声明的源文件>` 的简写 */
+  build(): Promise<ShellResult>;
+  /** 跑 `./bench` */
+  run(): Promise<ShellResult>;
+  /** 编译 + 运行，任一步失败就抛 —— 用例里最常用的那条路 */
+  buildAndRun(): Promise<void>;
+  /** 开着 racecheck 再跑一遍 */
+  racecheck(): Promise<SanitizerReport>;
+
+  /** 门槛读的那棵指标树 */
+  metrics(): GpuMetrics;
+  /** 寄存器 / 共享内存 / 占用率 */
+  staticMetrics(): StaticMetrics | null;
+
+  /** 把一个缓冲区读回来 */
+  buffer(name: string): Float32Array;
+  bufferInts(name: string): Int32Array;
+
+  /** 和参考值比一比 */
+  compare(actual: ArrayLike<number>, expected: ArrayLike<number>): Deviation;
+
+  /** 机器磁盘 */
+  readFile(path: string): string | undefined;
+  exists(path: string): boolean;
+  /** 学员敲过的每一条命令 */
+  transcript(): CommandRecord[];
+
+  /** 需要更底层的东西时的出口 */
+  world: GpuWorld;
+}
+
+export function createGpuLabModules(world: GpuWorld): Record<string, unknown> {
+  return { '@gpu/lab': createGpuLabApi(world) };
+}
+
+export class GpuLabError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GpuLabError';
+  }
+}
+
+export function createGpuLabApi(world: GpuWorld): GpuLabApi {
+  const binary = '/root/bench';
+
+  const build = async (): Promise<ShellResult> => {
+    const sources = world.spec.bench?.sources ?? [];
+    if (!sources.length) throw new GpuLabError('这一关没有声明要编译的源文件');
+    return world.run(`nvcc -o bench ${sources.join(' ')}`);
+  };
+
+  return {
+    sh: (command) => world.run(command),
+    build,
+    run: () => runBench(world, binary),
+
+    async buildAndRun() {
+      const compiled = await build();
+      if (compiled.code !== 0) {
+        throw new GpuLabError(`编译没通过：\n${compiled.stderr.trim()}`);
+      }
+      const ran = await runBench(world, binary);
+      if (ran.code !== 0) {
+        throw new GpuLabError(`跑挂了：\n${ran.stderr.trim()}`);
+      }
+    },
+
+    racecheck: async () => {
+      await runBench(world, binary, { racecheck: true });
+      return world.gpu.sanitizerReport();
+    },
+
+    metrics: () => world.gpu.metrics(),
+    staticMetrics: () => world.gpu.staticMetrics(),
+
+    buffer(name) {
+      const buffer = world.buffers.get(name);
+      if (!buffer) {
+        throw new GpuLabError(
+          `没有叫 \`${name}\` 的缓冲区 —— 有的是：${[...world.buffers.keys()].join(', ') || '（还没跑过 ./bench）'}`
+        );
+      }
+      return world.gpu.copyOut(buffer.address, buffer.length);
+    },
+
+    bufferInts(name) {
+      const buffer = world.buffers.get(name);
+      if (!buffer) throw new GpuLabError(`没有叫 \`${name}\` 的缓冲区`);
+      return world.gpu.copyOutInts(buffer.address, buffer.length);
+    },
+
+    compare(actual, expected) {
+      const length = Math.min(actual.length, expected.length);
+      let maxAbs = 0;
+      let maxRel = 0;
+      let maxUlp = 0;
+      let firstBadIndex = -1;
+      let hasNonFinite = false;
+
+      for (let i = 0; i < length; i += 1) {
+        const a = actual[i];
+        const b = expected[i];
+        if (!Number.isFinite(a)) {
+          hasNonFinite = true;
+          if (firstBadIndex < 0) firstBadIndex = i;
+          continue;
+        }
+        const abs = Math.abs(a - b);
+        const rel = abs / Math.max(1, Math.abs(b));
+        const ulp = ulpDistanceOf(Math.fround(a), Math.fround(b));
+        if (abs > maxAbs) maxAbs = abs;
+        if (rel > maxRel) { maxRel = rel; if (firstBadIndex < 0 && rel > 1e-3) firstBadIndex = i; }
+        if (ulp > maxUlp) maxUlp = ulp;
+      }
+
+      return { maxAbs, maxRel, maxUlp, firstBadIndex, hasNonFinite };
+    },
+
+    readFile: (path) => (world.machine.vfs.exists(path) ? world.machine.vfs.readFile(path) : undefined),
+    exists: (path) => world.machine.vfs.exists(path),
+    transcript: () => world.machine.transcript(),
+
+    world,
+  };
+}

--- a/src/lib/gpulab/lab/numeric.ts
+++ b/src/lib/gpulab/lab/numeric.ts
@@ -1,0 +1,41 @@
+/**
+ * 数值判定的尺子
+ *
+ * design/gpulab.md 第八节定的三层：fp64 参考、理论误差界、重放逐位一致。
+ * 这里是第二层用到的两件工具。
+ */
+
+const bitsBuffer = new ArrayBuffer(4);
+const bitsF32 = new Float32Array(bitsBuffer);
+const bitsI32 = new Int32Array(bitsBuffer);
+
+/**
+ * 两个 fp32 之间差多少个 ulp。
+ *
+ * 判定用它而不是只看相对误差：相对误差在接近 0 的地方会炸，
+ * 而 ulp 在整个数值范围上都是同一把尺子。
+ */
+export function ulpDistanceOf(a: number, b: number): number {
+  if (Number.isNaN(a) || Number.isNaN(b)) return Number.POSITIVE_INFINITY;
+  if (a === b) return 0;
+  const ordered = (value: number): number => {
+    bitsF32[0] = value;
+    const bits = bitsI32[0];
+    // 负数的位模式是反的，翻成一条单调的整数轴
+    return bits < 0 ? 0x80000000 - bits : bits;
+  };
+  return Math.abs(ordered(a) - ordered(b));
+}
+
+/**
+ * K 项累加在 fp32 下的相对误差界。
+ *
+ * 顺序累加的最坏情况是 O(K·ε)，但实际误差是随机游走，所以按 √K 给界；
+ * 系数 C 留出余量（分块累加、FMA、不同的规约顺序都会让常数变一点）。
+ *
+ * 关卡的题面里要把这个界和它的来历写出来 —— 一个凭空的阈值教不会任何事。
+ */
+export function accumulationTolerance(terms: number, c = 8): number {
+  const epsilon = 2 ** -23; // fp32 的机器精度
+  return c * Math.sqrt(Math.max(1, terms)) * epsilon;
+}

--- a/src/lib/gpulab/lab/runner.ts
+++ b/src/lib/gpulab/lab/runner.ts
@@ -1,0 +1,215 @@
+/**
+ * 跑一个 GPU 关卡的判定
+ *
+ * 和 `runOpsStage` 是姐妹：同一套隐藏用例机制、同一份 `StageRunReport`，
+ * 所以结果面板、计分卡、AI 评审、进度存档全部复用。
+ *
+ * **一处关键的不同：门槛真的会算。**
+ * `runOpsStage` 永远返回 `gates: []` —— ops 关卡不走指标门槛。
+ * 而 gpulab 的门槛是主角（「优化真的生效」全靠它证明），所以这里把
+ * `evaluateGates` 接了进来，并且把 GPU 的指标树挂到 `LabMetrics.gpu` 下。
+ * 门槛写起来就是 `{ metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5 }`。
+ */
+import { createModuleRuntime } from '../../engineering/moduleRuntime';
+import { evaluateGates } from '../../engineering/runner';
+import { AssertionError, createSpecCollector } from '../../engineering/specRunner';
+import type {
+  ConsoleEntry, GateResult, LabMetrics, MetricGate,
+  SpecCaseResult, SpecFile, StageRunReport,
+} from '../../engineering/types';
+import { createGpuLabModules } from './modules';
+import type { GpuWorld } from './world';
+
+export interface RunGpuStageOptions {
+  world: GpuWorld;
+  specs: SpecFile[];
+  gates?: MetricGate[];
+  /** 隐藏用例之外，还要让 spec 能 import 的文件 */
+  files?: Record<string, string>;
+  transpile?: (code: string, filePath: string) => string;
+  /** 单条用例的真实时间预算 */
+  caseWallClockMs?: number;
+}
+
+/**
+ * 把 GPU 的指标整理成一棵能被 `getMetricValue` 一层层走下去的树。
+ *
+ * 静态指标（寄存器、占用率）与 sanitizer 的结果也放进来 ——
+ * 它们和运行时计数器一样是门槛要读的东西。
+ */
+export function gpuMetricTree(world: GpuWorld): Record<string, unknown> {
+  const metrics = world.gpu.metrics();
+  const stat = world.gpu.staticMetrics();
+  const sanitizer = world.gpu.sanitizerReport();
+
+  return {
+    ...metrics,
+    registers: { perThread: stat?.registersPerThread ?? 0 },
+    occupancy: {
+      theoretical: stat?.occupancy.theoretical ?? 0,
+      warpsPerSm: stat?.occupancy.warpsPerSm ?? 0,
+      blocksPerSm: stat?.occupancy.blocksPerSm ?? 0,
+    },
+    sanitizer: {
+      races: sanitizer.races.length + sanitizer.truncated,
+      /** warp 同步原语用错的次数，和 races 一样是恒为 0 的硬门槛 */
+      warpSyncErrors: metrics.warp.syncErrors,
+    },
+    /** 显存峰值 —— FlashAttention、KV cache 那几关的门槛读它 */
+    memoryPeakBytes: world.gpu.usedBytes,
+  };
+}
+
+/** GPU 关卡没有请求级指标，但报告结构要一致 —— 给一份空的，再挂上 gpu 那棵树 */
+export function gpuLabMetrics(world: GpuWorld): LabMetrics {
+  return {
+    virtualElapsedMs: 0,
+    maxConcurrency: 0,
+    concurrencyTimeline: [],
+    requests: { total: 0, ok: 0, failed: 0, throttled: 0, retries: 0, duplicated: 0, byUrl: {} },
+    samples: [],
+    counters: {},
+    gpu: gpuMetricTree(world),
+  };
+}
+
+export async function runGpuStage(options: RunGpuStageOptions): Promise<StageRunReport> {
+  const startedAt = Date.now();
+  const cases: SpecCaseResult[] = [];
+  const consoleEntries: ConsoleEntry[] = [];
+
+  const builtins = createGpuLabModules(options.world);
+
+  try {
+    for (const spec of options.specs) {
+      const collector = createSpecCollector();
+      const runtime = createModuleRuntime({
+        files: { ...(options.files ?? {}), [spec.path]: spec.content },
+        builtins,
+        globals: {
+          ...collector.globals,
+          console: makeConsole(consoleEntries),
+        },
+        transpile: options.transpile,
+      });
+
+      runtime.require(`./${spec.path}`);
+      collector.finalize();
+
+      for (const testCase of collector.cases) {
+        if (testCase.skipped) {
+          cases.push({
+            suite: testCase.suite, name: testCase.name,
+            passed: true, durationMs: 0, error: 'skipped',
+          });
+          continue;
+        }
+
+        const caseStartedAt = Date.now();
+        let failure: { message: string; expected?: string; actual?: string } | null = null;
+        try {
+          await withTimeout(async () => {
+            for (const hook of testCase.beforeEach.flat()) await hook();
+            try {
+              await testCase.fn();
+            } finally {
+              for (const hook of testCase.afterEach.flat()) await hook();
+            }
+          }, options.caseWallClockMs ?? 60_000, `${testCase.suite} ${testCase.name}`);
+        } catch (error) {
+          failure = describeError(error);
+        }
+
+        cases.push({
+          suite: testCase.suite,
+          name: testCase.name,
+          passed: !failure,
+          durationMs: Date.now() - caseStartedAt,
+          ...(failure ?? {}),
+          ...(failure ? { error: failure.message } : {}),
+        });
+      }
+    }
+  } catch (error) {
+    const detail = describeError(error);
+    const passedSoFar = cases.filter((item) => item.passed).length;
+    return {
+      status: 'error',
+      totals: { total: cases.length, passed: passedSoFar, failed: cases.length - passedSoFar },
+      cases,
+      gates: [],
+      metrics: gpuLabMetrics(options.world),
+      console: consoleEntries.slice(0, 200),
+      wallClockMs: Date.now() - startedAt,
+      error: detail.message,
+    };
+  }
+
+  const metrics = gpuLabMetrics(options.world);
+  // 门槛只看整次运行的聚合指标，没有按用例分组的概念 ——
+  // 一次 launch 的计量本来就是整体的。
+  const gates: GateResult[] = evaluateGates(options.gates ?? [], [], metrics);
+
+  const passed = cases.filter((item) => item.passed).length;
+  const failed = cases.length - passed;
+  const allGatesPassed = gates.every((gate) => gate.passed);
+
+  return {
+    status: failed === 0 && allGatesPassed ? 'passed' : 'failed',
+    totals: { total: cases.length, passed, failed },
+    cases,
+    gates,
+    metrics,
+    console: consoleEntries.slice(0, 200),
+    wallClockMs: Date.now() - startedAt,
+  };
+}
+
+/**
+ * 用例的真实时间预算。
+ *
+ * GPU 的用例会真的编译并跑 kernel。jest 之外（也就是学员那一侧）
+ * 一次 N=256 的 GEMM 是几百毫秒量级，但一关可能跑好几遍，
+ * 所以给得比 ops 宽一点。
+ */
+function withTimeout<T>(run: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`用例超时（${ms}ms）：${label}`)), ms);
+    run().then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); }
+    );
+  });
+}
+
+function describeError(error: unknown): { message: string; expected?: string; actual?: string } {
+  if (error instanceof AssertionError) {
+    return { message: error.message, expected: error.expected, actual: error.actual };
+  }
+  if (error instanceof Error) {
+    const stackLine = (error.stack ?? '').split('\n')[1]?.trim();
+    return { message: stackLine ? `${error.message}\n  ${stackLine}` : error.message };
+  }
+  return { message: String(error) };
+}
+
+function makeConsole(sink: ConsoleEntry[]) {
+  const push = (level: ConsoleEntry['level']) => (...args: unknown[]) => {
+    if (sink.length >= 200) return;
+    sink.push({
+      level,
+      text: args.map((value) => (typeof value === 'string' ? value : safeJson(value))).join(' '),
+      at: 0,
+      source: 'user',
+    });
+  };
+  return { log: push('log'), info: push('log'), warn: push('warn'), error: push('error'), debug: push('log') };
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/tests/gpulab/judging.test.ts
+++ b/tests/gpulab/judging.test.ts
@@ -1,0 +1,218 @@
+/**
+ * 判定管线
+ *
+ * 这一套证明的是整个项目最核心的那句话能不能兑现：
+ * **「优化真的生效」是能被证明的，而不是自称的。**
+ *
+ * 做法：拿同一关的两份实现（没优化的、优化过的）跑同一套隐藏用例与门槛。
+ * 两份都必须通过用例（结果都对），但只有优化过的能过门槛。
+ */
+import { buildWorld, runGpuStage, type GpuWorldSpec } from '../../src/lib/gpulab/lab';
+import { createTranspiler } from '../../src/lib/engineering/transpile';
+import type { MetricGate, SpecFile } from '../../src/lib/engineering/types';
+import * as ts from 'typescript';
+
+/**
+ * 隐藏用例是 TS，模块运行时要一个转译器才跑得动。
+ * 学员那一侧由工作台按需懒加载（见 engineering/transpile.ts），
+ * 测试里直接给一个。
+ */
+const transpile = createTranspiler(ts);
+
+jest.setTimeout(180_000);
+
+/**
+ * 第 2 关的形状：同一个拷贝，换个下标就是 8 倍的传输量。
+ *
+ * 关键是**每个元素都要搬到**，只是顺序不对 —— 否则挂的就是用例而不是门槛，
+ * 演示不出「结果全对但传输量差 8 倍」这件事。
+ * 这里让一个 warp 里的 32 个 lane 各隔 n/32 个元素，正好各占一个扇区。
+ */
+const NAIVE = `
+__global__ void copyKernel(const float* in, float* out, int n) {
+  int t = blockIdx.x * blockDim.x + threadIdx.x;
+  int lane = t % 32;
+  int row = t / 32;
+  int i = lane * (n / 32) + row;
+  if (i < n) out[i] = in[i];
+}
+`;
+
+const COALESCED = `
+__global__ void copyKernel(const float* in, float* out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i];
+}
+`;
+
+const N = 2048;
+
+function spec(source: string): GpuWorldSpec {
+  return {
+    seed: 3,
+    globalBytes: 1024 * 1024,
+    machine: { files: { '/root/kernel.cu': source } },
+    bench: {
+      sources: ['/root/kernel.cu'],
+      buffers: [
+        { name: 'in', length: N, fill: { kind: 'iota', scale: 0.25 } },
+        { name: 'out', length: N, fill: { kind: 'zeros' } },
+      ],
+      launches: [
+        { kernel: 'copyKernel', grid: [N / 64], block: [64], args: ['in', 'out', N] },
+      ],
+    },
+  };
+}
+
+/** 隐藏用例：只管「算对没有」，不管怎么算的 */
+const SPECS: SpecFile[] = [{
+  path: 'spec.ts',
+  content: `
+    const lab = require('@gpu/lab');
+
+    describe('拷贝', () => {
+      it('每个元素都搬过去了', async () => {
+        await lab.buildAndRun();
+        const out = lab.buffer('out');
+        const input = lab.buffer('in');
+        const diff = lab.compare(out, input);
+        expect(diff.maxAbs).toBe(0);
+      });
+
+      it('没有竞态', async () => {
+        const report = await lab.racecheck();
+        expect(report.races.length).toBe(0);
+      });
+    });
+  `,
+}];
+
+/** 门槛：结构性计量，与硬件型号无关 */
+const GATES: MetricGate[] = [
+  {
+    metric: 'gpu.global.sectorsPerRequest',
+    op: 'lte',
+    value: 4.5,
+    label: { en: 'sectors per request', zh: '每次访存的扇区数' },
+    dimension: 'latency',
+  },
+  {
+    metric: 'gpu.sanitizer.races',
+    op: 'eq',
+    value: 0,
+    label: { en: 'data races', zh: '竞态' },
+    dimension: 'correctness',
+  },
+];
+
+async function judge(source: string) {
+  const world = buildWorld(spec(source));
+  return runGpuStage({ world, specs: SPECS, gates: GATES, transpile });
+}
+
+describe('门槛真的会算 —— 这是和 ops 关卡最本质的区别', () => {
+  it('优化过的实现：用例全绿，门槛全过', async () => {
+    const report = await judge(COALESCED);
+    expect(report.totals.failed).toBe(0);
+    expect(report.gates.every((gate) => gate.passed)).toBe(true);
+    expect(report.status).toBe('passed');
+  });
+
+  it('**没优化的实现：用例照样全绿，但门槛挂了**', async () => {
+    const report = await judge(NAIVE);
+    // 结果完全正确 —— 学员没算错任何东西
+    expect(report.totals.failed).toBe(0);
+    // 但传输量是 8 倍，门槛不认
+    const sectors = report.gates.find((gate) => gate.gate.metric === 'gpu.global.sectorsPerRequest')!;
+    expect(sectors.passed).toBe(false);
+    expect(sectors.actual).toBe(32);
+    expect(report.status).toBe('failed');
+  });
+
+  it('两份实现算出来的结果一模一样 —— 差别只在怎么访存', async () => {
+    const fast = buildWorld(spec(COALESCED));
+    const slow = buildWorld(spec(NAIVE));
+    for (const world of [fast, slow]) {
+      await world.run('nvcc -o bench kernel.cu');
+      await world.run('./bench');
+    }
+    const a = fast.gpu.copyOut(fast.buffers.get('out')!.address, N);
+    const b = slow.gpu.copyOut(slow.buffers.get('out')!.address, N);
+    expect(Array.from(b)).toEqual(Array.from(a));
+
+    // 访存指令的**条数**一样 —— 每个元素都是一读一写，没人少做事
+    expect(slow.gpu.metrics().global.loadRequests)
+      .toBe(fast.gpu.metrics().global.loadRequests);
+    // 但搬过去的字节数差 8 倍，这才是门槛抓住的东西
+    expect(slow.gpu.metrics().memory.readBytes / fast.gpu.metrics().memory.readBytes).toBe(8);
+  });
+});
+
+describe('指标树能被门槛的路径解析到', () => {
+  it('嵌套路径一层层走得下去', async () => {
+    const report = await judge(COALESCED);
+    const tree = report.metrics.gpu as Record<string, any>;
+    expect(tree.global.sectorsPerRequest).toBe(4);
+    expect(tree.sanitizer.races).toBe(0);
+    expect(tree.occupancy.theoretical).toBeGreaterThan(0);
+    expect(tree.registers.perThread).toBeGreaterThan(0);
+    expect(tree.memoryPeakBytes).toBeGreaterThan(0);
+  });
+
+  it('写错指标名会挂，而不是悄悄当成 0 过掉', async () => {
+    const world = buildWorld(spec(COALESCED));
+    const report = await runGpuStage({
+      world,
+      specs: SPECS,
+      transpile,
+      gates: [{
+        metric: 'gpu.nonexistent.thing',
+        op: 'lte',
+        value: 1,
+        label: { en: 'typo', zh: '写错的指标' },
+      }],
+    });
+    expect(report.gates[0].passed).toBe(false);
+    expect(Number.isNaN(report.gates[0].actual)).toBe(true);
+  });
+});
+
+describe('编译失败与跑挂', () => {
+  it('编不过时用例报的是编译错误原文', async () => {
+    const report = await judge('__global__ void copyKernel(float* a) { a[0] = }');
+    expect(report.totals.failed).toBeGreaterThan(0);
+    const failure = report.cases.find((item) => !item.passed)!;
+    expect(failure.error).toContain('编译没通过');
+    expect(failure.error).toContain('kernel.cu(');
+  });
+
+  it('kernel 越界时用例报越界，不是报「结果不对」', async () => {
+    const report = await judge(`
+__global__ void copyKernel(const float* in, float* out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  out[i + 900000] = in[i];
+}
+`);
+    const failure = report.cases.find((item) => !item.passed)!;
+    expect(failure.error).toMatch(/invalid __global__|越界/);
+  });
+});
+
+describe('反向验证的形状', () => {
+  /**
+   * 出题时每一关都要满足这个：**参考解全绿，起始代码必须挂。**
+   * 这里用第 2 关的两份实现演示一遍，后面每关的内容都按这个模板写。
+   */
+  it('参考解全绿', async () => {
+    const report = await judge(COALESCED);
+    expect(report.status).toBe('passed');
+  });
+
+  it('起始代码必须挂 —— 挂在门槛上而不是用例上', async () => {
+    const report = await judge(NAIVE);
+    expect(report.status).toBe('failed');
+    expect(report.totals.failed).toBe(0);       // 用例是过的
+    expect(report.gates.some((g) => !g.passed)).toBe(true); // 挂在门槛
+  });
+});


### PR DESCRIPTION
和 ops 关卡最本质的区别在这里：**`runOpsStage` 永远返回 `gates: []`，而 gpulab 的门槛是主角**。「优化真的生效」这句话全靠它证明。

## 接了三件事

1. `WorkspaceKind` 加 `'gpu'` 一支，配套 `GpuWorkspaceSpec` / `GpuStageSpec`。世界写在项目上、每关只写增量 —— 和 ops 一个路子。
2. **`@gpu/lab`**：隐藏用例能拿到 `sh` / `build` / `run` / `buildAndRun` / `racecheck` / `metrics` / `buffer` / `compare`。判定读的是**工作台里那个世界**，学员在终端里编过跑过的东西必须算数。
3. `runGpuStage` 把 `evaluateGates` 接了进来，GPU 指标挂到 `LabMetrics.gpu` 下。门槛写起来就是 `{ metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5 }` —— `getMetricValue` 本来就会一层层走下去，解析一行都不用改。

## 用例直接演了一遍反向验证

同一关的两份实现，跑同一套用例与门槛：

| | 用例 | `sectorsPerRequest` | 结果 |
| --- | --- | ---: | --- |
| 合并访问 | 全绿 | **4.0** | `passed` |
| 未合并 | **也全绿** | **32.0** | `failed`（挂在门槛） |

两份算出来的数据**逐位相同**、访存指令**条数一样**（每个元素都是一读一写，没人少做事），但搬过去的字节数差 8 倍。这就是后面每一关内容要照着写的模板。

## 修掉两个会让判定读到空指标的洞

都是**假阳性**，比报错危险得多：

- **racecheck 把真实指标冲掉了**。它是额外跑的一遍，`reset()` 了设备而自身又不累加，于是真实那一遍的计数器归零。现在跑之前存快照、跑完放回去。
- **`launchWithRacecheck` 之前不填静态指标**，而 `reset()` 又清了 `lastStatic`，于是占用率与寄存器数在 racecheck 之后变成 0。现在它也填（同一个 kernel 同一个配置，静态指标本来就一样）。

如果不修，`gpu.occupancy.theoretical >= 0.5` 这类门槛会在 racecheck 之后读到 0 —— 然后**轻松通过**任何 `lte` 门槛。

## 验证

`tsc` 干净 · `npm test` 10/10（gpulab **103** 个用例，新增 9）· `projects:verify` 全绿 · `npm run build` 过 `check-bundle` 闸门

🤖 Generated with [Claude Code](https://claude.com/claude-code)