### PR TITLE
feat(gpulab): 时序模型（四单元 + roofline）

### DIFF
--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -11,6 +11,7 @@ import { lowerTranslationUnit } from './cuda/lower';
 import { parseCuda, type CudaParserOptions } from './cuda/parser';
 import { flattenMetrics, staticMetricsOf, toMetrics, type GpuMetrics, type StaticMetrics } from './metrics';
 import { H100, computeOccupancy, type DeviceSpec } from './device';
+import { estimateTiming, roofline, type RooflinePoint, type TimingResult } from './timing';
 import { LinearMemory } from './vm/memory';
 import { RaceDetector, formatRaceReports, type SanitizerReport } from './vm/sanitizer';
 import { emptyCounters, launchKernel, type Dim3, type GpuCounters, type LaunchConfig, type KernelArg } from './vm/vm';
@@ -21,6 +22,8 @@ export { KernelError, dim3, launchKernel } from './vm/vm';
 export { LinearMemory, MemoryFault, SECTOR_BYTES, WARP_SIZE } from './vm/memory';
 export { flattenMetrics, staticMetricsOf, toMetrics } from './metrics';
 export { H100, B200, DEVICES, computeOccupancy } from './device';
+export { estimateTiming, roofline, timingFor, H100_TIMING, B200_TIMING } from './timing';
+export type { TimingResult, RooflinePoint, TimingSpec, UnitCycles } from './timing';
 export type { DeviceSpec, Occupancy } from './device';
 export type { StaticMetrics } from './metrics';
 export { RaceDetector, formatRaceReports } from './vm/sanitizer';
@@ -160,6 +163,29 @@ export class GpuDevice {
     });
     this.lastSanitizer = detector.result();
     return this.lastSanitizer;
+  }
+
+  /**
+   * 时序估算。
+   *
+   * **只用于展示与同关相对比较，不作门槛** —— 见 timing.ts 开头的说明。
+   */
+  timing(): TimingResult {
+    return estimateTiming({
+      counters: this.counters,
+      device: this.device,
+      occupancy: this.lastStatic?.occupancy.theoretical ?? 0,
+    });
+  }
+
+  /** roofline 上的那个点 */
+  roofline(): RooflinePoint {
+    return roofline({
+      counters: this.counters,
+      device: this.device,
+      occupancy: this.lastStatic?.occupancy.theoretical ?? 0,
+      timing: this.timing(),
+    });
   }
 
   /** 最近一次 launch 的静态指标（寄存器、共享内存、占用率） */

--- a/src/lib/gpulab/ir/program.ts
+++ b/src/lib/gpulab/ir/program.ts
@@ -79,6 +79,17 @@ export const FN = {
   __popc: 16, __clz: 17, __ffs: 18,
 } as const;
 
+/**
+ * 哪些内建函数走 **SFU**（特殊功能单元）。
+ *
+ * 用查表而不是判断 FN 的区间：区间判断依赖枚举顺序，将来往中间插一个
+ * 函数就会静默算错，而这个数直接决定 softmax 那几关的瓶颈在哪。
+ */
+export const SFU_FNS = new Uint8Array(32);
+for (const fn of ['sqrtf', 'rsqrtf', 'expf', 'logf', 'tanhf', 'powf', '__expf', '__logf', '__fdividef'] as const) {
+  SFU_FNS[FN[fn]] = 1;
+}
+
 export const SREG = {
   'tid.x': 0, 'tid.y': 1, 'tid.z': 2,
   'ctaid.x': 3, 'ctaid.y': 4, 'ctaid.z': 5,

--- a/src/lib/gpulab/lab/modules.ts
+++ b/src/lib/gpulab/lab/modules.ts
@@ -10,6 +10,7 @@
  *  3. **过程指标** —— `metrics()`，也就是门槛读的那棵树。
  */
 import type { GpuMetrics, StaticMetrics } from '../metrics';
+import type { RooflinePoint, TimingResult } from '../timing';
 import type { SanitizerReport } from '../vm/sanitizer';
 import type { CommandRecord } from '../../labkit/machine';
 import { ulpDistanceOf } from './numeric';
@@ -55,6 +56,13 @@ export interface GpuLabApi {
   metrics(): GpuMetrics;
   /** 寄存器 / 共享内存 / 占用率 */
   staticMetrics(): StaticMetrics | null;
+  /**
+   * 时序估算。**只能用来做同关的相对比较**，不要写成绝对阈值的断言 ——
+   * 这个模型没有真卡可校准，绝对值不可迁移。
+   */
+  timing(): TimingResult;
+  /** roofline 上的那个点 */
+  roofline(): RooflinePoint;
 
   /** 把一个缓冲区读回来 */
   buffer(name: string): Float32Array;
@@ -116,6 +124,8 @@ export function createGpuLabApi(world: GpuWorld): GpuLabApi {
 
     metrics: () => world.gpu.metrics(),
     staticMetrics: () => world.gpu.staticMetrics(),
+    timing: () => world.gpu.timing(),
+    roofline: () => world.gpu.roofline(),
 
     buffer(name) {
       const buffer = world.buffers.get(name);

--- a/src/lib/gpulab/lab/runner.ts
+++ b/src/lib/gpulab/lab/runner.ts
@@ -41,6 +41,8 @@ export function gpuMetricTree(world: GpuWorld): Record<string, unknown> {
   const metrics = world.gpu.metrics();
   const stat = world.gpu.staticMetrics();
   const sanitizer = world.gpu.sanitizerReport();
+  const timing = world.gpu.timing();
+  const line = world.gpu.roofline();
 
   return {
     ...metrics,
@@ -57,6 +59,24 @@ export function gpuMetricTree(world: GpuWorld): Record<string, unknown> {
     },
     /** 显存峰值 —— FlashAttention、KV cache 那几关的门槛读它 */
     memoryPeakBytes: world.gpu.usedBytes,
+    /**
+     * 时序估算与 roofline。
+     *
+     * **放进来是给用例读的，不是给门槛读的。** 关卡可以用它做同关的相对
+     * 比较（「比上一版快 3 倍」），但绝不能写成绝对阈值的门槛 ——
+     * 这是 design/gpulab.md 立的硬规矩，理由见 timing.ts 开头。
+     */
+    timing: {
+      cycles: timing.cycles,
+      nanoseconds: timing.nanoseconds,
+      latencyHiding: timing.latencyHiding,
+      units: timing.units,
+    },
+    roofline: {
+      arithmeticIntensity: line.arithmeticIntensity,
+      efficiency: line.efficiency,
+      ridgePoint: line.ridgePoint,
+    },
   };
 }
 

--- a/src/lib/gpulab/metrics.ts
+++ b/src/lib/gpulab/metrics.ts
@@ -89,6 +89,10 @@ export interface GpuMetrics {
     laneExecuted: number;
     fma: number;
     ldst: number;
+    /** 走 SFU 的指令（exp / log / rsqrt…），吞吐只有 FMA 的 1/8 */
+    sfu: number;
+    /** tensor core 乘加 */
+    mma: number;
   };
   launch: {
     blocks: number;
@@ -136,6 +140,8 @@ export function toMetrics(counters: GpuCounters): GpuMetrics {
       laneExecuted: counters.laneInsts,
       fma: counters.instFma,
       ldst: counters.instLdSt,
+      sfu: counters.instSfu,
+      mma: counters.instMma,
     },
     launch: {
       blocks: counters.blocksLaunched,

--- a/src/lib/gpulab/timing.ts
+++ b/src/lib/gpulab/timing.ts
@@ -1,0 +1,256 @@
+/**
+ * 时序模型
+ *
+ * ## 这个模型是干什么用的，以及**不是**干什么用的
+ *
+ * design/gpulab.md 立的硬规矩：**所有门槛只建立在结构性计量上，
+ * 绝不建立在模拟耗时的绝对值上。** 这个文件算出来的周期数只做两件事：
+ *
+ *   1. **展示** —— roofline 的纵坐标、剖析面板上那个「大概多久」；
+ *   2. **同一关内的相对比较** —— 「比上一版快了几倍」。
+ *
+ * 它不是周期精确的硬件模型，也没打算是。没有真卡可校准，编一个看起来
+ * 很精确的数字只会让 roofline 上的每条结论都不可信。
+ *
+ * ## 用的是什么模型
+ *
+ * 经典的 **interval / roofline 模型**：把一次 kernel 的工作按功能单元拆开，
+ * 各算各的时间，能并行的取最大值，不能并行的相加。
+ *
+ *   计算侧 = max(ALU, FMA, SFU, TensorCore)   四个是独立单元，可以同时忙
+ *   访存侧 = max(LSU, 共享内存, DRAM)
+ *   总时间 = max(计算侧, 访存侧) × 延迟惩罚(占用率)
+ *
+ * **把四个计算单元分开是这个文件存在的主要理由。** 少了它，
+ * 「tensor core 快到让 SFU 成为瓶颈」这件事就演不出来 —— 而那正是
+ * FlashAttention-4 要在两个 tile 之间 ping-pong 的原因
+ * （PyTorch 官方博客的原话：tensor core 变快了，SFU 没跟上）。
+ *
+ * ## 参数从哪来
+ *
+ * 每 SM 每周期的吞吐来自公开的架构白皮书与编程指南。它们是**参数化**的，
+ * 将来如果能借到一张真卡跑一轮校准（见 design/gpulab.md 拍板记录第 7 条），
+ * 改的就是下面这张表，模型结构不用动。
+ */
+import type { DeviceSpec } from './device';
+import type { GpuCounters } from './vm/vm';
+
+/** 一个 SM 每周期能干多少活 */
+export interface SmThroughput {
+  /** fp32 融合乘加，每周期多少个 lane */
+  fma: number;
+  /** 整数与其它简单运算 */
+  alu: number;
+  /**
+   * 特殊功能单元：exp / log / rsqrt / sin。
+   *
+   * **它比 FMA 少一个数量级**，这不是笔误。softmax 里那个 `expf` 之所以
+   * 能成为瓶颈，就是因为这个比例。
+   */
+  sfu: number;
+  /** 访存单元：每周期能处理几条 warp 级访存请求 */
+  lsu: number;
+  /** 共享内存：每周期几条无冲突的 warp 请求 */
+  shared: number;
+  /** tensor core：每周期多少次 fp16 乘加 */
+  tensor: number;
+}
+
+export interface TimingSpec {
+  /** SM 频率，Hz */
+  clock: number;
+  throughput: SmThroughput;
+  /** DRAM 每周期能搬多少字节（由带宽与频率算出来） */
+  dramBytesPerCycle: number;
+}
+
+/**
+ * H100 SXM 的吞吐。
+ *
+ * FMA / ALU：每 SM 128 个 fp32 lane（4 个分区 × 32）。
+ * SFU：每 SM 16 个（每分区 4 个）。**是 FMA 的 1/8。**
+ * LSU / 共享内存：每分区每周期一条 warp 请求，合起来 4。
+ * Tensor core：第四代，每 SM 每周期 1024 次 fp16 乘加。
+ * 频率取 boost 的 1.755 GHz；DRAM 3.35 TB/s 换算过来约 1900 字节/周期。
+ */
+export const H100_TIMING: TimingSpec = {
+  clock: 1.755e9,
+  throughput: { fma: 128, alu: 128, sfu: 16, lsu: 4, shared: 4, tensor: 1024 },
+  dramBytesPerCycle: 3.35e12 / 1.755e9,
+};
+
+/**
+ * B200 的吞吐 —— **只有 tensor core 与带宽变了，SFU 没动。**
+ *
+ * 这正是第 16 关要学员亲眼看到的事：同一份 FlashAttention 换到这组参数上，
+ * 瓶颈会从访存挪到 SFU，因为 tensor core 快了一大截而 `expf` 还是那么快。
+ */
+export const B200_TIMING: TimingSpec = {
+  clock: 1.965e9,
+  throughput: { fma: 128, alu: 128, sfu: 16, lsu: 4, shared: 4, tensor: 4096 },
+  dramBytesPerCycle: 8.0e12 / 1.965e9,
+};
+
+export function timingFor(device: DeviceSpec): TimingSpec {
+  return device.computeCapability >= 100 ? B200_TIMING : H100_TIMING;
+}
+
+/** 各单元各自要多少周期 —— 剖析面板会把这张表画成柱状图 */
+export interface UnitCycles {
+  alu: number;
+  fma: number;
+  sfu: number;
+  tensor: number;
+  lsu: number;
+  shared: number;
+  dram: number;
+}
+
+export interface TimingResult {
+  /** 估算的总周期数 */
+  cycles: number;
+  /** 换算成纳秒 */
+  nanoseconds: number;
+  units: UnitCycles;
+  /**
+   * 谁是瓶颈。
+   *
+   * 和 `ncu` 的 Speed Of Light 一节一个意思：先看清是算力还是带宽卡住，
+   * 再决定往哪个方向优化。
+   */
+  bottleneck: keyof UnitCycles;
+  /**
+   * 延迟隐藏得怎么样，0~1。
+   *
+   * 占用率低时访存延迟盖不住，总时间要按这个系数放大。
+   */
+  latencyHiding: number;
+}
+
+export interface TimingInput {
+  counters: GpuCounters;
+  device: DeviceSpec;
+  /** 理论占用率，0~1 */
+  occupancy: number;
+}
+
+/**
+ * 占用率不够时，访存延迟盖不住多少。
+ *
+ * 真硬件上一次 DRAM 访问要几百个周期，靠切换到别的 warp 来盖。
+ * 驻留的 warp 越少能盖住的越少。这里用一条简单的饱和曲线：
+ * 占用率 50% 以上基本盖得住，低于 25% 开始明显吃亏。
+ *
+ * 这是**模型里最粗的一处**，也是最需要真卡校准的一处。
+ */
+function latencyHidingOf(occupancy: number): number {
+  if (occupancy <= 0) return 0.1;
+  return Math.min(1, 0.15 + 1.7 * occupancy);
+}
+
+export function estimateTiming(input: TimingInput): TimingResult {
+  const { counters, device, occupancy } = input;
+  const spec = timingFor(device);
+  const sms = device.smCount;
+  const { throughput } = spec;
+
+  // 指令按功能单元分派。ALU 是「剩下的那些」：总 lane 指令减掉已经归到别处的，
+  // 再减掉**记账指令**。
+  //
+  // 减记账指令这一步是必须的：我们的 IR 故意不做优化，于是每个表达式都会
+  // 产生一堆 const 与 mov，而真编译器把它们折叠进操作数、硬件上并不存在。
+  // 不扣掉的话，任何 kernel 算出来都是「ALU 卡住」，瓶颈归因彻底失效。
+  //
+  // 这里**没有**扣掉循环计数与分支的开销，那些指令在硬件上是真的存在，
+  // 只是真 nvcc 会展开定长循环把它们摊薄。所以一个循环体里只有一次运算的
+  // kernel，在这个模型里会显示成受循环开销限制 —— 那其实是实话。
+  const accounted = counters.instFma + counters.instLdSt + counters.instSfu
+    + counters.instMma + counters.instBookkeeping;
+  const instAlu = Math.max(0, counters.laneInsts - accounted);
+
+  const perSm = (work: number, rate: number) => (rate > 0 ? work / (rate * sms) : 0);
+
+  const units: UnitCycles = {
+    alu: perSm(instAlu, throughput.alu),
+    fma: perSm(counters.instFma, throughput.fma),
+    sfu: perSm(counters.instSfu, throughput.sfu),
+    tensor: perSm(counters.instMma, throughput.tensor),
+    lsu: perSm(
+      counters.globalLoadRequests + counters.globalStoreRequests,
+      throughput.lsu
+    ),
+    // bank 冲突就是串行化：n 路冲突等于这条请求要发 n+1 次
+    shared: perSm(
+      counters.sharedLoadRequests + counters.sharedStoreRequests + counters.sharedBankConflicts,
+      throughput.shared
+    ),
+    dram: spec.dramBytesPerCycle > 0
+      ? (counters.globalLoadSectors + counters.globalStoreSectors) * 32 / spec.dramBytesPerCycle
+      : 0,
+  };
+
+  // 计算侧的四个单元是独立的，可以同时忙；访存侧同理
+  const compute = Math.max(units.alu, units.fma, units.sfu, units.tensor);
+  const memory = Math.max(units.lsu, units.shared, units.dram);
+  const latencyHiding = latencyHidingOf(occupancy);
+
+  const cycles = Math.max(compute, memory) / latencyHiding;
+
+  let bottleneck: keyof UnitCycles = 'alu';
+  let worst = -1;
+  for (const [name, value] of Object.entries(units) as Array<[keyof UnitCycles, number]>) {
+    if (value > worst) { worst = value; bottleneck = name; }
+  }
+
+  return {
+    cycles,
+    nanoseconds: (cycles / spec.clock) * 1e9,
+    units,
+    bottleneck,
+    latencyHiding,
+  };
+}
+
+/**
+ * roofline 上的一个点。
+ *
+ * 横坐标是算术强度（每从 DRAM 搬一个字节做多少次浮点运算），
+ * 纵坐标是达到的算力。屋顶由两段组成：带宽限制的斜坡与算力限制的平台。
+ */
+export interface RooflinePoint {
+  arithmeticIntensity: number;
+  /** 达到的 FLOP/s */
+  achieved: number;
+  /** 这个算术强度下的理论上限 */
+  ceiling: number;
+  /** 距离屋顶还有多远，0~1 */
+  efficiency: number;
+  /** 拐点：算术强度到这里之后就不再受带宽限制 */
+  ridgePoint: number;
+}
+
+export function roofline(input: TimingInput & { timing: TimingResult }): RooflinePoint {
+  const { counters, device, timing } = input;
+  const spec = timingFor(device);
+
+  const bytes = (counters.globalLoadSectors + counters.globalStoreSectors) * 32;
+  // FMA 算两次浮点运算；tensor core 的一次 mma 也是乘加
+  const flops = counters.instFma * 2 + counters.instMma * 2;
+  const intensity = bytes > 0 ? flops / bytes : 0;
+
+  const peakFlops = spec.throughput.fma * 2 * device.smCount * spec.clock;
+  const peakBandwidth = spec.dramBytesPerCycle * spec.clock;
+  const ridgePoint = peakBandwidth > 0 ? peakFlops / peakBandwidth : 0;
+
+  const ceiling = Math.min(peakFlops, intensity * peakBandwidth);
+  const seconds = timing.nanoseconds / 1e9;
+  const achieved = seconds > 0 ? flops / seconds : 0;
+
+  return {
+    arithmeticIntensity: intensity,
+    achieved,
+    ceiling,
+    efficiency: ceiling > 0 ? Math.min(1, achieved / ceiling) : 0,
+    ridgePoint,
+  };
+}

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -20,7 +20,7 @@
  *  3. 收尾**不要用闭包**：闭包一旦捕获可变局部，V8 会把它们挪进堆上的
  *     context 对象，每条指令多出好几次堆访问。
  */
-import { encode, type ExecutableKernel, type Program, ATOM, BIN, FN, OP, SHFL, SLOTS, SPACE, SREG, TY, UN } from '../ir/program';
+import { encode, type ExecutableKernel, type Program, ATOM, BIN, FN, OP, SFU_FNS, SHFL, SLOTS, SPACE, SREG, TY, UN } from '../ir/program';
 import type { CompiledKernel } from '../ir/types';
 import {
   addF32, divF32, expF32, fastDivF32, fastExpF32, fastLogF32, floatToInt, floatToUint,
@@ -55,6 +55,23 @@ export interface GpuCounters {
   laneInsts: number;
   instFma: number;
   instLdSt: number;
+  /**
+   * 走特殊功能单元的指令：exp / log / rsqrt / tanh。
+   *
+   * 单独数是因为 **SFU 的吞吐是 FMA 的 1/8**，softmax 里那个 expf
+   * 能不能成为瓶颈全看这个数。
+   */
+  instSfu: number;
+  /** tensor core 的乘加次数 */
+  instMma: number;
+  /**
+   * 记账指令：立即数与寄存器搬运。
+   *
+   * 我们的 IR **故意不做优化**，这样指令数才反映学员写了什么。
+   * 但 const 与 mov 在任何真编译器里都会被折叠进操作数，硬件上并不存在。
+   * 时序模型必须把它们扣掉，否则瓶颈归因会被这些幽灵指令带偏。
+   */
+  instBookkeeping: number;
   globalLoadRequests: number;
   globalStoreRequests: number;
   globalLoadSectors: number;
@@ -89,7 +106,7 @@ export interface GpuCounters {
 
 export function emptyCounters(): GpuCounters {
   return {
-    warpInsts: 0, laneInsts: 0, instFma: 0, instLdSt: 0,
+    warpInsts: 0, laneInsts: 0, instFma: 0, instLdSt: 0, instSfu: 0, instMma: 0, instBookkeeping: 0,
     globalLoadRequests: 0, globalStoreRequests: 0,
     globalLoadSectors: 0, globalStoreSectors: 0,
     sharedLoadRequests: 0, sharedStoreRequests: 0, sharedBankConflicts: 0,
@@ -316,6 +333,8 @@ class Executor {
     let laneInsts = 0;
     let instFma = 0;
     let instLdSt = 0;
+    let instSfu = 0;
+    let instBookkeeping = 0;
     let divergent = 0;
     let atomics = 0;
     let shuffles = 0;
@@ -329,6 +348,7 @@ class Executor {
           warp.done = true;
           counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
           counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.instSfu += instSfu; counters.instBookkeeping += instBookkeeping;
           counters.divergentBranches += divergent;
           counters.atomics += atomics; counters.shuffles += shuffles;
           counters.warpSyncErrors += warpSyncErrors;
@@ -339,6 +359,7 @@ class Executor {
         if (counters.warpInsts + warpInsts > this.maxWarpInsts) {
           counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
           counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.instSfu += instSfu; counters.instBookkeeping += instBookkeeping;
           counters.divergentBranches += divergent;
           counters.atomics += atomics; counters.shuffles += shuffles;
           counters.warpSyncErrors += warpSyncErrors;
@@ -363,6 +384,7 @@ class Executor {
             for (let lane = 0; lane < WARP_SIZE; lane += 1) {
               if (active & (1 << lane)) regs[dst + lane] = value;
             }
+            instBookkeeping += lanes;
             pc += 1;
             break;
           }
@@ -373,6 +395,7 @@ class Executor {
             for (let lane = 0; lane < WARP_SIZE; lane += 1) {
               if (active & (1 << lane)) regs[dst + lane] = regs[src + lane];
             }
+            instBookkeeping += lanes;
             pc += 1;
             break;
           }
@@ -626,6 +649,7 @@ class Executor {
             warp.pc = pc + 1;
             counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
             counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.instSfu += instSfu; counters.instBookkeeping += instBookkeeping;
             counters.divergentBranches += divergent;
           counters.atomics += atomics; counters.shuffles += shuffles;
           counters.warpSyncErrors += warpSyncErrors;
@@ -669,6 +693,8 @@ class Executor {
               regs[dst + lane] = out;
             }
             if (fn === FN.fmaf) instFma += lanes;
+            // 超越函数走 SFU，吞吐只有 FMA 的 1/8
+            else if (SFU_FNS[fn]) instSfu += lanes;
             pc += 1;
             break;
           }
@@ -831,6 +857,7 @@ class Executor {
             warp.done = true;
             counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
             counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.instSfu += instSfu; counters.instBookkeeping += instBookkeeping;
             counters.divergentBranches += divergent;
           counters.atomics += atomics; counters.shuffles += shuffles;
           counters.warpSyncErrors += warpSyncErrors;
@@ -843,6 +870,7 @@ class Executor {
     } catch (error) {
       counters.warpInsts += warpInsts; counters.laneInsts += laneInsts;
       counters.instFma += instFma; counters.instLdSt += instLdSt;
+          counters.instSfu += instSfu; counters.instBookkeeping += instBookkeeping;
       counters.divergentBranches += divergent;
           counters.atomics += atomics; counters.shuffles += shuffles;
           counters.warpSyncErrors += warpSyncErrors;

--- a/tests/gpulab/timing.test.ts
+++ b/tests/gpulab/timing.test.ts
@@ -1,0 +1,208 @@
+/**
+ * 时序模型
+ *
+ * 这个模型**只用于展示与同关相对比较**，绝不作门槛（见 timing.ts 开头）。
+ * 所以这里断言的都是**方向**与**比例关系**，不是绝对数字：
+ * 「访存密集的 kernel 瓶颈在 DRAM」「换到 tensor core 更快的卡上瓶颈会挪位置」。
+ *
+ * 断言绝对周期数就等于把一个没有真卡校准的数字变成了契约，
+ * 那正是设计文档里明令禁止的事。
+ */
+import { B200, GpuDevice, H100, compileSource, dim3 } from '../../src/lib/gpulab';
+
+jest.setTimeout(180_000);
+
+async function compileOne(source: string, name: string) {
+  return (await compileSource(source)).get(name)!;
+}
+
+/** 访存密集：每个元素只做一次乘法 */
+const STREAM = `
+__global__ void stream(const float* in, float* out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] * 2.0f;
+}
+`;
+
+/**
+ * 算力密集：每读一个数做很多次 FMA。
+ *
+ * 循环体里放 8 次 FMA 而不是 1 次 —— 循环体只有一次运算的 kernel
+ * 本来就不是算力受限的，它受限于循环开销，真卡上也一样
+ * （区别只是 nvcc 会展开定长循环，我们的 IR 不展开）。
+ */
+const COMPUTE = `
+__global__ void compute(const float* in, float* out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) {
+    float v = in[i];
+    float a = 0.0f; float b = 0.0f; float c = 0.0f; float d = 0.0f;
+    for (int k = 0; k < 50; ++k) {
+      a = fmaf(v, 1.0009765625f, a);
+      b = fmaf(v, 1.0019531250f, b);
+      c = fmaf(v, 1.0029296875f, c);
+      d = fmaf(v, 1.0039062500f, d);
+      a = fmaf(a, 1.0009765625f, b);
+      b = fmaf(b, 1.0019531250f, c);
+      c = fmaf(c, 1.0029296875f, d);
+      d = fmaf(d, 1.0039062500f, a);
+    }
+    out[i] = a + b + c + d;
+  }
+}
+`;
+
+/** SFU 密集：每读一个数做很多次 expf，同样把循环体写密 */
+const TRANSCENDENTAL = `
+__global__ void trans(const float* in, float* out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) {
+    float v = in[i] * 0.001f;
+    float acc = 0.0f;
+    for (int k = 0; k < 20; ++k) {
+      acc += expf(v);
+      acc += expf(v * 1.03125f);
+      acc += expf(v * 1.06250f);
+      acc += expf(v * 1.09375f);
+      acc += expf(v * 1.12500f);
+      acc += expf(v * 1.15625f);
+      acc += expf(v * 1.18750f);
+      acc += expf(v * 1.21875f);
+    }
+    out[i] = acc;
+  }
+}
+`;
+
+async function run(source: string, name: string, device = H100) {
+  const kernel = await compileOne(source, name);
+  const gpu = new GpuDevice({ globalBytes: 4 * 1024 * 1024, device });
+  const n = 4096;
+  const din = gpu.malloc(n * 4);
+  const dout = gpu.malloc(n * 4);
+  gpu.copyIn(din, Float32Array.from({ length: n }, (_, i) => (i % 13) * 0.5));
+  gpu.launch(kernel, { grid: dim3(n / 128), block: dim3(128) }, [din, dout, n]);
+  return { gpu, timing: gpu.timing(), roof: gpu.roofline(), metrics: gpu.metrics() };
+}
+
+describe('瓶颈判定', () => {
+  it('访存密集的 kernel 卡在访存侧', async () => {
+    const { timing } = await run(STREAM, 'stream');
+    expect(['dram', 'lsu']).toContain(timing.bottleneck);
+  });
+
+  it('算力密集的 kernel 卡在 FMA 上', async () => {
+    const { timing } = await run(COMPUTE, 'compute');
+    expect(timing.bottleneck).toBe('fma');
+  });
+
+  it('**expf 密集的 kernel 卡在 SFU 上，哪怕 FMA 一点不忙**', async () => {
+    const { timing, metrics } = await run(TRANSCENDENTAL, 'trans');
+    expect(metrics.inst.sfu).toBeGreaterThan(0);
+    expect(timing.bottleneck).toBe('sfu');
+    // SFU 的吞吐只有 FMA 的 1/8，所以同样的指令数它要花 8 倍的周期
+    expect(timing.units.sfu).toBeGreaterThan(timing.units.fma);
+  });
+
+  it('四个计算单元是分开算的，不会被混成一坨', async () => {
+    const { timing } = await run(TRANSCENDENTAL, 'trans');
+    expect(timing.units).toEqual(expect.objectContaining({
+      alu: expect.any(Number), fma: expect.any(Number),
+      sfu: expect.any(Number), tensor: expect.any(Number),
+      lsu: expect.any(Number), shared: expect.any(Number), dram: expect.any(Number),
+    }));
+  });
+});
+
+describe('roofline', () => {
+  it('算力密集的算术强度远高于访存密集的', async () => {
+    const stream = await run(STREAM, 'stream');
+    const compute = await run(COMPUTE, 'compute');
+    expect(compute.roof.arithmeticIntensity)
+      .toBeGreaterThan(stream.roof.arithmeticIntensity * 20);
+  });
+
+  it('拐点是「算力峰值 / 带宽峰值」，H100 上是几十 FLOP/byte 量级', async () => {
+    const { roof } = await run(STREAM, 'stream');
+    expect(roof.ridgePoint).toBeGreaterThan(10);
+    expect(roof.ridgePoint).toBeLessThan(500);
+  });
+
+  it('达到的算力不会超过屋顶', async () => {
+    for (const [source, name] of [[STREAM, 'stream'], [COMPUTE, 'compute']] as const) {
+      const { roof } = await run(source, name);
+      expect(roof.efficiency).toBeLessThanOrEqual(1);
+      expect(roof.efficiency).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('占用率影响延迟隐藏', () => {
+  it('占用率越低，延迟隐藏系数越小', async () => {
+    const kernel = await compileOne(`
+      __global__ void hog(const float* in, float* out, int n) {
+        __shared__ float big[12000];
+        int t = threadIdx.x;
+        big[t] = in[t];
+        __syncthreads();
+        out[t] = big[t];
+      }
+    `, 'hog');
+    const light = await run(STREAM, 'stream');
+
+    const gpu = new GpuDevice({
+      globalBytes: 1024 * 1024, device: H100, sharedBytesPerBlock: 96 * 1024,
+    });
+    const din = gpu.malloc(128 * 4);
+    const dout = gpu.malloc(128 * 4);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(128) }, [din, dout, 128]);
+
+    expect(gpu.timing().latencyHiding).toBeLessThan(light.timing.latencyHiding);
+  });
+});
+
+describe('换一组硬件参数，瓶颈会挪位置', () => {
+  /**
+   * design/gpulab.md 拍板记录第 2 条的核心：**一套 ISA，两组硬件参数**。
+   * 学员的 kernel 一个字不用改，换到 B200 上跑，tensor core 快了而 SFU 没动，
+   * 于是瓶颈自己挪。第 16 关讲 FlashAttention-4 的 ping-pong 就靠这个。
+   */
+  it('B200 上 SFU 的相对压力更大 —— 因为它的 tensor core 快了而 SFU 没变', async () => {
+    const hopper = await run(TRANSCENDENTAL, 'trans', H100);
+    const blackwell = await run(TRANSCENDENTAL, 'trans', B200);
+
+    // 同一份代码、同样的指令数
+    expect(blackwell.metrics.inst.sfu).toBe(hopper.metrics.inst.sfu);
+    // 两边都是 SFU 卡住
+    expect(hopper.timing.bottleneck).toBe('sfu');
+    expect(blackwell.timing.bottleneck).toBe('sfu');
+    // B200 的 tensor core 吞吐是 H100 的 4 倍，SFU 一样 ——
+    // 所以真跑起 tensor core 时这个差距会被放大，这一关就是那件事的伏笔
+    expect(B200.name).toContain('B200');
+  });
+
+  it('B200 的带宽更高，访存密集的 kernel 相对更快', async () => {
+    const hopper = await run(STREAM, 'stream', H100);
+    const blackwell = await run(STREAM, 'stream', B200);
+    expect(blackwell.timing.units.dram).toBeLessThan(hopper.timing.units.dram);
+  });
+});
+
+describe('模型的边界（写在用例里，免得被当成精确值用）', () => {
+  it('周期数是估的，但同一份代码跑两遍必须一样', async () => {
+    const a = await run(COMPUTE, 'compute');
+    const b = await run(COMPUTE, 'compute');
+    expect(b.timing.cycles).toBe(a.timing.cycles);
+  });
+
+  it('空 kernel 不会算出负数或 NaN', async () => {
+    const kernel = await compileOne('__global__ void noop(float* out) { }', 'noop');
+    const gpu = new GpuDevice({ globalBytes: 64 * 1024 });
+    const out = gpu.malloc(128);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [out]);
+    const timing = gpu.timing();
+    expect(Number.isFinite(timing.cycles)).toBe(true);
+    expect(timing.cycles).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(gpu.roofline().arithmeticIntensity)).toBe(true);
+  });
+});


### PR DESCRIPTION
拍板记录第 4 条要的那件事：**把 Tensor Core / SFU / LSU / ALU 分成四个独立单元**。少了它，「tensor core 快到让 SFU 成为瓶颈」就演不出来，而那正是 FlashAttention-4 要在两个 tile 之间 ping-pong 的原因。

## 模型

经典的 interval / roofline：按功能单元拆开各算各的时间。

```
计算侧 = max(ALU, FMA, SFU, TensorCore)    四个独立单元，可以同时忙
访存侧 = max(LSU, 共享内存, DRAM)
总时间 = max(计算侧, 访存侧) / 延迟隐藏(占用率)
```

**周期数只用于展示与同关相对比较，绝不作门槛。** 这条硬规矩写在 `timing.ts` 开头、runner 的指标树注释里、`@gpu/lab` 的类型注释里，以及测试文件开头。测试只断言方向与比例（谁是瓶颈、换卡后怎么变），**一条绝对周期数的断言都没有**。

## 实现时撞到的真问题

**任何 kernel 算出来都是「ALU 卡住」。**

原因：我们的 IR 故意不做优化（这样指令数才反映学员写了什么），于是每个表达式都产生一堆 `const` 与 `mov`，而真编译器把它们折叠进操作数、硬件上并不存在。不扣掉的话瓶颈归因彻底失效。

现在单独数这些「记账指令」并从 ALU 里扣掉。

**但没有扣掉循环计数与分支** —— 那些指令在硬件上是真的存在，只是 nvcc 会展开定长循环把它们摊薄。所以：

> 一个循环体里只有一次运算的 kernel，在这个模型里会显示成受循环开销限制。那其实是实话。

我最初的测试 kernel 就是这样（循环体一次 FMA），模型说它不是算力受限的 —— 模型是对的，测试写得不对。改成循环体 8 次 FMA 之后归因就正确了。这个取舍写进了注释。

## 一处防退化的细节

SFU 的分类用**查表**而不是判断 `FN` 的区间。区间判断依赖枚举顺序，将来往中间插一个函数就会静默算错，而这个数直接决定 softmax 那几关的瓶颈在哪。

## 验证

`tsc` 干净 · `npm test` 10/10（gpulab 新增 12 个用例）· `projects:verify` 全绿 · `npm run build` 过 `check-bundle` 闸门

🤖 Generated with [Claude Code](https://claude.com/claude-code)