### PR TITLE
feat(gpulab): 集群基础设施（多卡地址空间 / 三种链路 / NCCL）

### DIFF
--- a/src/lib/gpulab/cluster/cluster.ts
+++ b/src/lib/gpulab/cluster/cluster.ts
@@ -1,0 +1,274 @@
+/**
+ * 一个 GPU 集群
+ *
+ * N 台设备，每台一份独立的显存与计量。集群这一层管三件事：
+ * **地址空间的隔离**、**通信的计量**、以及虚拟时钟上的传输耗时。
+ *
+ * ## 地址为什么要带设备号
+ *
+ * 真卡上一个设备的指针在另一个设备上是非法的，误用会得到
+ * illegal memory access。模拟器如果让它「碰巧能读到东西」，
+ * 那就是这个项目最防的那种失败 —— 程序照跑，结果静静地错。
+ *
+ * 所以设备 d 的地址从 `(d + 1) * SPAN` 起算。SPAN 取 256MB，
+ * 远大于关卡里任何一个标量参数（都是几千的量级），
+ * 于是**从一个数就能看出它是不是指针、是哪张卡的指针**。
+ */
+import { GpuDevice, type DeviceOptions } from '../index';
+import type { ExecutableKernel } from '../ir/program';
+import type { Dim3, LaunchConfig } from '../vm/vm';
+import {
+  linkBetween, nodeOf, transferSeconds,
+  type ClusterSpec, type LinkKind, type LinkSpec,
+} from './topology';
+
+/**
+ * 每张卡的地址空间跨度。
+ *
+ * 取 2^25（32MB）而不是更大的数，是因为**带设备号的地址必须留在 int32 里**：
+ * 宿主运行时对参数一律做 `| 0`（C 的 int 语义），
+ * 设备 d 的基地址是 `(d + 1) * SPAN`，16 张卡时 2^28 会算到 24 亿，
+ * 直接回绕成负数 —— 而回绕之后地址查不到、报错说的是"不在任何一次分配里"，
+ * 完全看不出真正的原因。构造函数里有一道显式的守卫。
+ */
+export const DEVICE_SPAN = 1 << 25;
+
+export class ClusterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClusterError';
+  }
+}
+
+interface Allocation {
+  /** 带设备号的基地址 */
+  base: number;
+  bytes: number;
+  device: number;
+}
+
+/** 通信的计量。**全部是结构性的**，所以可以作门槛 */
+export interface CommMetrics {
+  /** 一共搬了多少字节 */
+  bytes: number;
+  /** 发了多少条消息 —— 不分桶会发几百条小的，门槛读它 */
+  messages: number;
+  /** 按链路种类分。张量并行跨机时 ib 会暴增 */
+  bytesByLink: Record<LinkKind, number>;
+  messagesByLink: Record<LinkKind, number>;
+  /** 通信占用的虚拟时间，秒 */
+  seconds: number;
+  /**
+   * 算法带宽与总线带宽。
+   *
+   * nccl-tests 的口径：algbw = 字节数 / 耗时，
+   * busbw = algbw × 修正因子。all-reduce 的修正因子是 `2(n-1)/n` ——
+   * 第 22 关要学员**自己数出**这个因子，而不是背下来。
+   */
+  algbw: number;
+  busbw: number;
+}
+
+export function emptyCommMetrics(): CommMetrics {
+  return {
+    bytes: 0, messages: 0,
+    bytesByLink: { nvlink: 0, pcie: 0, ib: 0 },
+    messagesByLink: { nvlink: 0, pcie: 0, ib: 0 },
+    seconds: 0, algbw: 0, busbw: 0,
+  };
+}
+
+export interface ClusterOptions extends DeviceOptions {
+  spec: ClusterSpec;
+}
+
+export class Cluster {
+  readonly devices: GpuDevice[] = [];
+  readonly spec: ClusterSpec;
+  readonly comm = emptyCommMetrics();
+  /** 当前 cudaSetDevice 选中的卡 */
+  current = 0;
+
+  private readonly allocations: Allocation[] = [];
+  /**
+   * 每条链路各自的忙碌时间。
+   *
+   * 多张卡同时通信时，总耗时是**最慢那条链路**的时间，
+   * 不是所有传输之和 —— ring all-reduce 的全部意义就在这里。
+   */
+  private readonly linkBusy = new Map<string, number>();
+
+  constructor(options: ClusterOptions) {
+    this.spec = options.spec;
+    const highest = (options.spec.devices + 1) * DEVICE_SPAN;
+    if (highest > 0x7fffffff) {
+      throw new ClusterError(
+        `${options.spec.devices} 张卡的地址空间放不进 int32（要 ${highest}）—— `
+        + '要么减少卡数，要么调小 DEVICE_SPAN'
+      );
+    }
+    const perDevice = options.globalBytes ?? 16 * 1024 * 1024;
+    if (perDevice > DEVICE_SPAN) {
+      throw new ClusterError(
+        `每张卡要 ${perDevice} 字节，超过了地址空间跨度 ${DEVICE_SPAN}`
+      );
+    }
+    for (let i = 0; i < options.spec.devices; i += 1) {
+      this.devices.push(new GpuDevice({
+        globalBytes: options.globalBytes ?? 16 * 1024 * 1024,
+        sharedBytesPerBlock: options.sharedBytesPerBlock,
+        device: options.device,
+        maxWarpInsts: options.maxWarpInsts,
+      }));
+    }
+  }
+
+  get count(): number {
+    return this.devices.length;
+  }
+
+  setDevice(index: number): void {
+    if (!Number.isInteger(index) || index < 0 || index >= this.count) {
+      throw new ClusterError(`没有编号 ${index} 的设备 —— 一共 ${this.count} 张卡`);
+    }
+    this.current = index;
+  }
+
+  /** 在当前设备上分配，返回**带设备号的**地址 */
+  malloc(bytes: number): number {
+    const device = this.current;
+    const local = this.devices[device].malloc(bytes);
+    const base = (device + 1) * DEVICE_SPAN + local;
+    this.allocations.push({ base, bytes, device });
+    return base;
+  }
+
+  /** 一个带设备号的地址属于哪块分配 */
+  private lookup(address: number): Allocation | null {
+    if (address < DEVICE_SPAN) return null;
+    for (const item of this.allocations) {
+      if (address >= item.base && address < item.base + item.bytes) return item;
+    }
+    return null;
+  }
+
+  /** 把带设备号的地址翻成设备本地地址，同时验它属于哪张卡 */
+  localAddress(address: number, expected: number, what: string): number {
+    const found = this.lookup(address);
+    if (!found) {
+      throw new ClusterError(
+        `${what}：地址 ${address} 不在任何一次 cudaMalloc 的范围里`
+      );
+    }
+    if (found.device !== expected) {
+      throw new ClusterError(
+        `${what}：这是设备 ${found.device} 的指针，却在设备 ${expected} 上用 —— `
+        + '真卡上这是 illegal memory access。先 cudaSetDevice，或者用 cudaMemcpyPeer 搬过去'
+      );
+    }
+    return address - (found.device + 1) * DEVICE_SPAN;
+  }
+
+  /** 一个数看起来像不像指针 */
+  isPointer(value: number): boolean {
+    return value >= DEVICE_SPAN;
+  }
+
+  copyIn(address: number, values: ArrayLike<number>): void {
+    const found = this.lookup(address);
+    if (!found) throw new ClusterError(`地址 ${address} 不在任何一次分配里`);
+    this.devices[found.device].copyIn(address - (found.device + 1) * DEVICE_SPAN, values);
+  }
+
+  copyOut(address: number, count: number): Float32Array {
+    const found = this.lookup(address);
+    if (!found) throw new ClusterError(`地址 ${address} 不在任何一次分配里`);
+    return this.devices[found.device].copyOut(address - (found.device + 1) * DEVICE_SPAN, count);
+  }
+
+  copyOutInts(address: number, count: number): Int32Array {
+    const found = this.lookup(address);
+    if (!found) throw new ClusterError(`地址 ${address} 不在任何一次分配里`);
+    return this.devices[found.device].copyOutInts(address - (found.device + 1) * DEVICE_SPAN, count);
+  }
+
+  launch(name: string, kernel: ExecutableKernel, config: LaunchConfig, args: number[]): void {
+    const device = this.current;
+    const translated = args.map((arg, index) => (
+      this.isPointer(arg)
+        ? this.localAddress(arg, device, `${name} 的第 ${index + 1} 个参数`)
+        : arg
+    ));
+    this.devices[device].launch(kernel, config, translated);
+  }
+
+  /**
+   * 设备之间搬一段字节。
+   *
+   * 这是 `cudaMemcpyPeer` 与 NCCL 的公共底座。
+   * 计量在这里做：字节数、消息数、走了哪条链路、占了多久。
+   */
+  peerCopy(dst: number, dstDevice: number, src: number, srcDevice: number, bytes: number): void {
+    if (bytes < 0) throw new ClusterError(`拷贝的字节数是负的：${bytes}`);
+    const dstLocal = this.localAddress(dst, dstDevice, 'cudaMemcpyPeer 的目标');
+    const srcLocal = this.localAddress(src, srcDevice, 'cudaMemcpyPeer 的来源');
+
+    const to = this.devices[dstDevice].memory;
+    const from = this.devices[srcDevice].memory;
+    if (dstLocal + bytes > to.capacity || srcLocal + bytes > from.capacity) {
+      throw new ClusterError(`cudaMemcpyPeer 越界：搬 ${bytes} 字节`);
+    }
+    new Uint8Array(to.bytes, dstLocal, bytes).set(new Uint8Array(from.bytes, srcLocal, bytes));
+
+    if (srcDevice === dstDevice) return;   // 同卡内的拷贝不算通信
+    this.account(srcDevice, dstDevice, bytes);
+  }
+
+  /** 记一次跨卡传输 */
+  account(from: number, to: number, bytes: number): void {
+    const link = linkBetween(from, to, this.spec);
+    const seconds = transferSeconds(bytes, link);
+
+    this.comm.bytes += bytes;
+    this.comm.messages += 1;
+    this.comm.bytesByLink[link.kind] += bytes;
+    this.comm.messagesByLink[link.kind] += 1;
+
+    // 同一条链路上的传输是串行的；不同链路可以同时忙。
+    // 于是总通信时间取所有链路里最忙的那一条 ——
+    // ring all-reduce 之所以能把 n 张卡的带宽都用上，就是因为
+    // 每一步用的都是不同的链路。
+    const key = `${Math.min(from, to)}-${Math.max(from, to)}`;
+    const busy = (this.linkBusy.get(key) ?? 0) + seconds;
+    this.linkBusy.set(key, busy);
+    if (busy > this.comm.seconds) this.comm.seconds = busy;
+  }
+
+  /**
+   * 按 nccl-tests 的口径算带宽。
+   *
+   * `payloadBytes` 是**一次集合操作在用户看来搬了多少**
+   * （all-reduce 就是缓冲区大小），`factor` 是集合操作的修正因子。
+   */
+  finishBandwidth(payloadBytes: number, factor: number): void {
+    if (this.comm.seconds <= 0) return;
+    this.comm.algbw = payloadBytes / this.comm.seconds;
+    this.comm.busbw = this.comm.algbw * factor;
+  }
+
+  nodeOf(device: number): number {
+    return nodeOf(device, this.spec);
+  }
+
+  linkFor(a: number, b: number): LinkSpec {
+    return linkBetween(a, b, this.spec);
+  }
+
+  reset(): void {
+    for (const device of this.devices) device.reset();
+    this.allocations.length = 0;
+    this.linkBusy.clear();
+    this.current = 0;
+    Object.assign(this.comm, emptyCommMetrics());
+  }
+}

--- a/src/lib/gpulab/cluster/nccl.ts
+++ b/src/lib/gpulab/cluster/nccl.ts
@@ -1,0 +1,227 @@
+/**
+ * NCCL 集合通信
+ *
+ * ## 算法是真做的
+ *
+ * `ncclAllReduce` 不是「把数加起来然后填回去」这么一句。它按 **ring 算法**
+ * 真的走 `2(n-1)` 步、真的记每一步走了哪条链路 —— 于是
+ * `comm.bytes` 与 `busbw` 是数出来的，不是套公式算的。
+ *
+ * 第 22 关让学员自己用 p2p 拼一个 ring all-reduce，第 23 关换成 NCCL：
+ * 那时候 `2(n-1)/n` 这个修正因子对他来说是**数出来的步数**，
+ * 不是一个背下来的公式。这是这两关分开做的全部理由。
+ *
+ * ## 归约的顺序是定死的
+ *
+ * 浮点加法不满足结合律，所以归约顺序不同结果就不同。
+ * ring 算法的顺序是确定的（按 rank 依次累加），我们照着做，
+ * 于是**重放逐位一致**这条硬承诺在多卡上依然成立。
+ * 真 NCCL 也是这个性质：同样的通信子、同样的规模，结果可复现。
+ */
+import type { Cluster } from './cluster';
+
+export type RedOp = 'sum' | 'prod' | 'max' | 'min';
+
+export function redOpOf(code: number): RedOp {
+  switch (code) {
+    case 1: return 'prod';
+    case 2: return 'max';
+    case 3: return 'min';
+    default: return 'sum';
+  }
+}
+
+function combine(a: number, b: number, op: RedOp): number {
+  switch (op) {
+    case 'prod': return Math.fround(a * b);
+    case 'max': return Math.max(a, b);
+    case 'min': return Math.min(a, b);
+    default: return Math.fround(a + b);
+  }
+}
+
+/** 一次集合操作里，每个 rank 的收发缓冲区 */
+export interface CommBuffers {
+  send: number;
+  recv: number;
+}
+
+/**
+ * ring all-reduce。
+ *
+ * 分两个阶段，每个阶段 n-1 步：
+ *   1. **reduce-scatter**：每张卡最后持有 1/n 的完整归约结果
+ *   2. **all-gather**：把这 n 份结果转一圈，人人拿全
+ *
+ * 一共 `2(n-1)` 步，每步搬 `count/n` 个元素。
+ * 每张卡搬的总量是 `2(n-1)/n × 缓冲区大小` ——
+ * **这就是 busbw 那个修正因子的来历**。
+ */
+export function ringAllReduce(
+  cluster: Cluster, buffers: CommBuffers[], count: number, op: RedOp
+): void {
+  const n = buffers.length;
+  if (n === 1) {
+    copyWithin(cluster, buffers[0].recv, buffers[0].send, count);
+    return;
+  }
+
+  // 先把 send 拷进 recv，之后全在 recv 上原地做 —— 真 NCCL 也允许原地
+  const data: Float32Array[] = [];
+  for (let rank = 0; rank < n; rank += 1) {
+    data.push(cluster.copyOut(buffers[rank].send, count));
+  }
+
+  const chunk = Math.ceil(count / n);
+  const range = (index: number) => {
+    const start = Math.min(index * chunk, count);
+    return { start, end: Math.min(start + chunk, count) };
+  };
+
+  // 阶段一：reduce-scatter
+  for (let step = 0; step < n - 1; step += 1) {
+    const pending: Array<{ rank: number; index: number; values: Float32Array }> = [];
+    for (let rank = 0; rank < n; rank += 1) {
+      const sendIndex = (rank - step + n) % n;
+      const { start, end } = range(sendIndex);
+      pending.push({
+        rank: (rank + 1) % n,
+        index: sendIndex,
+        values: data[rank].slice(start, end),
+      });
+      cluster.account(rank, (rank + 1) % n, (end - start) * 4);
+    }
+    for (const item of pending) {
+      const { start, end } = range(item.index);
+      for (let i = start; i < end; i += 1) {
+        data[item.rank][i] = combine(data[item.rank][i], item.values[i - start], op);
+      }
+    }
+  }
+
+  // 阶段二：all-gather。这时 rank r 持有第 (r + 1) % n 块的完整结果
+  for (let step = 0; step < n - 1; step += 1) {
+    const pending: Array<{ rank: number; index: number; values: Float32Array }> = [];
+    for (let rank = 0; rank < n; rank += 1) {
+      const sendIndex = (rank + 1 - step + n) % n;
+      const { start, end } = range(sendIndex);
+      pending.push({
+        rank: (rank + 1) % n,
+        index: sendIndex,
+        values: data[rank].slice(start, end),
+      });
+      cluster.account(rank, (rank + 1) % n, (end - start) * 4);
+    }
+    for (const item of pending) {
+      const { start, end } = range(item.index);
+      for (let i = start; i < end; i += 1) data[item.rank][i] = item.values[i - start];
+    }
+  }
+
+  for (let rank = 0; rank < n; rank += 1) cluster.copyIn(buffers[rank].recv, data[rank]);
+}
+
+/** all-gather：每张卡贡献 count 个元素，人人拿到 n × count */
+export function ringAllGather(cluster: Cluster, buffers: CommBuffers[], count: number): void {
+  const n = buffers.length;
+  const parts: Float32Array[] = [];
+  for (let rank = 0; rank < n; rank += 1) {
+    parts.push(cluster.copyOut(buffers[rank].send, count));
+  }
+  for (let step = 0; step < n - 1; step += 1) {
+    for (let rank = 0; rank < n; rank += 1) cluster.account(rank, (rank + 1) % n, count * 4);
+  }
+  const all = new Float32Array(n * count);
+  for (let rank = 0; rank < n; rank += 1) all.set(parts[rank], rank * count);
+  for (let rank = 0; rank < n; rank += 1) cluster.copyIn(buffers[rank].recv, all);
+}
+
+/** reduce-scatter：归约之后每张卡只拿自己那 1/n */
+export function ringReduceScatter(
+  cluster: Cluster, buffers: CommBuffers[], recvCount: number, op: RedOp
+): void {
+  const n = buffers.length;
+  const total = recvCount * n;
+  const data: Float32Array[] = [];
+  for (let rank = 0; rank < n; rank += 1) {
+    data.push(cluster.copyOut(buffers[rank].send, total));
+  }
+  for (let step = 0; step < n - 1; step += 1) {
+    for (let rank = 0; rank < n; rank += 1) cluster.account(rank, (rank + 1) % n, recvCount * 4);
+  }
+  for (let rank = 0; rank < n; rank += 1) {
+    const out = new Float32Array(recvCount);
+    for (let i = 0; i < recvCount; i += 1) {
+      // 归约顺序按 rank 从小到大，固定 —— 浮点加法不满足结合律，
+      // 顺序一变结果就变，而我们承诺过重放逐位一致
+      let acc = data[0][rank * recvCount + i];
+      for (let other = 1; other < n; other += 1) {
+        acc = combine(acc, data[other][rank * recvCount + i], op);
+      }
+      out[i] = acc;
+    }
+    cluster.copyIn(buffers[rank].recv, out);
+  }
+}
+
+/** broadcast：root 的内容发给所有人。用二叉树，log(n) 步 */
+export function treeBroadcast(
+  cluster: Cluster, buffers: CommBuffers[], count: number, root: number
+): void {
+  const n = buffers.length;
+  const values = cluster.copyOut(buffers[root].send, count);
+  // 二叉树：第 k 轮，已经拿到数据的卡各自发给一张没拿到的
+  const have = [root];
+  while (have.length < n) {
+    const wave = have.slice();
+    for (const source of wave) {
+      if (have.length >= n) break;
+      let target = -1;
+      for (let candidate = 0; candidate < n; candidate += 1) {
+        if (!have.includes(candidate)) { target = candidate; break; }
+      }
+      if (target < 0) break;
+      cluster.account(source, target, count * 4);
+      have.push(target);
+    }
+  }
+  for (let rank = 0; rank < n; rank += 1) cluster.copyIn(buffers[rank].recv, values);
+}
+
+/** reduce：归约到 root 一张卡上 */
+export function treeReduce(
+  cluster: Cluster, buffers: CommBuffers[], count: number, root: number, op: RedOp
+): void {
+  const n = buffers.length;
+  const data: Float32Array[] = [];
+  for (let rank = 0; rank < n; rank += 1) data.push(cluster.copyOut(buffers[rank].send, count));
+  for (let rank = 0; rank < n; rank += 1) {
+    if (rank !== root) cluster.account(rank, root, count * 4);
+  }
+  const out = new Float32Array(count);
+  for (let i = 0; i < count; i += 1) {
+    let acc = data[0][i];
+    for (let rank = 1; rank < n; rank += 1) acc = combine(acc, data[rank][i], op);
+    out[i] = acc;
+  }
+  cluster.copyIn(buffers[root].recv, out);
+}
+
+function copyWithin(cluster: Cluster, dst: number, src: number, count: number): void {
+  if (dst === src) return;
+  cluster.copyIn(dst, cluster.copyOut(src, count));
+}
+
+/**
+ * 各个集合操作的 busbw 修正因子。
+ *
+ * 口径来自 nccl-tests 的 README：算法带宽换算成总线带宽时，
+ * 每种操作在环上实际搬的总量与用户看到的字节数之比不同。
+ */
+export const BUS_FACTOR: Record<string, (n: number) => number> = {
+  allreduce: (n) => (2 * (n - 1)) / n,
+  allgather: (n) => (n - 1) / n,
+  reducescatter: (n) => (n - 1) / n,
+  broadcast: () => 1,
+  reduce: () => 1,
+};

--- a/src/lib/gpulab/cluster/run.ts
+++ b/src/lib/gpulab/cluster/run.ts
@@ -1,0 +1,141 @@
+/**
+ * 在一个集群上跑宿主程序
+ *
+ * 单卡版是 `GpuDevice.runHost`；这里是多卡版。区别只在
+ * `HostEnvironment` 的实现：分配、拷贝、起 kernel 都要先问"哪张卡"，
+ * 并且多出 NCCL 那一套。
+ */
+import { HostRuntime, type HostEnvironment } from '../host/runtime';
+import { HostRuntimeError } from '../host/containers';
+import type { ExecutableKernel } from '../ir/program';
+import { LinearMemory } from '../vm/memory';
+import { dim3, launchKernel } from '../vm/vm';
+import { DEVICE_SPAN, type Cluster } from './cluster';
+import {
+  BUS_FACTOR, redOpOf, ringAllGather, ringAllReduce, ringReduceScatter,
+  treeBroadcast, treeReduce,
+} from './nccl';
+
+export interface ClusterRunResult {
+  stdout: string;
+}
+
+export function runClusterHost(
+  cluster: Cluster,
+  host: ExecutableKernel,
+  kernels: Map<string, ExecutableKernel>,
+  buffers: Array<{ address: number; length: number }> = []
+): ClusterRunResult {
+  const output: string[] = [];
+  const hostLocal = new LinearMemory(Math.max(64, host.localBytes), 'local');
+  /** 这一轮里最大的一次集合操作的载荷，用来算 busbw */
+  let payload = 0;
+  let factorKind = 'allreduce';
+
+  const environment: HostEnvironment = {
+    cudaMalloc: (bytes) => cluster.malloc(bytes),
+    cudaFree: () => {},
+    copy: (dst, src, bytes, kind) => {
+      // 主机端 = 宿主线程的 local 空间；设备端 = 某张卡的显存
+      if (kind === 1) {                       // HostToDevice
+        const local = cluster.localAddress(dst, deviceOf(dst), 'cudaMemcpy 的目标');
+        const target = cluster.devices[deviceOf(dst)].memory;
+        new Uint8Array(target.bytes, local, bytes)
+          .set(new Uint8Array(hostLocal.bytes, src, bytes));
+        return;
+      }
+      if (kind === 2) {                       // DeviceToHost
+        const local = cluster.localAddress(src, deviceOf(src), 'cudaMemcpy 的来源');
+        const source = cluster.devices[deviceOf(src)].memory;
+        new Uint8Array(hostLocal.bytes, dst, bytes)
+          .set(new Uint8Array(source.bytes, local, bytes));
+        return;
+      }
+      if (kind === 0) {                       // HostToHost
+        new Uint8Array(hostLocal.bytes, dst, bytes)
+          .set(new Uint8Array(hostLocal.bytes, src, bytes));
+        return;
+      }
+      // DeviceToDevice。**跨卡的 DeviceToDevice 要明确拒绝** ——
+      // 真 CUDA 需要 cudaMemcpyPeer，混用会静默读到别的卡上的东西
+      cluster.peerCopy(dst, deviceOf(dst), src, deviceOf(src), bytes);
+    },
+    memset: (address, value, bytes) => {
+      const device = deviceOf(address);
+      const local = cluster.localAddress(address, device, 'cudaMemset');
+      new Uint8Array(cluster.devices[device].memory.bytes, local, bytes).fill(value & 0xff);
+    },
+    launch: (name, grid, block, args, line) => {
+      const kernel = kernels.get(name);
+      if (!kernel) {
+        throw new HostRuntimeError(
+          `第 ${line} 行：找不到 kernel \`${name}\` —— 编出来的有：${[...kernels.keys()].join(', ')}`
+        );
+      }
+      cluster.launch(name, kernel, { grid, block }, args);
+    },
+    replay: () => {
+      throw new HostRuntimeError('集群关卡还不支持 CUDA Graph');
+    },
+    write: (text) => { output.push(text); },
+    buffer: (index) => {
+      const found = buffers[index];
+      if (!found) {
+        throw new HostRuntimeError(
+          `没有第 ${index} 号缓冲区 —— 这一关声明了 ${buffers.length} 个（编号从 0 开始）`
+        );
+      }
+      return found;
+    },
+
+    deviceCount: () => cluster.count,
+    getDevice: () => cluster.current,
+    setDevice: (index) => cluster.setDevice(index),
+    peerCopy: (dst, dstDevice, src, srcDevice, bytes) => {
+      cluster.peerCopy(dst, dstDevice, src, srcDevice, bytes);
+    },
+    writeHostInts: (address, values) => {
+      const view = new Int32Array(hostLocal.bytes, address, values.length);
+      for (let i = 0; i < values.length; i += 1) view[i] = values[i] | 0;
+    },
+    collective: (kind, ranks, count, op, root) => {
+      const sorted = ranks.slice().sort((a, b) => a.device - b.device);
+      if (sorted.length < 1) return;
+      for (let i = 0; i < sorted.length; i += 1) {
+        if (sorted[i].device !== i) {
+          throw new HostRuntimeError(
+            `${kind}：group 里的通信子应该是 0..${sorted.length - 1} 各一个，`
+            + `实际有 ${sorted.map((r) => r.device).join(', ')}`
+          );
+        }
+      }
+      const reduce = redOpOf(op);
+      switch (kind) {
+        case 'allreduce': ringAllReduce(cluster, sorted, count, reduce); break;
+        case 'allgather': ringAllGather(cluster, sorted, count); break;
+        case 'reducescatter': ringReduceScatter(cluster, sorted, count, reduce); break;
+        case 'broadcast': treeBroadcast(cluster, sorted, count, Math.max(0, root)); break;
+        case 'reduce': treeReduce(cluster, sorted, count, Math.max(0, root), reduce); break;
+        default: throw new HostRuntimeError(`不认识的集合操作 ${kind}`);
+      }
+      const bytes = count * 4 * (kind === 'reducescatter' ? sorted.length : 1);
+      if (bytes > payload) { payload = bytes; factorKind = kind; }
+    },
+  };
+
+  function deviceOf(address: number): number {
+    // 地址自带设备号，见 cluster.ts 开头
+    return Math.floor(address / DEVICE_SPAN) - 1;
+  }
+
+  const runtime = new HostRuntime(environment, host.strings ?? []);
+  launchKernel(host, { grid: dim3(1), block: dim3(1) }, [], {
+    memory: cluster.devices[0].memory,
+    host: runtime,
+    localMemory: hostLocal,
+  });
+
+  const factor = BUS_FACTOR[factorKind] ?? (() => 1);
+  cluster.finishBandwidth(payload, factor(cluster.count));
+  return { stdout: output.join('') };
+}

--- a/src/lib/gpulab/cluster/topology.ts
+++ b/src/lib/gpulab/cluster/topology.ts
@@ -1,0 +1,110 @@
+/**
+ * 集群拓扑
+ *
+ * ## 为什么要建三种链路
+ *
+ * 「scale-up 走 NVLink（张量并行），scale-out 走 InfiniBand（数据并行）」
+ * 这条现实约束是后半程一半关卡的题眼。张量并行一旦跨了机，
+ * `comm.bytesByLink.ib` 立刻暴增 —— 门槛直接抓得住，
+ * 而这正是真实工程里最常见、代价也最大的一类配置错误。
+ *
+ * ## 参数从哪来
+ *
+ * 带宽与延迟来自公开的产品规格。它们是**参数化**的：
+ * 换一代硬件改的是下面这张表，模型结构不用动。
+ * 和 timing.ts 一样，这些数字用于**相对比较与结构性计量**，
+ * 不作绝对耗时的门槛。
+ */
+
+export type LinkKind = 'nvlink' | 'pcie' | 'ib';
+
+export interface LinkSpec {
+  kind: LinkKind;
+  /** 单向带宽，字节/秒 */
+  bandwidth: number;
+  /** 链路延迟，秒 */
+  latency: number;
+  /**
+   * 每条消息的固定开销，秒。
+   *
+   * **这一项决定了「多发小消息」为什么慢**：第 23 关的梯度分桶、
+   * 第 27 关的重叠粒度，代价都记在这里。
+   */
+  perMessage: number;
+  /**
+   * 有效带宽系数。
+   *
+   * 协议头、流控、纠错都要占带宽，标称值拿不满。
+   * NVLink 约 0.85，IB 约 0.90。
+   */
+  efficiency: number;
+}
+
+/** NVLink 4（H100）：18 条 × 25 GB/s，单向 450 GB/s */
+export const NVLINK4: LinkSpec = {
+  kind: 'nvlink', bandwidth: 450e9, latency: 1.5e-6, perMessage: 0.5e-6, efficiency: 0.85,
+};
+
+/** NVLink 5（Blackwell）：18 × 50 GB/s，单向 900 GB/s */
+export const NVLINK5: LinkSpec = {
+  kind: 'nvlink', bandwidth: 900e9, latency: 1.5e-6, perMessage: 0.5e-6, efficiency: 0.85,
+};
+
+/** PCIe Gen5 x16 */
+export const PCIE5: LinkSpec = {
+  kind: 'pcie', bandwidth: 64e9, latency: 3e-6, perMessage: 1e-6, efficiency: 0.85,
+};
+
+/** InfiniBand NDR，400 Gb/s */
+export const IB_NDR: LinkSpec = {
+  kind: 'ib', bandwidth: 50e9, latency: 5e-6, perMessage: 2e-6, efficiency: 0.90,
+};
+
+/** InfiniBand XDR，800 Gb/s（ConnectX-8） */
+export const IB_XDR: LinkSpec = {
+  kind: 'ib', bandwidth: 100e9, latency: 5e-6, perMessage: 2e-6, efficiency: 0.90,
+};
+
+export interface ClusterSpec {
+  /** 一共几张卡 */
+  devices: number;
+  /** 每台机器几张卡。机内走 NVLink，跨机走 IB */
+  devicesPerNode: number;
+  nvlink?: LinkSpec;
+  ib?: LinkSpec;
+  pcie?: LinkSpec;
+}
+
+/** 常见的一台 8 卡 H100 机器 */
+export const SINGLE_NODE_8: ClusterSpec = {
+  devices: 8, devicesPerNode: 8, nvlink: NVLINK4, ib: IB_NDR, pcie: PCIE5,
+};
+
+/** 两台 8 卡机，一共 16 张 —— 张量并行跨机的那些关用它 */
+export const TWO_NODE_16: ClusterSpec = {
+  devices: 16, devicesPerNode: 8, nvlink: NVLINK4, ib: IB_NDR, pcie: PCIE5,
+};
+
+export function nodeOf(device: number, spec: ClusterSpec): number {
+  return Math.floor(device / spec.devicesPerNode);
+}
+
+/**
+ * 两张卡之间走哪条链路。
+ *
+ * 同一台机器里走 NVLink，跨机走 IB。**没有第三种可能** ——
+ * 这个二分正是「张量并行必须留在机内」那条约束的来源。
+ */
+export function linkBetween(a: number, b: number, spec: ClusterSpec): LinkSpec {
+  if (a === b) throw new Error(`不能和自己通信：设备 ${a}`);
+  if (nodeOf(a, spec) === nodeOf(b, spec)) {
+    return spec.nvlink ?? PCIE5;
+  }
+  return spec.ib ?? IB_NDR;
+}
+
+/** 传一段字节要多久 */
+export function transferSeconds(bytes: number, link: LinkSpec): number {
+  const effective = link.bandwidth * link.efficiency;
+  return link.perMessage + link.latency + bytes / effective;
+}

--- a/src/lib/gpulab/host/headers.ts
+++ b/src/lib/gpulab/host/headers.ts
@@ -149,10 +149,76 @@ half __nv_cvt_fp8_to_halfraw(int storage, int interpretation);
 #endif
 `;
 
+export const NCCL_H = `/* nccl.h -- 集合通信
+ *
+ * 名字与参数顺序和真 NCCL 一致。两处偏差：
+ *
+ * 1. ncclCommInitAll 的真签名是 (comms, ndev, devlist)。这里省掉 devlist ——
+ *    设备固定就是 0..ndev-1。comms 仍然按真 API 那样被填上。
+ * 2. 通信子是一个 int（就是 rank 号），不是不透明句柄。
+ *
+ * ⚠️ **单线程管多张卡时，集合操作必须放在 ncclGroupStart / ncclGroupEnd 之间。**
+ * 每个 NCCL 调用都可能阻塞在等对端上，不成组就会死锁 ——
+ * 这一条是 NVIDIA 文档里明写的，这里不成组会直接报错而不是跑出个结果。
+ */
+#ifndef NCCL_H
+#define NCCL_H
+
+/* ncclDataType_t */
+#define ncclFloat  0
+#define ncclInt    1
+
+/* ncclRedOp_t */
+#define ncclSum   0
+#define ncclProd  1
+#define ncclMax   2
+#define ncclMin   3
+
+#define ncclSuccess 0
+
+int ncclCommInitAll(int* comms, int ndev);
+int ncclCommDestroy(int comm);
+
+int ncclGroupStart(void);
+int ncclGroupEnd(void);
+
+int ncclAllReduce(const void* send, void* recv, int count, int datatype,
+                  int op, int comm, int stream);
+int ncclAllGather(const void* send, void* recv, int sendcount, int datatype,
+                  int comm, int stream);
+int ncclReduceScatter(const void* send, void* recv, int recvcount, int datatype,
+                      int op, int comm, int stream);
+int ncclBroadcast(const void* send, void* recv, int count, int datatype,
+                  int root, int comm, int stream);
+int ncclReduce(const void* send, void* recv, int count, int datatype,
+               int op, int root, int comm, int stream);
+
+#endif
+`;
+
+export const CLUSTER_H = `/* cluster.h -- 多卡
+ *
+ * 每张卡有自己的地址空间。**一张卡的指针在另一张卡上是非法的** ——
+ * 真卡上误用会得到 illegal memory access，这里会直接报错告诉你
+ * 那是哪张卡的指针。要跨卡搬数据，用 cudaMemcpyPeer。
+ */
+#ifndef CLUSTER_H
+#define CLUSTER_H
+
+int cudaGetDeviceCount(int* count);
+int cudaSetDevice(int device);
+int cudaGetDevice(int* device);
+int cudaMemcpyPeer(void* dst, int dstDevice, const void* src, int srcDevice, int bytes);
+
+#endif
+`;
+
 /** 挂进机器磁盘的那几个头文件 */
 export const HOST_HEADERS: Record<string, string> = {
   '/root/containers.h': CONTAINERS_H,
   '/root/engine.h': ENGINE_H,
   '/root/cuda_runtime.h': CUDA_RUNTIME_H,
   '/root/cuda_fp8.h': CUDA_FP8_H,
+  '/root/nccl.h': NCCL_H,
+  '/root/cluster.h': CLUSTER_H,
 };

--- a/src/lib/gpulab/host/runtime.ts
+++ b/src/lib/gpulab/host/runtime.ts
@@ -40,6 +40,22 @@ export interface HostEnvironment {
   replay(nodes: GraphReplayNode[]): void;
   /** 收集标准输出 */
   write(text: string): void;
+
+  /* ---- 多卡。单卡的关卡不给这几个，用到就报错 ---- */
+  deviceCount?(): number;
+  /** 往宿主端的 int 数组里写 —— ncclCommInitAll 的出参是这么给的 */
+  writeHostInts?(address: number, values: number[]): void;
+  setDevice?(index: number): void;
+  getDevice?(): number;
+  peerCopy?(dst: number, dstDevice: number, src: number, srcDevice: number, bytes: number): void;
+  /** 一次集合操作。`kind` 是操作名，`ranks` 是每个 rank 的收发缓冲区 */
+  collective?(
+    kind: string,
+    ranks: Array<{ device: number; send: number; recv: number }>,
+    count: number,
+    op: number,
+    root: number
+  ): void;
   /**
    * 关卡在 `BenchSpec.buffers` 里声明的第 index 个缓冲区。
    *
@@ -78,6 +94,17 @@ interface LaunchNode {
   line: number;
 }
 
+/** group 里攒着的一次集合操作 */
+interface PendingCollective {
+  kind: string;
+  send: number;
+  recv: number;
+  count: number;
+  op: number;
+  comm: number;
+  root: number;
+}
+
 /** 一个宿主程序跑起来需要的全部状态 */
 export class HostRuntime implements HostServices {
   private readonly containers = new ContainerStore();
@@ -85,6 +112,15 @@ export class HostRuntime implements HostServices {
   private capturing: GraphNode[] | null = null;
   private readonly graphs: GraphNode[][] = [];
   private readonly execs: GraphNode[][] = [];
+  /**
+   * 正在攒的 group。
+   *
+   * NCCL 的调用是**流序异步**的：单线程管多设备时必须用 group 语义，
+   * 因为每个调用都可能阻塞在等对端上。攒到 `ncclGroupEnd` 一起发，
+   * 死锁才不会发生 —— 这一条是 NVIDIA 文档里明写的。
+   */
+  private group: PendingCollective[] | null = null;
+  private commCount = 0;
 
   constructor(
     private readonly env: HostEnvironment,
@@ -110,6 +146,58 @@ export class HostRuntime implements HostServices {
       return;
     }
     this.env.launch(name, grid, block, args, line);
+  }
+
+  private requireCluster(what: string): HostEnvironment {
+    if (!this.env.deviceCount) {
+      throw new HostRuntimeError(`${what}：这一关只有一张卡，没有集群`);
+    }
+    return this.env;
+  }
+
+  /**
+   * 把一次集合操作攒进 group。
+   *
+   * 不在 group 里的话立刻发 —— 真 NCCL 也允许单卡不用 group，
+   * 但**单线程管多设备时不用 group 会死锁**，所以这里不在 group 里
+   * 而通信子多于一个时明确报错，而不是让它跑出一个看似正常的结果。
+   */
+  private enqueue(
+    kind: string, send: number, recv: number, count: number,
+    op: number, comm: number, root: number
+  ): number {
+    const item: PendingCollective = { kind, send, recv, count, op, comm, root };
+    if (this.group) {
+      this.group.push(item);
+      return 0;
+    }
+    if (this.commCount > 1) {
+      throw new HostRuntimeError(
+        `${kind}：单线程管多张卡时必须把调用放在 ncclGroupStart / ncclGroupEnd 之间 —— `
+        + '每个 NCCL 调用都可能阻塞在等对端上，不成组会死锁'
+      );
+    }
+    this.flushGroup([item]);
+    return 0;
+  }
+
+  private flushGroup(pending: PendingCollective[]): void {
+    if (!pending.length) return;
+    const env = this.requireCluster('NCCL');
+    // 同一种操作、同一批 rank 的调用凑成一次集合操作
+    const byKind = new Map<string, PendingCollective[]>();
+    for (const item of pending) {
+      const key = `${item.kind}:${item.count}:${item.op}:${item.root}`;
+      const list = byKind.get(key);
+      if (list) list.push(item);
+      else byKind.set(key, [item]);
+    }
+    for (const [, list] of byKind) {
+      const ranks = list.map((item) => ({
+        device: item.comm, send: item.send, recv: item.recv,
+      }));
+      env.collective!(list[0].kind, ranks, list[0].count, list[0].op, list[0].root);
+    }
   }
 
   private dispatch(fn: number, args: number[]): number {
@@ -177,6 +265,73 @@ export class HostRuntime implements HostServices {
         // 和 cudaFree 一样：句柄不回收。峰值计量要的是"一共开过多少"，
         // 能回收就量不出差别了。写出来仍然是对的习惯。
         return 0;
+
+      /* ---- 多卡 ---- */
+      case HOST.cudaGetDeviceCount:
+        return this.requireCluster('cudaGetDeviceCount').deviceCount!();
+      case HOST.cudaGetDevice:
+        return this.requireCluster('cudaGetDevice').getDevice!();
+      case HOST.cudaSetDevice:
+        this.requireCluster('cudaSetDevice').setDevice!(args[0] | 0);
+        return 0;
+      case HOST.cudaMemcpyPeer:
+        this.requireCluster('cudaMemcpyPeer').peerCopy!(
+          args[0] | 0, args[1] | 0, args[2] | 0, args[3] | 0, args[4] | 0
+        );
+        return 0;
+
+      /* ---- NCCL ---- */
+      case HOST.ncclCommInitAll: {
+        // comms 是一个 int 数组，第 i 项是设备 i 的通信子。
+        // 这个子集里通信子就是 rank 号加一（0 留给"没初始化"）。
+        const count = args[1] | 0;
+        const env = this.requireCluster('ncclCommInitAll');
+        if (count > env.deviceCount!()) {
+          throw new HostRuntimeError(
+            `要 ${count} 个通信子，但一共只有 ${env.deviceCount!()} 张卡`
+          );
+        }
+        this.commCount = count;
+        // 真 API 是 ncclCommInitAll(comms, ndev, devlist)，把每个设备的
+        // 通信子写进 comms。这个子集里通信子就是 rank 号本身，
+        // devlist 省掉了（设备固定是 0..n-1），这条偏差写在 nccl.h 里。
+        env.writeHostInts!(args[0] | 0, Array.from({ length: count }, (_, i) => i));
+        return 0;
+      }
+      case HOST.ncclCommDestroy:
+        return 0;
+      case HOST.ncclGroupStart:
+        if (this.group) throw new HostRuntimeError('ncclGroupStart 不能嵌套');
+        this.group = [];
+        return 0;
+      case HOST.ncclGroupEnd: {
+        if (!this.group) throw new HostRuntimeError('没有在 group 里，ncclGroupEnd 无从结束');
+        const pending = this.group;
+        this.group = null;
+        this.flushGroup(pending);
+        return 0;
+      }
+      // 参数位置按真 nccl.h：
+      //   AllReduce(send, recv, count, datatype, op, comm, stream)
+      //   AllGather(send, recv, sendcount, datatype, comm, stream)
+      //   ReduceScatter(send, recv, recvcount, datatype, op, comm, stream)
+      //   Broadcast(send, recv, count, datatype, root, comm, stream)
+      //   Reduce(send, recv, count, datatype, op, root, comm, stream)
+      case HOST.ncclAllReduce:
+        return this.enqueue('allreduce', args[0], args[1], args[2] | 0, args[4] | 0, args[5] | 0, -1);
+      case HOST.ncclAllGather:
+        return this.enqueue('allgather', args[0], args[1], args[2] | 0, 0, args[4] | 0, -1);
+      case HOST.ncclReduceScatter:
+        return this.enqueue('reducescatter', args[0], args[1], args[2] | 0, args[4] | 0, args[5] | 0, -1);
+      case HOST.ncclBroadcast:
+        return this.enqueue('broadcast', args[0], args[1], args[2] | 0, 0, args[5] | 0, args[4] | 0);
+      case HOST.ncclReduce:
+        return this.enqueue('reduce', args[0], args[1], args[2] | 0, args[4] | 0, args[6] | 0, args[5] | 0);
+      case HOST.ncclSend:
+      case HOST.ncclRecv:
+        throw new HostRuntimeError(
+          'ncclSend / ncclRecv 还没做 —— 点对点请用 cudaMemcpyPeer'
+        );
 
       case HOST.cudaDeviceSynchronize:
         // 我们的 launch 是同步的，所以这里没有实际工作。**保留它不是装样子**：

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -36,6 +36,15 @@ export { encode } from './ir/program';
 export type { ExecutableKernel } from './ir/program';
 export type { Dim3, LaunchConfig, KernelArg, GpuCounters } from './vm/vm';
 export { HostRuntimeError } from './host/containers';
+export { Cluster, ClusterError, DEVICE_SPAN } from './cluster/cluster';
+export type { CommMetrics, ClusterOptions } from './cluster/cluster';
+export { runClusterHost } from './cluster/run';
+export {
+  NVLINK4, NVLINK5, PCIE5, IB_NDR, IB_XDR, SINGLE_NODE_8, TWO_NODE_16,
+  linkBetween, nodeOf, transferSeconds,
+} from './cluster/topology';
+export type { ClusterSpec, LinkSpec, LinkKind } from './cluster/topology';
+export { BUS_FACTOR } from './cluster/nccl';
 export { formatPrintf } from './host/runtime';
 
 /** 宿主程序跑完的结果 */

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -216,6 +216,25 @@ const HOST_FNS: Record<string, { fn: HostFn; arity: number; scalar: 'int' | 'voi
   cudaGraphDestroy: { fn: 'cudaGraphDestroy', arity: 1, scalar: 'int' },
   cudaGraphExecDestroy: { fn: 'cudaGraphExecDestroy', arity: 1, scalar: 'int' },
 
+  cudaGetDeviceCount: { fn: 'cudaGetDeviceCount', arity: 1, scalar: 'int' },
+  cudaSetDevice: { fn: 'cudaSetDevice', arity: 1, scalar: 'int' },
+  cudaGetDevice: { fn: 'cudaGetDevice', arity: 1, scalar: 'int' },
+  cudaMemcpyPeer: { fn: 'cudaMemcpyPeer', arity: 5, scalar: 'int' },
+
+  // NCCL。真 API 的形状：通信子按设备各一个，集合操作在 group 里发起。
+  ncclCommInitAll: { fn: 'ncclCommInitAll', arity: 2, scalar: 'int' },
+  // 下面几个的参数个数与真 nccl.h 一致
+  ncclCommDestroy: { fn: 'ncclCommDestroy', arity: 1, scalar: 'int' },
+  ncclGroupStart: { fn: 'ncclGroupStart', arity: 0, scalar: 'int' },
+  ncclGroupEnd: { fn: 'ncclGroupEnd', arity: 0, scalar: 'int' },
+  ncclAllReduce: { fn: 'ncclAllReduce', arity: 7, scalar: 'int' },
+  ncclAllGather: { fn: 'ncclAllGather', arity: 6, scalar: 'int' },
+  ncclReduceScatter: { fn: 'ncclReduceScatter', arity: 7, scalar: 'int' },
+  ncclBroadcast: { fn: 'ncclBroadcast', arity: 7, scalar: 'int' },
+  ncclReduce: { fn: 'ncclReduce', arity: 8, scalar: 'int' },
+  ncclSend: { fn: 'ncclSend', arity: 5, scalar: 'int' },
+  ncclRecv: { fn: 'ncclRecv', arity: 5, scalar: 'int' },
+
   vec_new: { fn: 'vec_new', arity: 0, scalar: 'int' },
   vec_push: { fn: 'vec_push', arity: 2, scalar: 'void' },
   vec_pop: { fn: 'vec_pop', arity: 1, scalar: 'int' },
@@ -256,6 +275,8 @@ const HOST_OUT_PARAM: Record<string, { at: number; hint: string }> = {
   // 提示按函数各写各的：学员在 cudaMalloc 上真正会敲的是 `(void**)&p`，
   // 报错里说成泛泛的「&变量」会让他以为要去掉那个 cast
   cudaMalloc: { at: 0, hint: '(void**)&指针变量' },
+  cudaGetDeviceCount: { at: 0, hint: '&变量' },
+  cudaGetDevice: { at: 0, hint: '&变量' },
   cudaStreamEndCapture: { at: 1, hint: '&变量' },
   cudaGraphInstantiate: { at: 0, hint: '&变量' },
 };
@@ -269,6 +290,15 @@ const DEVICE_CONSTANTS: Record<string, number> = {
   cudaStreamCaptureModeGlobal: 0,
   cudaStreamCaptureModeThreadLocal: 1,
   cudaStreamCaptureModeRelaxed: 2,
+  /** ncclDataType_t —— 这个子集只用得上 float */
+  ncclFloat: 0,
+  ncclInt: 1,
+  /** ncclRedOp_t */
+  ncclSum: 0,
+  ncclProd: 1,
+  ncclMax: 2,
+  ncclMin: 3,
+  ncclSuccess: 0,
 };
 
 /** `cudaMemcpyKind` 的四个取值，和真头文件里的顺序一致 */

--- a/src/lib/gpulab/ir/program.ts
+++ b/src/lib/gpulab/ir/program.ts
@@ -73,6 +73,11 @@ export const HOST: Record<HostFn, number> = {
   cudaStreamBeginCapture: 40, cudaStreamEndCapture: 41,
   cudaGraphInstantiate: 42, cudaGraphLaunch: 43,
   cudaGraphDestroy: 44, cudaGraphExecDestroy: 45,
+  cudaGetDeviceCount: 50, cudaSetDevice: 51, cudaGetDevice: 52, cudaMemcpyPeer: 53,
+  ncclCommInitAll: 60, ncclCommDestroy: 61,
+  ncclGroupStart: 62, ncclGroupEnd: 63,
+  ncclAllReduce: 64, ncclAllGather: 65, ncclReduceScatter: 66,
+  ncclBroadcast: 67, ncclReduce: 68, ncclSend: 69, ncclRecv: 70,
   vec_new: 10, vec_push: 11, vec_pop: 12, vec_get: 13, vec_set: 14, vec_len: 15, vec_clear: 16,
   map_new: 20, map_set: 21, map_get: 22, map_has: 23, map_del: 24, map_len: 25,
   ring_new: 30, ring_push: 31, ring_pop: 32, ring_peek: 33, ring_len: 34,
@@ -153,6 +158,7 @@ export function encode(kernel: CompiledKernel): ExecutableKernel {
   const code = new Int32Array(count * SLOTS);
   const lines = new Int32Array(count);
   const pool: number[] = [];
+  const hostArgs: number[][] = [];
 
   const constant = (value: number): number => {
     // 常量很多是重复的（下标步长、0、1），去重能让池小一个量级
@@ -279,10 +285,16 @@ export function encode(kernel: CompiledKernel): ExecutableKernel {
         code[at + 1] = inst.dst;
         code[at + 2] = HOST[inst.fn];
         code[at + 3] = inst.args.length;
-        code[at + 4] = inst.args[0] ?? 0;
-        code[at + 5] = inst.args[1] ?? 0;
-        code[at + 6] = inst.args[2] ?? 0;
-        code[at + 7] = inst.args[3] ?? 0;
+        if (inst.args.length > 4) {
+          // 放不下就走边表，at+4 存下标。argc > 4 是它的标志
+          code[at + 4] = hostArgs.length;
+          hostArgs.push(inst.args.slice());
+        } else {
+          code[at + 4] = inst.args[0] ?? 0;
+          code[at + 5] = inst.args[1] ?? 0;
+          code[at + 6] = inst.args[2] ?? 0;
+          code[at + 7] = inst.args[3] ?? 0;
+        }
         break;
       case 'launch':
         code[at] = OP.LAUNCH;
@@ -363,6 +375,7 @@ export function encode(kernel: CompiledKernel): ExecutableKernel {
   return {
     ...kernel,
     program: { code, pool: Float64Array.from(pool), count, lines },
+    ...(hostArgs.length ? { hostArgs } : {}),
     paramTypes: Int32Array.from(kernel.params.map((param) => tyCode(param.ty))),
   };
 }

--- a/src/lib/gpulab/ir/types.ts
+++ b/src/lib/gpulab/ir/types.ts
@@ -184,6 +184,13 @@ export type HostFn =
   | 'cudaStreamBeginCapture' | 'cudaStreamEndCapture'
   | 'cudaGraphInstantiate' | 'cudaGraphLaunch'
   | 'cudaGraphDestroy' | 'cudaGraphExecDestroy'
+  /** 多卡 */
+  | 'cudaGetDeviceCount' | 'cudaSetDevice' | 'cudaGetDevice' | 'cudaMemcpyPeer'
+  /** NCCL 集合通信 */
+  | 'ncclCommInitAll' | 'ncclCommDestroy'
+  | 'ncclGroupStart' | 'ncclGroupEnd'
+  | 'ncclAllReduce' | 'ncclAllGather' | 'ncclReduceScatter'
+  | 'ncclBroadcast' | 'ncclReduce' | 'ncclSend' | 'ncclRecv'
   | 'vec_new' | 'vec_push' | 'vec_pop' | 'vec_get' | 'vec_set' | 'vec_len' | 'vec_clear'
   | 'map_new' | 'map_set' | 'map_get' | 'map_has' | 'map_del' | 'map_len'
   | 'ring_new' | 'ring_push' | 'ring_pop' | 'ring_peek' | 'ring_len';
@@ -229,6 +236,14 @@ export interface CompiledKernel {
   strings?: string[];
   /** `<<<>>>` 现场表，只有宿主程序有 */
   launches?: LaunchSite[];
+  /**
+   * 超过 4 个参数的 hostcall 的实参寄存器表。
+   *
+   * 定长记录里只放得下 4 个（8 个槽减去操作码、dst、函数号、argc）。
+   * NCCL 的真签名有 7 到 8 个参数，所以多出来的走这张边表 ——
+   * 和 `launches` 一个路子。为了 NCCL 去加宽每一条指令不划算。
+   */
+  hostArgs?: number[][];
 }
 
 /**

--- a/src/lib/gpulab/lab/cli.ts
+++ b/src/lib/gpulab/lab/cli.ts
@@ -14,6 +14,7 @@
  */
 import type { CommandHandler, CommandResult } from '../../labkit/machine';
 import { compileProgram } from '../index';
+import { runClusterHost } from '../cluster/run';
 import { CudaCompileError } from '../cuda/lower';
 import { CudaSyntaxError } from '../cuda/parser';
 import { KernelError } from '../vm/vm';
@@ -196,14 +197,19 @@ export async function runBench(
   const preserved = options.racecheck ? world.gpu.snapshotCounters() : null;
 
   // 重新建一台干净的设备：显存内容、分配游标、指标全部归零
-  world.gpu.reset();
+  if (world.cluster) world.cluster.reset();
+  else world.gpu.reset();
   world.buffers.clear();
 
   const seed = world.spec.seed ?? 1;
   for (const buffer of bench.buffers) {
     const data = materialize(buffer, seed);
-    const address = world.gpu.malloc(buffer.length * 4);
-    if (buffer.type === 'int') world.gpu.copyInInts(address, data as Int32Array);
+    // 集群关卡的缓冲区分配在 0 号卡上，地址因此带着设备号
+    const address = world.cluster
+      ? world.cluster.malloc(buffer.length * 4)
+      : world.gpu.malloc(buffer.length * 4);
+    if (world.cluster) world.cluster.copyIn(address, data as Float32Array);
+    else if (buffer.type === 'int') world.gpu.copyInInts(address, data as Int32Array);
     else world.gpu.copyIn(address, data as Float32Array);
     world.buffers.set(buffer.name, {
       address, length: buffer.length, type: buffer.type ?? 'float',
@@ -222,9 +228,11 @@ export async function runBench(
       return { address: found?.address ?? 0, length: found?.length ?? 0 };
     });
     try {
-      const result = world.gpu.runHost(artifact.host, artifact.kernels, ordered, {
-        racecheck: options.racecheck,
-      });
+      const result = world.cluster
+        ? runClusterHost(world.cluster, artifact.host, artifact.kernels, ordered)
+        : world.gpu.runHost(artifact.host, artifact.kernels, ordered, {
+            racecheck: options.racecheck,
+          });
       world.lastRun = { artifact, launches: [], wallClockMs: Date.now() - startedAt };
       if (preserved) world.gpu.restoreCounters(preserved);
       return { stdout: result.stdout, stderr: '', code: 0 };

--- a/src/lib/gpulab/lab/modules.ts
+++ b/src/lib/gpulab/lab/modules.ts
@@ -10,6 +10,7 @@
  *  3. **过程指标** —— `metrics()`，也就是门槛读的那棵树。
  */
 import type { GpuMetrics, StaticMetrics } from '../metrics';
+import type { CommMetrics } from '../cluster/cluster';
 import type { RooflinePoint, TimingResult } from '../timing';
 import type { SanitizerReport } from '../vm/sanitizer';
 import type { CommandRecord } from '../../labkit/machine';
@@ -54,6 +55,10 @@ export interface GpuLabApi {
 
   /** 门槛读的那棵指标树 */
   metrics(): GpuMetrics;
+  /** 集群关卡的通信计量。单卡关卡上是 null */
+  comm(): CommMetrics | null;
+  /** 集群里第 index 张卡的指标 */
+  deviceMetrics(index: number): GpuMetrics;
   /** 寄存器 / 共享内存 / 占用率 */
   staticMetrics(): StaticMetrics | null;
   /**
@@ -131,6 +136,18 @@ export function createGpuLabApi(world: GpuWorld): GpuLabApi {
     },
 
     metrics: () => world.gpu.metrics(),
+    comm: () => world.cluster?.comm ?? null,
+    deviceMetrics: (index) => {
+      if (!world.cluster) {
+        if (index !== 0) throw new GpuLabError('这一关只有一张卡');
+        return world.gpu.metrics();
+      }
+      const device = world.cluster.devices[index];
+      if (!device) {
+        throw new GpuLabError(`没有编号 ${index} 的设备 —— 一共 ${world.cluster.count} 张卡`);
+      }
+      return device.metrics();
+    },
     staticMetrics: () => world.gpu.staticMetrics(),
     timing: () => world.gpu.timing(),
     roofline: () => world.gpu.roofline(),
@@ -143,13 +160,17 @@ export function createGpuLabApi(world: GpuWorld): GpuLabApi {
           `没有叫 \`${name}\` 的缓冲区 —— 有的是：${[...world.buffers.keys()].join(', ') || '（还没跑过 ./bench）'}`
         );
       }
-      return world.gpu.copyOut(buffer.address, buffer.length);
+      return world.cluster
+        ? world.cluster.copyOut(buffer.address, buffer.length)
+        : world.gpu.copyOut(buffer.address, buffer.length);
     },
 
     bufferInts(name) {
       const buffer = world.buffers.get(name);
       if (!buffer) throw new GpuLabError(`没有叫 \`${name}\` 的缓冲区`);
-      return world.gpu.copyOutInts(buffer.address, buffer.length);
+      return world.cluster
+        ? world.cluster.copyOutInts(buffer.address, buffer.length)
+        : world.gpu.copyOutInts(buffer.address, buffer.length);
     },
 
     compare(actual, expected) {

--- a/src/lib/gpulab/lab/runner.ts
+++ b/src/lib/gpulab/lab/runner.ts
@@ -60,6 +60,14 @@ export function gpuMetricTree(world: GpuWorld): Record<string, unknown> {
     /** 显存峰值 —— FlashAttention、KV cache 那几关的门槛读它 */
     memoryPeakBytes: world.gpu.usedBytes,
     /**
+     * 通信计量。集群关卡的主角。
+     *
+     * **全部是结构性的**（字节数、消息数、按链路分），所以可以作门槛 ——
+     * 和模拟耗时不是一回事。`bytesByLink.ib` 尤其要紧：
+     * 张量并行一旦跨了机，它立刻暴增。
+     */
+    ...(world.cluster ? { comm: world.cluster.comm } : {}),
+    /**
      * 算术强度：每从 DRAM 搬一个字节做了多少次浮点运算。
      *
      * **这是结构性计量，可以作门槛** —— 分子是 FMA 与 MMA 的条数、

--- a/src/lib/gpulab/lab/world.ts
+++ b/src/lib/gpulab/lab/world.ts
@@ -17,6 +17,8 @@ import { B200, H100, type DeviceSpec } from '../device';
 import type { ExecutableKernel } from '../ir/program';
 import type { Dim3 } from '../vm/vm';
 import { HOST_HEADERS } from '../host/headers';
+import { Cluster } from '../cluster/cluster';
+import { IB_NDR, NVLINK4, NVLINK5, PCIE5 } from '../cluster/topology';
 
 /** 缓冲区里一开始装什么。要能写进 JSON，所以是声明而不是函数。 */
 export type BufferFill =
@@ -55,6 +57,13 @@ export interface BenchSpec {
 }
 
 export interface GpuWorldSpec {
+  /**
+   * 集群关卡：几张卡、每台机器几张。
+   *
+   * 不给就是单卡，和前 21 关一样。给了之后 `cudaSetDevice` 那一套才可用，
+   * 判定也才拿得到 `gpu.comm.*`。
+   */
+  cluster?: { devices: number; devicesPerNode: number; link?: 'nvlink4' | 'nvlink5' };
   seed?: number;
   device?: 'H100' | 'B200';
   /** 显存大小，默认 64MB */
@@ -89,6 +98,8 @@ export interface CompiledArtifact {
 }
 
 export interface GpuWorld {
+  /** 集群关卡才有 */
+  cluster?: Cluster;
   machine: Machine;
   gpu: GpuDevice;
   spec: GpuWorldSpec;
@@ -187,9 +198,26 @@ export function createGpuWorld(spec: GpuWorldSpec): GpuWorld {
     files: { ...HOST_HEADERS, ...(spec.machine?.files ?? {}) },
   });
 
+  const cluster = spec.cluster
+    ? new Cluster({
+        ...options,
+        // 每张卡的显存独立算，别拿单卡的总量去乘卡数
+        globalBytes: spec.globalBytes ?? 16 * 1024 * 1024,
+        spec: {
+          devices: spec.cluster.devices,
+          devicesPerNode: spec.cluster.devicesPerNode,
+          nvlink: spec.cluster.link === 'nvlink5' ? NVLINK5 : NVLINK4,
+          ib: IB_NDR,
+          pcie: PCIE5,
+        },
+      })
+    : undefined;
+
   const world: GpuWorld = {
     machine,
-    gpu: new GpuDevice(options),
+    // 集群关卡里，`gpu` 指的是 0 号卡 —— 单卡的那些指标照常读得到
+    gpu: cluster ? cluster.devices[0] : new GpuDevice(options),
+    ...(cluster ? { cluster } : {}),
     spec,
     device: deviceSpec,
     artifacts: new Map(),

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -796,7 +796,13 @@ class Executor {
             const fn = code[at + 2];
             const argc = code[at + 3];
             hostArgs.length = 0;
-            for (let i = 0; i < argc; i += 1) hostArgs.push(regs[code[at + 4 + i] * WARP_SIZE]);
+            if (argc > 4) {
+              const site = this.kernel.hostArgs?.[code[at + 4]];
+              if (!site) throw new KernelError('宿主调用的实参表丢了', lines[pc]);
+              for (const reg of site) hostArgs.push(regs[reg * WARP_SIZE]);
+            } else {
+              for (let i = 0; i < argc; i += 1) hostArgs.push(regs[code[at + 4 + i] * WARP_SIZE]);
+            }
             regs[dst] = services.call(fn, hostArgs, lines[pc]);
             instBookkeeping += lanes;
             pc += 1;

--- a/tests/gpulab/cluster.test.ts
+++ b/tests/gpulab/cluster.test.ts
@@ -1,0 +1,300 @@
+/**
+ * 集群
+ *
+ * 这套用例钉住三件事：
+ *  1. **一张卡的指针在另一张卡上是非法的**，而且报错说得清是哪张卡的；
+ *  2. 通信计量（字节、消息、按链路分）是精确的；
+ *  3. ring all-reduce 走的是真的 `2(n-1)` 步，于是 `2(n-1)/n` 那个
+ *     修正因子是数出来的。
+ */
+import {
+  Cluster, SINGLE_NODE_8, TWO_NODE_16, compileProgram, runClusterHost,
+} from '../../src/lib/gpulab';
+
+jest.setTimeout(180_000);
+
+const KERNELS = `
+__global__ void fill(float* a, float value, int n) {
+  int i = threadIdx.x;
+  if (i < n) a[i] = value;
+}
+__global__ void addInto(float* a, const float* b, int n) {
+  int i = threadIdx.x;
+  if (i < n) a[i] = a[i] + b[i];
+}
+`;
+
+async function run(source: string, devices = 4, spec = SINGLE_NODE_8) {
+  const cluster = new Cluster({
+    spec: { ...spec, devices },
+    globalBytes: 1024 * 1024,
+  });
+  const program = await compileProgram(`${KERNELS}\n#include "cluster.h"\n#include "nccl.h"\n${source}`);
+  const result = runClusterHost(cluster, program.host!, program.kernels);
+  return { cluster, stdout: result.stdout };
+}
+
+describe('地址空间是分开的', () => {
+  it('每张卡自己分配、自己算', async () => {
+    const { cluster, stdout } = await run(`
+      int main(void) {
+        int n;
+        cudaGetDeviceCount(&n);
+        printf("devices=%d\\n", n);
+        for (int d = 0; d < n; ++d) {
+          cudaSetDevice(d);
+          float* a;
+          cudaMalloc((void**)&a, 32);
+          fill<<<1, 8>>>(a, (float)(d + 1), 8);
+        }
+        return 0;
+      }
+    `);
+    expect(stdout).toBe('devices=4\n');
+    // 四张卡各起了一次
+    for (let d = 0; d < 4; d += 1) {
+      expect(cluster.devices[d].metrics().launch.blocks).toBe(1);
+    }
+  });
+
+  it('**拿别的卡的指针去起 kernel 会报错，并且说清是哪张卡的**', async () => {
+    await expect(run(`
+      int main(void) {
+        cudaSetDevice(0);
+        float* a;
+        cudaMalloc((void**)&a, 32);
+        cudaSetDevice(1);
+        fill<<<1, 8>>>(a, 1.0f, 8);      // a 是设备 0 的
+        return 0;
+      }
+    `)).rejects.toThrow(/设备 0 的指针，却在设备 1 上用/);
+  });
+
+  it('cudaMemcpyPeer 才是跨卡搬数据的办法', async () => {
+    const { cluster } = await run(`
+      int main(void) {
+        cudaSetDevice(0);
+        float* a;
+        cudaMalloc((void**)&a, 32);
+        fill<<<1, 8>>>(a, 3.0f, 8);
+
+        cudaSetDevice(1);
+        float* b;
+        cudaMalloc((void**)&b, 32);
+        cudaMemcpyPeer(b, 1, a, 0, 32);
+        return 0;
+      }
+    `);
+    expect(cluster.comm.bytes).toBe(32);
+    expect(cluster.comm.messages).toBe(1);
+    // 同一台机器里，走 NVLink
+    expect(cluster.comm.bytesByLink.nvlink).toBe(32);
+    expect(cluster.comm.bytesByLink.ib).toBe(0);
+  });
+
+  it('设备号越界会说清一共几张卡', async () => {
+    await expect(run(`
+      int main(void) { cudaSetDevice(9); return 0; }
+    `)).rejects.toThrow(/一共 4 张卡/);
+  });
+});
+
+describe('链路选择', () => {
+  it('**跨机的流量走 IB，不是 NVLink** —— 张量并行跨机就是被这条抓住的', async () => {
+    const { cluster } = await run(`
+      int main(void) {
+        cudaSetDevice(0);
+        float* a; cudaMalloc((void**)&a, 64);
+        cudaSetDevice(8);
+        float* b; cudaMalloc((void**)&b, 64);
+        cudaMemcpyPeer(b, 8, a, 0, 64);
+        return 0;
+      }
+    `, 16, TWO_NODE_16);
+    // 设备 0 在节点 0，设备 8 在节点 1
+    expect(cluster.comm.bytesByLink.ib).toBe(64);
+    expect(cluster.comm.bytesByLink.nvlink).toBe(0);
+  });
+
+  it('机内还是走 NVLink', async () => {
+    const { cluster } = await run(`
+      int main(void) {
+        cudaSetDevice(0);
+        float* a; cudaMalloc((void**)&a, 64);
+        cudaSetDevice(7);
+        float* b; cudaMalloc((void**)&b, 64);
+        cudaMemcpyPeer(b, 7, a, 0, 64);
+        return 0;
+      }
+    `, 16, TWO_NODE_16);
+    expect(cluster.comm.bytesByLink.nvlink).toBe(64);
+    expect(cluster.comm.bytesByLink.ib).toBe(0);
+  });
+});
+
+describe('NCCL', () => {
+  const ALLREDUCE = (n: number) => `
+    int main(void) {
+      const int N = 16;
+      int comms[8];
+      ncclCommInitAll(comms, ${n});
+      int send[8]; int recv[8];
+      for (int d = 0; d < ${n}; ++d) {
+        cudaSetDevice(d);
+        float* s; float* r;
+        cudaMalloc((void**)&s, N * 4);
+        cudaMalloc((void**)&r, N * 4);
+        fill<<<1, 16>>>(s, (float)(d + 1), N);
+        send[d] = s; recv[d] = r;
+      }
+      ncclGroupStart();
+      for (int d = 0; d < ${n}; ++d) {
+        ncclAllReduce(send[d], recv[d], N, ncclFloat, ncclSum, comms[d], 0);
+      }
+      ncclGroupEnd();
+      // recv[d] 里存的是**地址**，要拷回宿主才能打印
+      float host[4];
+      for (int d = 0; d < ${n}; ++d) {
+        cudaSetDevice(d);
+        cudaMemcpy(host, recv[d], 4, cudaMemcpyDeviceToHost);
+        printf("%.1f ", host[0]);
+      }
+      printf("\\n");
+      return 0;
+    }
+  `;
+
+  it('all-reduce 之后人人拿到同一个和', async () => {
+    const { stdout } = await run(ALLREDUCE(4), 4);
+    // 1 + 2 + 3 + 4 = 10，四张卡都是 10
+    expect(stdout).toBe('10.0 10.0 10.0 10.0 \n');
+  });
+
+  it('**走的是真的 ring：2(n-1) 步**', async () => {
+    const { cluster } = await run(ALLREDUCE(4), 4);
+    const n = 4;
+    // 每一步每张卡发一次，一共 2(n-1) 步 × n 张卡
+    expect(cluster.comm.messages).toBe(2 * (n - 1) * n);
+    // 每张卡搬的总量 = 2(n-1)/n × 缓冲区大小
+    const payload = 16 * 4;
+    expect(cluster.comm.bytes).toBe(2 * (n - 1) * n * (payload / n));
+  });
+
+  it('busbw 的修正因子是 2(n-1)/n', async () => {
+    const { cluster } = await run(ALLREDUCE(4), 4);
+    const ratio = cluster.comm.busbw / cluster.comm.algbw;
+    expect(ratio).toBeCloseTo((2 * (4 - 1)) / 4, 6);
+  });
+
+  it('**不成组会报错，而不是死锁或跑出个看似正常的结果**', async () => {
+    await expect(run(`
+      int main(void) {
+        int comms[8];
+        ncclCommInitAll(comms, 2);
+        int send[8]; int recv[8];
+        for (int d = 0; d < 2; ++d) {
+          cudaSetDevice(d);
+          float* s; float* r;
+          cudaMalloc((void**)&s, 64); cudaMalloc((void**)&r, 64);
+          send[d] = s; recv[d] = r;
+        }
+        ncclAllReduce(send[0], recv[0], 16, ncclFloat, ncclSum, comms[0], 0);
+        return 0;
+      }
+    `, 2)).rejects.toThrow(/ncclGroupStart/);
+  });
+
+  it('all-gather 把每张卡的那一份拼起来', async () => {
+    const { stdout } = await run(`
+      int main(void) {
+        const int N = 4;
+        int comms[8];
+        ncclCommInitAll(comms, 4);
+        int send[8]; int recv[8];
+        for (int d = 0; d < 4; ++d) {
+          cudaSetDevice(d);
+          float* s; float* r;
+          cudaMalloc((void**)&s, N * 4);
+          cudaMalloc((void**)&r, N * 4 * 4);
+          fill<<<1, 4>>>(s, (float)(d + 1), N);
+          send[d] = s; recv[d] = r;
+        }
+        ncclGroupStart();
+        for (int d = 0; d < 4; ++d) {
+          ncclAllGather(send[d], recv[d], N, ncclFloat, comms[d], 0);
+        }
+        ncclGroupEnd();
+        cudaSetDevice(2);
+        float host[16];
+        cudaMemcpy(host, recv[2], 16 * 4, cudaMemcpyDeviceToHost);
+        printf("%.0f %.0f %.0f\\n", host[0], host[4], host[8]);
+        return 0;
+      }
+    `, 4);
+    // 四张卡各贡献 4 个元素，拼起来是 1 1 1 1 2 2 2 2 3 3 3 3 4 4 4 4
+    expect(stdout).toBe('1 2 3\n');
+  });
+
+  it('reduce-scatter：归约之后每张卡只拿自己那 1/n', async () => {
+    const { cluster } = await run(`
+      int main(void) {
+        const int PER = 4;
+        int comms[8];
+        ncclCommInitAll(comms, 4);
+        int send[8]; int recv[8];
+        for (int d = 0; d < 4; ++d) {
+          cudaSetDevice(d);
+          float* s; float* r;
+          cudaMalloc((void**)&s, PER * 4 * 4);
+          cudaMalloc((void**)&r, PER * 4);
+          fill<<<1, 16>>>(s, (float)(d + 1), PER * 4);
+          send[d] = s; recv[d] = r;
+        }
+        ncclGroupStart();
+        for (int d = 0; d < 4; ++d) {
+          ncclReduceScatter(send[d], recv[d], PER, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        return 0;
+      }
+    `, 4);
+    // reduce-scatter 每张卡搬 (n-1) × recvCount，比 all-reduce 少一半
+    expect(cluster.comm.messages).toBe(3 * 4);
+  });
+});
+
+describe('确定性', () => {
+  it('多卡的 all-reduce 跑 10 遍逐位相同', async () => {
+    const source = `
+      int main(void) {
+        const int N = 32;
+        int comms[8];
+        ncclCommInitAll(comms, 4);
+        int send[8]; int recv[8];
+        for (int d = 0; d < 4; ++d) {
+          cudaSetDevice(d);
+          float* s; float* r;
+          cudaMalloc((void**)&s, N * 4); cudaMalloc((void**)&r, N * 4);
+          fill<<<1, 32>>>(s, 0.1f * (float)(d + 1), N);
+          send[d] = s; recv[d] = r;
+        }
+        ncclGroupStart();
+        for (int d = 0; d < 4; ++d) {
+          ncclAllReduce(send[d], recv[d], N, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        float host[1];
+        cudaSetDevice(0);
+        cudaMemcpy(host, recv[0], 4, cudaMemcpyDeviceToHost);
+        printf("%.9f\\n", host[0]);
+        return 0;
+      }
+    `;
+    const first = await run(source, 4);
+    for (let i = 0; i < 10; i += 1) {
+      const again = await run(source, 4);
+      expect(again.stdout).toBe(first.stdout);
+      expect(again.cluster.comm.bytes).toBe(first.cluster.comm.bytes);
+    }
+  });
+});

--- a/tests/gpulab/host.test.ts
+++ b/tests/gpulab/host.test.ts
@@ -7,7 +7,7 @@
  * （不支持的东西必须报错，不能悄悄跑错）。
  */
 import {
-  CONTAINERS_H, CUDA_FP8_H, CUDA_RUNTIME_H, ENGINE_H,
+  CLUSTER_H, CONTAINERS_H, CUDA_FP8_H, CUDA_RUNTIME_H, ENGINE_H, NCCL_H,
 } from '../../src/lib/gpulab/host/headers';
 import { GpuDevice, compileProgram, formatPrintf } from '../../src/lib/gpulab';
 
@@ -471,16 +471,20 @@ describe('头文件与编译器的签名是对得上的', () => {
    * 头文件是学员唯一的参考。它写了什么函数，编译器就必须认什么函数 ——
    * 两边分家的话，学员照着头文件写会撞上「暂不支持」，而那是平台的错。
    */
-  const declared = [...`${CONTAINERS_H}\n${ENGINE_H}\n${CUDA_RUNTIME_H}\n${CUDA_FP8_H}`.matchAll(
+  const declared = [...[
+    CONTAINERS_H, ENGINE_H, CUDA_RUNTIME_H, CUDA_FP8_H, NCCL_H, CLUSTER_H,
+  ].join('\n').matchAll(
     /^\s*(?:int|void|float\*|half)\s+(\w+)\s*\(/gm
   )].map((match) => match[1]);
 
   it.each(declared)('头文件里的 %s 编译器认得', async (name) => {
-    // 拿一个明显错误的参数个数去调用：认得的函数会抱怨参数，
-    // 不认得的函数会说「暂不支持」
+    // 拿一个**不可能对**的参数个数去调用：认得的函数会抱怨参数个数，
+    // 不认得的函数会说「暂不支持」。
+    // 9 个是刻意的 —— 这些原型里最长的（ncclReduce）也才 8 个参数，
+    // 用 6 个的话正好撞上 ncclAllGather 的真 arity，那条就不报错了。
     await expect(compileProgram(`
-      int main(void) { ${name}(1, 2, 3, 4, 5, 6); return 0; }
-    `)).rejects.toThrow(/参数|\(void\*\*\)&|格式串/);
+      int main(void) { ${name}(1, 2, 3, 4, 5, 6, 7, 8, 9); return 0; }
+    `)).rejects.toThrow(/参数|\(void\*\*\)&|&变量|格式串/);
   });
 
   it('头文件是只读的 —— 学员改不了接口契约', () => {


### PR DESCRIPTION
四期的地基，四块。

## 拓扑与链路
NVLink 4/5、PCIe Gen5、IB NDR/XDR，各有带宽、延迟、每消息开销、有效带宽系数。
**同机走 NVLink、跨机走 IB，没有第三种可能** —— 这个二分正是「张量并行必须留在
机内」那条约束的来源，门槛靠 `comm.bytesByLink.ib` 直接抓。

## 地址空间隔离
设备 d 的地址从 `(d+1) * SPAN` 起算，于是**从一个数就能看出它是不是指针、是哪张卡的**。
拿别的卡的指针起 kernel 会报错并说清是哪张卡的 —— 真卡上这是 illegal memory access，
模拟器让它「碰巧能读到东西」就是这个项目最防的失败。

## NCCL：算法是真做的
`ncclAllReduce` 按 ring 走完整的 `2(n-1)` 步、每一步都记链路。于是 busbw 那个
**`2(n-1)/n` 修正因子是数出来的步数，不是套的公式** —— 第 22 关要学员自己数出它，
第 23 关换成 NCCL 时那个数才有意义。归约顺序按 rank 固定，多卡上重放依然逐位一致。

**group 语义**：单线程管多设备时不成组会明确报错，而不是跑出个看似正常的结果。

接口全按真签名（`nccl.h` / `cluster.h` 两个只读头文件），两处偏差写在头文件注释里。

## 踩的两个坑
1. **带设备号的地址溢出 int32**：宿主运行时对参数一律 `| 0`，SPAN 取 2^28 时 16 张卡的基地址算到 24 亿直接回绕成负数 —— 而报错说的是「不在任何一次分配里」，完全看不出原因。改 2^25 并加显式守卫。
2. **hostcall 装不下 NCCL 的真签名**：定长记录只放得下 4 个参数而 `ncclReduce` 有 8 个。加边表，而不是为此加宽每一条指令。

## 验证
`tests/gpulab/cluster.test.ts` 13 条；`npm test` 10/10；`projects:verify`；`npm run build` 含 check-bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)