### PR TITLE
feat(gpulab): fp8 数值语义与转换内建函数

### DIFF
--- a/src/lib/gpulab/host/headers.ts
+++ b/src/lib/gpulab/host/headers.ts
@@ -93,9 +93,43 @@ int cudaDeviceSynchronize(void);
 #endif
 `;
 
+export const CUDA_FP8_H = `/* cuda_fp8.h -- fp8 转换
+ *
+ * 名字、参数、枚举取值都和真 CUDA 一致。
+ *
+ * **一处刻意的偏差**：真 API 的 __nv_cvt_fp8_to_halfraw 返回 __half_raw
+ * （一个结构体，取值要写 .x），这个子集没有 struct，所以直接返回 half。
+ * 语义没有区别，写法上少一次 .x。
+ *
+ * 另外：fp8 在这里没有独立的存储类型。真 CUDA 有 __nv_fp8_storage_t
+ * （一个 unsigned char）与 __nv_fp8x4_e4m3（一个 32 位、装 4 个）。
+ * 这个子集的显存按 4 字节寻址，所以照真实 kernel 的做法来：
+ * 自己把 4 个 8 位存储移位拼进一个 int，读的时候再拆开。
+ * 量化省下来的显存因此是真的省下来了，ncu 上量得出来。
+ */
+#ifndef CUDA_FP8_H
+#define CUDA_FP8_H
+
+/* __nv_saturation_t */
+#define __NV_NOSAT      0
+#define __NV_SATFINITE  1   /* 溢出夹到最大有限值，推理里的默认 */
+
+/* __nv_fp8_interpretation_t */
+#define __NV_E4M3  0   /* 4 位指数 3 位尾数，最大 448，没有 inf。权重与激活用它 */
+#define __NV_E5M2  1   /* 5 位指数 2 位尾数，最大 57344，有 inf。梯度用它 */
+
+/* float -> fp8 的 8 位存储（0..255） */
+int  __nv_cvt_float_to_fp8(float x, int saturate, int interpretation);
+/* fp8 存储 -> half */
+half __nv_cvt_fp8_to_halfraw(int storage, int interpretation);
+
+#endif
+`;
+
 /** 挂进机器磁盘的那几个头文件 */
 export const HOST_HEADERS: Record<string, string> = {
   '/root/containers.h': CONTAINERS_H,
   '/root/engine.h': ENGINE_H,
   '/root/cuda_runtime.h': CUDA_RUNTIME_H,
+  '/root/cuda_fp8.h': CUDA_FP8_H,
 };

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -56,6 +56,10 @@ const BUILTIN_FNS: Record<string, { fn: BuiltinFn; arity: number; ty: IrType }> 
   min: { fn: 'min', arity: 2, ty: 'i32' },
   max: { fn: 'max', arity: 2, ty: 'i32' },
   abs: { fn: 'abs', arity: 1, ty: 'i32' },
+  // fp8 转换。第一个是「float 转 fp8 的 8 位存储」，返回 0..255；
+  // 第二个转回来。参数与真 cuda_fp8.h 一致：(值, 饱和模式, 格式)。
+  __nv_cvt_float_to_fp8: { fn: '__nv_cvt_float_to_fp8', arity: 3, ty: 'i32' },
+  __nv_cvt_fp8_to_halfraw: { fn: '__nv_cvt_fp8_to_halfraw', arity: 2, ty: 'f32' },
   __popc: { fn: '__popc', arity: 1, ty: 'i32' },
   __clz: { fn: '__clz', arity: 1, ty: 'i32' },
   __ffs: { fn: '__ffs', arity: 1, ty: 'i32' },
@@ -227,6 +231,18 @@ const HOST_FNS: Record<string, { fn: HostFn; arity: number; scalar: 'int' | 'voi
   ring_len: { fn: 'ring_len', arity: 1, scalar: 'int' },
 };
 
+/**
+ * 设备侧也认的常量，kernel 与宿主代码都能用。
+ *
+ * 取值与 `cuda_fp8.h` 里那两个枚举一致。
+ */
+const DEVICE_CONSTANTS: Record<string, number> = {
+  __NV_NOSAT: 0,
+  __NV_SATFINITE: 1,
+  __NV_E4M3: 0,
+  __NV_E5M2: 1,
+};
+
 /** `cudaMemcpyKind` 的四个取值，和真头文件里的顺序一致 */
 const HOST_CONSTANTS: Record<string, number> = {
   cudaMemcpyHostToHost: 0,
@@ -310,6 +326,11 @@ class Compiler {
         elementBytes: pointer ? sizeOf((param.type as { to: CudaType }).to) : 4,
       });
     });
+
+    for (const [name, value] of Object.entries(DEVICE_CONSTANTS)) {
+      const reg = this.constant(value, 'i32', this.kernel.span.line);
+      this.bind(name, { where: 'reg', reg, type: { kind: 'scalar', scalar: 'int' } });
+    }
 
     if (this.ctx.host) {
       for (const [name, value] of Object.entries(HOST_CONSTANTS)) {
@@ -1051,7 +1072,18 @@ class Compiler {
     const target: CudaType = spec.ty === 'f32'
       ? { kind: 'scalar', scalar: 'float' }
       : { kind: 'scalar', scalar: 'int' };
-    const args = node.args.map((arg) => this.convert(this.expr(arg), target, node.span.line).reg);
+    // fp8 那两个的参数类型不齐：第一个按各自的类型，后面两个是枚举（int）。
+    // 一律按返回类型转的话，`__nv_cvt_fp8_to_halfraw(storage, __NV_E4M3)`
+    // 会把存储字节转成 float 再传，解码就全错了。
+    const isFp8 = spec.fn === '__nv_cvt_float_to_fp8' || spec.fn === '__nv_cvt_fp8_to_halfraw';
+    const args = node.args.map((arg, index) => {
+      const argTarget: CudaType = isFp8
+        ? (index === 0 && spec.fn === '__nv_cvt_float_to_fp8'
+            ? { kind: 'scalar', scalar: 'float' }
+            : { kind: 'scalar', scalar: 'int' })
+        : target;
+      return this.convert(this.expr(arg), argTarget, node.span.line).reg;
+    });
     const dst = this.alloc();
     this.emit({ op: 'call', dst, fn: spec.fn, args, ty: spec.ty }, node.span.line);
     return { reg: dst, type: target };

--- a/src/lib/gpulab/ir/program.ts
+++ b/src/lib/gpulab/ir/program.ts
@@ -98,6 +98,7 @@ export const FN = {
   __expf: 10, __logf: 11, __fdividef: 12,
   min: 13, max: 14, abs: 15,
   __popc: 16, __clz: 17, __ffs: 18,
+  __nv_cvt_float_to_fp8: 19, __nv_cvt_fp8_to_halfraw: 20,
 } as const;
 
 /**

--- a/src/lib/gpulab/ir/types.ts
+++ b/src/lib/gpulab/ir/types.ts
@@ -40,7 +40,15 @@ export type BuiltinFn =
   | '__expf' | '__logf' | '__fdividef'
   | 'min' | 'max' | 'abs'
   /** 位操作 —— 和 __ballot_sync 配套用，数掩码里有几位、最低位在哪 */
-  | '__popc' | '__clz' | '__ffs';
+  | '__popc' | '__clz' | '__ffs'
+  /**
+   * fp8 转换，名字与参数照抄 `cuda_fp8.h`。
+   *
+   * **一处刻意的偏差**：真 CUDA 的 `__nv_cvt_fp8_to_halfraw` 返回
+   * `__half_raw`（一个结构体），这个子集没有 struct，所以直接返回 half。
+   * 语义没有区别，写法上少一次 `.x`。这条偏差写在 `cuda_fp8.h` 的注释里。
+   */
+  | '__nv_cvt_float_to_fp8' | '__nv_cvt_fp8_to_halfraw';
 
 /**
  * warp 内的数据交换方式。

--- a/src/lib/gpulab/vm/float.ts
+++ b/src/lib/gpulab/vm/float.ts
@@ -290,3 +290,150 @@ export function floatToUint(value: number): number {
   if (Number.isNaN(value) || value < 0) return 0;
   return Math.trunc(value) >>> 0;
 }
+
+/* ------------------------------------------------------------------ */
+/* fp8                                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * fp8 的两种格式。
+ *
+ * 这两个名字与位宽分配来自 OCP 的 FP8 规范，也是 CUDA `cuda_fp8.h` 里
+ * `__nv_fp8_interpretation_t` 的两个取值：
+ *
+ *   E4M3：4 位指数 3 位尾数，最大 448，最小正规数 2^-6。**没有 inf**，
+ *         0x7F / 0xFF 是 NaN。推理里权重与激活用它 —— 尾数多一位，
+ *         而推理的动态范围本来就该靠 scale 压住。
+ *   E5M2：5 位指数 2 位尾数，最大 57344，有 inf 也有 NaN，
+ *         和 IEEE 的规矩一致。动态范围大但精度差，训练里的梯度用它。
+ *
+ * **注意 E4M3 的动态范围有多窄**：从 2^-9（最小次正规数）到 448，
+ * 也就是不到 19 个二进制数量级。fp32 是 277 个。
+ * 所有量化工程的难处都从这一行开始。
+ */
+export interface Fp8Format {
+  /** 尾数位数 */
+  mantissaBits: number;
+  /** 最小正规数的指数 */
+  minNormalExp: number;
+  /** 能表示的最大有限值 */
+  maxFinite: number;
+  /** 有没有 inf（E4M3 没有） */
+  hasInfinity: boolean;
+}
+
+export const FP8_E4M3: Fp8Format = {
+  mantissaBits: 3, minNormalExp: -6, maxFinite: 448, hasInfinity: false,
+};
+
+export const FP8_E5M2: Fp8Format = {
+  mantissaBits: 2, minNormalExp: -14, maxFinite: 57344, hasInfinity: true,
+};
+
+/**
+ * 舍到某个 fp8 格式能表示的最近的值。
+ *
+ * 舍入规则和 fp16 那条一样是就近取偶 —— 理由也一样：
+ * 我们对外承诺重放逐位一致。
+ */
+/**
+ * 舍到某个 fp8 格式能表示的最近的值。
+ *
+ * `saturate` 对应真 API 的 `__nv_saturation_t`：
+ *
+ *   SATFINITE（推理里的默认）：超出范围的夹到最大有限值。
+ *     **这是有意的** —— 一个溢出的激活值变成 inf，会顺着 softmax
+ *     传染成一整行 NaN，而夹住只是这一个数不准。
+ *   NOSAT：按 IEEE 的规矩来，E5M2 溢出成 inf，E4M3 没有 inf 所以是 NaN。
+ *
+ * 舍入规则和 fp16 那条一样是就近取偶 —— 理由也一样：
+ * 我们对外承诺重放逐位一致。
+ */
+export function toFp8(value: number, format: Fp8Format, saturate = true): number {
+  if (Number.isNaN(value)) return NaN;
+  if (value === 0) return value;
+
+  const sign = value < 0 ? -1 : 1;
+
+  // 非有限的输入要先处理掉：往下走的话 `Math.log2(Infinity)` 会让
+  // step 也变成 Infinity，`Infinity / Infinity` 就是 NaN，
+  // 于是一个 inf 悄悄变成 NaN
+  if (!Number.isFinite(value)) {
+    if (!saturate) return format.hasInfinity ? sign * Infinity : NaN;
+    return sign * format.maxFinite;
+  }
+
+  const abs = Math.abs(value);
+
+  // 次正规数的步长固定在 2^(minNormalExp - mantissaBits)
+  const subnormalStep = Math.pow(2, format.minNormalExp - format.mantissaBits);
+  if (abs < subnormalStep / 2) return sign * 0;
+
+  const minNormal = Math.pow(2, format.minNormalExp);
+  const step = abs < minNormal
+    ? subnormalStep
+    : Math.pow(2, Math.floor(Math.log2(abs)) - format.mantissaBits);
+
+  const rounded = f32(sign * roundHalfToEven(abs / step) * step);
+  if (Math.abs(rounded) > format.maxFinite) {
+    if (saturate) return sign * format.maxFinite;
+    return format.hasInfinity ? sign * Infinity : NaN;
+  }
+  return rounded;
+}
+
+/**
+ * 编码成 8 位存储（0..255），和 CUDA 的 `__nv_fp8_storage_t` 一个意思。
+ *
+ * 真实的 kernel 就是这么用的：一次拿一个 32 位字，里面装 4 个 fp8
+ * （`__nv_fp8x4_e4m3` 就是这么定义的）。这个工作台的显存按 4 字节寻址，
+ * 所以「4 个打包进一个 int」不是变通，是照着真实做法来的 ——
+ * 也只有这样，量化省下来的显存才真的量得出来。
+ */
+export function fp8ToStorage(value: number, format: Fp8Format, saturate = true): number {
+  const quantized = toFp8(value, format, saturate);
+  if (Number.isNaN(quantized)) return format === FP8_E4M3 ? 0x7f : 0x7e;
+
+  const sign = quantized < 0 || Object.is(quantized, -0) ? 1 : 0;
+  const abs = Math.abs(quantized);
+  const bias = format === FP8_E4M3 ? 7 : 15;
+  const expBits = format === FP8_E4M3 ? 4 : 5;
+  const mantBits = format.mantissaBits;
+
+  if (abs === 0) return sign << 7;
+
+  const minNormal = Math.pow(2, format.minNormalExp);
+  if (abs < minNormal) {
+    const step = Math.pow(2, format.minNormalExp - mantBits);
+    return (sign << 7) | Math.round(abs / step);
+  }
+  if (!Number.isFinite(abs)) return (sign << 7) | (((1 << expBits) - 1) << mantBits);
+
+  const exponent = Math.floor(Math.log2(abs));
+  const mantissa = Math.round((abs / Math.pow(2, exponent) - 1) * Math.pow(2, mantBits));
+  return (sign << 7) | ((exponent + bias) << mantBits) | mantissa;
+}
+
+/** 从 8 位存储解回来 */
+export function storageToFp8(storage: number, format: Fp8Format): number {
+  const bits = storage & 0xff;
+  const sign = bits & 0x80 ? -1 : 1;
+  const expBits = format === FP8_E4M3 ? 4 : 5;
+  const mantBits = format.mantissaBits;
+  const bias = format === FP8_E4M3 ? 7 : 15;
+  const expField = (bits >> mantBits) & ((1 << expBits) - 1);
+  const mantissa = bits & ((1 << mantBits) - 1);
+
+  if (expField === (1 << expBits) - 1) {
+    if (format === FP8_E4M3) {
+      // E4M3 没有 inf：全 1 指数配全 1 尾数是 NaN，别的还是正常的数
+      if (mantissa === (1 << mantBits) - 1) return NaN;
+      return f32(sign * Math.pow(2, expField - bias) * (1 + mantissa / Math.pow(2, mantBits)));
+    }
+    return mantissa === 0 ? sign * Infinity : NaN;
+  }
+  if (expField === 0) {
+    return f32(sign * mantissa * Math.pow(2, format.minNormalExp - mantBits));
+  }
+  return f32(sign * Math.pow(2, expField - bias) * (1 + mantissa / Math.pow(2, mantBits)));
+}

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -25,6 +25,7 @@ import type { CompiledKernel } from '../ir/types';
 import {
   addF32, divF32, expF32, fastDivF32, fastExpF32, fastLogF32, floatToInt, floatToUint,
   fmaF32, logF32, maxF32, minF32, mulF32, powF32, rsqrtF32, sqrtF32, subF32, tanhF32, toHalf,
+  FP8_E4M3, FP8_E5M2, fp8ToStorage, storageToFp8,
 } from './float';
 import {
   LinearMemory, MemoryFault, SECTOR_BYTES, WARP_SIZE,
@@ -744,6 +745,17 @@ class Executor {
                 case FN.abs: out = Math.abs(x | 0) | 0; break;
                 case FN.__popc: out = popcount(x | 0); break;
                 case FN.__clz: out = (x | 0) === 0 ? 32 : Math.clz32(x >>> 0); break;
+                // fp8：签名是 (值, 饱和模式, 格式)，**格式是第三个参数**。
+                // 读成第二个的话 __NV_SATFINITE（= 1）会被当成 E5M2，
+                // 于是每一次「E4M3 量化」其实都跑成了 E5M2。
+                case FN.__nv_cvt_float_to_fp8:
+                  out = fp8ToStorage(x, z === 1 ? FP8_E5M2 : FP8_E4M3, y === 1);
+                  break;
+                case FN.__nv_cvt_fp8_to_halfraw:
+                  // 真 API 的返回类型就是 half。fp8 的每个值 fp16 都装得下，
+                  // 所以这一道舍入不改值，但类型语义得对。
+                  out = toHalf(storageToFp8(x | 0, y === 1 ? FP8_E5M2 : FP8_E4M3));
+                  break;
                 // __ffs 是 1 起算的最低置位位号，0 表示没有置位
                 default: out = (x | 0) === 0 ? 0 : 32 - Math.clz32(((x | 0) & -(x | 0)) >>> 0); break;
               }

--- a/tests/gpulab/fp8.test.ts
+++ b/tests/gpulab/fp8.test.ts
@@ -1,0 +1,163 @@
+import { GpuDevice, compileSource, dim3 } from '../../src/lib/gpulab';
+import { FP8_E4M3, FP8_E5M2, fp8ToStorage, storageToFp8, toFp8 } from '../../src/lib/gpulab/vm/float';
+jest.setTimeout(180_000);
+
+describe('fp8 的数值语义', () => {
+  it('E4M3 的边界：最大 448，最小次正规数 2^-9，没有 inf', () => {
+    expect(toFp8(448, FP8_E4M3)).toBe(448);
+    // SATFINITE：超出范围夹到最大有限值，不产生 inf
+    expect(toFp8(1e6, FP8_E4M3)).toBe(448);
+    expect(toFp8(-1e6, FP8_E4M3)).toBe(-448);
+    expect(toFp8(Math.pow(2, -9), FP8_E4M3)).toBe(Math.pow(2, -9));
+    expect(toFp8(Math.pow(2, -12), FP8_E4M3)).toBe(0);
+  });
+
+  it('E5M2 的范围更大但精度更差', () => {
+    expect(toFp8(57344, FP8_E5M2)).toBe(57344);
+    // 3 位尾数 vs 2 位尾数：1.1 在两个格式里落到不同的格点
+    expect(toFp8(1.1, FP8_E4M3)).toBeCloseTo(1.125, 6);
+    expect(toFp8(1.1, FP8_E5M2)).toBeCloseTo(1.0, 6);
+  });
+
+  it('**E4M3 的动态范围只有 19 个二进制数量级**', () => {
+    const decades = Math.log2(448 / Math.pow(2, -9));
+    expect(decades).toBeLessThan(19);
+    // fp32 是 277 个 —— 所有量化工程的难处都从这个比值开始
+    expect(Math.log2(3.4e38 / 1.4e-45)).toBeGreaterThan(270);
+  });
+
+  it('编码解码来回一趟不丢东西', () => {
+    for (const format of [FP8_E4M3, FP8_E5M2]) {
+      for (let bits = 0; bits < 256; bits += 1) {
+        const value = storageToFp8(bits, format);
+        // NaN 与 inf 不参与：SATFINITE 下 inf 会被夹成最大有限值，
+        // 所以它本来就不是一个能来回的值
+        if (!Number.isFinite(value)) continue;
+        expect(fp8ToStorage(value, format)).toBe(bits === 0x80 ? 0x80 : bits);
+      }
+    }
+  });
+
+  it('饱和模式是真的在起作用，不是收下就扔', () => {
+    // SATFINITE：溢出夹到最大有限值。推理里就要这个 ——
+    // 一个 inf 会顺着 softmax 传染成一整行 NaN
+    expect(toFp8(1e9, FP8_E5M2, true)).toBe(57344);
+    // NOSAT：按 IEEE 来，E5M2 有 inf
+    expect(toFp8(1e9, FP8_E5M2, false)).toBe(Infinity);
+    // E4M3 没有 inf，NOSAT 溢出只能是 NaN
+    expect(Number.isNaN(toFp8(1e9, FP8_E4M3, false))).toBe(true);
+    expect(toFp8(1e9, FP8_E4M3, true)).toBe(448);
+  });
+
+  it('±inf 进来不会悄悄变成 NaN', () => {
+    expect(toFp8(Infinity, FP8_E5M2, false)).toBe(Infinity);
+    expect(toFp8(-Infinity, FP8_E5M2, false)).toBe(-Infinity);
+    expect(toFp8(Infinity, FP8_E4M3, true)).toBe(448);
+  });
+
+  it('舍入是就近取偶，不是 Math.round', () => {
+    // E4M3 在 1.0 附近步长是 2^-3 = 0.125，1.0625 正好在 1.0 和 1.125 中间
+    expect(toFp8(1.0625, FP8_E4M3)).toBe(1);
+    // 1.1875 在 1.125 和 1.25 中间，取偶数尾数的那个
+    expect(toFp8(1.1875, FP8_E4M3)).toBe(1.25);
+  });
+});
+
+describe('kernel 里的 fp8 内建函数', () => {
+  async function roundTrip(values: number[], interp: string) {
+    const kernel = (await compileSource(`
+      __global__ void quantize(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        if (i >= n) return;
+        int storage = __nv_cvt_float_to_fp8(in[i], __NV_SATFINITE, ${interp});
+        half back = __nv_cvt_fp8_to_halfraw(storage, ${interp});
+        out[i] = (float)back;
+      }
+    `)).get('quantize')!;
+    const gpu = new GpuDevice({ globalBytes: 64 * 1024 });
+    const din = gpu.malloc(values.length * 4);
+    const dout = gpu.malloc(values.length * 4);
+    gpu.copyIn(din, Float32Array.from(values));
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, values.length]);
+    return Array.from(gpu.copyOut(dout, values.length));
+  }
+
+  it('名字与参数照抄 cuda_fp8.h，走一趟回来是量化后的值', async () => {
+    const out = await roundTrip([1.0, 1.1, 2.5, -3.75, 0.001, 1000], '__NV_E4M3');
+    expect(out[0]).toBe(1);
+    expect(out[1]).toBeCloseTo(1.125, 5);
+    expect(out[2]).toBe(2.5);
+    expect(out[3]).toBe(-3.75);
+    // 1000 超出 E4M3 的范围，夹到 448
+    expect(out[5]).toBe(448);
+  });
+
+  it('两种格式在同一个值上给出不同结果', async () => {
+    const e4 = await roundTrip([1.1, 1000], '__NV_E4M3');
+    const e5 = await roundTrip([1.1, 1000], '__NV_E5M2');
+    expect(e4[0]).not.toBe(e5[0]);
+    // E5M2 装得下 1000，E4M3 装不下
+    expect(e5[1]).toBe(1024);
+    expect(e4[1]).toBe(448);
+  });
+
+  it('**打包 4 个 fp8 进一个 int** —— 真 kernel 就是这么省显存的', async () => {
+    const kernel = (await compileSource(`
+      __global__ void pack(const float* in, int* out, int n) {
+        int i = threadIdx.x;
+        if (i * 4 >= n) return;
+        int a = __nv_cvt_float_to_fp8(in[i * 4 + 0], __NV_SATFINITE, __NV_E4M3);
+        int b = __nv_cvt_float_to_fp8(in[i * 4 + 1], __NV_SATFINITE, __NV_E4M3);
+        int c = __nv_cvt_float_to_fp8(in[i * 4 + 2], __NV_SATFINITE, __NV_E4M3);
+        int d = __nv_cvt_float_to_fp8(in[i * 4 + 3], __NV_SATFINITE, __NV_E4M3);
+        out[i] = a | (b << 8) | (c << 16) | (d << 24);
+      }
+    `)).get('pack')!;
+    const gpu = new GpuDevice({ globalBytes: 64 * 1024 });
+    const values = [1.0, 2.0, -1.0, 0.5];
+    const din = gpu.malloc(16);
+    const dout = gpu.malloc(4);
+    gpu.copyIn(din, Float32Array.from(values));
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, 4]);
+    const packed = gpu.copyOutInts(dout, 1)[0];
+    for (let i = 0; i < 4; i += 1) {
+      const byte = (packed >> (i * 8)) & 0xff;
+      expect(storageToFp8(byte, FP8_E4M3)).toBe(values[i]);
+    }
+  });
+
+  it('**per-tensor 的 scale 在有离群值时会把正常值直接压成 0**', () => {
+    // 真实的激活值就长这样：绝大多数在 0.01 量级，个别通道能到上万。
+    // 论文里管这叫 outlier channel，也是 SmoothQuant / AWQ 那一串工作的起点。
+    const values = [0.01, 0.02, 0.03, 0.04, 20000];
+
+    // per-tensor：一个 scale 管全部。离群值把 scale 拉到 448/20000，
+    // 于是 0.01 缩到 0.000224 —— 比 E4M3 的最小次正规数（2^-9）还小
+    const tensorScale = 448 / 20000;
+    const perTensor = values.map((v) => toFp8(v * tensorScale, FP8_E4M3) / tensorScale);
+    expect(perTensor.slice(0, 4).every((q) => q === 0)).toBe(true);
+
+    // per-block：离群值单独一组，正常值那一组按自己的最大值定 scale
+    const blockScale = 448 / 0.04;
+    const perBlock = values.slice(0, 4).map((v) => toFp8(v * blockScale, FP8_E4M3) / blockScale);
+    const errors = perBlock.map((q, i) => Math.abs(q - values[i]) / values[i]);
+    // 3 位尾数在一个 binade 里的分辨率大约是 6%，所以误差在这个量级 ——
+    // 但至少值还在，而不是变成 0
+    expect(Math.max(...errors)).toBeLessThan(0.07);
+    expect(perBlock.every((q) => q > 0)).toBe(true);
+  });
+
+  it('scale 的粒度决定一切，而不是格式本身', () => {
+    // 同一批数、同一个 fp8 格式，只改 scale 的分组方式，结果天差地别。
+    // 这就是第 19 关的全部内容。
+    const values = [0.01, 0.02, 0.03, 0.04, 20000];
+    const relative = (scale: number, slice: number[]) =>
+      slice.map((v) => Math.abs(toFp8(v * scale, FP8_E4M3) / scale - v) / v);
+
+    const tensorErrors = relative(448 / 20000, values.slice(0, 4));
+    const blockErrors = relative(448 / 0.04, values.slice(0, 4));
+    // per-tensor 的相对误差是 100%（值没了），per-block 是个位数百分比
+    expect(Math.min(...tensorErrors)).toBe(1);
+    expect(Math.max(...blockErrors)).toBeLessThan(0.07);
+  });
+});

--- a/tests/gpulab/host.test.ts
+++ b/tests/gpulab/host.test.ts
@@ -7,7 +7,7 @@
  * （不支持的东西必须报错，不能悄悄跑错）。
  */
 import {
-  CONTAINERS_H, CUDA_RUNTIME_H, ENGINE_H,
+  CONTAINERS_H, CUDA_FP8_H, CUDA_RUNTIME_H, ENGINE_H,
 } from '../../src/lib/gpulab/host/headers';
 import { GpuDevice, compileProgram, formatPrintf } from '../../src/lib/gpulab';
 
@@ -471,8 +471,8 @@ describe('头文件与编译器的签名是对得上的', () => {
    * 头文件是学员唯一的参考。它写了什么函数，编译器就必须认什么函数 ——
    * 两边分家的话，学员照着头文件写会撞上「暂不支持」，而那是平台的错。
    */
-  const declared = [...`${CONTAINERS_H}\n${ENGINE_H}\n${CUDA_RUNTIME_H}`.matchAll(
-    /^\s*(?:int|void|float\*)\s+(\w+)\s*\(/gm
+  const declared = [...`${CONTAINERS_H}\n${ENGINE_H}\n${CUDA_RUNTIME_H}\n${CUDA_FP8_H}`.matchAll(
+    /^\s*(?:int|void|float\*|half)\s+(\w+)\s*\(/gm
   )].map((match) => match[1]);
 
   it.each(declared)('头文件里的 %s 编译器认得', async (name) => {


### PR DESCRIPTION
第 19 关（量化）的前置。

## 格式
E4M3（最大 448、最小次正规数 2^-9、**没有 inf**）与 E5M2（最大 57344、有 inf），
位宽与边界照 OCP 的 FP8 规范，舍入同 fp16 是就近取偶。

## 接口
名字与参数照抄 `cuda_fp8.h`：`__nv_cvt_float_to_fp8(x, __NV_SATFINITE, __NV_E4M3)`
返回 8 位存储，`__nv_cvt_fp8_to_halfraw(storage, __NV_E4M3)` 转回来。
一处刻意的偏差写在头文件里（真 API 返回 `__half_raw` 结构体，这个子集没有 struct）。

## 存储按真实做法来
fp8 没有独立类型，学员自己把 4 个存储移位拼进一个 int —— 真 kernel 里
`__nv_fp8x4_e4m3` 就是 32 位装 4 个。**这样量化省下的显存才真的量得出来**；
每个 fp8 仍占 4 字节存着的话，这一关根本没有门槛可言。

## 钉住的那条结论
per-tensor 的 scale 碰上大 6 个数量级的离群值时，正常值缩到比 E4M3 的最小
次正规数还小，**直接量化成 0**；换成 per-block，同样的数、同样的格式，
误差回到个位数百分比。

## 三个踩到的坑（都写进注释了）
1. `__nv_cvt_float_to_fp8` 的格式是**第三个**参数。读成第二个的话 `__NV_SATFINITE`（=1）被当成 E5M2 —— 每次「E4M3 量化」其实跑的是 E5M2，而结果看起来完全正常。
2. `toFp8(±inf)` 算出 NaN：`Math.log2(Infinity)` 让步长也是 Infinity，相除得 NaN。
3. **饱和模式收下了却没用** —— 学员写 `__NV_NOSAT` 会拿到 SATFINITE 的行为。无声的谎，修了。

## 验证
`tests/gpulab` 270/270（新增 12 条 fp8），头文件契约用例已覆盖 fp8 的两个原型；
`tsc --noEmit` / `projects:verify` / `npm test` 10/10 / `npm run build` 含 check-bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)