### PR TITLE
feat(gpulab): 第 21 关 连续批处理（三期收官）

### DIFF
--- a/projects/definitions/llm-accelerator.js
+++ b/projects/definitions/llm-accelerator.js
@@ -4836,6 +4836,372 @@ const STAGE_20 = {
 };
 
 /* ------------------------------------------------------------------ */
+/* 第 21 关：连续批处理                                                  */
+/* ------------------------------------------------------------------ */
+
+const B_DIM = 32;
+const B_SLOTS = 4;
+/** 长度差别很大 —— 静态批的痛点全在这里 */
+const B_LENGTHS = [40, 3, 25, 5, 60, 4, 18, 6, 33, 2, 50, 8];
+const B_TOTAL = B_LENGTHS.reduce((sum, n) => sum + n, 0);
+
+/**
+ * 一步一个槽位。
+ *
+ * `active[slot] == 0` 的槽位直接返回 —— 那是 padding，
+ * 真卡上它一样要占着计算资源走完一遍。
+ * `progress[req]` 由**平台**记账，学员改不了：
+ * 判定要的是「每个请求都被服务到了它该有的步数」，
+ * 而这个数只有 kernel 自己数得准。
+ */
+const BATCH_KERNEL = code`
+  __global__ void stepSlot(int* progress, float* state, const int* active,
+                           int slot, int req, int dim) {
+    int d = threadIdx.x;
+    if (active[slot] == 0) return;
+    if (d == 0) progress[req] = progress[req] + 1;
+    state[slot * dim + d] = state[slot * dim + d] * 1.0009765625f + 0.001f;
+  }
+`;
+
+const B_LENS = B_LENGTHS.map((n) => `vec_push(lens, ${n});`).join('\n            ');
+
+const batchBench = {
+  sources: ['/root/scheduler.cu'],
+  buffers: [
+    { name: 'state', length: B_SLOTS * B_DIM, fill: { kind: 'const', value: 0.5 } },
+    { name: 'progress', length: B_LENGTHS.length, type: 'int', fill: { kind: 'zeros' } },
+  ],
+  launches: [],
+};
+
+const STAGE_21 = {
+  id: 'continuous-batching',
+  title: t('连续批处理 —— 空出来的槽位立刻补上',
+    'Continuous batching — refill a slot the moment it frees'),
+  goal: t(
+    [
+      'GPU 喜欢大批量。可是解码时每条序列**长度差别极大**：',
+      '有的两个 token 就结束，有的要生成几百个。',
+      '',
+      '朴素的做法是**静态批**：凑够 4 条一起跑，等这一批全部结束再收下一批。',
+      '于是那条 2 个 token 的请求跑完之后，它的槽位要空转到最长那条结束为止 ——',
+      '空转不是免费的，padding 的槽位在真卡上照样占着计算资源走完一遍。',
+      '',
+      '这 12 个请求的长度是 40 / 3 / 25 / 5 / 60 / 4 / 18 / 6 / 33 / 2 / 50 / 8，',
+      '一共 254 个真实的槽位步。静态批要跑 **150 步 × 4 槽 = 600** ——',
+      '**58% 花在 padding 上**。',
+      '',
+      '连续批处理（continuous batching，也叫 in-flight batching）的做法很简单：',
+      '**不等整批结束，哪个槽位空了就立刻从队列里取下一个请求塞进去。**',
+      '批是流动的，不是一批一批的。',
+      '',
+      '`scheduler.cu` 现在是静态批。改成连续批：',
+      '',
+      '1. 请求排成一个队列（`ring`）',
+      '2. 每一步开始前先扫一遍槽位，空的就补一个新请求进来',
+      '3. 照常跑这一步',
+      '',
+      '```bash',
+      'nvcc -o bench scheduler.cu && ncu ./bench',
+      '```',
+      '',
+      '**通关标准**',
+      '',
+      '- **12 个请求一个不漏，每个都跑够它自己的步数**（平台记账，改不了）',
+      '- 提交次数 ≤ 400（静态批是 600）',
+    ].join('\n'),
+    [
+      'GPUs like big batches. But during decoding, sequence lengths **vary enormously**: some finish',
+      'in two tokens, some generate hundreds.',
+      '',
+      'The naive approach is **static batching**: gather 4 sequences, run them together, wait for the',
+      'whole batch before taking the next. So once that 2-token request finishes, its slot idles',
+      'until the longest one is done, and idling is not free: a padded slot still occupies compute on',
+      'real hardware for the whole step.',
+      '',
+      'These 12 requests are 40 / 3 / 25 / 5 / 60 / 4 / 18 / 6 / 33 / 2 / 50 / 8 tokens long, 254',
+      'real slot-steps in total. Static batching runs **150 steps x 4 slots = 600**, so **58% goes',
+      'to padding**.',
+      '',
+      'Continuous batching (also called in-flight batching) is simple: **do not wait for the batch;',
+      'the moment a slot frees, pull the next request from the queue into it.** The batch flows',
+      'rather than proceeding in lockstep.',
+      '',
+      '`scheduler.cu` is static right now. Make it continuous:',
+      '',
+      '1. put the requests in a queue (`ring`)',
+      '2. before each step, scan the slots and refill any that are empty',
+      '3. run the step as before',
+      '',
+      '```bash',
+      'nvcc -o bench scheduler.cu && ncu ./bench',
+      '```',
+      '',
+      '**To pass**',
+      '',
+      '- **all 12 requests served, each for exactly its own number of steps** (counted by the',
+      '  platform, not by you)',
+      '- at most 400 submissions (600 static)',
+    ].join('\n')
+  ),
+  checklist: [
+    t('用 ring 排队等待的请求', 'Queue the waiting requests in a `ring`'),
+    t('每一步开始前把空槽位补上', 'Refill empty slots before each step'),
+    t('槽位空了就立刻补，不等整批结束', 'Refill as soon as a slot frees, not after the batch'),
+  ],
+  hints: [
+    t('每个槽位记两件事：**还剩几步**，以及**在跑哪个请求**。'
+      + '补位时两个一起换。',
+      'Track two things per slot: **steps remaining** and **which request is in it**. Refill swaps '
+      + 'both at once.'),
+    t('队列空了之后还有槽位在跑 —— 那时候补不了位，剩下的照常跑完。'
+      + '所以循环的结束条件是「所有槽位都空且队列也空」。',
+      'Once the queue empties some slots are still running and cannot be refilled; let them finish. '
+      + 'So the loop ends when every slot is empty and the queue is too.'),
+  ],
+  pitfalls: [
+    t('**补位时忘了换请求号。** 步数对了，但记账全记到上一个请求头上 ——'
+      + '于是有的请求"跑了两倍的步数"，有的一步没跑。这一关的判定专抓这个。',
+      '**Refilling the step count but not the request id.** The steps are right but the accounting '
+      + 'all lands on the previous request, so some appear to run twice as long and others not at '
+      + 'all. The check here is built to catch exactly this.'),
+    t('**只在整批空了才补位。** 那还是静态批，只是写法绕了一圈。'
+      + '补位要在**每一步**开始前做。',
+      '**Only refilling when the whole batch is empty.** That is still static batching with extra '
+      + 'steps. Refill before **every** step.'),
+    t('**队列空了之后死循环。** 结束条件要同时看槽位和队列，'
+      + '只看队列的话最后几条序列还没跑完就退出了。',
+      '**Looping forever once the queue is empty.** The exit condition must consider both slots and '
+      + 'queue; checking only the queue exits while the last sequences are still running.'),
+  ],
+  extension: t(
+    '连续批处理是 Orca 那篇论文（OSDI 2022）提出的，'
+    + '现在 vLLM、TensorRT-LLM、SGLang 全都是这么做的。'
+    + 'TensorRT-LLM 管它叫 in-flight batching，名字不同东西一样。'
+    + '\n\n'
+    + '它和第 18 关的分页 KV 是一对：**连续批处理让批一直是满的，'
+    + '分页 KV 让满的批装得下**。'
+    + '没有分页，每条序列按最长上下文预留显存，同时能装的序列数很少，'
+    + '连续批处理也就没多少可调度的余地了。vLLM 的吞吐提升是这两件事一起来的。'
+    + '\n\n'
+    + '真实调度器要处理的事比这一关多得多：预填充和解码要不要混在同一批里'
+    + '（chunked prefill）、显存不够时抢占谁（vLLM 的 preemption 会把一条序列的'
+    + 'KV 换出去、之后重算或换回来）、怎么保证长请求不被饿死、'
+    + '以及第 20 关提到的那个约束 —— **批大小只能是 CUDA Graph 预先捕获过的那几档**，'
+    + '所以调度器挑的往往不是"最优的批"，而是"最接近某一档的批"。'
+    + '\n\n'
+    + '还有一个这一关量不出来但很重要的事：连续批处理改善的是**吞吐**，'
+    + '对单个请求的**延迟**可能是负面的 —— 你的请求会和更多别人的请求挤在一起。'
+    + '所以生产里通常同时盯 TTFT（首 token 时延）与 TPOT（每 token 时延）两条线，'
+    + '而不是只看吞吐。',
+    'Continuous batching came from the Orca paper (OSDI 2022) and is now how vLLM, TensorRT-LLM and '
+    + 'SGLang all work. TensorRT-LLM calls it in-flight batching; same thing, different name.\n\n'
+    + 'It pairs with paged KV from stage 18: **continuous batching keeps the batch full, paging '
+    + 'makes a full batch fit.** Without paging, each sequence reserves memory for its maximum '
+    + 'context, few fit at once, and there is little left to schedule. vLLM\'s throughput gain comes '
+    + 'from both together.\n\n'
+    + 'Real schedulers handle far more: whether to mix prefill and decode in one batch (chunked '
+    + 'prefill), whom to preempt when memory runs out (vLLM swaps a sequence\'s KV out and either '
+    + 'recomputes or swaps it back), how to keep long requests from starving, and the constraint '
+    + 'from stage 20 that **batch sizes must be ones a CUDA Graph was captured for**, so the '
+    + 'scheduler usually picks not the optimal batch but the one nearest a captured size.\n\n'
+    + 'One more thing this stage cannot measure but that matters: continuous batching improves '
+    + '**throughput** and can hurt an individual request\'s **latency**, since your request now '
+    + 'shares the GPU with more of everyone else\'s. Production systems therefore watch TTFT (time '
+    + 'to first token) and TPOT (time per output token) alongside throughput, not throughput alone.'
+  ),
+  gpu: {
+    files: {
+      '/root/scheduler.cu': code`
+        #include "engine.h"
+        #include "containers.h"
+
+        ${BATCH_KERNEL}
+
+        int main(void) {
+          const int DIM = ${B_DIM};
+          const int SLOTS = ${B_SLOTS};
+          const int N = ${B_LENGTHS.length};
+
+          int lens = vec_new();
+          ${B_LENS}
+
+          float* state = lab_buffer(0);
+          int* progress;
+          cudaMalloc((void**)&progress, N * 4);
+          cudaMemset(progress, 0, N * 4);
+
+          int* active;
+          cudaMalloc((void**)&active, SLOTS * 4);
+          int host[4];
+
+          // TODO: 静态批 —— 凑够一批跑到全部结束，再收下一批。
+          //       改成连续批：哪个槽位空了就立刻从队列里补一个进来。
+          int next = 0;
+          while (next < N) {
+            int remain = vec_new();
+            int who = vec_new();
+            for (int s = 0; s < SLOTS; ++s) {
+              if (next < N) {
+                vec_push(remain, vec_get(lens, next));
+                vec_push(who, next);
+                next += 1;
+              } else {
+                vec_push(remain, 0);
+                vec_push(who, 0);
+              }
+            }
+
+            int alive = 1;
+            while (alive == 1) {
+              alive = 0;
+              for (int s = 0; s < SLOTS; ++s) {
+                host[s] = vec_get(remain, s) > 0 ? 1 : 0;
+                if (host[s] == 1) { alive = 1; }
+              }
+              if (alive == 0) { break; }
+              cudaMemcpy(active, host, SLOTS * 4, cudaMemcpyHostToDevice);
+              for (int s = 0; s < SLOTS; ++s) {
+                stepSlot<<<1, DIM>>>(progress, state, active, s, vec_get(who, s), DIM);
+              }
+              for (int s = 0; s < SLOTS; ++s) {
+                int r = vec_get(remain, s);
+                if (r > 0) vec_set(remain, s, r - 1);
+              }
+            }
+          }
+
+          // 把记账拷回平台准备的缓冲区
+          cudaMemcpy(lab_buffer(1), progress, N * 4, cudaMemcpyDeviceToDevice);
+          cudaFree(progress);
+          cudaFree(active);
+          return 0;
+        }
+      `,
+    },
+    bench: batchBench,
+    referenceFiles: {
+      '/root/scheduler.cu': code`
+        #include "engine.h"
+        #include "containers.h"
+
+        ${BATCH_KERNEL}
+
+        int main(void) {
+          const int DIM = ${B_DIM};
+          const int SLOTS = ${B_SLOTS};
+          const int N = ${B_LENGTHS.length};
+
+          int lens = vec_new();
+          ${B_LENS}
+
+          float* state = lab_buffer(0);
+          int* progress;
+          cudaMalloc((void**)&progress, N * 4);
+          cudaMemset(progress, 0, N * 4);
+
+          int* active;
+          cudaMalloc((void**)&active, SLOTS * 4);
+          int host[4];
+
+          // 等待的请求排成一个队列
+          int queue = ring_new();
+          for (int i = 0; i < N; ++i) ring_push(queue, i);
+
+          // 每个槽位记两件事：还剩几步、在跑哪个请求
+          int remain = vec_new();
+          int who = vec_new();
+          for (int s = 0; s < SLOTS; ++s) { vec_push(remain, 0); vec_push(who, 0); }
+
+          int alive = 1;
+          while (alive == 1) {
+            alive = 0;
+
+            // 补位：空槽立刻取下一个请求。**两件事一起换** ——
+            // 只换步数不换请求号，记账就全记到上一个请求头上了
+            for (int s = 0; s < SLOTS; ++s) {
+              if (vec_get(remain, s) == 0) {
+                if (ring_len(queue) > 0) {
+                  int req = ring_pop(queue);
+                  vec_set(who, s, req);
+                  vec_set(remain, s, vec_get(lens, req));
+                }
+              }
+            }
+
+            for (int s = 0; s < SLOTS; ++s) {
+              host[s] = vec_get(remain, s) > 0 ? 1 : 0;
+              if (host[s] == 1) { alive = 1; }
+            }
+            // 槽位全空且队列也空，才是真的结束
+            if (alive == 0) { break; }
+
+            cudaMemcpy(active, host, SLOTS * 4, cudaMemcpyHostToDevice);
+            for (int s = 0; s < SLOTS; ++s) {
+              stepSlot<<<1, DIM>>>(progress, state, active, s, vec_get(who, s), DIM);
+            }
+            for (int s = 0; s < SLOTS; ++s) {
+              int r = vec_get(remain, s);
+              if (r > 0) vec_set(remain, s, r - 1);
+            }
+          }
+
+          cudaMemcpy(lab_buffer(1), progress, N * 4, cudaMemcpyDeviceToDevice);
+          cudaFree(progress);
+          cudaFree(active);
+          return 0;
+        }
+      `,
+    },
+  },
+  specs: [
+    spec('scheduler.spec.ts', code`
+      const lab = require('@gpu/lab');
+      const LENGTHS = ${JSON.stringify(B_LENGTHS)};
+      const TOTAL = ${B_TOTAL};
+
+      describe('连续批处理', () => {
+        it('**12 个请求一个不漏，每个都跑够它自己的步数**', async () => {
+          await lab.buildAndRun();
+          const progress = lab.bufferInts('progress');
+          expect(Array.from(progress)).toEqual(LENGTHS);
+        });
+
+        it('真实工作量没变 —— 省的是 padding', async () => {
+          await lab.buildAndRun();
+          const progress = lab.bufferInts('progress');
+          const done = Array.from(progress).reduce((sum, n) => sum + n, 0);
+          expect(done).toBe(TOTAL);
+        });
+
+        it('提交次数降下来了', async () => {
+          await lab.buildAndRun();
+          expect(lab.metrics().launch.kernels).toBeLessThanOrEqual(400);
+        });
+
+        it('padding 的比例降到三成以下', async () => {
+          await lab.buildAndRun();
+          // 每次提交就是一个槽位一步，其中只有 TOTAL 次是真活
+          const submitted = lab.metrics().launch.kernels;
+          expect(1 - TOTAL / submitted).toBeLessThan(0.3);
+        });
+      });
+    `),
+  ],
+  gates: [
+    ...SAFETY_GATES,
+    gate({
+      metric: 'gpu.launch.kernels', op: 'lte', value: 400,
+      zh: '提交次数（静态批是 600，其中 58% 是 padding）',
+      en: 'submissions (600 static, 58% of it padding)',
+      unit: 'launch', dimension: 'throughput',
+    }),
+  ],
+  focus: ['throughput', 'correctness'],
+};
+
+/* ------------------------------------------------------------------ */
 
 module.exports = {
   id: 'llm-accelerator',
@@ -4902,5 +5268,5 @@ module.exports = {
   },
   workspace: { kind: 'gpu', world: WORLD },
   files: [],
-  stages: [STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12, STAGE_13, STAGE_14, STAGE_15, STAGE_16, STAGE_17, STAGE_18, STAGE_19, STAGE_20],
+  stages: [STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12, STAGE_13, STAGE_14, STAGE_15, STAGE_16, STAGE_17, STAGE_18, STAGE_19, STAGE_20, STAGE_21],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -26410,6 +26410,138 @@
           "zh": "解码的处境很特别：每一步只算一个 token，计算量极小，而要起的 kernel 不少，真实的一层 Transformer 有几十个，80 层就是上千个。真卡上每次提交有几微秒的固定开销，于是提交本身成了瓶颈，GPU 大部分时间在等下一个 kernel 被交上来。\n\nCUDA Graph 把一串 launch 录下来，之后一次性提交。省下来的纯粹是提交开销，kernel 该干的活一点没少，block 数、FMA 数全都不变。这也解释了它为什么对预填充几乎没用：一次算几千个 token 时每个 kernel 本来就跑很久，几微秒可以忽略。CUDA Graph 是解码专属的优化。\n\n用起来有一个硬约束：图录下来的是**捕获那一刻的实参值**。指针是稳定的地址，重放没问题；而按值传的标量录下来就定死了。所以真实引擎会把所有随步数变化的量都做成显存里的值，让 kernel 从指针读，序列长度、批里每条序列的状态，全都如此。\n\n还有一个后果值得留意：图是按形状固定的。批大小变了、序列长度跨过某个桶了，就得换一张图。于是引擎预先为若干个批大小各捕获一张，运行时挑最接近的、把多余的位置填成 padding。你看到连续批处理的批大小往往是几个固定档位而不是任意数，原因就在这里。",
           "en": "Decoding is peculiar: each step computes a single token, almost no work, across quite a few kernels. A real Transformer layer has dozens, and eighty layers means thousands. On real hardware each submission costs a few microseconds of fixed overhead, so submission becomes the bottleneck and the GPU spends most of its time waiting for more work.\n\nCUDA Graphs record a run of launches and submit them in one go. What is saved is purely the submission overhead: the kernels do the same work, the same blocks, the same FMAs. That also explains why graphs do almost nothing for prefill, where each kernel already runs a long time and microseconds are noise. Graphs are a decode-side optimisation.\n\nThere is one hard constraint. A graph records the argument values **at capture time**. Pointers are stable addresses so replay is fine, but a scalar passed by value is frozen. Real engines therefore make every step-varying quantity device-resident and have kernels read it through a pointer: sequence lengths, per-sequence state in the batch, all of it.\n\nOne more consequence is worth noticing: graphs are fixed by shape. Change the batch size, or cross a sequence-length bucket, and you need a different graph. So engines capture one per batch size ahead of time and pick the nearest at runtime, padding the unused slots. That is why continuous batching tends to use a handful of fixed batch sizes rather than arbitrary ones."
         }
+      },
+      {
+        "id": "continuous-batching",
+        "title": {
+          "zh": "连续批处理 —— 空出来的槽位立刻补上",
+          "en": "Continuous batching — refill a slot the moment it frees"
+        },
+        "goal": {
+          "zh": "GPU 喜欢大批量。可是解码时每条序列**长度差别极大**：\n有的两个 token 就结束，有的要生成几百个。\n\n朴素的做法是**静态批**：凑够 4 条一起跑，等这一批全部结束再收下一批。\n于是那条 2 个 token 的请求跑完之后，它的槽位要空转到最长那条结束为止 ——\n空转不是免费的，padding 的槽位在真卡上照样占着计算资源走完一遍。\n\n这 12 个请求的长度是 40 / 3 / 25 / 5 / 60 / 4 / 18 / 6 / 33 / 2 / 50 / 8，\n一共 254 个真实的槽位步。静态批要跑 **150 步 × 4 槽 = 600** ——\n**58% 花在 padding 上**。\n\n连续批处理（continuous batching，也叫 in-flight batching）的做法很简单：\n**不等整批结束，哪个槽位空了就立刻从队列里取下一个请求塞进去。**\n批是流动的，不是一批一批的。\n\n`scheduler.cu` 现在是静态批。改成连续批：\n\n1. 请求排成一个队列（`ring`）\n2. 每一步开始前先扫一遍槽位，空的就补一个新请求进来\n3. 照常跑这一步\n\n```bash\nnvcc -o bench scheduler.cu && ncu ./bench\n```\n\n**通关标准**\n\n- **12 个请求一个不漏，每个都跑够它自己的步数**（平台记账，改不了）\n- 提交次数 ≤ 400（静态批是 600）",
+          "en": "GPUs like big batches. But during decoding, sequence lengths **vary enormously**: some finish\nin two tokens, some generate hundreds.\n\nThe naive approach is **static batching**: gather 4 sequences, run them together, wait for the\nwhole batch before taking the next. So once that 2-token request finishes, its slot idles\nuntil the longest one is done, and idling is not free: a padded slot still occupies compute on\nreal hardware for the whole step.\n\nThese 12 requests are 40 / 3 / 25 / 5 / 60 / 4 / 18 / 6 / 33 / 2 / 50 / 8 tokens long, 254\nreal slot-steps in total. Static batching runs **150 steps x 4 slots = 600**, so **58% goes\nto padding**.\n\nContinuous batching (also called in-flight batching) is simple: **do not wait for the batch;\nthe moment a slot frees, pull the next request from the queue into it.** The batch flows\nrather than proceeding in lockstep.\n\n`scheduler.cu` is static right now. Make it continuous:\n\n1. put the requests in a queue (`ring`)\n2. before each step, scan the slots and refill any that are empty\n3. run the step as before\n\n```bash\nnvcc -o bench scheduler.cu && ncu ./bench\n```\n\n**To pass**\n\n- **all 12 requests served, each for exactly its own number of steps** (counted by the\n  platform, not by you)\n- at most 400 submissions (600 static)"
+        },
+        "checklist": [
+          {
+            "zh": "用 ring 排队等待的请求",
+            "en": "Queue the waiting requests in a `ring`"
+          },
+          {
+            "zh": "每一步开始前把空槽位补上",
+            "en": "Refill empty slots before each step"
+          },
+          {
+            "zh": "槽位空了就立刻补，不等整批结束",
+            "en": "Refill as soon as a slot frees, not after the batch"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "每个槽位记两件事：**还剩几步**，以及**在跑哪个请求**。补位时两个一起换。",
+            "en": "Track two things per slot: **steps remaining** and **which request is in it**. Refill swaps both at once."
+          },
+          {
+            "zh": "队列空了之后还有槽位在跑 —— 那时候补不了位，剩下的照常跑完。所以循环的结束条件是「所有槽位都空且队列也空」。",
+            "en": "Once the queue empties some slots are still running and cannot be refilled; let them finish. So the loop ends when every slot is empty and the queue is too."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**补位时忘了换请求号。** 步数对了，但记账全记到上一个请求头上 ——于是有的请求\"跑了两倍的步数\"，有的一步没跑。这一关的判定专抓这个。",
+            "en": "**Refilling the step count but not the request id.** The steps are right but the accounting all lands on the previous request, so some appear to run twice as long and others not at all. The check here is built to catch exactly this."
+          },
+          {
+            "zh": "**只在整批空了才补位。** 那还是静态批，只是写法绕了一圈。补位要在**每一步**开始前做。",
+            "en": "**Only refilling when the whole batch is empty.** That is still static batching with extra steps. Refill before **every** step."
+          },
+          {
+            "zh": "**队列空了之后死循环。** 结束条件要同时看槽位和队列，只看队列的话最后几条序列还没跑完就退出了。",
+            "en": "**Looping forever once the queue is empty.** The exit condition must consider both slots and queue; checking only the queue exits while the last sequences are still running."
+          }
+        ],
+        "extension": {
+          "zh": "连续批处理是 Orca 那篇论文（OSDI 2022）提出的，现在 vLLM、TensorRT-LLM、SGLang 全都是这么做的。TensorRT-LLM 管它叫 in-flight batching，名字不同东西一样。\n\n它和第 18 关的分页 KV 是一对：**连续批处理让批一直是满的，分页 KV 让满的批装得下**。没有分页，每条序列按最长上下文预留显存，同时能装的序列数很少，连续批处理也就没多少可调度的余地了。vLLM 的吞吐提升是这两件事一起来的。\n\n真实调度器要处理的事比这一关多得多：预填充和解码要不要混在同一批里（chunked prefill）、显存不够时抢占谁（vLLM 的 preemption 会把一条序列的KV 换出去、之后重算或换回来）、怎么保证长请求不被饿死、以及第 20 关提到的那个约束 —— **批大小只能是 CUDA Graph 预先捕获过的那几档**，所以调度器挑的往往不是\"最优的批\"，而是\"最接近某一档的批\"。\n\n还有一个这一关量不出来但很重要的事：连续批处理改善的是**吞吐**，对单个请求的**延迟**可能是负面的 —— 你的请求会和更多别人的请求挤在一起。所以生产里通常同时盯 TTFT（首 token 时延）与 TPOT（每 token 时延）两条线，而不是只看吞吐。",
+          "en": "Continuous batching came from the Orca paper (OSDI 2022) and is now how vLLM, TensorRT-LLM and SGLang all work. TensorRT-LLM calls it in-flight batching; same thing, different name.\n\nIt pairs with paged KV from stage 18: **continuous batching keeps the batch full, paging makes a full batch fit.** Without paging, each sequence reserves memory for its maximum context, few fit at once, and there is little left to schedule. vLLM's throughput gain comes from both together.\n\nReal schedulers handle far more: whether to mix prefill and decode in one batch (chunked prefill), whom to preempt when memory runs out (vLLM swaps a sequence's KV out and either recomputes or swaps it back), how to keep long requests from starving, and the constraint from stage 20 that **batch sizes must be ones a CUDA Graph was captured for**, so the scheduler usually picks not the optimal batch but the one nearest a captured size.\n\nOne more thing this stage cannot measure but that matters: continuous batching improves **throughput** and can hurt an individual request's **latency**, since your request now shares the GPU with more of everyone else's. Production systems therefore watch TTFT (time to first token) and TPOT (time per output token) alongside throughput, not throughput alone."
+        },
+        "gpu": {
+          "files": {
+            "/root/scheduler.cu": "        #include \"engine.h\"\n        #include \"containers.h\"\n\n        __global__ void stepSlot(int* progress, float* state, const int* active,\n                         int slot, int req, int dim) {\n  int d = threadIdx.x;\n  if (active[slot] == 0) return;\n  if (d == 0) progress[req] = progress[req] + 1;\n  state[slot * dim + d] = state[slot * dim + d] * 1.0009765625f + 0.001f;\n}\n\n\n        int main(void) {\n          const int DIM = 32;\n          const int SLOTS = 4;\n          const int N = 12;\n\n          int lens = vec_new();\n          vec_push(lens, 40);\n            vec_push(lens, 3);\n            vec_push(lens, 25);\n            vec_push(lens, 5);\n            vec_push(lens, 60);\n            vec_push(lens, 4);\n            vec_push(lens, 18);\n            vec_push(lens, 6);\n            vec_push(lens, 33);\n            vec_push(lens, 2);\n            vec_push(lens, 50);\n            vec_push(lens, 8);\n\n          float* state = lab_buffer(0);\n          int* progress;\n          cudaMalloc((void**)&progress, N * 4);\n          cudaMemset(progress, 0, N * 4);\n\n          int* active;\n          cudaMalloc((void**)&active, SLOTS * 4);\n          int host[4];\n\n          // TODO: 静态批 —— 凑够一批跑到全部结束，再收下一批。\n          //       改成连续批：哪个槽位空了就立刻从队列里补一个进来。\n          int next = 0;\n          while (next < N) {\n            int remain = vec_new();\n            int who = vec_new();\n            for (int s = 0; s < SLOTS; ++s) {\n              if (next < N) {\n                vec_push(remain, vec_get(lens, next));\n                vec_push(who, next);\n                next += 1;\n              } else {\n                vec_push(remain, 0);\n                vec_push(who, 0);\n              }\n            }\n\n            int alive = 1;\n            while (alive == 1) {\n              alive = 0;\n              for (int s = 0; s < SLOTS; ++s) {\n                host[s] = vec_get(remain, s) > 0 ? 1 : 0;\n                if (host[s] == 1) { alive = 1; }\n              }\n              if (alive == 0) { break; }\n              cudaMemcpy(active, host, SLOTS * 4, cudaMemcpyHostToDevice);\n              for (int s = 0; s < SLOTS; ++s) {\n                stepSlot<<<1, DIM>>>(progress, state, active, s, vec_get(who, s), DIM);\n              }\n              for (int s = 0; s < SLOTS; ++s) {\n                int r = vec_get(remain, s);\n                if (r > 0) vec_set(remain, s, r - 1);\n              }\n            }\n          }\n\n          // 把记账拷回平台准备的缓冲区\n          cudaMemcpy(lab_buffer(1), progress, N * 4, cudaMemcpyDeviceToDevice);\n          cudaFree(progress);\n          cudaFree(active);\n          return 0;\n        }\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/scheduler.cu"
+            ],
+            "buffers": [
+              {
+                "name": "state",
+                "length": 128,
+                "fill": {
+                  "kind": "const",
+                  "value": 0.5
+                }
+              },
+              {
+                "name": "progress",
+                "length": 12,
+                "type": "int",
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": []
+          },
+          "referenceFiles": {
+            "/root/scheduler.cu": "        #include \"engine.h\"\n        #include \"containers.h\"\n\n        __global__ void stepSlot(int* progress, float* state, const int* active,\n                         int slot, int req, int dim) {\n  int d = threadIdx.x;\n  if (active[slot] == 0) return;\n  if (d == 0) progress[req] = progress[req] + 1;\n  state[slot * dim + d] = state[slot * dim + d] * 1.0009765625f + 0.001f;\n}\n\n\n        int main(void) {\n          const int DIM = 32;\n          const int SLOTS = 4;\n          const int N = 12;\n\n          int lens = vec_new();\n          vec_push(lens, 40);\n            vec_push(lens, 3);\n            vec_push(lens, 25);\n            vec_push(lens, 5);\n            vec_push(lens, 60);\n            vec_push(lens, 4);\n            vec_push(lens, 18);\n            vec_push(lens, 6);\n            vec_push(lens, 33);\n            vec_push(lens, 2);\n            vec_push(lens, 50);\n            vec_push(lens, 8);\n\n          float* state = lab_buffer(0);\n          int* progress;\n          cudaMalloc((void**)&progress, N * 4);\n          cudaMemset(progress, 0, N * 4);\n\n          int* active;\n          cudaMalloc((void**)&active, SLOTS * 4);\n          int host[4];\n\n          // 等待的请求排成一个队列\n          int queue = ring_new();\n          for (int i = 0; i < N; ++i) ring_push(queue, i);\n\n          // 每个槽位记两件事：还剩几步、在跑哪个请求\n          int remain = vec_new();\n          int who = vec_new();\n          for (int s = 0; s < SLOTS; ++s) { vec_push(remain, 0); vec_push(who, 0); }\n\n          int alive = 1;\n          while (alive == 1) {\n            alive = 0;\n\n            // 补位：空槽立刻取下一个请求。**两件事一起换** ——\n            // 只换步数不换请求号，记账就全记到上一个请求头上了\n            for (int s = 0; s < SLOTS; ++s) {\n              if (vec_get(remain, s) == 0) {\n                if (ring_len(queue) > 0) {\n                  int req = ring_pop(queue);\n                  vec_set(who, s, req);\n                  vec_set(remain, s, vec_get(lens, req));\n                }\n              }\n            }\n\n            for (int s = 0; s < SLOTS; ++s) {\n              host[s] = vec_get(remain, s) > 0 ? 1 : 0;\n              if (host[s] == 1) { alive = 1; }\n            }\n            // 槽位全空且队列也空，才是真的结束\n            if (alive == 0) { break; }\n\n            cudaMemcpy(active, host, SLOTS * 4, cudaMemcpyHostToDevice);\n            for (int s = 0; s < SLOTS; ++s) {\n              stepSlot<<<1, DIM>>>(progress, state, active, s, vec_get(who, s), DIM);\n            }\n            for (int s = 0; s < SLOTS; ++s) {\n              int r = vec_get(remain, s);\n              if (r > 0) vec_set(remain, s, r - 1);\n            }\n          }\n\n          cudaMemcpy(lab_buffer(1), progress, N * 4, cudaMemcpyDeviceToDevice);\n          cudaFree(progress);\n          cudaFree(active);\n          return 0;\n        }\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "scheduler.spec.ts",
+            "content": "const lab = require('@gpu/lab');\nconst LENGTHS = [40,3,25,5,60,4,18,6,33,2,50,8];\nconst TOTAL = 254;\n\ndescribe('连续批处理', () => {\n  it('**12 个请求一个不漏，每个都跑够它自己的步数**', async () => {\n    await lab.buildAndRun();\n    const progress = lab.bufferInts('progress');\n    expect(Array.from(progress)).toEqual(LENGTHS);\n  });\n\n  it('真实工作量没变 —— 省的是 padding', async () => {\n    await lab.buildAndRun();\n    const progress = lab.bufferInts('progress');\n    const done = Array.from(progress).reduce((sum, n) => sum + n, 0);\n    expect(done).toBe(TOTAL);\n  });\n\n  it('提交次数降下来了', async () => {\n    await lab.buildAndRun();\n    expect(lab.metrics().launch.kernels).toBeLessThanOrEqual(400);\n  });\n\n  it('padding 的比例降到三成以下', async () => {\n    await lab.buildAndRun();\n    // 每次提交就是一个槽位一步，其中只有 TOTAL 次是真活\n    const submitted = lab.metrics().launch.kernels;\n    expect(1 - TOTAL / submitted).toBeLessThan(0.3);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.launch.kernels",
+            "op": "lte",
+            "value": 400,
+            "label": {
+              "zh": "提交次数（静态批是 600，其中 58% 是 padding）",
+              "en": "submissions (600 static, 58% of it padding)"
+            },
+            "unit": "launch",
+            "dimension": "throughput"
+          }
+        ],
+        "focus": [
+          "throughput",
+          "correctness"
+        ],
+        "primer": {
+          "zh": "GPU 喜欢大批量，可是解码时每条序列的长度差别极大：有的两个 token 就结束，有的要生成几百个。朴素的静态批是凑够一批一起跑、等全部结束再收下一批 --于是短的那条跑完之后，它的槽位要空转到最长那条结束为止。空转不是免费的：padding 的槽位在真卡上照样占着计算资源走完一遍。\n\n连续批处理的做法很简单：不等整批结束，哪个槽位空了就立刻从队列里取下一个请求塞进去。批是流动的，不是一批一批的。Orca 那篇论文（OSDI 2022）提出了它，现在 vLLM、TensorRT-LLM、SGLang 全都是这么做的，TensorRT-LLM 管它叫 in-flight batching。\n\n它和分页 KV 是一对：连续批处理让批一直是满的，分页 KV 让满的批装得下。没有分页，每条序列按最长上下文预留显存，同时能装的序列数很少，连续批处理也就没多少可调度的余地。两件事是一起起作用的。\n\n真实调度器要处理的比这多得多：预填充和解码要不要混在同一批里、显存不够时抢占谁、怎么不让长请求被饿死、以及批大小只能是 CUDA Graph 预先捕获过的那几档 --所以调度器挑的往往不是最优的批，而是最接近某一档的批。还有一件量不出来但很重要的事：连续批处理改善的是吞吐，对单个请求的延迟可能是负面的，因为你的请求要和更多别人的挤在一起。生产里因此同时盯首 token 时延与每 token 时延，而不是只看吞吐。",
+          "en": "GPUs like big batches, but decoding sequence lengths vary enormously: some finish in two tokens, some generate hundreds. Naive static batching gathers a batch, runs it, and waits for all of it before taking the next, so once the short sequence finishes its slot idles until the longest one is done. Idling is not free: a padded slot still occupies compute on real hardware for the whole step.\n\nContinuous batching is simple: do not wait for the batch; the moment a slot frees, pull the next request from the queue into it. The batch flows rather than proceeding in lockstep. The Orca paper (OSDI 2022) introduced it and vLLM, TensorRT-LLM and SGLang all work this way now, with TensorRT-LLM calling it in-flight batching.\n\nIt pairs with paged KV: continuous batching keeps the batch full, paging makes a full batch fit. Without paging each sequence reserves memory for its maximum context, few fit at once, and there is little left to schedule. The two work together.\n\nReal schedulers handle far more: whether to mix prefill and decode in one batch, whom to preempt when memory runs out, how to keep long requests from starving, and the fact that batch sizes must be ones a CUDA Graph was captured for, so the scheduler usually picks not the optimal batch but the one nearest a captured size. One more thing that is hard to measure but matters: continuous batching improves throughput and can hurt an individual request latency, since your request now shares the GPU with more of everyone else. Production systems therefore watch time to first token and time per output token alongside throughput, not throughput alone."
+        }
       }
     ]
   },

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1708,6 +1708,51 @@ const primers = {
         + 'arbitrary ones.'
       )
     ),
+    'continuous-batching': t(
+      p(
+        'GPU 喜欢大批量，可是解码时每条序列的长度差别极大：'
+        + '有的两个 token 就结束，有的要生成几百个。'
+        + '朴素的静态批是凑够一批一起跑、等全部结束再收下一批 --'
+        + '于是短的那条跑完之后，它的槽位要空转到最长那条结束为止。'
+        + '空转不是免费的：padding 的槽位在真卡上照样占着计算资源走完一遍。',
+        '连续批处理的做法很简单：不等整批结束，哪个槽位空了就立刻从队列里'
+        + '取下一个请求塞进去。批是流动的，不是一批一批的。'
+        + 'Orca 那篇论文（OSDI 2022）提出了它，现在 vLLM、TensorRT-LLM、SGLang '
+        + '全都是这么做的，TensorRT-LLM 管它叫 in-flight batching。',
+        '它和分页 KV 是一对：连续批处理让批一直是满的，分页 KV 让满的批装得下。'
+        + '没有分页，每条序列按最长上下文预留显存，同时能装的序列数很少，'
+        + '连续批处理也就没多少可调度的余地。两件事是一起起作用的。',
+        '真实调度器要处理的比这多得多：预填充和解码要不要混在同一批里、'
+        + '显存不够时抢占谁、怎么不让长请求被饿死、'
+        + '以及批大小只能是 CUDA Graph 预先捕获过的那几档 --'
+        + '所以调度器挑的往往不是最优的批，而是最接近某一档的批。'
+        + '还有一件量不出来但很重要的事：连续批处理改善的是吞吐，'
+        + '对单个请求的延迟可能是负面的，因为你的请求要和更多别人的挤在一起。'
+        + '生产里因此同时盯首 token 时延与每 token 时延，而不是只看吞吐。'
+      ),
+      p(
+        'GPUs like big batches, but decoding sequence lengths vary enormously: some finish in two '
+        + 'tokens, some generate hundreds. Naive static batching gathers a batch, runs it, and waits '
+        + 'for all of it before taking the next, so once the short sequence finishes its slot idles '
+        + 'until the longest one is done. Idling is not free: a padded slot still occupies compute on '
+        + 'real hardware for the whole step.',
+        'Continuous batching is simple: do not wait for the batch; the moment a slot frees, pull the '
+        + 'next request from the queue into it. The batch flows rather than proceeding in lockstep. '
+        + 'The Orca paper (OSDI 2022) introduced it and vLLM, TensorRT-LLM and SGLang all work this '
+        + 'way now, with TensorRT-LLM calling it in-flight batching.',
+        'It pairs with paged KV: continuous batching keeps the batch full, paging makes a full batch '
+        + 'fit. Without paging each sequence reserves memory for its maximum context, few fit at '
+        + 'once, and there is little left to schedule. The two work together.',
+        'Real schedulers handle far more: whether to mix prefill and decode in one batch, whom to '
+        + 'preempt when memory runs out, how to keep long requests from starving, and the fact that '
+        + 'batch sizes must be ones a CUDA Graph was captured for, so the scheduler usually picks '
+        + 'not the optimal batch but the one nearest a captured size. One more thing that is hard to '
+        + 'measure but matters: continuous batching improves throughput and can hurt an individual '
+        + 'request latency, since your request now shares the GPU with more of everyone else. '
+        + 'Production systems therefore watch time to first token and time per output token '
+        + 'alongside throughput, not throughput alone.'
+      )
+    ),
   },
 
   'intranet-k8s': {

--- a/public/projects.json
+++ b/public/projects.json
@@ -26410,6 +26410,138 @@
           "zh": "解码的处境很特别：每一步只算一个 token，计算量极小，而要起的 kernel 不少，真实的一层 Transformer 有几十个，80 层就是上千个。真卡上每次提交有几微秒的固定开销，于是提交本身成了瓶颈，GPU 大部分时间在等下一个 kernel 被交上来。\n\nCUDA Graph 把一串 launch 录下来，之后一次性提交。省下来的纯粹是提交开销，kernel 该干的活一点没少，block 数、FMA 数全都不变。这也解释了它为什么对预填充几乎没用：一次算几千个 token 时每个 kernel 本来就跑很久，几微秒可以忽略。CUDA Graph 是解码专属的优化。\n\n用起来有一个硬约束：图录下来的是**捕获那一刻的实参值**。指针是稳定的地址，重放没问题；而按值传的标量录下来就定死了。所以真实引擎会把所有随步数变化的量都做成显存里的值，让 kernel 从指针读，序列长度、批里每条序列的状态，全都如此。\n\n还有一个后果值得留意：图是按形状固定的。批大小变了、序列长度跨过某个桶了，就得换一张图。于是引擎预先为若干个批大小各捕获一张，运行时挑最接近的、把多余的位置填成 padding。你看到连续批处理的批大小往往是几个固定档位而不是任意数，原因就在这里。",
           "en": "Decoding is peculiar: each step computes a single token, almost no work, across quite a few kernels. A real Transformer layer has dozens, and eighty layers means thousands. On real hardware each submission costs a few microseconds of fixed overhead, so submission becomes the bottleneck and the GPU spends most of its time waiting for more work.\n\nCUDA Graphs record a run of launches and submit them in one go. What is saved is purely the submission overhead: the kernels do the same work, the same blocks, the same FMAs. That also explains why graphs do almost nothing for prefill, where each kernel already runs a long time and microseconds are noise. Graphs are a decode-side optimisation.\n\nThere is one hard constraint. A graph records the argument values **at capture time**. Pointers are stable addresses so replay is fine, but a scalar passed by value is frozen. Real engines therefore make every step-varying quantity device-resident and have kernels read it through a pointer: sequence lengths, per-sequence state in the batch, all of it.\n\nOne more consequence is worth noticing: graphs are fixed by shape. Change the batch size, or cross a sequence-length bucket, and you need a different graph. So engines capture one per batch size ahead of time and pick the nearest at runtime, padding the unused slots. That is why continuous batching tends to use a handful of fixed batch sizes rather than arbitrary ones."
         }
+      },
+      {
+        "id": "continuous-batching",
+        "title": {
+          "zh": "连续批处理 —— 空出来的槽位立刻补上",
+          "en": "Continuous batching — refill a slot the moment it frees"
+        },
+        "goal": {
+          "zh": "GPU 喜欢大批量。可是解码时每条序列**长度差别极大**：\n有的两个 token 就结束，有的要生成几百个。\n\n朴素的做法是**静态批**：凑够 4 条一起跑，等这一批全部结束再收下一批。\n于是那条 2 个 token 的请求跑完之后，它的槽位要空转到最长那条结束为止 ——\n空转不是免费的，padding 的槽位在真卡上照样占着计算资源走完一遍。\n\n这 12 个请求的长度是 40 / 3 / 25 / 5 / 60 / 4 / 18 / 6 / 33 / 2 / 50 / 8，\n一共 254 个真实的槽位步。静态批要跑 **150 步 × 4 槽 = 600** ——\n**58% 花在 padding 上**。\n\n连续批处理（continuous batching，也叫 in-flight batching）的做法很简单：\n**不等整批结束，哪个槽位空了就立刻从队列里取下一个请求塞进去。**\n批是流动的，不是一批一批的。\n\n`scheduler.cu` 现在是静态批。改成连续批：\n\n1. 请求排成一个队列（`ring`）\n2. 每一步开始前先扫一遍槽位，空的就补一个新请求进来\n3. 照常跑这一步\n\n```bash\nnvcc -o bench scheduler.cu && ncu ./bench\n```\n\n**通关标准**\n\n- **12 个请求一个不漏，每个都跑够它自己的步数**（平台记账，改不了）\n- 提交次数 ≤ 400（静态批是 600）",
+          "en": "GPUs like big batches. But during decoding, sequence lengths **vary enormously**: some finish\nin two tokens, some generate hundreds.\n\nThe naive approach is **static batching**: gather 4 sequences, run them together, wait for the\nwhole batch before taking the next. So once that 2-token request finishes, its slot idles\nuntil the longest one is done, and idling is not free: a padded slot still occupies compute on\nreal hardware for the whole step.\n\nThese 12 requests are 40 / 3 / 25 / 5 / 60 / 4 / 18 / 6 / 33 / 2 / 50 / 8 tokens long, 254\nreal slot-steps in total. Static batching runs **150 steps x 4 slots = 600**, so **58% goes\nto padding**.\n\nContinuous batching (also called in-flight batching) is simple: **do not wait for the batch;\nthe moment a slot frees, pull the next request from the queue into it.** The batch flows\nrather than proceeding in lockstep.\n\n`scheduler.cu` is static right now. Make it continuous:\n\n1. put the requests in a queue (`ring`)\n2. before each step, scan the slots and refill any that are empty\n3. run the step as before\n\n```bash\nnvcc -o bench scheduler.cu && ncu ./bench\n```\n\n**To pass**\n\n- **all 12 requests served, each for exactly its own number of steps** (counted by the\n  platform, not by you)\n- at most 400 submissions (600 static)"
+        },
+        "checklist": [
+          {
+            "zh": "用 ring 排队等待的请求",
+            "en": "Queue the waiting requests in a `ring`"
+          },
+          {
+            "zh": "每一步开始前把空槽位补上",
+            "en": "Refill empty slots before each step"
+          },
+          {
+            "zh": "槽位空了就立刻补，不等整批结束",
+            "en": "Refill as soon as a slot frees, not after the batch"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "每个槽位记两件事：**还剩几步**，以及**在跑哪个请求**。补位时两个一起换。",
+            "en": "Track two things per slot: **steps remaining** and **which request is in it**. Refill swaps both at once."
+          },
+          {
+            "zh": "队列空了之后还有槽位在跑 —— 那时候补不了位，剩下的照常跑完。所以循环的结束条件是「所有槽位都空且队列也空」。",
+            "en": "Once the queue empties some slots are still running and cannot be refilled; let them finish. So the loop ends when every slot is empty and the queue is too."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**补位时忘了换请求号。** 步数对了，但记账全记到上一个请求头上 ——于是有的请求\"跑了两倍的步数\"，有的一步没跑。这一关的判定专抓这个。",
+            "en": "**Refilling the step count but not the request id.** The steps are right but the accounting all lands on the previous request, so some appear to run twice as long and others not at all. The check here is built to catch exactly this."
+          },
+          {
+            "zh": "**只在整批空了才补位。** 那还是静态批，只是写法绕了一圈。补位要在**每一步**开始前做。",
+            "en": "**Only refilling when the whole batch is empty.** That is still static batching with extra steps. Refill before **every** step."
+          },
+          {
+            "zh": "**队列空了之后死循环。** 结束条件要同时看槽位和队列，只看队列的话最后几条序列还没跑完就退出了。",
+            "en": "**Looping forever once the queue is empty.** The exit condition must consider both slots and queue; checking only the queue exits while the last sequences are still running."
+          }
+        ],
+        "extension": {
+          "zh": "连续批处理是 Orca 那篇论文（OSDI 2022）提出的，现在 vLLM、TensorRT-LLM、SGLang 全都是这么做的。TensorRT-LLM 管它叫 in-flight batching，名字不同东西一样。\n\n它和第 18 关的分页 KV 是一对：**连续批处理让批一直是满的，分页 KV 让满的批装得下**。没有分页，每条序列按最长上下文预留显存，同时能装的序列数很少，连续批处理也就没多少可调度的余地了。vLLM 的吞吐提升是这两件事一起来的。\n\n真实调度器要处理的事比这一关多得多：预填充和解码要不要混在同一批里（chunked prefill）、显存不够时抢占谁（vLLM 的 preemption 会把一条序列的KV 换出去、之后重算或换回来）、怎么保证长请求不被饿死、以及第 20 关提到的那个约束 —— **批大小只能是 CUDA Graph 预先捕获过的那几档**，所以调度器挑的往往不是\"最优的批\"，而是\"最接近某一档的批\"。\n\n还有一个这一关量不出来但很重要的事：连续批处理改善的是**吞吐**，对单个请求的**延迟**可能是负面的 —— 你的请求会和更多别人的请求挤在一起。所以生产里通常同时盯 TTFT（首 token 时延）与 TPOT（每 token 时延）两条线，而不是只看吞吐。",
+          "en": "Continuous batching came from the Orca paper (OSDI 2022) and is now how vLLM, TensorRT-LLM and SGLang all work. TensorRT-LLM calls it in-flight batching; same thing, different name.\n\nIt pairs with paged KV from stage 18: **continuous batching keeps the batch full, paging makes a full batch fit.** Without paging, each sequence reserves memory for its maximum context, few fit at once, and there is little left to schedule. vLLM's throughput gain comes from both together.\n\nReal schedulers handle far more: whether to mix prefill and decode in one batch (chunked prefill), whom to preempt when memory runs out (vLLM swaps a sequence's KV out and either recomputes or swaps it back), how to keep long requests from starving, and the constraint from stage 20 that **batch sizes must be ones a CUDA Graph was captured for**, so the scheduler usually picks not the optimal batch but the one nearest a captured size.\n\nOne more thing this stage cannot measure but that matters: continuous batching improves **throughput** and can hurt an individual request's **latency**, since your request now shares the GPU with more of everyone else's. Production systems therefore watch TTFT (time to first token) and TPOT (time per output token) alongside throughput, not throughput alone."
+        },
+        "gpu": {
+          "files": {
+            "/root/scheduler.cu": "        #include \"engine.h\"\n        #include \"containers.h\"\n\n        __global__ void stepSlot(int* progress, float* state, const int* active,\n                         int slot, int req, int dim) {\n  int d = threadIdx.x;\n  if (active[slot] == 0) return;\n  if (d == 0) progress[req] = progress[req] + 1;\n  state[slot * dim + d] = state[slot * dim + d] * 1.0009765625f + 0.001f;\n}\n\n\n        int main(void) {\n          const int DIM = 32;\n          const int SLOTS = 4;\n          const int N = 12;\n\n          int lens = vec_new();\n          vec_push(lens, 40);\n            vec_push(lens, 3);\n            vec_push(lens, 25);\n            vec_push(lens, 5);\n            vec_push(lens, 60);\n            vec_push(lens, 4);\n            vec_push(lens, 18);\n            vec_push(lens, 6);\n            vec_push(lens, 33);\n            vec_push(lens, 2);\n            vec_push(lens, 50);\n            vec_push(lens, 8);\n\n          float* state = lab_buffer(0);\n          int* progress;\n          cudaMalloc((void**)&progress, N * 4);\n          cudaMemset(progress, 0, N * 4);\n\n          int* active;\n          cudaMalloc((void**)&active, SLOTS * 4);\n          int host[4];\n\n          // TODO: 静态批 —— 凑够一批跑到全部结束，再收下一批。\n          //       改成连续批：哪个槽位空了就立刻从队列里补一个进来。\n          int next = 0;\n          while (next < N) {\n            int remain = vec_new();\n            int who = vec_new();\n            for (int s = 0; s < SLOTS; ++s) {\n              if (next < N) {\n                vec_push(remain, vec_get(lens, next));\n                vec_push(who, next);\n                next += 1;\n              } else {\n                vec_push(remain, 0);\n                vec_push(who, 0);\n              }\n            }\n\n            int alive = 1;\n            while (alive == 1) {\n              alive = 0;\n              for (int s = 0; s < SLOTS; ++s) {\n                host[s] = vec_get(remain, s) > 0 ? 1 : 0;\n                if (host[s] == 1) { alive = 1; }\n              }\n              if (alive == 0) { break; }\n              cudaMemcpy(active, host, SLOTS * 4, cudaMemcpyHostToDevice);\n              for (int s = 0; s < SLOTS; ++s) {\n                stepSlot<<<1, DIM>>>(progress, state, active, s, vec_get(who, s), DIM);\n              }\n              for (int s = 0; s < SLOTS; ++s) {\n                int r = vec_get(remain, s);\n                if (r > 0) vec_set(remain, s, r - 1);\n              }\n            }\n          }\n\n          // 把记账拷回平台准备的缓冲区\n          cudaMemcpy(lab_buffer(1), progress, N * 4, cudaMemcpyDeviceToDevice);\n          cudaFree(progress);\n          cudaFree(active);\n          return 0;\n        }\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/scheduler.cu"
+            ],
+            "buffers": [
+              {
+                "name": "state",
+                "length": 128,
+                "fill": {
+                  "kind": "const",
+                  "value": 0.5
+                }
+              },
+              {
+                "name": "progress",
+                "length": 12,
+                "type": "int",
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": []
+          },
+          "referenceFiles": {
+            "/root/scheduler.cu": "        #include \"engine.h\"\n        #include \"containers.h\"\n\n        __global__ void stepSlot(int* progress, float* state, const int* active,\n                         int slot, int req, int dim) {\n  int d = threadIdx.x;\n  if (active[slot] == 0) return;\n  if (d == 0) progress[req] = progress[req] + 1;\n  state[slot * dim + d] = state[slot * dim + d] * 1.0009765625f + 0.001f;\n}\n\n\n        int main(void) {\n          const int DIM = 32;\n          const int SLOTS = 4;\n          const int N = 12;\n\n          int lens = vec_new();\n          vec_push(lens, 40);\n            vec_push(lens, 3);\n            vec_push(lens, 25);\n            vec_push(lens, 5);\n            vec_push(lens, 60);\n            vec_push(lens, 4);\n            vec_push(lens, 18);\n            vec_push(lens, 6);\n            vec_push(lens, 33);\n            vec_push(lens, 2);\n            vec_push(lens, 50);\n            vec_push(lens, 8);\n\n          float* state = lab_buffer(0);\n          int* progress;\n          cudaMalloc((void**)&progress, N * 4);\n          cudaMemset(progress, 0, N * 4);\n\n          int* active;\n          cudaMalloc((void**)&active, SLOTS * 4);\n          int host[4];\n\n          // 等待的请求排成一个队列\n          int queue = ring_new();\n          for (int i = 0; i < N; ++i) ring_push(queue, i);\n\n          // 每个槽位记两件事：还剩几步、在跑哪个请求\n          int remain = vec_new();\n          int who = vec_new();\n          for (int s = 0; s < SLOTS; ++s) { vec_push(remain, 0); vec_push(who, 0); }\n\n          int alive = 1;\n          while (alive == 1) {\n            alive = 0;\n\n            // 补位：空槽立刻取下一个请求。**两件事一起换** ——\n            // 只换步数不换请求号，记账就全记到上一个请求头上了\n            for (int s = 0; s < SLOTS; ++s) {\n              if (vec_get(remain, s) == 0) {\n                if (ring_len(queue) > 0) {\n                  int req = ring_pop(queue);\n                  vec_set(who, s, req);\n                  vec_set(remain, s, vec_get(lens, req));\n                }\n              }\n            }\n\n            for (int s = 0; s < SLOTS; ++s) {\n              host[s] = vec_get(remain, s) > 0 ? 1 : 0;\n              if (host[s] == 1) { alive = 1; }\n            }\n            // 槽位全空且队列也空，才是真的结束\n            if (alive == 0) { break; }\n\n            cudaMemcpy(active, host, SLOTS * 4, cudaMemcpyHostToDevice);\n            for (int s = 0; s < SLOTS; ++s) {\n              stepSlot<<<1, DIM>>>(progress, state, active, s, vec_get(who, s), DIM);\n            }\n            for (int s = 0; s < SLOTS; ++s) {\n              int r = vec_get(remain, s);\n              if (r > 0) vec_set(remain, s, r - 1);\n            }\n          }\n\n          cudaMemcpy(lab_buffer(1), progress, N * 4, cudaMemcpyDeviceToDevice);\n          cudaFree(progress);\n          cudaFree(active);\n          return 0;\n        }\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "scheduler.spec.ts",
+            "content": "const lab = require('@gpu/lab');\nconst LENGTHS = [40,3,25,5,60,4,18,6,33,2,50,8];\nconst TOTAL = 254;\n\ndescribe('连续批处理', () => {\n  it('**12 个请求一个不漏，每个都跑够它自己的步数**', async () => {\n    await lab.buildAndRun();\n    const progress = lab.bufferInts('progress');\n    expect(Array.from(progress)).toEqual(LENGTHS);\n  });\n\n  it('真实工作量没变 —— 省的是 padding', async () => {\n    await lab.buildAndRun();\n    const progress = lab.bufferInts('progress');\n    const done = Array.from(progress).reduce((sum, n) => sum + n, 0);\n    expect(done).toBe(TOTAL);\n  });\n\n  it('提交次数降下来了', async () => {\n    await lab.buildAndRun();\n    expect(lab.metrics().launch.kernels).toBeLessThanOrEqual(400);\n  });\n\n  it('padding 的比例降到三成以下', async () => {\n    await lab.buildAndRun();\n    // 每次提交就是一个槽位一步，其中只有 TOTAL 次是真活\n    const submitted = lab.metrics().launch.kernels;\n    expect(1 - TOTAL / submitted).toBeLessThan(0.3);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.launch.kernels",
+            "op": "lte",
+            "value": 400,
+            "label": {
+              "zh": "提交次数（静态批是 600，其中 58% 是 padding）",
+              "en": "submissions (600 static, 58% of it padding)"
+            },
+            "unit": "launch",
+            "dimension": "throughput"
+          }
+        ],
+        "focus": [
+          "throughput",
+          "correctness"
+        ],
+        "primer": {
+          "zh": "GPU 喜欢大批量，可是解码时每条序列的长度差别极大：有的两个 token 就结束，有的要生成几百个。朴素的静态批是凑够一批一起跑、等全部结束再收下一批 --于是短的那条跑完之后，它的槽位要空转到最长那条结束为止。空转不是免费的：padding 的槽位在真卡上照样占着计算资源走完一遍。\n\n连续批处理的做法很简单：不等整批结束，哪个槽位空了就立刻从队列里取下一个请求塞进去。批是流动的，不是一批一批的。Orca 那篇论文（OSDI 2022）提出了它，现在 vLLM、TensorRT-LLM、SGLang 全都是这么做的，TensorRT-LLM 管它叫 in-flight batching。\n\n它和分页 KV 是一对：连续批处理让批一直是满的，分页 KV 让满的批装得下。没有分页，每条序列按最长上下文预留显存，同时能装的序列数很少，连续批处理也就没多少可调度的余地。两件事是一起起作用的。\n\n真实调度器要处理的比这多得多：预填充和解码要不要混在同一批里、显存不够时抢占谁、怎么不让长请求被饿死、以及批大小只能是 CUDA Graph 预先捕获过的那几档 --所以调度器挑的往往不是最优的批，而是最接近某一档的批。还有一件量不出来但很重要的事：连续批处理改善的是吞吐，对单个请求的延迟可能是负面的，因为你的请求要和更多别人的挤在一起。生产里因此同时盯首 token 时延与每 token 时延，而不是只看吞吐。",
+          "en": "GPUs like big batches, but decoding sequence lengths vary enormously: some finish in two tokens, some generate hundreds. Naive static batching gathers a batch, runs it, and waits for all of it before taking the next, so once the short sequence finishes its slot idles until the longest one is done. Idling is not free: a padded slot still occupies compute on real hardware for the whole step.\n\nContinuous batching is simple: do not wait for the batch; the moment a slot frees, pull the next request from the queue into it. The batch flows rather than proceeding in lockstep. The Orca paper (OSDI 2022) introduced it and vLLM, TensorRT-LLM and SGLang all work this way now, with TensorRT-LLM calling it in-flight batching.\n\nIt pairs with paged KV: continuous batching keeps the batch full, paging makes a full batch fit. Without paging each sequence reserves memory for its maximum context, few fit at once, and there is little left to schedule. The two work together.\n\nReal schedulers handle far more: whether to mix prefill and decode in one batch, whom to preempt when memory runs out, how to keep long requests from starving, and the fact that batch sizes must be ones a CUDA Graph was captured for, so the scheduler usually picks not the optimal batch but the one nearest a captured size. One more thing that is hard to measure but matters: continuous batching improves throughput and can hurt an individual request latency, since your request now shares the GPU with more of everyone else. Production systems therefore watch time to first token and time per output token alongside throughput, not throughput alone."
+        }
       }
     ]
   },


### PR DESCRIPTION
12 个请求，长度 40/3/25/5/60/4/18/6/33/2/50/8，一共 **254 个真实槽位步**，4 个槽位。

| | 步数 | 提交次数 | padding 占比 |
| --- | --- | --- | --- |
| 静态批 | 150 | 600 | **58%** |
| 连续批 | 83 | 332 | 23% |

## 判定是不可伪造的
`progress[req]` 由**平台的 kernel** 记账，用例要求它逐个等于每个请求该有的步数。
于是「补位时忘了换请求号」这个最常见的错（步数对但全记到上一个请求头上）
会被直接抓出来，而不是靠学员自己打印的数。

## 正文里点的两处联系
- 连续批与**第 18 关的分页 KV 是一对**：前者让批一直是满的，后者让满的批装得下。没有分页，同时能装的序列数很少，连续批也就没多少可调度的余地。
- 批大小只能是**第 20 关那些预先捕获过的 CUDA Graph 档位**，所以调度器挑的往往不是最优的批，而是最接近某一档的批。

以及一件量不出来但要说的：连续批改善的是**吞吐**，对单个请求的**延迟**可能是负面的 —— 生产里同时盯 TTFT 与 TPOT。

## 验证
`tests/gpulab/stages.test.ts` **64/64**（21 关全部反向验证）；
`tsc` / `projects:verify` / `npm test` 10/10 / `npm run build` 含 check-bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)