### PR TITLE
feat(gpulab): 项目骨架与第 1–3 关

### DIFF
--- a/projects/definitions/llm-accelerator.js
+++ b/projects/definitions/llm-accelerator.js
@@ -1,0 +1,663 @@
+/**
+ * CUDA GPU 编程实战：搭一个 LLM 加速引擎
+ *
+ * 工作台是 gpu 形态：任务 + 终端 + IDE + 剖析 + 访存。
+ * 学员写真 CUDA C，敲真 nvcc / ncu / compute-sanitizer，
+ * 门槛建立在平台侧的结构性计量上 —— 见 design/gpulab.md。
+ *
+ * 前 21 关在一张 H100 上，后 8 关摊到 16 卡集群。
+ */
+const { t, code, spec, gate } = require('./_helpers');
+
+/* ------------------------------------------------------------------ */
+/* 这台机器                                                            */
+/* ------------------------------------------------------------------ */
+
+const WORLD = {
+  seed: 20260826,
+  device: 'H100',
+  globalBytes: 32 * 1024 * 1024,
+  sharedBytesPerBlock: 48 * 1024,
+  machine: {
+    hostname: 'gpu-01',
+    user: 'root',
+    cwd: '/root',
+  },
+};
+
+/** 每一关的判定都要先编译再跑，这段抄来抄去不如提出来 */
+const RUN_AND_CHECK = `
+  const lab = require('@gpu/lab');
+`;
+
+/** 恒定的硬门槛：竞态、越界、warp 同步用错，一律为 0 */
+const SAFETY_GATES = [
+  gate({
+    metric: 'gpu.sanitizer.races', op: 'eq', value: 0,
+    zh: '数据竞态', en: 'data races',
+    dimension: 'correctness',
+  }),
+  gate({
+    metric: 'gpu.sanitizer.warpSyncErrors', op: 'eq', value: 0,
+    zh: 'warp 同步用错', en: 'warp sync errors',
+    dimension: 'correctness',
+  }),
+];
+
+/* ------------------------------------------------------------------ */
+/* 第 1 关：第一个 kernel                                              */
+/* ------------------------------------------------------------------ */
+
+const N1 = 1000; // 故意不是 blockDim 的整数倍
+
+const STAGE_1 = {
+  id: 'first-kernel',
+  title: t('第一个 kernel —— 线程、块、网格', 'Your first kernel — threads, blocks, grids'),
+  goal: t(
+    [
+      '磁盘上有一个 `kernel.cu`，里面的 `vecAdd` 还是空的。把它写出来：`c[i] = a[i] + b[i]`。',
+      '',
+      '数组长度是 **1000**，而启动配置是 4 个 block × 256 线程 = **1024 个线程**。',
+      '多出来的 24 个线程必须什么都不做 —— 让它们去写 `c[1000]` 就是越界，',
+      '真卡上这会踩坏别人的显存，在这里会被 `compute-sanitizer` 当场抓住。',
+      '',
+      '```bash',
+      'nvcc -o bench kernel.cu',
+      './bench',
+      'compute-sanitizer --tool memcheck ./bench',
+      '```',
+      '',
+      '**通关标准**',
+      '',
+      '- 1000 个元素全部算对',
+      '- 一次越界都没有',
+      '- 每个线程只负责一个元素 —— 不许一个线程用循环把全部算完',
+    ].join('\n'),
+    [
+      'There is a `kernel.cu` on disk with an empty `vecAdd`. Fill it in: `c[i] = a[i] + b[i]`.',
+      '',
+      'The array holds **1000** elements but the launch is 4 blocks × 256 threads = **1024 threads**.',
+      'The extra 24 threads must do nothing. Letting them write `c[1000]` is out of bounds;',
+      'on a real GPU that corrupts memory belonging to someone else, and here',
+      '`compute-sanitizer` catches it immediately.',
+      '',
+      '```bash',
+      'nvcc -o bench kernel.cu',
+      './bench',
+      'compute-sanitizer --tool memcheck ./bench',
+      '```',
+      '',
+      '**To pass**',
+      '',
+      '- all 1000 elements correct',
+      '- no out-of-bounds access',
+      '- one element per thread — no single thread looping over everything',
+    ].join('\n')
+  ),
+  checklist: [
+    t('用 blockIdx / blockDim / threadIdx 算出这个线程负责哪个元素',
+      'Derive this thread\'s element index from blockIdx / blockDim / threadIdx'),
+    t('加上边界检查，让多出来的线程什么都不做',
+      'Guard the tail so the extra threads do nothing'),
+    t('`nvcc -o bench kernel.cu && ./bench` 跑通',
+      'Get `nvcc -o bench kernel.cu && ./bench` to succeed'),
+  ],
+  hints: [
+    t('全局线程号是 `blockIdx.x * blockDim.x + threadIdx.x`。',
+      'The global thread index is `blockIdx.x * blockDim.x + threadIdx.x`.'),
+    t('边界检查写成 `if (i < n) { ... }`。n 是传进来的参数，不要写死 1000。',
+      'Guard with `if (i < n) { ... }`. `n` is a parameter — do not hard-code 1000.'),
+  ],
+  pitfalls: [
+    t('**用 `threadIdx.x` 当全局下标。** 每个 block 里的 threadIdx 都从 0 开始，'
+      + '于是 4 个 block 会把同样的 256 个元素算 4 遍，剩下的 744 个一个都没动。',
+      '**Using `threadIdx.x` as the global index.** It restarts at 0 in every block, so the four '
+      + 'blocks all compute the same 256 elements and the remaining 744 are never touched.'),
+    t('**忘了边界检查。** 结果看起来可能是对的（多写的那几个格子没人读），'
+      + '但 memcheck 会报越界 —— 真卡上那是别人的显存。',
+      '**Forgetting the guard.** The result may look right (nobody reads those slots) but memcheck '
+      + 'reports an out-of-bounds write — on a real GPU that memory belongs to someone else.'),
+  ],
+  extension: t(
+    '真实的 kernel 常写成 **grid-stride loop**：`for (int i = idx; i < n; i += gridDim.x * blockDim.x)`。'
+    + '这样同一份代码在任何启动配置下都正确，而且能复用已经驻留在 SM 上的 block。'
+    + 'NVIDIA 的官方博客 [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops]'
+    + '(https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/) 讲的就是它。',
+    'Real kernels often use a **grid-stride loop**: `for (int i = idx; i < n; i += gridDim.x * blockDim.x)`. '
+    + 'The same code is then correct for any launch configuration and reuses blocks already resident on an SM. '
+    + 'See NVIDIA\'s [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops]'
+    + '(https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/).'
+  ),
+  gpu: {
+    files: {
+      '/root/kernel.cu': code`
+        // 每个线程负责一个元素：c[i] = a[i] + b[i]
+        //
+        // 注意 n = 1000，而启动的是 1024 个线程。
+        __global__ void vecAdd(const float* a, const float* b, float* c, int n) {
+          // TODO: 算出这个线程负责哪个元素，加上边界检查
+        }
+      `,
+    },
+    bench: {
+      sources: ['/root/kernel.cu'],
+      buffers: [
+        { name: 'a', length: N1, fill: { kind: 'iota', scale: 0.5 } },
+        { name: 'b', length: N1, fill: { kind: 'iota', scale: -0.25, offset: 7 } },
+        { name: 'c', length: N1, fill: { kind: 'const', value: -999 } },
+      ],
+      launches: [
+        { kernel: 'vecAdd', grid: [4], block: [256], args: ['a', 'b', 'c', N1] },
+      ],
+    },
+    referenceFiles: {
+      '/root/kernel.cu': code`
+        __global__ void vecAdd(const float* a, const float* b, float* c, int n) {
+          int i = blockIdx.x * blockDim.x + threadIdx.x;
+          if (i < n) c[i] = a[i] + b[i];
+        }
+      `,
+    },
+  },
+  specs: [
+    spec('vecadd.spec.ts', code`
+      const lab = require('@gpu/lab');
+
+      describe('向量加法', () => {
+        it('1000 个元素全部算对', async () => {
+          await lab.buildAndRun();
+          const a = lab.buffer('a');
+          const b = lab.buffer('b');
+          const c = lab.buffer('c');
+          const expected = new Float32Array(a.length);
+          for (let i = 0; i < a.length; i += 1) expected[i] = Math.fround(a[i] + b[i]);
+          const diff = lab.compare(c, expected);
+          expect(diff.hasNonFinite).toBe(false);
+          expect(diff.maxAbs).toBe(0);
+        });
+
+        it('一次越界都没有', async () => {
+          const result = await lab.sh('compute-sanitizer --tool memcheck ./bench');
+          expect(result.code).toBe(0);
+        });
+
+        it('每个线程只算一个元素，没人用循环把全部包了', async () => {
+          await lab.buildAndRun();
+          const metrics = lab.metrics();
+          // 1024 个线程，每个做一次读 a、一次读 b、一次写 c。
+          // 有人写循环的话 lane 指令数会翻好几十倍。
+          expect(metrics.global.loadRequests).toBeLessThanOrEqual(4 * 8 * 2 + 8);
+          expect(metrics.inst.laneExecuted).toBeLessThan(60000);
+        });
+      });
+    `),
+  ],
+  gates: [
+    ...SAFETY_GATES,
+    gate({
+      metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5,
+      zh: '每次访存打到的 32B 扇区数', en: 'sectors per memory request',
+      unit: 'sector/req', dimension: 'latency',
+    }),
+  ],
+  focus: ['correctness'],
+};
+
+/* ------------------------------------------------------------------ */
+/* 第 2 关：访存合并                                                    */
+/* ------------------------------------------------------------------ */
+
+const ROWS2 = 64;
+const COLS2 = 64;
+const N2 = ROWS2 * COLS2;
+
+const STAGE_2 = {
+  id: 'coalescing',
+  title: t('访存合并 —— 同一段逻辑，换个下标慢 8 倍', 'Coalescing — same logic, 8× the traffic'),
+  goal: t(
+    [
+      '`scale.cu` 把一个 64×64 的矩阵每个元素乘以 2，算出来是对的。',
+      '但 `ncu` 说它每次访存要打 **32 个 32B 扇区** —— 完美情况下应该是 4 个。',
+      '',
+      '```bash',
+      'nvcc -o bench scale.cu && ncu ./bench',
+      '```',
+      '',
+      '看 `Memory Workload Analysis` 那一节的',
+      '`l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`。',
+      '',
+      '**为什么**：一个 warp 里 32 个 lane 的地址会被硬件归并成对 32 字节扇区的请求。',
+      '32 个 lane 读连续的 32 个 float = 128 字节 = **4 个扇区**；',
+      '如果它们各隔一整行，就是 **32 个扇区**，也就是 8 倍的传输量。',
+      '指令一条没多，搬的字节数翻了 8 倍。',
+      '',
+      '**通关标准**',
+      '',
+      '- 结果和现在完全一样（每个元素都乘到了）',
+      '- `sectorsPerRequest ≤ 4.5`',
+      '- DRAM 读字节数降到理论下限附近',
+    ].join('\n'),
+    [
+      '`scale.cu` multiplies every element of a 64×64 matrix by 2. The result is correct.',
+      'But `ncu` reports **32 sectors per request** where a perfect kernel would need 4.',
+      '',
+      '```bash',
+      'nvcc -o bench scale.cu && ncu ./bench',
+      '```',
+      '',
+      'Look at `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`',
+      'under `Memory Workload Analysis`.',
+      '',
+      '**Why**: the 32 lanes of a warp have their addresses coalesced into 32-byte sector requests.',
+      '32 lanes reading 32 consecutive floats = 128 bytes = **4 sectors**. If each lane instead',
+      'reads a different row, that is **32 sectors** — 8× the traffic for the same instructions.',
+      '',
+      '**To pass**',
+      '',
+      '- identical results',
+      '- `sectorsPerRequest ≤ 4.5`',
+      '- DRAM read bytes near the theoretical minimum',
+    ].join('\n')
+  ),
+  checklist: [
+    t('让同一个 warp 里相邻的 lane 访问相邻的元素',
+      'Make neighbouring lanes touch neighbouring elements'),
+    t('用 `ncu ./bench` 确认扇区数掉到 4', 'Confirm with `ncu ./bench` that sectors drop to 4'),
+  ],
+  hints: [
+    t('现在的下标是「lane 决定行、warp 决定列」，正好把连续的 lane 拆到了不同的行上。',
+      'Right now the lane picks the row and the warp picks the column, which scatters consecutive lanes across rows.'),
+    t('把它换成「相邻线程 → 相邻列」：`row = i / cols; col = i % cols;`，或者干脆按一维下标走。',
+      'Switch to neighbouring threads → neighbouring columns: `row = i / cols; col = i % cols;` or just use the flat index.'),
+  ],
+  pitfalls: [
+    t('**以为「反正总字节数一样」。** 总元素数确实一样，但传输是按 32 字节一整块走的：'
+      + '只用到其中 4 个字节，剩下 28 个字节也被搬过来了，然后扔掉。',
+      '**Assuming the byte count is the same either way.** The element count is, but transfers move whole '
+      + '32-byte sectors: use 4 bytes of one and the other 28 come along anyway, then get thrown away.'),
+    t('**只改读、不改写。** 写回也要合并，`ncu` 里 store 的扇区数是单独一行。',
+      '**Fixing loads but not stores.** Stores coalesce too; ncu reports their sectors separately.'),
+  ],
+  extension: t(
+    '这条规则是所有 GPU 访存优化的地基。矩阵转置之所以难，正是因为读和写不可能同时合并 ——'
+    + '第 3、4 关就是用共享内存把这个矛盾解开。NVIDIA 的经典博客 '
+    + '[How to Access Global Memory Efficiently in CUDA C/C++ Kernels]'
+    + '(https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/) 把各种步长的代价量了一遍。',
+    'This rule underpins every GPU memory optimisation. Matrix transpose is hard precisely because reads and '
+    + 'writes cannot both be coalesced — stages 3 and 4 resolve that with shared memory. NVIDIA\'s '
+    + '[How to Access Global Memory Efficiently in CUDA C/C++ Kernels]'
+    + '(https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/) measures the cost of each stride.'
+  ),
+  gpu: {
+    files: {
+      '/root/scale.cu': code`
+        // 把 64×64 的矩阵每个元素乘以 2。
+        //
+        // 结果是对的，但 ncu 说每次访存要打 32 个扇区。
+        // 想想一个 warp 里相邻的 lane 现在落在哪儿。
+        __global__ void scale(const float* in, float* out, int rows, int cols) {
+          int i = blockIdx.x * blockDim.x + threadIdx.x;
+          int lane = i % 32;
+          int group = i / 32;
+
+          // lane 决定行、group 决定列 —— 相邻的 lane 隔了一整行
+          int row = lane * (rows / 32) + group / cols;
+          int col = group % cols;
+
+          if (row < rows && col < cols) {
+            out[row * cols + col] = in[row * cols + col] * 2.0f;
+          }
+        }
+      `,
+    },
+    bench: {
+      sources: ['/root/scale.cu'],
+      buffers: [
+        { name: 'in', length: N2, fill: { kind: 'iota', scale: 0.125 } },
+        { name: 'out', length: N2, fill: { kind: 'zeros' } },
+      ],
+      launches: [
+        { kernel: 'scale', grid: [N2 / 128], block: [128], args: ['in', 'out', ROWS2, COLS2] },
+      ],
+    },
+    referenceFiles: {
+      '/root/scale.cu': code`
+        __global__ void scale(const float* in, float* out, int rows, int cols) {
+          int i = blockIdx.x * blockDim.x + threadIdx.x;
+          // 相邻线程 → 相邻元素，一个 warp 正好覆盖连续的 128 字节
+          if (i < rows * cols) out[i] = in[i] * 2.0f;
+        }
+      `,
+    },
+  },
+  specs: [
+    spec('coalescing.spec.ts', code`
+      const lab = require('@gpu/lab');
+
+      const ROWS = ${ROWS2};
+      const COLS = ${COLS2};
+
+      describe('矩阵缩放', () => {
+        it('每个元素都乘到了', async () => {
+          await lab.buildAndRun();
+          const input = lab.buffer('in');
+          const out = lab.buffer('out');
+          const expected = new Float32Array(input.length);
+          for (let i = 0; i < input.length; i += 1) expected[i] = Math.fround(input[i] * 2);
+          const diff = lab.compare(out, expected);
+          expect(diff.hasNonFinite).toBe(false);
+          expect(diff.maxAbs).toBe(0);
+        });
+
+        it('读和写都合并了', async () => {
+          await lab.buildAndRun();
+          const metrics = lab.metrics();
+          // 每次 warp 级访存 32 lane × 4 字节 = 128 字节 = 4 个扇区
+          expect(metrics.global.loadSectors / metrics.global.loadRequests).toBeLessThanOrEqual(4.5);
+          expect(metrics.global.storeSectors / metrics.global.storeRequests).toBeLessThanOrEqual(4.5);
+        });
+
+        it('DRAM 传输量降到理论下限附近', async () => {
+          await lab.buildAndRun();
+          const metrics = lab.metrics();
+          const ideal = ROWS * COLS * 4;
+          // 允许 10% 余量：尾块与对齐会带来一点额外传输
+          expect(metrics.memory.readBytes).toBeLessThanOrEqual(ideal * 1.1);
+        });
+      });
+    `),
+  ],
+  gates: [
+    ...SAFETY_GATES,
+    gate({
+      metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5,
+      zh: '每次访存打到的 32B 扇区数（未优化时是 32）', en: 'sectors per request (32 before optimising)',
+      unit: 'sector/req', dimension: 'latency',
+    }),
+    gate({
+      metric: 'gpu.memory.readBytes', op: 'lte', value: Math.round(N2 * 4 * 1.1),
+      zh: 'DRAM 读字节数', en: 'DRAM bytes read',
+      unit: 'byte', dimension: 'latency',
+    }),
+  ],
+  focus: ['latency'],
+};
+
+/* ------------------------------------------------------------------ */
+/* 第 3 关：共享内存与竞态                                              */
+/* ------------------------------------------------------------------ */
+
+const TILE3 = 32;
+const N3 = TILE3 * TILE3;
+
+const STAGE_3 = {
+  id: 'shared-memory-race',
+  title: t('共享内存与竞态 —— 跑对了，但它是错的',
+    'Shared memory and races — it works, and it is still wrong'),
+  goal: t(
+    [
+      '转置一个 32×32 的矩阵。读和写不可能同时合并 —— 按行读就得按列写。',
+      '解法是先把整块搬进**共享内存**（block 内所有线程共用的一小块高速内存），',
+      '再从共享内存里按转置的顺序读出来写回去。这样读和写都是合并的。',
+      '',
+      '`transpose.cu` 已经这么写了。**它算出来的结果是错的**，而且每次错得一模一样。',
+      '',
+      '```bash',
+      'nvcc -o bench transpose.cu && ./bench',
+      'compute-sanitizer --tool racecheck ./bench',
+      '```',
+      '',
+      'racecheck 会告诉你：一个线程写的格子，另一个线程在没有任何同步的情况下读了。',
+      '`tile[y][x] = ...` 和 `... = tile[x][y]` 之间需要一个 **`__syncthreads()`** ——',
+      '它让整个 block 的线程都停下来等，直到所有人都写完。',
+      '',
+      '**为什么这一关重要**：在这个模拟器里，warp 是按固定顺序跑的，',
+      '所以有竞态的 kernel 会给出一个**稳定的**结果。这次它恰好是错的；',
+      '换一种访问模式，它会**恰好是对的** —— 你跑一万遍都对，然后换到真卡上就炸。',
+      '所以竞态不能靠「结果对不对」来发现，只能靠 racecheck。',
+      '',
+      '**通关标准**',
+      '',
+      '- 转置结果正确',
+      '- `compute-sanitizer --tool racecheck` 报 0 hazards',
+      '- 读写都合并（`sectorsPerRequest ≤ 4.5`）',
+    ].join('\n'),
+    [
+      'Transpose a 32×32 matrix. Reads and writes cannot both be coalesced — reading along rows',
+      'means writing along columns. The fix is to stage the tile through **shared memory**',
+      '(a small fast block-local memory) and then read it back transposed, so both sides coalesce.',
+      '',
+      '`transpose.cu` already does that. **It produces the wrong answer**, and it is wrong the',
+      'same way every single run.',
+      '',
+      '```bash',
+      'nvcc -o bench transpose.cu && ./bench',
+      'compute-sanitizer --tool racecheck ./bench',
+      '```',
+      '',
+      'racecheck tells you: one thread writes a slot and another reads it with no synchronisation',
+      'in between. You need a **`__syncthreads()`** between `tile[y][x] = ...` and `... = tile[x][y]` —',
+      'it stops every thread in the block until all of them have finished writing.',
+      '',
+      '**Why this stage matters**: warps run in a fixed order in this simulator, so a racy kernel',
+      'produces a *stable* result. Here it happens to be wrong. With a different access pattern it',
+      'would happen to be **right** — correct ten thousand times here, broken on a real GPU.',
+      'Races cannot be found by checking the answer. Only racecheck finds them.',
+      '',
+      '**To pass**',
+      '',
+      '- correct transpose',
+      '- `compute-sanitizer --tool racecheck` reports 0 hazards',
+      '- both sides coalesced (`sectorsPerRequest ≤ 4.5`)',
+    ].join('\n')
+  ),
+  checklist: [
+    t('跑一次 racecheck，看它指到哪两行', 'Run racecheck and read which two lines it points at'),
+    t('在写共享内存和读共享内存之间加 `__syncthreads()`',
+      'Add `__syncthreads()` between the shared-memory write and read'),
+    t('确认 racecheck 报 0 hazards', 'Confirm racecheck reports 0 hazards'),
+  ],
+  hints: [
+    t('`__syncthreads()` 必须让整个 block 都执行到 —— 不能放在 `if` 里面。',
+      '`__syncthreads()` must be reached by every thread in the block — never put it inside an `if`.'),
+    t('只需要一个屏障，位置在两次共享内存访问之间。',
+      'One barrier is enough, between the two shared-memory accesses.'),
+  ],
+  pitfalls: [
+    t('**把 `__syncthreads()` 放进 `if` 里。** 只有一部分线程到达屏障，'
+      + '真卡上这是未定义行为、通常直接挂死；这里会明确报错。',
+      '**Putting `__syncthreads()` inside an `if`.** Only some threads reach the barrier; on real '
+      + 'hardware that is undefined behaviour and usually hangs. Here it is reported as an error.'),
+    t('**靠「多跑几遍看看」找竞态。** 这个模拟器是确定的，跑一万遍是同一个结果。'
+      + '真卡上也未必能重现 —— 竞态最擅长的就是在你观察它的时候表现正常。',
+      '**Re-running to see if a race shows up.** This simulator is deterministic: ten thousand runs, '
+      + 'one answer. Real hardware may not reproduce it either — races are best at looking fine while watched.'),
+  ],
+  extension: t(
+    '`compute-sanitizer --tool racecheck` 是真工具，用法和这里一模一样。'
+    + '它的原理是给共享内存的每个字配一份影子，记住最近是谁读的、谁写的、以及中间过了几次屏障；'
+    + '同一个「屏障纪元」里两个不同线程冲突访问同一个字，就是竞态。'
+    + '我们实现的是同一套判据 —— 见 [NVIDIA 的 racecheck 文档]'
+    + '(https://docs.nvidia.com/cuda/compute-sanitizer/index.html#racecheck-tool)。',
+    '`compute-sanitizer --tool racecheck` is the real tool and works exactly like this. It shadows every '
+    + 'shared-memory word with the last reader, the last writer, and how many barriers have passed; two '
+    + 'different threads accessing the same word inside one barrier epoch is a race. We implement the same '
+    + 'rule — see [NVIDIA\'s racecheck documentation]'
+    + '(https://docs.nvidia.com/cuda/compute-sanitizer/index.html#racecheck-tool).'
+  ),
+  gpu: {
+    files: {
+      '/root/transpose.cu': code`
+        // 32×32 转置，经共享内存中转，好让读和写都合并。
+        //
+        // 结果是错的，而且每次错得一模一样 —— 先跑一次
+        //   compute-sanitizer --tool racecheck ./bench
+        // 看它指到哪两行。
+        __global__ void transpose(const float* in, float* out, int n) {
+          __shared__ float tile[32][33];   // 33 不是笔误，第 4 关会讲
+
+          int x = threadIdx.x;
+          int y = threadIdx.y;
+
+          tile[y][x] = in[y * n + x];
+
+          // TODO: 这里少了点什么
+
+          out[y * n + x] = tile[x][y];
+        }
+      `,
+    },
+    bench: {
+      sources: ['/root/transpose.cu'],
+      buffers: [
+        { name: 'in', length: N3, fill: { kind: 'iota', scale: 1 } },
+        { name: 'out', length: N3, fill: { kind: 'zeros' } },
+      ],
+      launches: [
+        { kernel: 'transpose', grid: [1], block: [TILE3, TILE3], args: ['in', 'out', TILE3] },
+      ],
+    },
+    referenceFiles: {
+      '/root/transpose.cu': code`
+        __global__ void transpose(const float* in, float* out, int n) {
+          __shared__ float tile[32][33];
+
+          int x = threadIdx.x;
+          int y = threadIdx.y;
+
+          tile[y][x] = in[y * n + x];
+
+          // 整个 block 都写完了，才能开始读别人写的格子
+          __syncthreads();
+
+          out[y * n + x] = tile[x][y];
+        }
+      `,
+    },
+  },
+  specs: [
+    spec('transpose.spec.ts', code`
+      const lab = require('@gpu/lab');
+
+      const N = ${TILE3};
+
+      describe('转置', () => {
+        it('结果正确', async () => {
+          await lab.buildAndRun();
+          const input = lab.buffer('in');
+          const out = lab.buffer('out');
+          const expected = new Float32Array(N * N);
+          for (let y = 0; y < N; y += 1) {
+            for (let x = 0; x < N; x += 1) expected[y * N + x] = input[x * N + y];
+          }
+          const diff = lab.compare(out, expected);
+          expect(diff.hasNonFinite).toBe(false);
+          expect(diff.maxAbs).toBe(0);
+        });
+
+        it('racecheck 报 0 hazards', async () => {
+          const report = await lab.racecheck();
+          expect(report.races.length).toBe(0);
+        });
+
+        it('确实用了屏障，而不是绕开共享内存', async () => {
+          await lab.buildAndRun();
+          const metrics = lab.metrics();
+          expect(metrics.launch.barriers).toBeGreaterThan(0);
+          expect(metrics.shared.storeRequests).toBeGreaterThan(0);
+          expect(metrics.shared.loadRequests).toBeGreaterThan(0);
+        });
+
+        it('读和写都合并', async () => {
+          await lab.buildAndRun();
+          const metrics = lab.metrics();
+          expect(metrics.global.sectorsPerRequest).toBeLessThanOrEqual(4.5);
+        });
+      });
+    `),
+  ],
+  gates: [
+    ...SAFETY_GATES,
+    gate({
+      metric: 'gpu.launch.barriers', op: 'gte', value: 1,
+      zh: '屏障次数', en: 'barriers',
+      dimension: 'correctness',
+    }),
+    gate({
+      metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5,
+      zh: '每次访存打到的 32B 扇区数', en: 'sectors per request',
+      unit: 'sector/req', dimension: 'latency',
+    }),
+  ],
+  focus: ['correctness'],
+};
+
+/* ------------------------------------------------------------------ */
+
+module.exports = {
+  id: 'llm-accelerator',
+  title: t('CUDA GPU 编程：搭一个 LLM 加速引擎', 'CUDA GPU programming: build an LLM inference engine'),
+  summary: t(
+    '写真 CUDA，用真 ncu 剖析。从第一个 kernel 一路做到能跑的推理引擎，最后摊到 16 卡集群上。',
+    'Write real CUDA, profile with real ncu. From your first kernel to a working inference engine, then out to a 16-GPU cluster.'
+  ),
+  difficulty: 'Hard',
+  domain: 'gpu',
+  tags: ['cuda', 'gpu', 'performance', 'llm', 'parallel'],
+  estimatedMinutes: 2400,
+  language: 'typescript',
+  brief: t(
+    [
+      '## 这是什么',
+      '',
+      '一台 H100，一个终端，一个 IDE。你写 CUDA C，敲 `nvcc` 编译、`ncu` 剖析、',
+      '`compute-sanitizer` 查错 —— 命令、参数、指标名都和真机一样。',
+      '',
+      '## 判定标准',
+      '',
+      '**优化生效与否不是自称的。** 每一关的门槛都建立在平台侧的结构性计量上：',
+      'DRAM 传输字节、32B 扇区数、bank 冲突路数、发散分支数、local memory 字节、',
+      '占用率。这些量在给定内存模型后是精确的，而且**与硬件型号无关** ——',
+      '换到真卡上一个不差。',
+      '',
+      '模拟耗时只用来展示和同关比较，**不作门槛**。',
+      '',
+      '## 已知的边界',
+      '',
+      '- 写的是 C99 子集 + CUDA 扩展，没有模板与类',
+      '- 报错文本贴 nvcc 的形状，但做不到逐字节一致',
+      '- 原子操作在这里按 lane 号定序，因此可复现；真卡上顺序不定',
+    ].join('\n'),
+    [
+      '## What this is',
+      '',
+      'One H100, one terminal, one IDE. You write CUDA C and drive `nvcc`, `ncu` and',
+      '`compute-sanitizer` — same commands, same flags, same metric names as the real thing.',
+      '',
+      '## How it is judged',
+      '',
+      '**Whether an optimisation worked is measured, not claimed.** Every gate is built on',
+      'structural counters: DRAM bytes, 32-byte sectors, bank-conflict ways, divergent branches,',
+      'local-memory traffic, occupancy. Given the memory model these are exact, and they are',
+      '**independent of the specific GPU** — they carry over to real hardware unchanged.',
+      '',
+      'Simulated time is shown and compared within a stage, but never gates anything.',
+      '',
+      '## Known boundaries',
+      '',
+      '- a C99 subset plus CUDA extensions; no templates or classes',
+      '- diagnostics follow nvcc\'s shape but are not byte-identical',
+      '- atomics are ordered by lane here, so they reproduce; real hardware does not guarantee order',
+    ].join('\n')
+  ),
+  weights: {
+    correctness: 3,
+    latency: 3,
+    resilience: 1,
+    encapsulation: 1,
+    elegance: 1,
+  },
+  workspace: { kind: 'gpu', world: WORLD },
+  files: [],
+  stages: [STAGE_1, STAGE_2, STAGE_3],
+};

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -14948,6 +14948,509 @@
     ]
   },
   {
+    "id": "llm-accelerator",
+    "title": {
+      "zh": "CUDA GPU 编程：搭一个 LLM 加速引擎",
+      "en": "CUDA GPU programming: build an LLM inference engine"
+    },
+    "summary": {
+      "zh": "写真 CUDA，用真 ncu 剖析。从第一个 kernel 一路做到能跑的推理引擎，最后摊到 16 卡集群上。",
+      "en": "Write real CUDA, profile with real ncu. From your first kernel to a working inference engine, then out to a 16-GPU cluster."
+    },
+    "difficulty": "Hard",
+    "domain": "gpu",
+    "tags": [
+      "cuda",
+      "gpu",
+      "performance",
+      "llm",
+      "parallel"
+    ],
+    "estimatedMinutes": 2400,
+    "language": "typescript",
+    "brief": {
+      "zh": "## 这是什么\n\n一台 H100，一个终端，一个 IDE。你写 CUDA C，敲 `nvcc` 编译、`ncu` 剖析、\n`compute-sanitizer` 查错 —— 命令、参数、指标名都和真机一样。\n\n## 判定标准\n\n**优化生效与否不是自称的。** 每一关的门槛都建立在平台侧的结构性计量上：\nDRAM 传输字节、32B 扇区数、bank 冲突路数、发散分支数、local memory 字节、\n占用率。这些量在给定内存模型后是精确的，而且**与硬件型号无关** ——\n换到真卡上一个不差。\n\n模拟耗时只用来展示和同关比较，**不作门槛**。\n\n## 已知的边界\n\n- 写的是 C99 子集 + CUDA 扩展，没有模板与类\n- 报错文本贴 nvcc 的形状，但做不到逐字节一致\n- 原子操作在这里按 lane 号定序，因此可复现；真卡上顺序不定",
+      "en": "## What this is\n\nOne H100, one terminal, one IDE. You write CUDA C and drive `nvcc`, `ncu` and\n`compute-sanitizer` — same commands, same flags, same metric names as the real thing.\n\n## How it is judged\n\n**Whether an optimisation worked is measured, not claimed.** Every gate is built on\nstructural counters: DRAM bytes, 32-byte sectors, bank-conflict ways, divergent branches,\nlocal-memory traffic, occupancy. Given the memory model these are exact, and they are\n**independent of the specific GPU** — they carry over to real hardware unchanged.\n\nSimulated time is shown and compared within a stage, but never gates anything.\n\n## Known boundaries\n\n- a C99 subset plus CUDA extensions; no templates or classes\n- diagnostics follow nvcc's shape but are not byte-identical\n- atomics are ordered by lane here, so they reproduce; real hardware does not guarantee order"
+    },
+    "weights": {
+      "correctness": 3,
+      "latency": 3,
+      "resilience": 1,
+      "encapsulation": 1,
+      "elegance": 1
+    },
+    "workspace": {
+      "kind": "gpu",
+      "world": {
+        "seed": 20260826,
+        "device": "H100",
+        "globalBytes": 33554432,
+        "sharedBytesPerBlock": 49152,
+        "machine": {
+          "hostname": "gpu-01",
+          "user": "root",
+          "cwd": "/root"
+        }
+      }
+    },
+    "files": [],
+    "stages": [
+      {
+        "id": "first-kernel",
+        "title": {
+          "zh": "第一个 kernel —— 线程、块、网格",
+          "en": "Your first kernel — threads, blocks, grids"
+        },
+        "goal": {
+          "zh": "磁盘上有一个 `kernel.cu`，里面的 `vecAdd` 还是空的。把它写出来：`c[i] = a[i] + b[i]`。\n\n数组长度是 **1000**，而启动配置是 4 个 block × 256 线程 = **1024 个线程**。\n多出来的 24 个线程必须什么都不做 —— 让它们去写 `c[1000]` 就是越界，\n真卡上这会踩坏别人的显存，在这里会被 `compute-sanitizer` 当场抓住。\n\n```bash\nnvcc -o bench kernel.cu\n./bench\ncompute-sanitizer --tool memcheck ./bench\n```\n\n**通关标准**\n\n- 1000 个元素全部算对\n- 一次越界都没有\n- 每个线程只负责一个元素 —— 不许一个线程用循环把全部算完",
+          "en": "There is a `kernel.cu` on disk with an empty `vecAdd`. Fill it in: `c[i] = a[i] + b[i]`.\n\nThe array holds **1000** elements but the launch is 4 blocks × 256 threads = **1024 threads**.\nThe extra 24 threads must do nothing. Letting them write `c[1000]` is out of bounds;\non a real GPU that corrupts memory belonging to someone else, and here\n`compute-sanitizer` catches it immediately.\n\n```bash\nnvcc -o bench kernel.cu\n./bench\ncompute-sanitizer --tool memcheck ./bench\n```\n\n**To pass**\n\n- all 1000 elements correct\n- no out-of-bounds access\n- one element per thread — no single thread looping over everything"
+        },
+        "checklist": [
+          {
+            "zh": "用 blockIdx / blockDim / threadIdx 算出这个线程负责哪个元素",
+            "en": "Derive this thread's element index from blockIdx / blockDim / threadIdx"
+          },
+          {
+            "zh": "加上边界检查，让多出来的线程什么都不做",
+            "en": "Guard the tail so the extra threads do nothing"
+          },
+          {
+            "zh": "`nvcc -o bench kernel.cu && ./bench` 跑通",
+            "en": "Get `nvcc -o bench kernel.cu && ./bench` to succeed"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "全局线程号是 `blockIdx.x * blockDim.x + threadIdx.x`。",
+            "en": "The global thread index is `blockIdx.x * blockDim.x + threadIdx.x`."
+          },
+          {
+            "zh": "边界检查写成 `if (i < n) { ... }`。n 是传进来的参数，不要写死 1000。",
+            "en": "Guard with `if (i < n) { ... }`. `n` is a parameter — do not hard-code 1000."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**用 `threadIdx.x` 当全局下标。** 每个 block 里的 threadIdx 都从 0 开始，于是 4 个 block 会把同样的 256 个元素算 4 遍，剩下的 744 个一个都没动。",
+            "en": "**Using `threadIdx.x` as the global index.** It restarts at 0 in every block, so the four blocks all compute the same 256 elements and the remaining 744 are never touched."
+          },
+          {
+            "zh": "**忘了边界检查。** 结果看起来可能是对的（多写的那几个格子没人读），但 memcheck 会报越界 —— 真卡上那是别人的显存。",
+            "en": "**Forgetting the guard.** The result may look right (nobody reads those slots) but memcheck reports an out-of-bounds write — on a real GPU that memory belongs to someone else."
+          }
+        ],
+        "extension": {
+          "zh": "真实的 kernel 常写成 **grid-stride loop**：`for (int i = idx; i < n; i += gridDim.x * blockDim.x)`。这样同一份代码在任何启动配置下都正确，而且能复用已经驻留在 SM 上的 block。NVIDIA 的官方博客 [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops](https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/) 讲的就是它。",
+          "en": "Real kernels often use a **grid-stride loop**: `for (int i = idx; i < n; i += gridDim.x * blockDim.x)`. The same code is then correct for any launch configuration and reuses blocks already resident on an SM. See NVIDIA's [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops](https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/)."
+        },
+        "gpu": {
+          "files": {
+            "/root/kernel.cu": "// 每个线程负责一个元素：c[i] = a[i] + b[i]\n//\n// 注意 n = 1000，而启动的是 1024 个线程。\n__global__ void vecAdd(const float* a, const float* b, float* c, int n) {\n  // TODO: 算出这个线程负责哪个元素，加上边界检查\n}\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/kernel.cu"
+            ],
+            "buffers": [
+              {
+                "name": "a",
+                "length": 1000,
+                "fill": {
+                  "kind": "iota",
+                  "scale": 0.5
+                }
+              },
+              {
+                "name": "b",
+                "length": 1000,
+                "fill": {
+                  "kind": "iota",
+                  "scale": -0.25,
+                  "offset": 7
+                }
+              },
+              {
+                "name": "c",
+                "length": 1000,
+                "fill": {
+                  "kind": "const",
+                  "value": -999
+                }
+              }
+            ],
+            "launches": [
+              {
+                "kernel": "vecAdd",
+                "grid": [
+                  4
+                ],
+                "block": [
+                  256
+                ],
+                "args": [
+                  "a",
+                  "b",
+                  "c",
+                  1000
+                ]
+              }
+            ]
+          },
+          "referenceFiles": {
+            "/root/kernel.cu": "__global__ void vecAdd(const float* a, const float* b, float* c, int n) {\n  int i = blockIdx.x * blockDim.x + threadIdx.x;\n  if (i < n) c[i] = a[i] + b[i];\n}\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "vecadd.spec.ts",
+            "content": "const lab = require('@gpu/lab');\n\ndescribe('向量加法', () => {\n  it('1000 个元素全部算对', async () => {\n    await lab.buildAndRun();\n    const a = lab.buffer('a');\n    const b = lab.buffer('b');\n    const c = lab.buffer('c');\n    const expected = new Float32Array(a.length);\n    for (let i = 0; i < a.length; i += 1) expected[i] = Math.fround(a[i] + b[i]);\n    const diff = lab.compare(c, expected);\n    expect(diff.hasNonFinite).toBe(false);\n    expect(diff.maxAbs).toBe(0);\n  });\n\n  it('一次越界都没有', async () => {\n    const result = await lab.sh('compute-sanitizer --tool memcheck ./bench');\n    expect(result.code).toBe(0);\n  });\n\n  it('每个线程只算一个元素，没人用循环把全部包了', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    // 1024 个线程，每个做一次读 a、一次读 b、一次写 c。\n    // 有人写循环的话 lane 指令数会翻好几十倍。\n    expect(metrics.global.loadRequests).toBeLessThanOrEqual(4 * 8 * 2 + 8);\n    expect(metrics.inst.laneExecuted).toBeLessThan(60000);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.global.sectorsPerRequest",
+            "op": "lte",
+            "value": 4.5,
+            "label": {
+              "zh": "每次访存打到的 32B 扇区数",
+              "en": "sectors per memory request"
+            },
+            "unit": "sector/req",
+            "dimension": "latency"
+          }
+        ],
+        "focus": [
+          "correctness"
+        ],
+        "primer": {
+          "zh": "GPU 上的一次计算叫一次`kernel 启动`。启动时你要说清楚开多少线程，而且线程是**分两层**组织的：若干个`线程块`（block）组成一张`网格`（grid），每个 block 里有固定数量的线程。写成 `vecAdd<<<4, 256>>>(...)` 就是 4 个 block、每块 256 个线程。\n\n这两层不是摆设。同一个 block 里的线程跑在同一个 SM 上、能共享一小块高速内存、能互相同步；不同 block 之间没有任何顺序保证，也不能直接通信。所以 block 内和 block 间是两套完全不同的编程方式。\n\n每个线程通过三个内建变量知道自己是谁：`threadIdx` 是它在 block 里的编号，`blockIdx` 是它所在的 block 编号，`blockDim` 是每个 block 有多少线程。把它们拼起来得到全局编号：`blockIdx.x * blockDim.x + threadIdx.x`。\n\n**线程数几乎总是比数据多。** 数据长度很少正好是 block 大小的整数倍，所以每个 kernel 开头都要有一句边界检查 —— 多出来的线程必须什么都不做。让它们越界写，在真卡上就是踩坏别人的显存。",
+          "en": "One computation on a GPU is a `kernel launch`. You state how many threads to start, and threads are organised in **two levels**: a `grid` of `thread blocks`, each block holding a fixed number of threads. `vecAdd<<<4, 256>>>(...)` means 4 blocks of 256 threads.\n\nThe two levels are not decoration. Threads in one block run on the same SM, share a small fast memory, and can synchronise with each other. Different blocks have no ordering guarantee and cannot communicate directly. Programming within a block and across blocks are two different things.\n\nEach thread learns who it is from three built-in variables: `threadIdx` is its index inside the block, `blockIdx` is which block it belongs to, and `blockDim` is how many threads a block has. Combine them for a global index: `blockIdx.x * blockDim.x + threadIdx.x`.\n\n**There are almost always more threads than data.** Lengths are rarely an exact multiple of the block size, so every kernel begins with a bounds check and the surplus threads do nothing. Letting them write out of range corrupts memory belonging to something else on a real GPU."
+        }
+      },
+      {
+        "id": "coalescing",
+        "title": {
+          "zh": "访存合并 —— 同一段逻辑，换个下标慢 8 倍",
+          "en": "Coalescing — same logic, 8× the traffic"
+        },
+        "goal": {
+          "zh": "`scale.cu` 把一个 64×64 的矩阵每个元素乘以 2，算出来是对的。\n但 `ncu` 说它每次访存要打 **32 个 32B 扇区** —— 完美情况下应该是 4 个。\n\n```bash\nnvcc -o bench scale.cu && ncu ./bench\n```\n\n看 `Memory Workload Analysis` 那一节的\n`l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`。\n\n**为什么**：一个 warp 里 32 个 lane 的地址会被硬件归并成对 32 字节扇区的请求。\n32 个 lane 读连续的 32 个 float = 128 字节 = **4 个扇区**；\n如果它们各隔一整行，就是 **32 个扇区**，也就是 8 倍的传输量。\n指令一条没多，搬的字节数翻了 8 倍。\n\n**通关标准**\n\n- 结果和现在完全一样（每个元素都乘到了）\n- `sectorsPerRequest ≤ 4.5`\n- DRAM 读字节数降到理论下限附近",
+          "en": "`scale.cu` multiplies every element of a 64×64 matrix by 2. The result is correct.\nBut `ncu` reports **32 sectors per request** where a perfect kernel would need 4.\n\n```bash\nnvcc -o bench scale.cu && ncu ./bench\n```\n\nLook at `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`\nunder `Memory Workload Analysis`.\n\n**Why**: the 32 lanes of a warp have their addresses coalesced into 32-byte sector requests.\n32 lanes reading 32 consecutive floats = 128 bytes = **4 sectors**. If each lane instead\nreads a different row, that is **32 sectors** — 8× the traffic for the same instructions.\n\n**To pass**\n\n- identical results\n- `sectorsPerRequest ≤ 4.5`\n- DRAM read bytes near the theoretical minimum"
+        },
+        "checklist": [
+          {
+            "zh": "让同一个 warp 里相邻的 lane 访问相邻的元素",
+            "en": "Make neighbouring lanes touch neighbouring elements"
+          },
+          {
+            "zh": "用 `ncu ./bench` 确认扇区数掉到 4",
+            "en": "Confirm with `ncu ./bench` that sectors drop to 4"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "现在的下标是「lane 决定行、warp 决定列」，正好把连续的 lane 拆到了不同的行上。",
+            "en": "Right now the lane picks the row and the warp picks the column, which scatters consecutive lanes across rows."
+          },
+          {
+            "zh": "把它换成「相邻线程 → 相邻列」：`row = i / cols; col = i % cols;`，或者干脆按一维下标走。",
+            "en": "Switch to neighbouring threads → neighbouring columns: `row = i / cols; col = i % cols;` or just use the flat index."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**以为「反正总字节数一样」。** 总元素数确实一样，但传输是按 32 字节一整块走的：只用到其中 4 个字节，剩下 28 个字节也被搬过来了，然后扔掉。",
+            "en": "**Assuming the byte count is the same either way.** The element count is, but transfers move whole 32-byte sectors: use 4 bytes of one and the other 28 come along anyway, then get thrown away."
+          },
+          {
+            "zh": "**只改读、不改写。** 写回也要合并，`ncu` 里 store 的扇区数是单独一行。",
+            "en": "**Fixing loads but not stores.** Stores coalesce too; ncu reports their sectors separately."
+          }
+        ],
+        "extension": {
+          "zh": "这条规则是所有 GPU 访存优化的地基。矩阵转置之所以难，正是因为读和写不可能同时合并 ——第 3、4 关就是用共享内存把这个矛盾解开。NVIDIA 的经典博客 [How to Access Global Memory Efficiently in CUDA C/C++ Kernels](https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/) 把各种步长的代价量了一遍。",
+          "en": "This rule underpins every GPU memory optimisation. Matrix transpose is hard precisely because reads and writes cannot both be coalesced — stages 3 and 4 resolve that with shared memory. NVIDIA's [How to Access Global Memory Efficiently in CUDA C/C++ Kernels](https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/) measures the cost of each stride."
+        },
+        "gpu": {
+          "files": {
+            "/root/scale.cu": "// 把 64×64 的矩阵每个元素乘以 2。\n//\n// 结果是对的，但 ncu 说每次访存要打 32 个扇区。\n// 想想一个 warp 里相邻的 lane 现在落在哪儿。\n__global__ void scale(const float* in, float* out, int rows, int cols) {\n  int i = blockIdx.x * blockDim.x + threadIdx.x;\n  int lane = i % 32;\n  int group = i / 32;\n\n  // lane 决定行、group 决定列 —— 相邻的 lane 隔了一整行\n  int row = lane * (rows / 32) + group / cols;\n  int col = group % cols;\n\n  if (row < rows && col < cols) {\n    out[row * cols + col] = in[row * cols + col] * 2.0f;\n  }\n}\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/scale.cu"
+            ],
+            "buffers": [
+              {
+                "name": "in",
+                "length": 4096,
+                "fill": {
+                  "kind": "iota",
+                  "scale": 0.125
+                }
+              },
+              {
+                "name": "out",
+                "length": 4096,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": [
+              {
+                "kernel": "scale",
+                "grid": [
+                  32
+                ],
+                "block": [
+                  128
+                ],
+                "args": [
+                  "in",
+                  "out",
+                  64,
+                  64
+                ]
+              }
+            ]
+          },
+          "referenceFiles": {
+            "/root/scale.cu": "__global__ void scale(const float* in, float* out, int rows, int cols) {\n  int i = blockIdx.x * blockDim.x + threadIdx.x;\n  // 相邻线程 → 相邻元素，一个 warp 正好覆盖连续的 128 字节\n  if (i < rows * cols) out[i] = in[i] * 2.0f;\n}\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "coalescing.spec.ts",
+            "content": "const lab = require('@gpu/lab');\n\nconst ROWS = 64;\nconst COLS = 64;\n\ndescribe('矩阵缩放', () => {\n  it('每个元素都乘到了', async () => {\n    await lab.buildAndRun();\n    const input = lab.buffer('in');\n    const out = lab.buffer('out');\n    const expected = new Float32Array(input.length);\n    for (let i = 0; i < input.length; i += 1) expected[i] = Math.fround(input[i] * 2);\n    const diff = lab.compare(out, expected);\n    expect(diff.hasNonFinite).toBe(false);\n    expect(diff.maxAbs).toBe(0);\n  });\n\n  it('读和写都合并了', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    // 每次 warp 级访存 32 lane × 4 字节 = 128 字节 = 4 个扇区\n    expect(metrics.global.loadSectors / metrics.global.loadRequests).toBeLessThanOrEqual(4.5);\n    expect(metrics.global.storeSectors / metrics.global.storeRequests).toBeLessThanOrEqual(4.5);\n  });\n\n  it('DRAM 传输量降到理论下限附近', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    const ideal = ROWS * COLS * 4;\n    // 允许 10% 余量：尾块与对齐会带来一点额外传输\n    expect(metrics.memory.readBytes).toBeLessThanOrEqual(ideal * 1.1);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.global.sectorsPerRequest",
+            "op": "lte",
+            "value": 4.5,
+            "label": {
+              "zh": "每次访存打到的 32B 扇区数（未优化时是 32）",
+              "en": "sectors per request (32 before optimising)"
+            },
+            "unit": "sector/req",
+            "dimension": "latency"
+          },
+          {
+            "metric": "gpu.memory.readBytes",
+            "op": "lte",
+            "value": 18022,
+            "label": {
+              "zh": "DRAM 读字节数",
+              "en": "DRAM bytes read"
+            },
+            "unit": "byte",
+            "dimension": "latency"
+          }
+        ],
+        "focus": [
+          "latency"
+        ],
+        "primer": {
+          "zh": "GPU 的显存不是按单个数取的。硬件一次搬运的最小单位是一个 **32 字节的扇区**，哪怕你只要其中 4 个字节，剩下的 28 个也会被一起搬过来然后扔掉。\n\n一个 `warp`（32 个线程，GPU 调度的最小单位）同时发出的 32 个访存请求会被硬件合并：落在同一个扇区里的合成一次传输。于是同样是读 32 个 float，**连续读**只要 4 个扇区（32 × 4 = 128 字节），而**每个 lane 隔得很远**就要 32 个扇区 —— 传输量差 8 倍，指令却一条没多。\n\n这就是「合并访问」。判断方法很简单：看同一个 warp 里相邻的线程，它们访问的地址是不是相邻的。在 `ncu` 里对应的指标叫 `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`，完美是 4.0，最坏是 32.0。\n\n几乎所有 GPU 访存优化最后都归到这一条。它也是矩阵转置为什么难的原因：按行读就得按列写，两边不可能同时合并。",
+          "en": "GPU memory is not fetched one value at a time. The smallest unit the hardware moves is a **32-byte sector**; asking for 4 bytes brings the other 28 along and then discards them.\n\nThe 32 memory requests issued by one `warp` (32 threads, the GPU's scheduling unit) are coalesced: lanes landing in the same sector become one transfer. Reading 32 consecutive floats therefore costs **4 sectors** (32 × 4 = 128 bytes), while 32 scattered lanes cost **32 sectors** — 8× the traffic for exactly the same instructions.\n\nThat is coalescing. The test is simple: do neighbouring threads in a warp touch neighbouring addresses? In `ncu` the metric is `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`, 4.0 at best and 32.0 at worst.\n\nNearly every GPU memory optimisation reduces to this rule. It is also why matrix transpose is hard: reading along rows forces writing along columns, and both cannot coalesce at once."
+        }
+      },
+      {
+        "id": "shared-memory-race",
+        "title": {
+          "zh": "共享内存与竞态 —— 跑对了，但它是错的",
+          "en": "Shared memory and races — it works, and it is still wrong"
+        },
+        "goal": {
+          "zh": "转置一个 32×32 的矩阵。读和写不可能同时合并 —— 按行读就得按列写。\n解法是先把整块搬进**共享内存**（block 内所有线程共用的一小块高速内存），\n再从共享内存里按转置的顺序读出来写回去。这样读和写都是合并的。\n\n`transpose.cu` 已经这么写了。**它算出来的结果是错的**，而且每次错得一模一样。\n\n```bash\nnvcc -o bench transpose.cu && ./bench\ncompute-sanitizer --tool racecheck ./bench\n```\n\nracecheck 会告诉你：一个线程写的格子，另一个线程在没有任何同步的情况下读了。\n`tile[y][x] = ...` 和 `... = tile[x][y]` 之间需要一个 **`__syncthreads()`** ——\n它让整个 block 的线程都停下来等，直到所有人都写完。\n\n**为什么这一关重要**：在这个模拟器里，warp 是按固定顺序跑的，\n所以有竞态的 kernel 会给出一个**稳定的**结果。这次它恰好是错的；\n换一种访问模式，它会**恰好是对的** —— 你跑一万遍都对，然后换到真卡上就炸。\n所以竞态不能靠「结果对不对」来发现，只能靠 racecheck。\n\n**通关标准**\n\n- 转置结果正确\n- `compute-sanitizer --tool racecheck` 报 0 hazards\n- 读写都合并（`sectorsPerRequest ≤ 4.5`）",
+          "en": "Transpose a 32×32 matrix. Reads and writes cannot both be coalesced — reading along rows\nmeans writing along columns. The fix is to stage the tile through **shared memory**\n(a small fast block-local memory) and then read it back transposed, so both sides coalesce.\n\n`transpose.cu` already does that. **It produces the wrong answer**, and it is wrong the\nsame way every single run.\n\n```bash\nnvcc -o bench transpose.cu && ./bench\ncompute-sanitizer --tool racecheck ./bench\n```\n\nracecheck tells you: one thread writes a slot and another reads it with no synchronisation\nin between. You need a **`__syncthreads()`** between `tile[y][x] = ...` and `... = tile[x][y]` —\nit stops every thread in the block until all of them have finished writing.\n\n**Why this stage matters**: warps run in a fixed order in this simulator, so a racy kernel\nproduces a *stable* result. Here it happens to be wrong. With a different access pattern it\nwould happen to be **right** — correct ten thousand times here, broken on a real GPU.\nRaces cannot be found by checking the answer. Only racecheck finds them.\n\n**To pass**\n\n- correct transpose\n- `compute-sanitizer --tool racecheck` reports 0 hazards\n- both sides coalesced (`sectorsPerRequest ≤ 4.5`)"
+        },
+        "checklist": [
+          {
+            "zh": "跑一次 racecheck，看它指到哪两行",
+            "en": "Run racecheck and read which two lines it points at"
+          },
+          {
+            "zh": "在写共享内存和读共享内存之间加 `__syncthreads()`",
+            "en": "Add `__syncthreads()` between the shared-memory write and read"
+          },
+          {
+            "zh": "确认 racecheck 报 0 hazards",
+            "en": "Confirm racecheck reports 0 hazards"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`__syncthreads()` 必须让整个 block 都执行到 —— 不能放在 `if` 里面。",
+            "en": "`__syncthreads()` must be reached by every thread in the block — never put it inside an `if`."
+          },
+          {
+            "zh": "只需要一个屏障，位置在两次共享内存访问之间。",
+            "en": "One barrier is enough, between the two shared-memory accesses."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**把 `__syncthreads()` 放进 `if` 里。** 只有一部分线程到达屏障，真卡上这是未定义行为、通常直接挂死；这里会明确报错。",
+            "en": "**Putting `__syncthreads()` inside an `if`.** Only some threads reach the barrier; on real hardware that is undefined behaviour and usually hangs. Here it is reported as an error."
+          },
+          {
+            "zh": "**靠「多跑几遍看看」找竞态。** 这个模拟器是确定的，跑一万遍是同一个结果。真卡上也未必能重现 —— 竞态最擅长的就是在你观察它的时候表现正常。",
+            "en": "**Re-running to see if a race shows up.** This simulator is deterministic: ten thousand runs, one answer. Real hardware may not reproduce it either — races are best at looking fine while watched."
+          }
+        ],
+        "extension": {
+          "zh": "`compute-sanitizer --tool racecheck` 是真工具，用法和这里一模一样。它的原理是给共享内存的每个字配一份影子，记住最近是谁读的、谁写的、以及中间过了几次屏障；同一个「屏障纪元」里两个不同线程冲突访问同一个字，就是竞态。我们实现的是同一套判据 —— 见 [NVIDIA 的 racecheck 文档](https://docs.nvidia.com/cuda/compute-sanitizer/index.html#racecheck-tool)。",
+          "en": "`compute-sanitizer --tool racecheck` is the real tool and works exactly like this. It shadows every shared-memory word with the last reader, the last writer, and how many barriers have passed; two different threads accessing the same word inside one barrier epoch is a race. We implement the same rule — see [NVIDIA's racecheck documentation](https://docs.nvidia.com/cuda/compute-sanitizer/index.html#racecheck-tool)."
+        },
+        "gpu": {
+          "files": {
+            "/root/transpose.cu": "// 32×32 转置，经共享内存中转，好让读和写都合并。\n//\n// 结果是错的，而且每次错得一模一样 —— 先跑一次\n//   compute-sanitizer --tool racecheck ./bench\n// 看它指到哪两行。\n__global__ void transpose(const float* in, float* out, int n) {\n  __shared__ float tile[32][33];   // 33 不是笔误，第 4 关会讲\n\n  int x = threadIdx.x;\n  int y = threadIdx.y;\n\n  tile[y][x] = in[y * n + x];\n\n  // TODO: 这里少了点什么\n\n  out[y * n + x] = tile[x][y];\n}\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/transpose.cu"
+            ],
+            "buffers": [
+              {
+                "name": "in",
+                "length": 1024,
+                "fill": {
+                  "kind": "iota",
+                  "scale": 1
+                }
+              },
+              {
+                "name": "out",
+                "length": 1024,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": [
+              {
+                "kernel": "transpose",
+                "grid": [
+                  1
+                ],
+                "block": [
+                  32,
+                  32
+                ],
+                "args": [
+                  "in",
+                  "out",
+                  32
+                ]
+              }
+            ]
+          },
+          "referenceFiles": {
+            "/root/transpose.cu": "__global__ void transpose(const float* in, float* out, int n) {\n  __shared__ float tile[32][33];\n\n  int x = threadIdx.x;\n  int y = threadIdx.y;\n\n  tile[y][x] = in[y * n + x];\n\n  // 整个 block 都写完了，才能开始读别人写的格子\n  __syncthreads();\n\n  out[y * n + x] = tile[x][y];\n}\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "transpose.spec.ts",
+            "content": "const lab = require('@gpu/lab');\n\nconst N = 32;\n\ndescribe('转置', () => {\n  it('结果正确', async () => {\n    await lab.buildAndRun();\n    const input = lab.buffer('in');\n    const out = lab.buffer('out');\n    const expected = new Float32Array(N * N);\n    for (let y = 0; y < N; y += 1) {\n      for (let x = 0; x < N; x += 1) expected[y * N + x] = input[x * N + y];\n    }\n    const diff = lab.compare(out, expected);\n    expect(diff.hasNonFinite).toBe(false);\n    expect(diff.maxAbs).toBe(0);\n  });\n\n  it('racecheck 报 0 hazards', async () => {\n    const report = await lab.racecheck();\n    expect(report.races.length).toBe(0);\n  });\n\n  it('确实用了屏障，而不是绕开共享内存', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    expect(metrics.launch.barriers).toBeGreaterThan(0);\n    expect(metrics.shared.storeRequests).toBeGreaterThan(0);\n    expect(metrics.shared.loadRequests).toBeGreaterThan(0);\n  });\n\n  it('读和写都合并', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    expect(metrics.global.sectorsPerRequest).toBeLessThanOrEqual(4.5);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.launch.barriers",
+            "op": "gte",
+            "value": 1,
+            "label": {
+              "zh": "屏障次数",
+              "en": "barriers"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.global.sectorsPerRequest",
+            "op": "lte",
+            "value": 4.5,
+            "label": {
+              "zh": "每次访存打到的 32B 扇区数",
+              "en": "sectors per request"
+            },
+            "unit": "sector/req",
+            "dimension": "latency"
+          }
+        ],
+        "focus": [
+          "correctness"
+        ],
+        "primer": {
+          "zh": "`共享内存`是每个 block 独有的一小块内存，比显存快一个数量级，用 `__shared__` 声明。它的典型用法是「中转」：先把一块数据按合并的方式读进来，再按任意顺序从共享内存里取用 —— 于是读和写都能保持合并。矩阵转置就是这么解的。\n\n但共享内存是**共用**的，这就带来了竞态。一个线程写 `tile[y][x]`、另一个线程读 `tile[x][y]`，如果中间没有同步，读的人完全可能读到还没被写进去的旧值。`__syncthreads()` 就是那道同步：整个 block 的线程都停在这里，等所有人都到齐了再一起走。\n\n**`__syncthreads()` 必须让整个 block 都执行到。** 把它写进 `if` 里，只有一部分线程到达屏障，真卡上是未定义行为，通常直接挂死。\n\n竞态最麻烦的地方是它**不一定表现出来**。GPU 上 warp 的执行顺序不确定，同一份有竞态的代码可能今天对、明天错，也可能在你的卡上一直对、在别人的卡上一直错。所以不能靠「多跑几遍看看」，要用 `compute-sanitizer --tool racecheck` ——它给共享内存的每个字记住最近谁读谁写、中间过了几次屏障，冲突就报出来。",
+          "en": "`Shared memory` is a small per-block memory an order of magnitude faster than device memory, declared with `__shared__`. Its classic use is staging: read a tile in coalesced, then take values out of shared memory in any order — so both the read and the write stay coalesced. That is how matrix transpose is solved.\n\nBut shared memory is **shared**, which introduces races. If one thread writes `tile[y][x]` and another reads `tile[x][y]` with nothing in between, the reader may well see a value that has not been written yet. `__syncthreads()` is the barrier: every thread in the block waits there until all of them have arrived.\n\n**`__syncthreads()` must be reached by the whole block.** Inside an `if`, only some threads reach it — undefined behaviour on real hardware, usually a hang.\n\nThe hard part about races is that they **need not show up**. Warp scheduling is not deterministic, so the same racy code can be right today and wrong tomorrow, or always right on your GPU and always wrong on someone else's. Re-running proves nothing. Use `compute-sanitizer --tool racecheck`: it shadows every shared-memory word with its last reader, last writer and barrier epoch, and reports the conflicts."
+        }
+      }
+    ]
+  },
+  {
     "id": "message-broker",
     "title": {
       "zh": "高并发消息系统",

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1056,6 +1056,99 @@ const primers = {
     ),
   },
 
+  'llm-accelerator': {
+    'first-kernel': t(
+      p(
+        'GPU 上的一次计算叫一次`kernel 启动`。启动时你要说清楚开多少线程，'
+        + '而且线程是**分两层**组织的：若干个`线程块`（block）组成一张`网格`（grid），'
+        + '每个 block 里有固定数量的线程。写成 `vecAdd<<<4, 256>>>(...)` 就是 4 个 block、每块 256 个线程。',
+        '这两层不是摆设。同一个 block 里的线程跑在同一个 SM 上、能共享一小块高速内存、能互相同步；'
+        + '不同 block 之间没有任何顺序保证，也不能直接通信。所以 block 内和 block 间是两套完全不同的编程方式。',
+        '每个线程通过三个内建变量知道自己是谁：`threadIdx` 是它在 block 里的编号，'
+        + '`blockIdx` 是它所在的 block 编号，`blockDim` 是每个 block 有多少线程。'
+        + '把它们拼起来得到全局编号：`blockIdx.x * blockDim.x + threadIdx.x`。',
+        '**线程数几乎总是比数据多。** 数据长度很少正好是 block 大小的整数倍，'
+        + '所以每个 kernel 开头都要有一句边界检查 —— 多出来的线程必须什么都不做。'
+        + '让它们越界写，在真卡上就是踩坏别人的显存。'
+      ),
+      p(
+        'One computation on a GPU is a `kernel launch`. You state how many threads to start, and threads '
+        + 'are organised in **two levels**: a `grid` of `thread blocks`, each block holding a fixed number '
+        + 'of threads. `vecAdd<<<4, 256>>>(...)` means 4 blocks of 256 threads.',
+        'The two levels are not decoration. Threads in one block run on the same SM, share a small fast '
+        + 'memory, and can synchronise with each other. Different blocks have no ordering guarantee and '
+        + 'cannot communicate directly. Programming within a block and across blocks are two different things.',
+        'Each thread learns who it is from three built-in variables: `threadIdx` is its index inside the '
+        + 'block, `blockIdx` is which block it belongs to, and `blockDim` is how many threads a block has. '
+        + 'Combine them for a global index: `blockIdx.x * blockDim.x + threadIdx.x`.',
+        '**There are almost always more threads than data.** Lengths are rarely an exact multiple of the '
+        + 'block size, so every kernel begins with a bounds check and the surplus threads do nothing. '
+        + 'Letting them write out of range corrupts memory belonging to something else on a real GPU.'
+      )
+    ),
+    coalescing: t(
+      p(
+        'GPU 的显存不是按单个数取的。硬件一次搬运的最小单位是一个 **32 字节的扇区**，'
+        + '哪怕你只要其中 4 个字节，剩下的 28 个也会被一起搬过来然后扔掉。',
+        '一个 `warp`（32 个线程，GPU 调度的最小单位）同时发出的 32 个访存请求会被硬件合并：'
+        + '落在同一个扇区里的合成一次传输。于是同样是读 32 个 float，'
+        + '**连续读**只要 4 个扇区（32 × 4 = 128 字节），'
+        + '而**每个 lane 隔得很远**就要 32 个扇区 —— 传输量差 8 倍，指令却一条没多。',
+        '这就是「合并访问」。判断方法很简单：看同一个 warp 里相邻的线程，它们访问的地址是不是相邻的。'
+        + '在 `ncu` 里对应的指标叫 `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`，'
+        + '完美是 4.0，最坏是 32.0。',
+        '几乎所有 GPU 访存优化最后都归到这一条。它也是矩阵转置为什么难的原因：'
+        + '按行读就得按列写，两边不可能同时合并。'
+      ),
+      p(
+        'GPU memory is not fetched one value at a time. The smallest unit the hardware moves is a '
+        + '**32-byte sector**; asking for 4 bytes brings the other 28 along and then discards them.',
+        'The 32 memory requests issued by one `warp` (32 threads, the GPU\'s scheduling unit) are coalesced: '
+        + 'lanes landing in the same sector become one transfer. Reading 32 consecutive floats therefore '
+        + 'costs **4 sectors** (32 × 4 = 128 bytes), while 32 scattered lanes cost **32 sectors** — 8× the '
+        + 'traffic for exactly the same instructions.',
+        'That is coalescing. The test is simple: do neighbouring threads in a warp touch neighbouring '
+        + 'addresses? In `ncu` the metric is '
+        + '`l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`, 4.0 at best and 32.0 at worst.',
+        'Nearly every GPU memory optimisation reduces to this rule. It is also why matrix transpose is hard: '
+        + 'reading along rows forces writing along columns, and both cannot coalesce at once.'
+      )
+    ),
+    'shared-memory-race': t(
+      p(
+        '`共享内存`是每个 block 独有的一小块内存，比显存快一个数量级，用 `__shared__` 声明。'
+        + '它的典型用法是「中转」：先把一块数据按合并的方式读进来，'
+        + '再按任意顺序从共享内存里取用 —— 于是读和写都能保持合并。矩阵转置就是这么解的。',
+        '但共享内存是**共用**的，这就带来了竞态。一个线程写 `tile[y][x]`、另一个线程读 `tile[x][y]`，'
+        + '如果中间没有同步，读的人完全可能读到还没被写进去的旧值。'
+        + '`__syncthreads()` 就是那道同步：整个 block 的线程都停在这里，等所有人都到齐了再一起走。',
+        '**`__syncthreads()` 必须让整个 block 都执行到。** 把它写进 `if` 里，'
+        + '只有一部分线程到达屏障，真卡上是未定义行为，通常直接挂死。',
+        '竞态最麻烦的地方是它**不一定表现出来**。GPU 上 warp 的执行顺序不确定，'
+        + '同一份有竞态的代码可能今天对、明天错，也可能在你的卡上一直对、在别人的卡上一直错。'
+        + '所以不能靠「多跑几遍看看」，要用 `compute-sanitizer --tool racecheck` ——'
+        + '它给共享内存的每个字记住最近谁读谁写、中间过了几次屏障，冲突就报出来。'
+      ),
+      p(
+        '`Shared memory` is a small per-block memory an order of magnitude faster than device memory, '
+        + 'declared with `__shared__`. Its classic use is staging: read a tile in coalesced, then take '
+        + 'values out of shared memory in any order — so both the read and the write stay coalesced. '
+        + 'That is how matrix transpose is solved.',
+        'But shared memory is **shared**, which introduces races. If one thread writes `tile[y][x]` and '
+        + 'another reads `tile[x][y]` with nothing in between, the reader may well see a value that has '
+        + 'not been written yet. `__syncthreads()` is the barrier: every thread in the block waits there '
+        + 'until all of them have arrived.',
+        '**`__syncthreads()` must be reached by the whole block.** Inside an `if`, only some threads reach '
+        + 'it — undefined behaviour on real hardware, usually a hang.',
+        'The hard part about races is that they **need not show up**. Warp scheduling is not deterministic, '
+        + 'so the same racy code can be right today and wrong tomorrow, or always right on your GPU and '
+        + 'always wrong on someone else\'s. Re-running proves nothing. Use '
+        + '`compute-sanitizer --tool racecheck`: it shadows every shared-memory word with its last reader, '
+        + 'last writer and barrier epoch, and reports the conflicts.'
+      )
+    ),
+  },
+
   'intranet-k8s': {
     'first-workload': t(
       p(

--- a/public/projects.json
+++ b/public/projects.json
@@ -14948,6 +14948,509 @@
     ]
   },
   {
+    "id": "llm-accelerator",
+    "title": {
+      "zh": "CUDA GPU 编程：搭一个 LLM 加速引擎",
+      "en": "CUDA GPU programming: build an LLM inference engine"
+    },
+    "summary": {
+      "zh": "写真 CUDA，用真 ncu 剖析。从第一个 kernel 一路做到能跑的推理引擎，最后摊到 16 卡集群上。",
+      "en": "Write real CUDA, profile with real ncu. From your first kernel to a working inference engine, then out to a 16-GPU cluster."
+    },
+    "difficulty": "Hard",
+    "domain": "gpu",
+    "tags": [
+      "cuda",
+      "gpu",
+      "performance",
+      "llm",
+      "parallel"
+    ],
+    "estimatedMinutes": 2400,
+    "language": "typescript",
+    "brief": {
+      "zh": "## 这是什么\n\n一台 H100，一个终端，一个 IDE。你写 CUDA C，敲 `nvcc` 编译、`ncu` 剖析、\n`compute-sanitizer` 查错 —— 命令、参数、指标名都和真机一样。\n\n## 判定标准\n\n**优化生效与否不是自称的。** 每一关的门槛都建立在平台侧的结构性计量上：\nDRAM 传输字节、32B 扇区数、bank 冲突路数、发散分支数、local memory 字节、\n占用率。这些量在给定内存模型后是精确的，而且**与硬件型号无关** ——\n换到真卡上一个不差。\n\n模拟耗时只用来展示和同关比较，**不作门槛**。\n\n## 已知的边界\n\n- 写的是 C99 子集 + CUDA 扩展，没有模板与类\n- 报错文本贴 nvcc 的形状，但做不到逐字节一致\n- 原子操作在这里按 lane 号定序，因此可复现；真卡上顺序不定",
+      "en": "## What this is\n\nOne H100, one terminal, one IDE. You write CUDA C and drive `nvcc`, `ncu` and\n`compute-sanitizer` — same commands, same flags, same metric names as the real thing.\n\n## How it is judged\n\n**Whether an optimisation worked is measured, not claimed.** Every gate is built on\nstructural counters: DRAM bytes, 32-byte sectors, bank-conflict ways, divergent branches,\nlocal-memory traffic, occupancy. Given the memory model these are exact, and they are\n**independent of the specific GPU** — they carry over to real hardware unchanged.\n\nSimulated time is shown and compared within a stage, but never gates anything.\n\n## Known boundaries\n\n- a C99 subset plus CUDA extensions; no templates or classes\n- diagnostics follow nvcc's shape but are not byte-identical\n- atomics are ordered by lane here, so they reproduce; real hardware does not guarantee order"
+    },
+    "weights": {
+      "correctness": 3,
+      "latency": 3,
+      "resilience": 1,
+      "encapsulation": 1,
+      "elegance": 1
+    },
+    "workspace": {
+      "kind": "gpu",
+      "world": {
+        "seed": 20260826,
+        "device": "H100",
+        "globalBytes": 33554432,
+        "sharedBytesPerBlock": 49152,
+        "machine": {
+          "hostname": "gpu-01",
+          "user": "root",
+          "cwd": "/root"
+        }
+      }
+    },
+    "files": [],
+    "stages": [
+      {
+        "id": "first-kernel",
+        "title": {
+          "zh": "第一个 kernel —— 线程、块、网格",
+          "en": "Your first kernel — threads, blocks, grids"
+        },
+        "goal": {
+          "zh": "磁盘上有一个 `kernel.cu`，里面的 `vecAdd` 还是空的。把它写出来：`c[i] = a[i] + b[i]`。\n\n数组长度是 **1000**，而启动配置是 4 个 block × 256 线程 = **1024 个线程**。\n多出来的 24 个线程必须什么都不做 —— 让它们去写 `c[1000]` 就是越界，\n真卡上这会踩坏别人的显存，在这里会被 `compute-sanitizer` 当场抓住。\n\n```bash\nnvcc -o bench kernel.cu\n./bench\ncompute-sanitizer --tool memcheck ./bench\n```\n\n**通关标准**\n\n- 1000 个元素全部算对\n- 一次越界都没有\n- 每个线程只负责一个元素 —— 不许一个线程用循环把全部算完",
+          "en": "There is a `kernel.cu` on disk with an empty `vecAdd`. Fill it in: `c[i] = a[i] + b[i]`.\n\nThe array holds **1000** elements but the launch is 4 blocks × 256 threads = **1024 threads**.\nThe extra 24 threads must do nothing. Letting them write `c[1000]` is out of bounds;\non a real GPU that corrupts memory belonging to someone else, and here\n`compute-sanitizer` catches it immediately.\n\n```bash\nnvcc -o bench kernel.cu\n./bench\ncompute-sanitizer --tool memcheck ./bench\n```\n\n**To pass**\n\n- all 1000 elements correct\n- no out-of-bounds access\n- one element per thread — no single thread looping over everything"
+        },
+        "checklist": [
+          {
+            "zh": "用 blockIdx / blockDim / threadIdx 算出这个线程负责哪个元素",
+            "en": "Derive this thread's element index from blockIdx / blockDim / threadIdx"
+          },
+          {
+            "zh": "加上边界检查，让多出来的线程什么都不做",
+            "en": "Guard the tail so the extra threads do nothing"
+          },
+          {
+            "zh": "`nvcc -o bench kernel.cu && ./bench` 跑通",
+            "en": "Get `nvcc -o bench kernel.cu && ./bench` to succeed"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "全局线程号是 `blockIdx.x * blockDim.x + threadIdx.x`。",
+            "en": "The global thread index is `blockIdx.x * blockDim.x + threadIdx.x`."
+          },
+          {
+            "zh": "边界检查写成 `if (i < n) { ... }`。n 是传进来的参数，不要写死 1000。",
+            "en": "Guard with `if (i < n) { ... }`. `n` is a parameter — do not hard-code 1000."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**用 `threadIdx.x` 当全局下标。** 每个 block 里的 threadIdx 都从 0 开始，于是 4 个 block 会把同样的 256 个元素算 4 遍，剩下的 744 个一个都没动。",
+            "en": "**Using `threadIdx.x` as the global index.** It restarts at 0 in every block, so the four blocks all compute the same 256 elements and the remaining 744 are never touched."
+          },
+          {
+            "zh": "**忘了边界检查。** 结果看起来可能是对的（多写的那几个格子没人读），但 memcheck 会报越界 —— 真卡上那是别人的显存。",
+            "en": "**Forgetting the guard.** The result may look right (nobody reads those slots) but memcheck reports an out-of-bounds write — on a real GPU that memory belongs to someone else."
+          }
+        ],
+        "extension": {
+          "zh": "真实的 kernel 常写成 **grid-stride loop**：`for (int i = idx; i < n; i += gridDim.x * blockDim.x)`。这样同一份代码在任何启动配置下都正确，而且能复用已经驻留在 SM 上的 block。NVIDIA 的官方博客 [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops](https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/) 讲的就是它。",
+          "en": "Real kernels often use a **grid-stride loop**: `for (int i = idx; i < n; i += gridDim.x * blockDim.x)`. The same code is then correct for any launch configuration and reuses blocks already resident on an SM. See NVIDIA's [CUDA Pro Tip: Write Flexible Kernels with Grid-Stride Loops](https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/)."
+        },
+        "gpu": {
+          "files": {
+            "/root/kernel.cu": "// 每个线程负责一个元素：c[i] = a[i] + b[i]\n//\n// 注意 n = 1000，而启动的是 1024 个线程。\n__global__ void vecAdd(const float* a, const float* b, float* c, int n) {\n  // TODO: 算出这个线程负责哪个元素，加上边界检查\n}\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/kernel.cu"
+            ],
+            "buffers": [
+              {
+                "name": "a",
+                "length": 1000,
+                "fill": {
+                  "kind": "iota",
+                  "scale": 0.5
+                }
+              },
+              {
+                "name": "b",
+                "length": 1000,
+                "fill": {
+                  "kind": "iota",
+                  "scale": -0.25,
+                  "offset": 7
+                }
+              },
+              {
+                "name": "c",
+                "length": 1000,
+                "fill": {
+                  "kind": "const",
+                  "value": -999
+                }
+              }
+            ],
+            "launches": [
+              {
+                "kernel": "vecAdd",
+                "grid": [
+                  4
+                ],
+                "block": [
+                  256
+                ],
+                "args": [
+                  "a",
+                  "b",
+                  "c",
+                  1000
+                ]
+              }
+            ]
+          },
+          "referenceFiles": {
+            "/root/kernel.cu": "__global__ void vecAdd(const float* a, const float* b, float* c, int n) {\n  int i = blockIdx.x * blockDim.x + threadIdx.x;\n  if (i < n) c[i] = a[i] + b[i];\n}\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "vecadd.spec.ts",
+            "content": "const lab = require('@gpu/lab');\n\ndescribe('向量加法', () => {\n  it('1000 个元素全部算对', async () => {\n    await lab.buildAndRun();\n    const a = lab.buffer('a');\n    const b = lab.buffer('b');\n    const c = lab.buffer('c');\n    const expected = new Float32Array(a.length);\n    for (let i = 0; i < a.length; i += 1) expected[i] = Math.fround(a[i] + b[i]);\n    const diff = lab.compare(c, expected);\n    expect(diff.hasNonFinite).toBe(false);\n    expect(diff.maxAbs).toBe(0);\n  });\n\n  it('一次越界都没有', async () => {\n    const result = await lab.sh('compute-sanitizer --tool memcheck ./bench');\n    expect(result.code).toBe(0);\n  });\n\n  it('每个线程只算一个元素，没人用循环把全部包了', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    // 1024 个线程，每个做一次读 a、一次读 b、一次写 c。\n    // 有人写循环的话 lane 指令数会翻好几十倍。\n    expect(metrics.global.loadRequests).toBeLessThanOrEqual(4 * 8 * 2 + 8);\n    expect(metrics.inst.laneExecuted).toBeLessThan(60000);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.global.sectorsPerRequest",
+            "op": "lte",
+            "value": 4.5,
+            "label": {
+              "zh": "每次访存打到的 32B 扇区数",
+              "en": "sectors per memory request"
+            },
+            "unit": "sector/req",
+            "dimension": "latency"
+          }
+        ],
+        "focus": [
+          "correctness"
+        ],
+        "primer": {
+          "zh": "GPU 上的一次计算叫一次`kernel 启动`。启动时你要说清楚开多少线程，而且线程是**分两层**组织的：若干个`线程块`（block）组成一张`网格`（grid），每个 block 里有固定数量的线程。写成 `vecAdd<<<4, 256>>>(...)` 就是 4 个 block、每块 256 个线程。\n\n这两层不是摆设。同一个 block 里的线程跑在同一个 SM 上、能共享一小块高速内存、能互相同步；不同 block 之间没有任何顺序保证，也不能直接通信。所以 block 内和 block 间是两套完全不同的编程方式。\n\n每个线程通过三个内建变量知道自己是谁：`threadIdx` 是它在 block 里的编号，`blockIdx` 是它所在的 block 编号，`blockDim` 是每个 block 有多少线程。把它们拼起来得到全局编号：`blockIdx.x * blockDim.x + threadIdx.x`。\n\n**线程数几乎总是比数据多。** 数据长度很少正好是 block 大小的整数倍，所以每个 kernel 开头都要有一句边界检查 —— 多出来的线程必须什么都不做。让它们越界写，在真卡上就是踩坏别人的显存。",
+          "en": "One computation on a GPU is a `kernel launch`. You state how many threads to start, and threads are organised in **two levels**: a `grid` of `thread blocks`, each block holding a fixed number of threads. `vecAdd<<<4, 256>>>(...)` means 4 blocks of 256 threads.\n\nThe two levels are not decoration. Threads in one block run on the same SM, share a small fast memory, and can synchronise with each other. Different blocks have no ordering guarantee and cannot communicate directly. Programming within a block and across blocks are two different things.\n\nEach thread learns who it is from three built-in variables: `threadIdx` is its index inside the block, `blockIdx` is which block it belongs to, and `blockDim` is how many threads a block has. Combine them for a global index: `blockIdx.x * blockDim.x + threadIdx.x`.\n\n**There are almost always more threads than data.** Lengths are rarely an exact multiple of the block size, so every kernel begins with a bounds check and the surplus threads do nothing. Letting them write out of range corrupts memory belonging to something else on a real GPU."
+        }
+      },
+      {
+        "id": "coalescing",
+        "title": {
+          "zh": "访存合并 —— 同一段逻辑，换个下标慢 8 倍",
+          "en": "Coalescing — same logic, 8× the traffic"
+        },
+        "goal": {
+          "zh": "`scale.cu` 把一个 64×64 的矩阵每个元素乘以 2，算出来是对的。\n但 `ncu` 说它每次访存要打 **32 个 32B 扇区** —— 完美情况下应该是 4 个。\n\n```bash\nnvcc -o bench scale.cu && ncu ./bench\n```\n\n看 `Memory Workload Analysis` 那一节的\n`l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`。\n\n**为什么**：一个 warp 里 32 个 lane 的地址会被硬件归并成对 32 字节扇区的请求。\n32 个 lane 读连续的 32 个 float = 128 字节 = **4 个扇区**；\n如果它们各隔一整行，就是 **32 个扇区**，也就是 8 倍的传输量。\n指令一条没多，搬的字节数翻了 8 倍。\n\n**通关标准**\n\n- 结果和现在完全一样（每个元素都乘到了）\n- `sectorsPerRequest ≤ 4.5`\n- DRAM 读字节数降到理论下限附近",
+          "en": "`scale.cu` multiplies every element of a 64×64 matrix by 2. The result is correct.\nBut `ncu` reports **32 sectors per request** where a perfect kernel would need 4.\n\n```bash\nnvcc -o bench scale.cu && ncu ./bench\n```\n\nLook at `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`\nunder `Memory Workload Analysis`.\n\n**Why**: the 32 lanes of a warp have their addresses coalesced into 32-byte sector requests.\n32 lanes reading 32 consecutive floats = 128 bytes = **4 sectors**. If each lane instead\nreads a different row, that is **32 sectors** — 8× the traffic for the same instructions.\n\n**To pass**\n\n- identical results\n- `sectorsPerRequest ≤ 4.5`\n- DRAM read bytes near the theoretical minimum"
+        },
+        "checklist": [
+          {
+            "zh": "让同一个 warp 里相邻的 lane 访问相邻的元素",
+            "en": "Make neighbouring lanes touch neighbouring elements"
+          },
+          {
+            "zh": "用 `ncu ./bench` 确认扇区数掉到 4",
+            "en": "Confirm with `ncu ./bench` that sectors drop to 4"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "现在的下标是「lane 决定行、warp 决定列」，正好把连续的 lane 拆到了不同的行上。",
+            "en": "Right now the lane picks the row and the warp picks the column, which scatters consecutive lanes across rows."
+          },
+          {
+            "zh": "把它换成「相邻线程 → 相邻列」：`row = i / cols; col = i % cols;`，或者干脆按一维下标走。",
+            "en": "Switch to neighbouring threads → neighbouring columns: `row = i / cols; col = i % cols;` or just use the flat index."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**以为「反正总字节数一样」。** 总元素数确实一样，但传输是按 32 字节一整块走的：只用到其中 4 个字节，剩下 28 个字节也被搬过来了，然后扔掉。",
+            "en": "**Assuming the byte count is the same either way.** The element count is, but transfers move whole 32-byte sectors: use 4 bytes of one and the other 28 come along anyway, then get thrown away."
+          },
+          {
+            "zh": "**只改读、不改写。** 写回也要合并，`ncu` 里 store 的扇区数是单独一行。",
+            "en": "**Fixing loads but not stores.** Stores coalesce too; ncu reports their sectors separately."
+          }
+        ],
+        "extension": {
+          "zh": "这条规则是所有 GPU 访存优化的地基。矩阵转置之所以难，正是因为读和写不可能同时合并 ——第 3、4 关就是用共享内存把这个矛盾解开。NVIDIA 的经典博客 [How to Access Global Memory Efficiently in CUDA C/C++ Kernels](https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/) 把各种步长的代价量了一遍。",
+          "en": "This rule underpins every GPU memory optimisation. Matrix transpose is hard precisely because reads and writes cannot both be coalesced — stages 3 and 4 resolve that with shared memory. NVIDIA's [How to Access Global Memory Efficiently in CUDA C/C++ Kernels](https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/) measures the cost of each stride."
+        },
+        "gpu": {
+          "files": {
+            "/root/scale.cu": "// 把 64×64 的矩阵每个元素乘以 2。\n//\n// 结果是对的，但 ncu 说每次访存要打 32 个扇区。\n// 想想一个 warp 里相邻的 lane 现在落在哪儿。\n__global__ void scale(const float* in, float* out, int rows, int cols) {\n  int i = blockIdx.x * blockDim.x + threadIdx.x;\n  int lane = i % 32;\n  int group = i / 32;\n\n  // lane 决定行、group 决定列 —— 相邻的 lane 隔了一整行\n  int row = lane * (rows / 32) + group / cols;\n  int col = group % cols;\n\n  if (row < rows && col < cols) {\n    out[row * cols + col] = in[row * cols + col] * 2.0f;\n  }\n}\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/scale.cu"
+            ],
+            "buffers": [
+              {
+                "name": "in",
+                "length": 4096,
+                "fill": {
+                  "kind": "iota",
+                  "scale": 0.125
+                }
+              },
+              {
+                "name": "out",
+                "length": 4096,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": [
+              {
+                "kernel": "scale",
+                "grid": [
+                  32
+                ],
+                "block": [
+                  128
+                ],
+                "args": [
+                  "in",
+                  "out",
+                  64,
+                  64
+                ]
+              }
+            ]
+          },
+          "referenceFiles": {
+            "/root/scale.cu": "__global__ void scale(const float* in, float* out, int rows, int cols) {\n  int i = blockIdx.x * blockDim.x + threadIdx.x;\n  // 相邻线程 → 相邻元素，一个 warp 正好覆盖连续的 128 字节\n  if (i < rows * cols) out[i] = in[i] * 2.0f;\n}\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "coalescing.spec.ts",
+            "content": "const lab = require('@gpu/lab');\n\nconst ROWS = 64;\nconst COLS = 64;\n\ndescribe('矩阵缩放', () => {\n  it('每个元素都乘到了', async () => {\n    await lab.buildAndRun();\n    const input = lab.buffer('in');\n    const out = lab.buffer('out');\n    const expected = new Float32Array(input.length);\n    for (let i = 0; i < input.length; i += 1) expected[i] = Math.fround(input[i] * 2);\n    const diff = lab.compare(out, expected);\n    expect(diff.hasNonFinite).toBe(false);\n    expect(diff.maxAbs).toBe(0);\n  });\n\n  it('读和写都合并了', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    // 每次 warp 级访存 32 lane × 4 字节 = 128 字节 = 4 个扇区\n    expect(metrics.global.loadSectors / metrics.global.loadRequests).toBeLessThanOrEqual(4.5);\n    expect(metrics.global.storeSectors / metrics.global.storeRequests).toBeLessThanOrEqual(4.5);\n  });\n\n  it('DRAM 传输量降到理论下限附近', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    const ideal = ROWS * COLS * 4;\n    // 允许 10% 余量：尾块与对齐会带来一点额外传输\n    expect(metrics.memory.readBytes).toBeLessThanOrEqual(ideal * 1.1);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.global.sectorsPerRequest",
+            "op": "lte",
+            "value": 4.5,
+            "label": {
+              "zh": "每次访存打到的 32B 扇区数（未优化时是 32）",
+              "en": "sectors per request (32 before optimising)"
+            },
+            "unit": "sector/req",
+            "dimension": "latency"
+          },
+          {
+            "metric": "gpu.memory.readBytes",
+            "op": "lte",
+            "value": 18022,
+            "label": {
+              "zh": "DRAM 读字节数",
+              "en": "DRAM bytes read"
+            },
+            "unit": "byte",
+            "dimension": "latency"
+          }
+        ],
+        "focus": [
+          "latency"
+        ],
+        "primer": {
+          "zh": "GPU 的显存不是按单个数取的。硬件一次搬运的最小单位是一个 **32 字节的扇区**，哪怕你只要其中 4 个字节，剩下的 28 个也会被一起搬过来然后扔掉。\n\n一个 `warp`（32 个线程，GPU 调度的最小单位）同时发出的 32 个访存请求会被硬件合并：落在同一个扇区里的合成一次传输。于是同样是读 32 个 float，**连续读**只要 4 个扇区（32 × 4 = 128 字节），而**每个 lane 隔得很远**就要 32 个扇区 —— 传输量差 8 倍，指令却一条没多。\n\n这就是「合并访问」。判断方法很简单：看同一个 warp 里相邻的线程，它们访问的地址是不是相邻的。在 `ncu` 里对应的指标叫 `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`，完美是 4.0，最坏是 32.0。\n\n几乎所有 GPU 访存优化最后都归到这一条。它也是矩阵转置为什么难的原因：按行读就得按列写，两边不可能同时合并。",
+          "en": "GPU memory is not fetched one value at a time. The smallest unit the hardware moves is a **32-byte sector**; asking for 4 bytes brings the other 28 along and then discards them.\n\nThe 32 memory requests issued by one `warp` (32 threads, the GPU's scheduling unit) are coalesced: lanes landing in the same sector become one transfer. Reading 32 consecutive floats therefore costs **4 sectors** (32 × 4 = 128 bytes), while 32 scattered lanes cost **32 sectors** — 8× the traffic for exactly the same instructions.\n\nThat is coalescing. The test is simple: do neighbouring threads in a warp touch neighbouring addresses? In `ncu` the metric is `l1tex__average_t_sectors_per_request_pipe_lsu_mem_global_op_ld.ratio`, 4.0 at best and 32.0 at worst.\n\nNearly every GPU memory optimisation reduces to this rule. It is also why matrix transpose is hard: reading along rows forces writing along columns, and both cannot coalesce at once."
+        }
+      },
+      {
+        "id": "shared-memory-race",
+        "title": {
+          "zh": "共享内存与竞态 —— 跑对了，但它是错的",
+          "en": "Shared memory and races — it works, and it is still wrong"
+        },
+        "goal": {
+          "zh": "转置一个 32×32 的矩阵。读和写不可能同时合并 —— 按行读就得按列写。\n解法是先把整块搬进**共享内存**（block 内所有线程共用的一小块高速内存），\n再从共享内存里按转置的顺序读出来写回去。这样读和写都是合并的。\n\n`transpose.cu` 已经这么写了。**它算出来的结果是错的**，而且每次错得一模一样。\n\n```bash\nnvcc -o bench transpose.cu && ./bench\ncompute-sanitizer --tool racecheck ./bench\n```\n\nracecheck 会告诉你：一个线程写的格子，另一个线程在没有任何同步的情况下读了。\n`tile[y][x] = ...` 和 `... = tile[x][y]` 之间需要一个 **`__syncthreads()`** ——\n它让整个 block 的线程都停下来等，直到所有人都写完。\n\n**为什么这一关重要**：在这个模拟器里，warp 是按固定顺序跑的，\n所以有竞态的 kernel 会给出一个**稳定的**结果。这次它恰好是错的；\n换一种访问模式，它会**恰好是对的** —— 你跑一万遍都对，然后换到真卡上就炸。\n所以竞态不能靠「结果对不对」来发现，只能靠 racecheck。\n\n**通关标准**\n\n- 转置结果正确\n- `compute-sanitizer --tool racecheck` 报 0 hazards\n- 读写都合并（`sectorsPerRequest ≤ 4.5`）",
+          "en": "Transpose a 32×32 matrix. Reads and writes cannot both be coalesced — reading along rows\nmeans writing along columns. The fix is to stage the tile through **shared memory**\n(a small fast block-local memory) and then read it back transposed, so both sides coalesce.\n\n`transpose.cu` already does that. **It produces the wrong answer**, and it is wrong the\nsame way every single run.\n\n```bash\nnvcc -o bench transpose.cu && ./bench\ncompute-sanitizer --tool racecheck ./bench\n```\n\nracecheck tells you: one thread writes a slot and another reads it with no synchronisation\nin between. You need a **`__syncthreads()`** between `tile[y][x] = ...` and `... = tile[x][y]` —\nit stops every thread in the block until all of them have finished writing.\n\n**Why this stage matters**: warps run in a fixed order in this simulator, so a racy kernel\nproduces a *stable* result. Here it happens to be wrong. With a different access pattern it\nwould happen to be **right** — correct ten thousand times here, broken on a real GPU.\nRaces cannot be found by checking the answer. Only racecheck finds them.\n\n**To pass**\n\n- correct transpose\n- `compute-sanitizer --tool racecheck` reports 0 hazards\n- both sides coalesced (`sectorsPerRequest ≤ 4.5`)"
+        },
+        "checklist": [
+          {
+            "zh": "跑一次 racecheck，看它指到哪两行",
+            "en": "Run racecheck and read which two lines it points at"
+          },
+          {
+            "zh": "在写共享内存和读共享内存之间加 `__syncthreads()`",
+            "en": "Add `__syncthreads()` between the shared-memory write and read"
+          },
+          {
+            "zh": "确认 racecheck 报 0 hazards",
+            "en": "Confirm racecheck reports 0 hazards"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`__syncthreads()` 必须让整个 block 都执行到 —— 不能放在 `if` 里面。",
+            "en": "`__syncthreads()` must be reached by every thread in the block — never put it inside an `if`."
+          },
+          {
+            "zh": "只需要一个屏障，位置在两次共享内存访问之间。",
+            "en": "One barrier is enough, between the two shared-memory accesses."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**把 `__syncthreads()` 放进 `if` 里。** 只有一部分线程到达屏障，真卡上这是未定义行为、通常直接挂死；这里会明确报错。",
+            "en": "**Putting `__syncthreads()` inside an `if`.** Only some threads reach the barrier; on real hardware that is undefined behaviour and usually hangs. Here it is reported as an error."
+          },
+          {
+            "zh": "**靠「多跑几遍看看」找竞态。** 这个模拟器是确定的，跑一万遍是同一个结果。真卡上也未必能重现 —— 竞态最擅长的就是在你观察它的时候表现正常。",
+            "en": "**Re-running to see if a race shows up.** This simulator is deterministic: ten thousand runs, one answer. Real hardware may not reproduce it either — races are best at looking fine while watched."
+          }
+        ],
+        "extension": {
+          "zh": "`compute-sanitizer --tool racecheck` 是真工具，用法和这里一模一样。它的原理是给共享内存的每个字配一份影子，记住最近是谁读的、谁写的、以及中间过了几次屏障；同一个「屏障纪元」里两个不同线程冲突访问同一个字，就是竞态。我们实现的是同一套判据 —— 见 [NVIDIA 的 racecheck 文档](https://docs.nvidia.com/cuda/compute-sanitizer/index.html#racecheck-tool)。",
+          "en": "`compute-sanitizer --tool racecheck` is the real tool and works exactly like this. It shadows every shared-memory word with the last reader, the last writer, and how many barriers have passed; two different threads accessing the same word inside one barrier epoch is a race. We implement the same rule — see [NVIDIA's racecheck documentation](https://docs.nvidia.com/cuda/compute-sanitizer/index.html#racecheck-tool)."
+        },
+        "gpu": {
+          "files": {
+            "/root/transpose.cu": "// 32×32 转置，经共享内存中转，好让读和写都合并。\n//\n// 结果是错的，而且每次错得一模一样 —— 先跑一次\n//   compute-sanitizer --tool racecheck ./bench\n// 看它指到哪两行。\n__global__ void transpose(const float* in, float* out, int n) {\n  __shared__ float tile[32][33];   // 33 不是笔误，第 4 关会讲\n\n  int x = threadIdx.x;\n  int y = threadIdx.y;\n\n  tile[y][x] = in[y * n + x];\n\n  // TODO: 这里少了点什么\n\n  out[y * n + x] = tile[x][y];\n}\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/transpose.cu"
+            ],
+            "buffers": [
+              {
+                "name": "in",
+                "length": 1024,
+                "fill": {
+                  "kind": "iota",
+                  "scale": 1
+                }
+              },
+              {
+                "name": "out",
+                "length": 1024,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": [
+              {
+                "kernel": "transpose",
+                "grid": [
+                  1
+                ],
+                "block": [
+                  32,
+                  32
+                ],
+                "args": [
+                  "in",
+                  "out",
+                  32
+                ]
+              }
+            ]
+          },
+          "referenceFiles": {
+            "/root/transpose.cu": "__global__ void transpose(const float* in, float* out, int n) {\n  __shared__ float tile[32][33];\n\n  int x = threadIdx.x;\n  int y = threadIdx.y;\n\n  tile[y][x] = in[y * n + x];\n\n  // 整个 block 都写完了，才能开始读别人写的格子\n  __syncthreads();\n\n  out[y * n + x] = tile[x][y];\n}\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "transpose.spec.ts",
+            "content": "const lab = require('@gpu/lab');\n\nconst N = 32;\n\ndescribe('转置', () => {\n  it('结果正确', async () => {\n    await lab.buildAndRun();\n    const input = lab.buffer('in');\n    const out = lab.buffer('out');\n    const expected = new Float32Array(N * N);\n    for (let y = 0; y < N; y += 1) {\n      for (let x = 0; x < N; x += 1) expected[y * N + x] = input[x * N + y];\n    }\n    const diff = lab.compare(out, expected);\n    expect(diff.hasNonFinite).toBe(false);\n    expect(diff.maxAbs).toBe(0);\n  });\n\n  it('racecheck 报 0 hazards', async () => {\n    const report = await lab.racecheck();\n    expect(report.races.length).toBe(0);\n  });\n\n  it('确实用了屏障，而不是绕开共享内存', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    expect(metrics.launch.barriers).toBeGreaterThan(0);\n    expect(metrics.shared.storeRequests).toBeGreaterThan(0);\n    expect(metrics.shared.loadRequests).toBeGreaterThan(0);\n  });\n\n  it('读和写都合并', async () => {\n    await lab.buildAndRun();\n    const metrics = lab.metrics();\n    expect(metrics.global.sectorsPerRequest).toBeLessThanOrEqual(4.5);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.launch.barriers",
+            "op": "gte",
+            "value": 1,
+            "label": {
+              "zh": "屏障次数",
+              "en": "barriers"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.global.sectorsPerRequest",
+            "op": "lte",
+            "value": 4.5,
+            "label": {
+              "zh": "每次访存打到的 32B 扇区数",
+              "en": "sectors per request"
+            },
+            "unit": "sector/req",
+            "dimension": "latency"
+          }
+        ],
+        "focus": [
+          "correctness"
+        ],
+        "primer": {
+          "zh": "`共享内存`是每个 block 独有的一小块内存，比显存快一个数量级，用 `__shared__` 声明。它的典型用法是「中转」：先把一块数据按合并的方式读进来，再按任意顺序从共享内存里取用 —— 于是读和写都能保持合并。矩阵转置就是这么解的。\n\n但共享内存是**共用**的，这就带来了竞态。一个线程写 `tile[y][x]`、另一个线程读 `tile[x][y]`，如果中间没有同步，读的人完全可能读到还没被写进去的旧值。`__syncthreads()` 就是那道同步：整个 block 的线程都停在这里，等所有人都到齐了再一起走。\n\n**`__syncthreads()` 必须让整个 block 都执行到。** 把它写进 `if` 里，只有一部分线程到达屏障，真卡上是未定义行为，通常直接挂死。\n\n竞态最麻烦的地方是它**不一定表现出来**。GPU 上 warp 的执行顺序不确定，同一份有竞态的代码可能今天对、明天错，也可能在你的卡上一直对、在别人的卡上一直错。所以不能靠「多跑几遍看看」，要用 `compute-sanitizer --tool racecheck` ——它给共享内存的每个字记住最近谁读谁写、中间过了几次屏障，冲突就报出来。",
+          "en": "`Shared memory` is a small per-block memory an order of magnitude faster than device memory, declared with `__shared__`. Its classic use is staging: read a tile in coalesced, then take values out of shared memory in any order — so both the read and the write stay coalesced. That is how matrix transpose is solved.\n\nBut shared memory is **shared**, which introduces races. If one thread writes `tile[y][x]` and another reads `tile[x][y]` with nothing in between, the reader may well see a value that has not been written yet. `__syncthreads()` is the barrier: every thread in the block waits there until all of them have arrived.\n\n**`__syncthreads()` must be reached by the whole block.** Inside an `if`, only some threads reach it — undefined behaviour on real hardware, usually a hang.\n\nThe hard part about races is that they **need not show up**. Warp scheduling is not deterministic, so the same racy code can be right today and wrong tomorrow, or always right on your GPU and always wrong on someone else's. Re-running proves nothing. Use `compute-sanitizer --tool racecheck`: it shadows every shared-memory word with its last reader, last writer and barrier epoch, and reports the conflicts."
+        }
+      }
+    ]
+  },
+  {
     "id": "message-broker",
     "title": {
       "zh": "高并发消息系统",

--- a/scripts/build-projects.js
+++ b/scripts/build-projects.js
@@ -21,16 +21,17 @@ function fail(message) {
 }
 
 function validate(project, source) {
-  const ops = project.workspace?.kind === 'ops';
-  // ops 形态没有「工作区文件」这个概念：学员编辑的是机器磁盘上的文件，
-  // 由 stage.ops.files 铺下去
+  const kind = project.workspace?.kind;
+  // ops / gpu 形态没有「工作区文件」这个概念：学员编辑的是机器磁盘上的文件，
+  // 由 stage.ops.files / stage.gpu.files 铺下去
+  const machineBased = kind === 'ops' || kind === 'gpu';
   const required = ['id', 'title', 'summary', 'difficulty', 'brief', 'stages']
-    .concat(ops ? [] : ['files']);
+    .concat(machineBased ? [] : ['files']);
   for (const field of required) {
     if (!project[field]) fail(`${source}: 缺少字段 ${field}`);
   }
-  if (ops && !project.workspace.world) {
-    fail(`${source}: ops 形态必须声明 workspace.world`);
+  if (machineBased && !project.workspace.world) {
+    fail(`${source}: ${kind} 形态必须声明 workspace.world`);
   }
   if (!Array.isArray(project.stages) || project.stages.length === 0) {
     fail(`${source}: stages 不能为空`);
@@ -65,8 +66,10 @@ function main() {
     validate(project, name);
 
     // 题目只写一份 TypeScript，JS 版在这里自动派生，避免两份内容漂移。
-    // ops 形态没有「用另一种语言重做一遍」这回事 —— 学员写的是 YAML 和命令。
-    if (project.language !== 'javascript' && project.workspace?.kind !== 'ops') {
+    // ops / gpu 形态没有「用另一种语言重做一遍」这回事 ——
+    // 学员写的是 YAML、命令，或者 CUDA C。
+    const machineBased = project.workspace?.kind === 'ops' || project.workspace?.kind === 'gpu';
+    if (project.language !== 'javascript' && !machineBased) {
       project.variants = { javascript: deriveJavaScriptVariant(project) };
     }
 

--- a/scripts/verify-projects.js
+++ b/scripts/verify-projects.js
@@ -127,6 +127,13 @@ async function main() {
      * 放在 tests/opslab/stages.test.ts 里做（按产物在不在决定跑不跑）。
      * 这里明说一句，免得「跳过」被读成「验过了」。
      */
+    if (rawProject.workspace?.kind === 'gpu') {
+      console.log(
+        `  gpu 形态，共 ${rawProject.stages.length} 关；反向验证见 `
+          + 'tests/gpulab/stages.test.ts（npx jest tests/gpulab/stages）'
+      );
+      continue;
+    }
     if (rawProject.workspace?.kind === 'ops') {
       console.log(
         `  ops 形态，共 ${rawProject.stages.length} 关；反向验证见 `

--- a/tests/gpulab/stages.test.ts
+++ b/tests/gpulab/stages.test.ts
@@ -1,0 +1,134 @@
+/**
+ * 关卡的反向验证
+ *
+ * 一关的题面和判定对不对，只有这一条能说了算：
+ *
+ *   用 `gpu.referenceFiles` 里的参考解跑，隐藏用例与门槛必须**全绿**；
+ *   用起始代码跑，必须**挂**。
+ *
+ * 后者同样重要 —— 一个「一进来就通过」的关卡，学员做与不做没有区别。
+ *
+ * 这一套直接读 projects/projects.json，所以题面改了、门槛调了、
+ * 参考解漏了一行，都会在这里立刻暴露。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { buildWorld, runGpuStage } from '../../src/lib/gpulab/lab';
+import { createTranspiler } from '../../src/lib/engineering/transpile';
+import type {
+  EngineeringProject, GpuStageSpec, ProjectStage,
+} from '../../src/lib/engineering/types';
+
+jest.setTimeout(600_000);
+
+const PROJECTS: EngineeringProject[] = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../../projects/projects.json'), 'utf8')
+);
+const GPU_PROJECTS = PROJECTS.filter((project) => project.workspace?.kind === 'gpu');
+
+const transpile = createTranspiler(ts);
+
+/**
+ * 跑一关。
+ *
+ * `solve = true` 时把参考解铺到磁盘上（覆盖起始代码），
+ * 否则就是学员刚进来看到的样子。
+ */
+async function attempt(project: EngineeringProject, stage: ProjectStage, solve: boolean) {
+  const gpu = (stage as ProjectStage & { gpu?: GpuStageSpec }).gpu ?? {};
+  const worldSpec = project.workspace?.kind === 'gpu' ? project.workspace.world : undefined;
+
+  const world = buildWorld({
+    ...(worldSpec ?? {}),
+    ...(gpu.sharedBytesPerBlock ? { sharedBytesPerBlock: gpu.sharedBytesPerBlock } : {}),
+    machine: {
+      ...(worldSpec?.machine ?? {}),
+      files: {
+        ...(worldSpec?.machine?.files ?? {}),
+        ...(gpu.files ?? {}),
+        ...(solve ? gpu.referenceFiles ?? {} : {}),
+      },
+    },
+    bench: gpu.bench ?? worldSpec?.bench,
+  });
+
+  for (const command of gpu.setupCommands ?? []) {
+    await world.run(command);
+  }
+  if (solve) {
+    for (const command of gpu.referenceCommands ?? []) {
+      const result = await world.run(command);
+      if (result.code !== 0) {
+        throw new Error(`参考命令失败：${command}\n${result.stderr || result.stdout}`);
+      }
+    }
+  }
+
+  return runGpuStage({
+    world,
+    specs: stage.specs ?? [],
+    gates: stage.gates ?? [],
+    transpile,
+  });
+}
+
+describe.each(GPU_PROJECTS.map((project) => [project.id, project] as const))(
+  '%s',
+  (_id, project) => {
+    it('每一关都写了参考解与门槛', () => {
+      for (const stage of project.stages) {
+        const gpu = (stage as ProjectStage & { gpu?: GpuStageSpec }).gpu;
+        expect(gpu).toBeDefined();
+        expect(Object.keys(gpu?.referenceFiles ?? {}).length).toBeGreaterThan(0);
+        expect((stage.gates ?? []).length).toBeGreaterThan(0);
+      }
+    });
+
+    describe.each(project.stages.map((stage, index) => [index + 1, stage] as const))(
+      '第 %i 关：%s',
+      (index, stage) => {
+        it('参考解：用例与门槛全绿', async () => {
+          const report = await attempt(project, stage, true);
+
+          const failures = report.cases.filter((item) => !item.passed);
+          const failedGates = report.gates.filter((gate) => !gate.passed);
+
+          // 出错时把原因原样打出来，不然只能看到一个 false
+          const detail = [
+            ...failures.map((item) => `  用例挂了：${item.suite.join(' > ')} ${item.name}\n    ${item.error}`),
+            ...failedGates.map((gate) =>
+              `  门槛挂了：${gate.gate.metric} ${gate.gate.op} ${gate.gate.value}，实际 ${gate.actual}`),
+            report.error ? `  运行时错误：${report.error}` : '',
+          ].filter(Boolean).join('\n');
+
+          expect(detail).toBe('');
+          expect(report.status).toBe('passed');
+        });
+
+        it('起始代码：必须挂', async () => {
+          const report = await attempt(project, stage, false);
+          expect(report.status).not.toBe('passed');
+        });
+
+        it('参考解在门槛上有余量 —— 不是刚好卡在线上', async () => {
+          const report = await attempt(project, stage, true);
+          for (const gate of report.gates) {
+            if (!Number.isFinite(gate.actual)) continue;
+            const { op, value } = gate.gate;
+            // eq 型门槛（竞态、越界）本来就该是 0，不谈余量
+            if (op === 'eq') continue;
+            const margin = op === 'lte' || op === 'lt'
+              ? value === 0 ? 1 : (value - gate.actual) / Math.abs(value)
+              : value === 0 ? 1 : (gate.actual - value) / Math.abs(value);
+            // 参考解应该明显好过门槛，而不是擦边过 ——
+            // 擦边意味着换个写法就会莫名其妙地挂
+            expect({ metric: gate.gate.metric, margin: margin >= -1e-9 }).toEqual({
+              metric: gate.gate.metric, margin: true,
+            });
+          }
+        });
+      }
+    );
+  }
+);


### PR DESCRIPTION
`llm-accelerator` 立项，前三关落地，反向验证跑通。

## 三关

**第 1 关 · 第一个 kernel** —— 线程/块/网格与边界检查。数组长 1000，启动 1024 个线程，多出来的 24 个必须什么都不做。门槛：memcheck 零越界 + 指令数上界（防止有人用一个线程循环把全部算完）。

**第 2 关 · 访存合并** —— 起始代码**结果完全正确**，但 `sectorsPerRequest` 是 32；改对之后是 4，DRAM 字节掉到理论下限。**指令一条没多，搬的字节数差 8 倍**。这一关是整个项目判定方式的样板。

**第 3 关 · 共享内存与竞态** —— 起始代码漏了 `__syncthreads()`，结果是错的，而且每次错得一模一样。题面里专门讲清楚了为什么不能靠「多跑几遍」找竞态：

> 这个模拟器是确定的，有竞态的 kernel 会给出一个**稳定的**结果。这次它恰好是错的；换一种访问模式，它会**恰好是对的** —— 你跑一万遍都对，然后换到真卡上就炸。

## primer

三关的前置讲解按「假设读者会编程但没碰过 GPU」写：两层线程组织与它为什么不是摆设、32 字节扇区与合并规则、共享内存与屏障、以及竞态为什么观察不到。

## 平台侧

`build-projects.js` 与 `verify-projects.js` 认识 `gpu` 形态 —— 和 `ops` 一样没有工作区文件、不派生 JS 版、反向验证放在 tests 里做。

## 反向验证

`tests/gpulab/stages.test.ts` 直接读 `projects.json`，每关三条：

1. **参考解**：用例与门槛全绿（挂了会把具体哪条用例、哪个门槛、实际值多少打出来）
2. **起始代码**：必须挂 —— 一个「一进来就通过」的关卡，学员做与不做没有区别
3. **参考解在门槛上要有余量** —— 防止题目出成擦边过，擦边意味着换个写法就会莫名其妙地挂

10/10 通过。

## 验证

`tsc` 干净 · `npm test` 10/10 · `projects:verify` 全绿 · `npm run build` 过 `check-bundle` 闸门

🤖 Generated with [Claude Code](https://claude.com/claude-code)