### PR TITLE
feat(gpulab): 第 24 关 张量并行（一层一次通信 + 不能跨机）

### DIFF
--- a/projects/definitions/llm-accelerator.js
+++ b/projects/definitions/llm-accelerator.js
@@ -5748,7 +5748,7 @@ const STAGE_23 = {
           ${DP_DECL}
 
           int comms[8];
-          ncclCommInitAll(comms, N);
+          ncclCommInitAll(comms, N, 0);
 
           int grad[8]; int out[8];
           for (int d = 0; d < N; ++d) {
@@ -5810,7 +5810,7 @@ const STAGE_23 = {
           ${DP_DECL}
 
           int comms[8];
-          ncclCommInitAll(comms, N);
+          ncclCommInitAll(comms, N, 0);
 
           int grad[8]; int out[8];
           for (int d = 0; d < N; ++d) {
@@ -5922,6 +5922,416 @@ const STAGE_23 = {
 };
 
 /* ------------------------------------------------------------------ */
+/* 第 24 关：张量并行                                                    */
+/* ------------------------------------------------------------------ */
+
+const TP_HIDDEN = 128;
+const TP_TOKENS = 32;
+const TP_WAYS = 8;
+
+/** 两台 8 卡机，一共 16 张 —— 跨机那件事得有机器可跨 */
+const TWO_NODE_WORLD = {
+  globalBytes: 2 * 1024 * 1024,
+  cluster: { devices: 16, devicesPerNode: 8 },
+};
+
+const TP_KERNELS = code`
+  __global__ void fill(float* a, float v, int n) {
+    int i = threadIdx.x;
+    if (i < n) a[i] = v;
+  }
+  // y = x W，W 是 [hidden, shard] 的一片
+  __global__ void matmulShard(const float* x, const float* W, float* y,
+                              int tokens, int hidden, int shard) {
+    int t = blockIdx.x;
+    int c = threadIdx.x;
+    if (c >= shard) return;
+    float acc = 0.0f;
+    for (int k = 0; k < hidden; ++k) acc = fmaf(x[t * hidden + k], W[k * shard + c], acc);
+    y[t * shard + c] = acc;
+  }
+`;
+
+const tpBench = {
+  sources: ['/root/tensorparallel.cu'],
+  buffers: [
+    { name: 'check', length: TP_WAYS, fill: { kind: 'zeros' } },
+  ],
+  launches: [],
+};
+
+const STAGE_24 = {
+  id: 'tensor-parallel',
+  title: t('张量并行 —— 一层只该通信一次，而且不能跨机',
+    'Tensor parallelism — one collective per layer, and never across nodes'),
+  goal: t(
+    [
+      '模型大到一张卡放不下时，就得把**单个权重矩阵**切开放到多张卡上 ——',
+      '这就是张量并行。这一关有 16 张卡（两台 8 卡机），做 8 路张量并行。',
+      '',
+      '一个前馈层是两次矩阵乘：`y = (x W1) W2`。切法有讲究：',
+      '',
+      '- **列并行**切 W1 的列。每张卡算出中间结果的一竖条 ——',
+      '  各算各的，**不需要通信**。',
+      '- **行并行**切 W2 的行。每张卡拿自己那一竖条中间结果，',
+      '  乘 W2 的对应横条，得到一个**部分和**。',
+      '  所有卡的部分和加起来才是答案 —— 这里需要一次 all-reduce。',
+      '',
+      '关键在于**列并行的输出形状正好是行并行想要的输入形状**。',
+      '于是一整层只需要**末尾一次** all-reduce。',
+      '',
+      '`tensorparallel.cu` 现在有两个问题：',
+      '',
+      '1. 它在两次矩阵乘**中间**也 all-reduce 了一次 —— 把分片的中间结果凑全。',
+      '   凑全了才能做行并行？不对，行并行要的就是分片的。',
+      '2. 它挑的 8 张卡是 0-3 和 8-11 —— **摊在两台机器上了**。',
+      '',
+      '第二条的代价比看上去大得多。这一关的两条链路：',
+      '',
+      '| | 单向带宽 | 延迟 |',
+      '| --- | --- | --- |',
+      '| NVLink 4（机内） | 450 GB/s | 1.5 µs |',
+      '| InfiniBand NDR（跨机） | 50 GB/s | 5 µs |',
+      '',
+      '**差 9 倍。** 而张量并行是每层都要通信的 ——',
+      '数据并行一步只 all-reduce 一次，张量并行 80 层就是 80 次。',
+      '这就是「scale-up 走 NVLink，scale-out 走 IB」那条铁律的由来。',
+      '',
+      '```bash',
+      'nvcc -o bench tensorparallel.cu && ./bench',
+      '```',
+      '',
+      '**通关标准**',
+      '',
+      '- 结果正确',
+      '- **走 IB 的字节数为 0** —— 8 路张量并行必须落在同一台机器里',
+      '- 通信总量 ≤ 240 KB（起始版是 252 KB）',
+    ].join('\n'),
+    [
+      'When a model is too large for one GPU, individual **weight matrices** get split across GPUs.',
+      'That is tensor parallelism. This stage has 16 GPUs (two 8-GPU nodes) and does 8-way TP.',
+      '',
+      'A feed-forward layer is two matmuls: `y = (x W1) W2`. How you split them matters:',
+      '',
+      '- **Column parallel** splits W1 by columns. Each GPU computes one vertical strip of the',
+      '  intermediate result, independently, with **no communication**.',
+      '- **Row parallel** splits W2 by rows. Each GPU takes its own strip of the intermediate,',
+      '  multiplies by the matching horizontal strip of W2, and gets a **partial sum**. Summing all',
+      '  the partials gives the answer, and that needs one all-reduce.',
+      '',
+      'The key is that **column-parallel output has exactly the shape row-parallel wants as input**,',
+      'so a whole layer needs only **one all-reduce, at the end**.',
+      '',
+      '`tensorparallel.cu` has two problems:',
+      '',
+      '1. It also all-reduces **between** the two matmuls, to assemble the full intermediate. But row',
+      '   parallel wants the sharded one, not the full one.',
+      '2. The 8 GPUs it picks are 0-3 and 8-11, **spread across two nodes**.',
+      '',
+      'The second costs far more than it looks. The two links here:',
+      '',
+      '| | one-way bandwidth | latency |',
+      '| --- | --- | --- |',
+      '| NVLink 4 (in-node) | 450 GB/s | 1.5 µs |',
+      '| InfiniBand NDR (cross-node) | 50 GB/s | 5 µs |',
+      '',
+      '**A factor of nine.** And tensor parallelism communicates every layer: data parallelism',
+      'all-reduces once per step, TP does it 80 times for 80 layers. That is where the rule',
+      '"scale up over NVLink, scale out over InfiniBand" comes from.',
+      '',
+      '```bash',
+      'nvcc -o bench tensorparallel.cu && ./bench',
+      '```',
+      '',
+      '**To pass**',
+      '',
+      '- correct results',
+      '- **zero bytes over InfiniBand**: 8-way TP has to fit in one node',
+      '- at most 240 KB of communication (252 KB to start)',
+    ].join('\n')
+  ),
+  checklist: [
+    t('去掉两次矩阵乘中间那次 all-reduce', 'Remove the all-reduce between the two matmuls'),
+    t('把 8 路张量并行落在同一台机器的 8 张卡上',
+      'Put the 8-way TP group on one node\'s 8 GPUs'),
+    t('末尾保留那一次 all-reduce —— 部分和必须加起来',
+      'Keep the final all-reduce: the partial sums do have to be summed'),
+  ],
+  hints: [
+    t('`ncclCommInitAll` 的第三个参数 `devlist` 决定第 i 个 rank 在哪张卡上。'
+      + '**它不是摆设** —— ring 是按实际的卡走的。',
+      'The third argument to `ncclCommInitAll`, `devlist`, decides which GPU each rank sits on. '
+      + '**It is not decorative**: the ring follows the actual GPUs.'),
+    t('列并行之后每张卡手上是中间结果的一竖条，正好就是行并行要的那一片 —— '
+      + '什么都不用做，直接喂给第二次矩阵乘。',
+      'After the column-parallel step each GPU holds one vertical strip of the intermediate, which '
+      + 'is exactly the slice row parallel needs. Feed it straight into the second matmul.'),
+  ],
+  pitfalls: [
+    t('**以为行并行需要完整的中间结果。** 正相反 —— 行并行要的就是分片的那一条。'
+      + '凑全了再切开，等于白白通信一次。',
+      '**Thinking row parallel needs the full intermediate.** The opposite is true: it wants exactly '
+      + 'the shard. Assembling the whole thing and re-splitting it is a wasted collective.'),
+    t('**把 TP 组摊到两台机器上。** 结果完全正确，只是慢得多 —— '
+      + '而且慢的方式很隐蔽：单看一层的耗时只是"有点慢"，'
+      + '乘上 80 层就是训练吞吐掉一半。`comm.bytesByLink.ib` 是唯一能直接看出来的地方。',
+      '**Spreading the TP group across nodes.** The results are perfectly correct, just much slower, '
+      + 'and slower in a sneaky way: one layer merely looks a bit slow, but across 80 layers it '
+      + 'halves training throughput. `comm.bytesByLink.ib` is the one place it shows directly.'),
+  ],
+  extension: t(
+    'Megatron-LM 那篇论文（2019）提出的就是这个切法，'
+    + '而"列并行接行并行"这个顺序是它最核心的设计 ——'
+    + '换成"行并行接列并行"，中间就得通信一次，一层两次 all-reduce。'
+    + '\n\n'
+    + '注意力层是同一个套路：QKV 投影按**头**切（等价于列并行），'
+    + '输出投影按行切，于是整个注意力块也只需要末尾一次 all-reduce。'
+    + '一个 Transformer 层因此是**两次** all-reduce（注意力一次、前馈一次），'
+    + '反向传播再两次。80 层的模型每步就是 320 次集合操作 ——'
+    + '这个频率解释了为什么张量并行对延迟极其敏感。'
+    + '\n\n'
+    + '所以现实中的并行策略是分层的：'
+    + '**张量并行只在机内**（8 张卡，NVLink），'
+    + '**流水线并行跨机**（IB，每级之间只传一次激活），'
+    + '**数据并行在最外层**（每步一次 all-reduce，频率最低）。'
+    + 'Megatron 的 6D 并行就是这几个维度的组合，而维度的排布顺序'
+    + '几乎完全由"这一维通信多频繁"决定。'
+    + '\n\n'
+    + '顺带一提，这一关的两条链路差 9 倍带宽、3 倍延迟。'
+    + 'GB200 NVL72 把 72 张卡用 NVLink 5 连成一个域，'
+    + '就是为了把"机内"这个范围从 8 张卡扩到 72 张 ——'
+    + '于是张量并行的可用宽度一下子大了 9 倍。',
+    'Megatron-LM (2019) introduced this split, and the column-then-row ordering is its core design. '
+    + 'Row-then-column would need a collective in the middle, two all-reduces per layer.\n\n'
+    + 'Attention layers follow the same pattern: QKV projections split by **head** (equivalent to '
+    + 'column parallel), the output projection splits by row, so an attention block also needs only '
+    + 'one all-reduce at the end. A Transformer layer is therefore **two** all-reduces (attention, '
+    + 'feed-forward) plus two more in backward. For an 80-layer model that is 320 collectives per '
+    + 'step, and that frequency is why tensor parallelism is so latency-sensitive.\n\n'
+    + 'Real parallel strategies are layered accordingly: **tensor parallelism stays in-node** (8 '
+    + 'GPUs, NVLink), **pipeline parallelism goes across nodes** (InfiniBand, one activation '
+    + 'transfer per stage boundary), and **data parallelism sits outermost** (one all-reduce per '
+    + 'step, the lowest frequency). Megatron\'s 6D parallelism combines these dimensions, and their '
+    + 'ordering is decided almost entirely by how often each one communicates.\n\n'
+    + 'Incidentally, the two links here differ by 9x in bandwidth and 3x in latency. GB200 NVL72 '
+    + 'connects 72 GPUs into one NVLink 5 domain precisely to stretch "in-node" from 8 GPUs to 72, '
+    + 'making the usable width for tensor parallelism nine times larger.'
+  ),
+  gpu: {
+    world: TWO_NODE_WORLD,
+    files: {
+      '/root/tensorparallel.cu': code`
+        #include "engine.h"
+        #include "cluster.h"
+        #include "nccl.h"
+
+        ${TP_KERNELS}
+
+        int main(void) {
+          const int TP = ${TP_WAYS};
+          const int HIDDEN = ${TP_HIDDEN};
+          const int TOKENS = ${TP_TOKENS};
+          const int SHARD = HIDDEN / TP;
+
+          // TODO: 这 8 张卡摊在两台机器上了（0-3 在节点 0，8-11 在节点 1）。
+          //       8 路张量并行必须落在同一台机器里。
+          int devs[16];
+          devs[0] = 0; devs[1] = 1; devs[2] = 2; devs[3] = 3;
+          devs[4] = 8; devs[5] = 9; devs[6] = 10; devs[7] = 11;
+
+          int comms[16];
+          ncclCommInitAll(comms, TP, devs);
+
+          int x[16]; int w1[16]; int mid[16]; int w2[16]; int part[16]; int outb[16];
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            float* a; float* b; float* c; float* d2; float* e; float* f;
+            cudaMalloc((void**)&a, TOKENS * HIDDEN * 4);
+            cudaMalloc((void**)&b, HIDDEN * SHARD * 4);
+            cudaMalloc((void**)&c, TOKENS * SHARD * 4);
+            cudaMalloc((void**)&d2, SHARD * HIDDEN * 4);
+            cudaMalloc((void**)&e, TOKENS * HIDDEN * 4);
+            cudaMalloc((void**)&f, TOKENS * HIDDEN * 4);
+            fill<<<1, 64>>>(a, 0.1f, 64);
+            fill<<<1, 64>>>(b, 0.01f, 64);
+            fill<<<1, 64>>>(d2, 0.02f, 64);
+            x[i] = a; w1[i] = b; mid[i] = c; w2[i] = d2; part[i] = e; outb[i] = f;
+          }
+
+          // 列并行：各算各的一竖条，不需要通信
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            matmulShard<<<TOKENS, 32>>>(x[i], w1[i], mid[i], TOKENS, HIDDEN, SHARD);
+          }
+
+          // TODO: 这一次 all-reduce 是多余的。行并行要的就是分片的中间结果，
+          //       凑全了再切开等于白白通信一次。
+          ncclGroupStart();
+          for (int i = 0; i < TP; ++i) {
+            ncclAllReduce(mid[i], mid[i], TOKENS * SHARD, ncclFloat, ncclSum, comms[i], 0);
+          }
+          ncclGroupEnd();
+
+          // 行并行：得到部分和
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            matmulShard<<<TOKENS, 32>>>(mid[i], w2[i], part[i], TOKENS, SHARD, HIDDEN);
+          }
+
+          // 部分和相加 —— 这一次是必须的
+          ncclGroupStart();
+          for (int i = 0; i < TP; ++i) {
+            ncclAllReduce(part[i], outb[i], TOKENS * HIDDEN, ncclFloat, ncclSum, comms[i], 0);
+          }
+          ncclGroupEnd();
+
+          float* check = lab_buffer(0);
+          float host[8];
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            float one[1];
+            cudaMemcpy(one, outb[i], 4, cudaMemcpyDeviceToHost);
+            host[i] = one[0];
+          }
+          cudaSetDevice(0);
+          cudaMemcpy(check, host, TP * 4, cudaMemcpyHostToDevice);
+          return 0;
+        }
+      `,
+    },
+    bench: tpBench,
+    referenceFiles: {
+      '/root/tensorparallel.cu': code`
+        #include "engine.h"
+        #include "cluster.h"
+        #include "nccl.h"
+
+        ${TP_KERNELS}
+
+        int main(void) {
+          const int TP = ${TP_WAYS};
+          const int HIDDEN = ${TP_HIDDEN};
+          const int TOKENS = ${TP_TOKENS};
+          const int SHARD = HIDDEN / TP;
+
+          // 8 路张量并行落在节点 0 的 8 张卡上 —— 全走 NVLink
+          int devs[16];
+          for (int i = 0; i < TP; ++i) devs[i] = i;
+
+          int comms[16];
+          ncclCommInitAll(comms, TP, devs);
+
+          int x[16]; int w1[16]; int mid[16]; int w2[16]; int part[16]; int outb[16];
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            float* a; float* b; float* c; float* d2; float* e; float* f;
+            cudaMalloc((void**)&a, TOKENS * HIDDEN * 4);
+            cudaMalloc((void**)&b, HIDDEN * SHARD * 4);
+            cudaMalloc((void**)&c, TOKENS * SHARD * 4);
+            cudaMalloc((void**)&d2, SHARD * HIDDEN * 4);
+            cudaMalloc((void**)&e, TOKENS * HIDDEN * 4);
+            cudaMalloc((void**)&f, TOKENS * HIDDEN * 4);
+            fill<<<1, 64>>>(a, 0.1f, 64);
+            fill<<<1, 64>>>(b, 0.01f, 64);
+            fill<<<1, 64>>>(d2, 0.02f, 64);
+            x[i] = a; w1[i] = b; mid[i] = c; w2[i] = d2; part[i] = e; outb[i] = f;
+          }
+
+          // 列并行：各算各的一竖条
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            matmulShard<<<TOKENS, 32>>>(x[i], w1[i], mid[i], TOKENS, HIDDEN, SHARD);
+          }
+
+          // **这里什么都不做。** 列并行的输出形状正好是行并行想要的输入形状 ——
+          // 凑全了再切开等于白白通信一次
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            matmulShard<<<TOKENS, 32>>>(mid[i], w2[i], part[i], TOKENS, SHARD, HIDDEN);
+          }
+
+          // 一整层唯一的一次通信：把部分和加起来
+          ncclGroupStart();
+          for (int i = 0; i < TP; ++i) {
+            ncclAllReduce(part[i], outb[i], TOKENS * HIDDEN, ncclFloat, ncclSum, comms[i], 0);
+          }
+          ncclGroupEnd();
+
+          float* check = lab_buffer(0);
+          float host[8];
+          for (int i = 0; i < TP; ++i) {
+            cudaSetDevice(devs[i]);
+            float one[1];
+            cudaMemcpy(one, outb[i], 4, cudaMemcpyDeviceToHost);
+            host[i] = one[0];
+          }
+          cudaSetDevice(0);
+          cudaMemcpy(check, host, TP * 4, cudaMemcpyHostToDevice);
+          return 0;
+        }
+      `,
+    },
+  },
+  specs: [
+    spec('tensorparallel.spec.ts', code`
+      const lab = require('@gpu/lab');
+      const TP = ${TP_WAYS};
+
+      describe('张量并行', () => {
+        it('八张卡的结果一致且有限', async () => {
+          await lab.buildAndRun();
+          const check = lab.buffer('check');
+          for (let i = 0; i < TP; i += 1) {
+            expect(Number.isFinite(check[i])).toBe(true);
+            expect(Math.abs(check[i] - check[0])).toBeLessThanOrEqual(1e-4);
+          }
+          // all-reduce 真的做了：部分和加起来不会是 0
+          expect(Math.abs(check[0])).toBeGreaterThan(0);
+        });
+
+        it('**一个字节都不该走 IB** —— 8 路张量并行必须落在同一台机器里', async () => {
+          await lab.buildAndRun();
+          expect(lab.comm().bytesByLink.ib).toBe(0);
+        });
+
+        it('一整层只通信一次', async () => {
+          await lab.buildAndRun();
+          // 一次 all-reduce = 2(n-1) × n 条消息
+          expect(lab.comm().messages).toBe(2 * (TP - 1) * TP);
+        });
+
+        it('通信总量降下来了', async () => {
+          await lab.buildAndRun();
+          expect(lab.comm().bytes).toBeLessThanOrEqual(240 * 1024);
+        });
+      });
+    `),
+  ],
+  gates: [
+    ...SAFETY_GATES,
+    gate({
+      metric: 'gpu.comm.bytesByLink.ib', op: 'lte', value: 0,
+      zh: '走 IB 的字节数 —— 张量并行跨机就是被这条抓住的',
+      en: 'bytes over InfiniBand: this is the gate that catches TP spanning nodes',
+      unit: 'byte', dimension: 'correctness',
+    }),
+    gate({
+      metric: 'gpu.comm.bytes', op: 'lte', value: 240 * 1024,
+      zh: '通信总量（起始版是 252KB，多了中间那次多余的 all-reduce）',
+      en: 'total communication (252KB to start, including the redundant middle all-reduce)',
+      unit: 'byte', dimension: 'throughput',
+    }),
+    gate({
+      metric: 'gpu.comm.messages', op: 'lte', value: 2 * 7 * 8,
+      zh: '消息条数 —— 一整层只该有一次 all-reduce',
+      en: 'messages: a whole layer should need only one all-reduce',
+      unit: 'message', dimension: 'throughput',
+    }),
+  ],
+  focus: ['throughput', 'correctness'],
+};
+
+/* ------------------------------------------------------------------ */
 
 module.exports = {
   id: 'llm-accelerator',
@@ -5988,5 +6398,5 @@ module.exports = {
   },
   workspace: { kind: 'gpu', world: WORLD },
   files: [],
-  stages: [STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12, STAGE_13, STAGE_14, STAGE_15, STAGE_16, STAGE_17, STAGE_18, STAGE_19, STAGE_20, STAGE_21, STAGE_22, STAGE_23],
+  stages: [STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12, STAGE_13, STAGE_14, STAGE_15, STAGE_16, STAGE_17, STAGE_18, STAGE_19, STAGE_20, STAGE_21, STAGE_22, STAGE_23, STAGE_24],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -26745,7 +26745,7 @@
             }
           },
           "files": {
-            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n\n          // 每一\"层\"的梯度有多少个元素\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // TODO: 每层各发一次 —— 32 次集合操作。\n          //       为 4 个 float 发一次 all-reduce，等于为 16 字节付一整套\n          //       ring 的固定开销。改成攒够 128 个元素再发。\n          int offset = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            int n = vec_get(sizes, layer);\n            ncclGroupStart();\n            for (int d = 0; d < N; ++d) {\n              ncclAllReduce(grad[d] + offset, out[d] + offset, n,\n                            ncclFloat, ncclSum, comms[d], 0);\n            }\n            ncclGroupEnd();\n            offset += n;\n          }\n\n          // 每张卡的第 0 个结果写回平台的缓冲区\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n\n          // 每一\"层\"的梯度有多少个元素\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N, 0);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // TODO: 每层各发一次 —— 32 次集合操作。\n          //       为 4 个 float 发一次 all-reduce，等于为 16 字节付一整套\n          //       ring 的固定开销。改成攒够 128 个元素再发。\n          int offset = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            int n = vec_get(sizes, layer);\n            ncclGroupStart();\n            for (int d = 0; d < N; ++d) {\n              ncclAllReduce(grad[d] + offset, out[d] + offset, n,\n                            ncclFloat, ncclSum, comms[d], 0);\n            }\n            ncclGroupEnd();\n            offset += n;\n          }\n\n          // 每张卡的第 0 个结果写回平台的缓冲区\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
           },
           "bench": {
             "sources": [
@@ -26763,7 +26763,7 @@
             "launches": []
           },
           "referenceFiles": {
-            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n          const int BUCKET = 128;\n\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // 梯度在显存里是连着放的，所以一桶就是一段连续区间：\n          // 记住起点与已攒长度，攒够了发一次\n          int start = 0;\n          int pending = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            pending += vec_get(sizes, layer);\n            // 最后一桶不管攒够没有都要发 —— 漏了它，最后几层的梯度\n            // 永远不同步，而训练照常收敛，只是各卡悄悄分叉\n            int last = layer == LAYERS - 1 ? 1 : 0;\n            if (pending >= BUCKET || last == 1) {\n              ncclGroupStart();\n              for (int d = 0; d < N; ++d) {\n                ncclAllReduce(grad[d] + start, out[d] + start, pending,\n                              ncclFloat, ncclSum, comms[d], 0);\n              }\n              ncclGroupEnd();\n              start += pending;\n              pending = 0;\n            }\n          }\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n          const int BUCKET = 128;\n\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N, 0);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // 梯度在显存里是连着放的，所以一桶就是一段连续区间：\n          // 记住起点与已攒长度，攒够了发一次\n          int start = 0;\n          int pending = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            pending += vec_get(sizes, layer);\n            // 最后一桶不管攒够没有都要发 —— 漏了它，最后几层的梯度\n            // 永远不同步，而训练照常收敛，只是各卡悄悄分叉\n            int last = layer == LAYERS - 1 ? 1 : 0;\n            if (pending >= BUCKET || last == 1) {\n              ncclGroupStart();\n              for (int d = 0; d < N; ++d) {\n                ncclAllReduce(grad[d] + start, out[d] + start, pending,\n                              ncclFloat, ncclSum, comms[d], 0);\n              }\n              ncclGroupEnd();\n              start += pending;\n              pending = 0;\n            }\n          }\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
           }
         },
         "specs": [
@@ -26834,6 +26834,154 @@
         "primer": {
           "zh": "数据并行是最简单的并行策略：每张卡放一份完整的模型、喂不同的数据，反向传播之后把梯度加起来，人人都拿到同一个和，再各自更新。加梯度这一步就是 all-reduce，真实工程里用 NCCL 做。\n\nNCCL 的调用是流序异步的，不是同步返回的函数。单线程管多张卡时必须用 group 语义：把所有卡的调用夹在 ncclGroupStart 与 ncclGroupEnd 之间一起发。因为每个 NCCL 调用都可能阻塞在等对端上，不成组就会死锁 --这一条 NVIDIA 的文档里明写着。\n\n真正的性能问题在别处。一个模型有几十上百层，每层的梯度大小差别极大：有的几百万个参数，有的只有几个偏置。为几个 float 发一次 all-reduce，等于为几十字节的数据付一整套 ring 的固定开销。解法是分桶：把连续的层攒到一定大小再发一次。\n\nPyTorch 的 DDP 默认就这么做，桶大小默认 25 MiB。还有一个更妙的细节：DDP 是按参数的反向顺序分桶的。因为反向传播从最后一层往前算，最后一层的梯度最先就绪；按反向顺序分桶，第一个桶在反向刚开始不久就能发出去，于是通信和剩下的反向计算重叠了起来。值得注意的是分桶前后搬运的总字节数一个不差，省的全是每消息的固定开销，通信优化几乎从来不是少搬点数据。",
           "en": "Data parallelism is the simplest strategy: every GPU holds a full copy of the model, is fed different data, and after backpropagation the gradients are summed so everyone has the same total before updating. Summing them is an all-reduce, done with NCCL in practice.\n\nNCCL calls are stream-ordered and asynchronous, not synchronous functions. With one thread driving several GPUs, group semantics are mandatory: put every GPU call between ncclGroupStart and ncclGroupEnd. Each NCCL call can block waiting on a peer, so without grouping you deadlock, and NVIDIA documents this explicitly.\n\nThe real performance problem is elsewhere. A model has dozens or hundreds of layers whose gradients vary enormously: millions of parameters in some, a handful of biases in others. Issuing an all-reduce for a few floats means paying a full ring of fixed overhead to move a few dozen bytes. The fix is bucketing: batch consecutive layers up to a size and send once.\n\nPyTorch DDP does this by default with a 25 MiB bucket. There is a neater detail too: DDP buckets in reverse parameter order, because backpropagation runs from the last layer backwards and the last layer is ready first. In reverse order the first bucket can go out shortly after backward starts, overlapping communication with the rest of the backward pass. Note that bucketing moves exactly the same total bytes; all it saves is per-message overhead. Communication optimisation is almost never about moving less data."
+        }
+      },
+      {
+        "id": "tensor-parallel",
+        "title": {
+          "zh": "张量并行 —— 一层只该通信一次，而且不能跨机",
+          "en": "Tensor parallelism — one collective per layer, and never across nodes"
+        },
+        "goal": {
+          "zh": "模型大到一张卡放不下时，就得把**单个权重矩阵**切开放到多张卡上 ——\n这就是张量并行。这一关有 16 张卡（两台 8 卡机），做 8 路张量并行。\n\n一个前馈层是两次矩阵乘：`y = (x W1) W2`。切法有讲究：\n\n- **列并行**切 W1 的列。每张卡算出中间结果的一竖条 ——\n  各算各的，**不需要通信**。\n- **行并行**切 W2 的行。每张卡拿自己那一竖条中间结果，\n  乘 W2 的对应横条，得到一个**部分和**。\n  所有卡的部分和加起来才是答案 —— 这里需要一次 all-reduce。\n\n关键在于**列并行的输出形状正好是行并行想要的输入形状**。\n于是一整层只需要**末尾一次** all-reduce。\n\n`tensorparallel.cu` 现在有两个问题：\n\n1. 它在两次矩阵乘**中间**也 all-reduce 了一次 —— 把分片的中间结果凑全。\n   凑全了才能做行并行？不对，行并行要的就是分片的。\n2. 它挑的 8 张卡是 0-3 和 8-11 —— **摊在两台机器上了**。\n\n第二条的代价比看上去大得多。这一关的两条链路：\n\n| | 单向带宽 | 延迟 |\n| --- | --- | --- |\n| NVLink 4（机内） | 450 GB/s | 1.5 µs |\n| InfiniBand NDR（跨机） | 50 GB/s | 5 µs |\n\n**差 9 倍。** 而张量并行是每层都要通信的 ——\n数据并行一步只 all-reduce 一次，张量并行 80 层就是 80 次。\n这就是「scale-up 走 NVLink，scale-out 走 IB」那条铁律的由来。\n\n```bash\nnvcc -o bench tensorparallel.cu && ./bench\n```\n\n**通关标准**\n\n- 结果正确\n- **走 IB 的字节数为 0** —— 8 路张量并行必须落在同一台机器里\n- 通信总量 ≤ 240 KB（起始版是 252 KB）",
+          "en": "When a model is too large for one GPU, individual **weight matrices** get split across GPUs.\nThat is tensor parallelism. This stage has 16 GPUs (two 8-GPU nodes) and does 8-way TP.\n\nA feed-forward layer is two matmuls: `y = (x W1) W2`. How you split them matters:\n\n- **Column parallel** splits W1 by columns. Each GPU computes one vertical strip of the\n  intermediate result, independently, with **no communication**.\n- **Row parallel** splits W2 by rows. Each GPU takes its own strip of the intermediate,\n  multiplies by the matching horizontal strip of W2, and gets a **partial sum**. Summing all\n  the partials gives the answer, and that needs one all-reduce.\n\nThe key is that **column-parallel output has exactly the shape row-parallel wants as input**,\nso a whole layer needs only **one all-reduce, at the end**.\n\n`tensorparallel.cu` has two problems:\n\n1. It also all-reduces **between** the two matmuls, to assemble the full intermediate. But row\n   parallel wants the sharded one, not the full one.\n2. The 8 GPUs it picks are 0-3 and 8-11, **spread across two nodes**.\n\nThe second costs far more than it looks. The two links here:\n\n| | one-way bandwidth | latency |\n| --- | --- | --- |\n| NVLink 4 (in-node) | 450 GB/s | 1.5 µs |\n| InfiniBand NDR (cross-node) | 50 GB/s | 5 µs |\n\n**A factor of nine.** And tensor parallelism communicates every layer: data parallelism\nall-reduces once per step, TP does it 80 times for 80 layers. That is where the rule\n\"scale up over NVLink, scale out over InfiniBand\" comes from.\n\n```bash\nnvcc -o bench tensorparallel.cu && ./bench\n```\n\n**To pass**\n\n- correct results\n- **zero bytes over InfiniBand**: 8-way TP has to fit in one node\n- at most 240 KB of communication (252 KB to start)"
+        },
+        "checklist": [
+          {
+            "zh": "去掉两次矩阵乘中间那次 all-reduce",
+            "en": "Remove the all-reduce between the two matmuls"
+          },
+          {
+            "zh": "把 8 路张量并行落在同一台机器的 8 张卡上",
+            "en": "Put the 8-way TP group on one node's 8 GPUs"
+          },
+          {
+            "zh": "末尾保留那一次 all-reduce —— 部分和必须加起来",
+            "en": "Keep the final all-reduce: the partial sums do have to be summed"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`ncclCommInitAll` 的第三个参数 `devlist` 决定第 i 个 rank 在哪张卡上。**它不是摆设** —— ring 是按实际的卡走的。",
+            "en": "The third argument to `ncclCommInitAll`, `devlist`, decides which GPU each rank sits on. **It is not decorative**: the ring follows the actual GPUs."
+          },
+          {
+            "zh": "列并行之后每张卡手上是中间结果的一竖条，正好就是行并行要的那一片 —— 什么都不用做，直接喂给第二次矩阵乘。",
+            "en": "After the column-parallel step each GPU holds one vertical strip of the intermediate, which is exactly the slice row parallel needs. Feed it straight into the second matmul."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**以为行并行需要完整的中间结果。** 正相反 —— 行并行要的就是分片的那一条。凑全了再切开，等于白白通信一次。",
+            "en": "**Thinking row parallel needs the full intermediate.** The opposite is true: it wants exactly the shard. Assembling the whole thing and re-splitting it is a wasted collective."
+          },
+          {
+            "zh": "**把 TP 组摊到两台机器上。** 结果完全正确，只是慢得多 —— 而且慢的方式很隐蔽：单看一层的耗时只是\"有点慢\"，乘上 80 层就是训练吞吐掉一半。`comm.bytesByLink.ib` 是唯一能直接看出来的地方。",
+            "en": "**Spreading the TP group across nodes.** The results are perfectly correct, just much slower, and slower in a sneaky way: one layer merely looks a bit slow, but across 80 layers it halves training throughput. `comm.bytesByLink.ib` is the one place it shows directly."
+          }
+        ],
+        "extension": {
+          "zh": "Megatron-LM 那篇论文（2019）提出的就是这个切法，而\"列并行接行并行\"这个顺序是它最核心的设计 ——换成\"行并行接列并行\"，中间就得通信一次，一层两次 all-reduce。\n\n注意力层是同一个套路：QKV 投影按**头**切（等价于列并行），输出投影按行切，于是整个注意力块也只需要末尾一次 all-reduce。一个 Transformer 层因此是**两次** all-reduce（注意力一次、前馈一次），反向传播再两次。80 层的模型每步就是 320 次集合操作 ——这个频率解释了为什么张量并行对延迟极其敏感。\n\n所以现实中的并行策略是分层的：**张量并行只在机内**（8 张卡，NVLink），**流水线并行跨机**（IB，每级之间只传一次激活），**数据并行在最外层**（每步一次 all-reduce，频率最低）。Megatron 的 6D 并行就是这几个维度的组合，而维度的排布顺序几乎完全由\"这一维通信多频繁\"决定。\n\n顺带一提，这一关的两条链路差 9 倍带宽、3 倍延迟。GB200 NVL72 把 72 张卡用 NVLink 5 连成一个域，就是为了把\"机内\"这个范围从 8 张卡扩到 72 张 ——于是张量并行的可用宽度一下子大了 9 倍。",
+          "en": "Megatron-LM (2019) introduced this split, and the column-then-row ordering is its core design. Row-then-column would need a collective in the middle, two all-reduces per layer.\n\nAttention layers follow the same pattern: QKV projections split by **head** (equivalent to column parallel), the output projection splits by row, so an attention block also needs only one all-reduce at the end. A Transformer layer is therefore **two** all-reduces (attention, feed-forward) plus two more in backward. For an 80-layer model that is 320 collectives per step, and that frequency is why tensor parallelism is so latency-sensitive.\n\nReal parallel strategies are layered accordingly: **tensor parallelism stays in-node** (8 GPUs, NVLink), **pipeline parallelism goes across nodes** (InfiniBand, one activation transfer per stage boundary), and **data parallelism sits outermost** (one all-reduce per step, the lowest frequency). Megatron's 6D parallelism combines these dimensions, and their ordering is decided almost entirely by how often each one communicates.\n\nIncidentally, the two links here differ by 9x in bandwidth and 3x in latency. GB200 NVL72 connects 72 GPUs into one NVLink 5 domain precisely to stretch \"in-node\" from 8 GPUs to 72, making the usable width for tensor parallelism nine times larger."
+        },
+        "gpu": {
+          "world": {
+            "globalBytes": 2097152,
+            "cluster": {
+              "devices": 16,
+              "devicesPerNode": 8
+            }
+          },
+          "files": {
+            "/root/tensorparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n// y = x W，W 是 [hidden, shard] 的一片\n__global__ void matmulShard(const float* x, const float* W, float* y,\n                            int tokens, int hidden, int shard) {\n  int t = blockIdx.x;\n  int c = threadIdx.x;\n  if (c >= shard) return;\n  float acc = 0.0f;\n  for (int k = 0; k < hidden; ++k) acc = fmaf(x[t * hidden + k], W[k * shard + c], acc);\n  y[t * shard + c] = acc;\n}\n\n\n        int main(void) {\n          const int TP = 8;\n          const int HIDDEN = 128;\n          const int TOKENS = 32;\n          const int SHARD = HIDDEN / TP;\n\n          // TODO: 这 8 张卡摊在两台机器上了（0-3 在节点 0，8-11 在节点 1）。\n          //       8 路张量并行必须落在同一台机器里。\n          int devs[16];\n          devs[0] = 0; devs[1] = 1; devs[2] = 2; devs[3] = 3;\n          devs[4] = 8; devs[5] = 9; devs[6] = 10; devs[7] = 11;\n\n          int comms[16];\n          ncclCommInitAll(comms, TP, devs);\n\n          int x[16]; int w1[16]; int mid[16]; int w2[16]; int part[16]; int outb[16];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float* a; float* b; float* c; float* d2; float* e; float* f;\n            cudaMalloc((void**)&a, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&b, HIDDEN * SHARD * 4);\n            cudaMalloc((void**)&c, TOKENS * SHARD * 4);\n            cudaMalloc((void**)&d2, SHARD * HIDDEN * 4);\n            cudaMalloc((void**)&e, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&f, TOKENS * HIDDEN * 4);\n            fill<<<1, 64>>>(a, 0.1f, 64);\n            fill<<<1, 64>>>(b, 0.01f, 64);\n            fill<<<1, 64>>>(d2, 0.02f, 64);\n            x[i] = a; w1[i] = b; mid[i] = c; w2[i] = d2; part[i] = e; outb[i] = f;\n          }\n\n          // 列并行：各算各的一竖条，不需要通信\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(x[i], w1[i], mid[i], TOKENS, HIDDEN, SHARD);\n          }\n\n          // TODO: 这一次 all-reduce 是多余的。行并行要的就是分片的中间结果，\n          //       凑全了再切开等于白白通信一次。\n          ncclGroupStart();\n          for (int i = 0; i < TP; ++i) {\n            ncclAllReduce(mid[i], mid[i], TOKENS * SHARD, ncclFloat, ncclSum, comms[i], 0);\n          }\n          ncclGroupEnd();\n\n          // 行并行：得到部分和\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(mid[i], w2[i], part[i], TOKENS, SHARD, HIDDEN);\n          }\n\n          // 部分和相加 —— 这一次是必须的\n          ncclGroupStart();\n          for (int i = 0; i < TP; ++i) {\n            ncclAllReduce(part[i], outb[i], TOKENS * HIDDEN, ncclFloat, ncclSum, comms[i], 0);\n          }\n          ncclGroupEnd();\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float one[1];\n            cudaMemcpy(one, outb[i], 4, cudaMemcpyDeviceToHost);\n            host[i] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, TP * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/tensorparallel.cu"
+            ],
+            "buffers": [
+              {
+                "name": "check",
+                "length": 8,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": []
+          },
+          "referenceFiles": {
+            "/root/tensorparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n// y = x W，W 是 [hidden, shard] 的一片\n__global__ void matmulShard(const float* x, const float* W, float* y,\n                            int tokens, int hidden, int shard) {\n  int t = blockIdx.x;\n  int c = threadIdx.x;\n  if (c >= shard) return;\n  float acc = 0.0f;\n  for (int k = 0; k < hidden; ++k) acc = fmaf(x[t * hidden + k], W[k * shard + c], acc);\n  y[t * shard + c] = acc;\n}\n\n\n        int main(void) {\n          const int TP = 8;\n          const int HIDDEN = 128;\n          const int TOKENS = 32;\n          const int SHARD = HIDDEN / TP;\n\n          // 8 路张量并行落在节点 0 的 8 张卡上 —— 全走 NVLink\n          int devs[16];\n          for (int i = 0; i < TP; ++i) devs[i] = i;\n\n          int comms[16];\n          ncclCommInitAll(comms, TP, devs);\n\n          int x[16]; int w1[16]; int mid[16]; int w2[16]; int part[16]; int outb[16];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float* a; float* b; float* c; float* d2; float* e; float* f;\n            cudaMalloc((void**)&a, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&b, HIDDEN * SHARD * 4);\n            cudaMalloc((void**)&c, TOKENS * SHARD * 4);\n            cudaMalloc((void**)&d2, SHARD * HIDDEN * 4);\n            cudaMalloc((void**)&e, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&f, TOKENS * HIDDEN * 4);\n            fill<<<1, 64>>>(a, 0.1f, 64);\n            fill<<<1, 64>>>(b, 0.01f, 64);\n            fill<<<1, 64>>>(d2, 0.02f, 64);\n            x[i] = a; w1[i] = b; mid[i] = c; w2[i] = d2; part[i] = e; outb[i] = f;\n          }\n\n          // 列并行：各算各的一竖条\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(x[i], w1[i], mid[i], TOKENS, HIDDEN, SHARD);\n          }\n\n          // **这里什么都不做。** 列并行的输出形状正好是行并行想要的输入形状 ——\n          // 凑全了再切开等于白白通信一次\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(mid[i], w2[i], part[i], TOKENS, SHARD, HIDDEN);\n          }\n\n          // 一整层唯一的一次通信：把部分和加起来\n          ncclGroupStart();\n          for (int i = 0; i < TP; ++i) {\n            ncclAllReduce(part[i], outb[i], TOKENS * HIDDEN, ncclFloat, ncclSum, comms[i], 0);\n          }\n          ncclGroupEnd();\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float one[1];\n            cudaMemcpy(one, outb[i], 4, cudaMemcpyDeviceToHost);\n            host[i] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, TP * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "tensorparallel.spec.ts",
+            "content": "const lab = require('@gpu/lab');\nconst TP = 8;\n\ndescribe('张量并行', () => {\n  it('八张卡的结果一致且有限', async () => {\n    await lab.buildAndRun();\n    const check = lab.buffer('check');\n    for (let i = 0; i < TP; i += 1) {\n      expect(Number.isFinite(check[i])).toBe(true);\n      expect(Math.abs(check[i] - check[0])).toBeLessThanOrEqual(1e-4);\n    }\n    // all-reduce 真的做了：部分和加起来不会是 0\n    expect(Math.abs(check[0])).toBeGreaterThan(0);\n  });\n\n  it('**一个字节都不该走 IB** —— 8 路张量并行必须落在同一台机器里', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().bytesByLink.ib).toBe(0);\n  });\n\n  it('一整层只通信一次', async () => {\n    await lab.buildAndRun();\n    // 一次 all-reduce = 2(n-1) × n 条消息\n    expect(lab.comm().messages).toBe(2 * (TP - 1) * TP);\n  });\n\n  it('通信总量降下来了', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().bytes).toBeLessThanOrEqual(240 * 1024);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.comm.bytesByLink.ib",
+            "op": "lte",
+            "value": 0,
+            "label": {
+              "zh": "走 IB 的字节数 —— 张量并行跨机就是被这条抓住的",
+              "en": "bytes over InfiniBand: this is the gate that catches TP spanning nodes"
+            },
+            "unit": "byte",
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.comm.bytes",
+            "op": "lte",
+            "value": 245760,
+            "label": {
+              "zh": "通信总量（起始版是 252KB，多了中间那次多余的 all-reduce）",
+              "en": "total communication (252KB to start, including the redundant middle all-reduce)"
+            },
+            "unit": "byte",
+            "dimension": "throughput"
+          },
+          {
+            "metric": "gpu.comm.messages",
+            "op": "lte",
+            "value": 112,
+            "label": {
+              "zh": "消息条数 —— 一整层只该有一次 all-reduce",
+              "en": "messages: a whole layer should need only one all-reduce"
+            },
+            "unit": "message",
+            "dimension": "throughput"
+          }
+        ],
+        "focus": [
+          "throughput",
+          "correctness"
+        ],
+        "primer": {
+          "zh": "模型大到一张卡放不下时，就得把单个权重矩阵切开放到多张卡上。切法有讲究：一个前馈层是两次矩阵乘，第一次按列切（每张卡算出中间结果的一竖条，各算各的、不需要通信），第二次按行切（每张卡拿自己那一竖条乘对应的横条，得到一个部分和）。所有部分和加起来才是答案，这需要一次 all-reduce。\n\n关键在于列并行的输出形状正好是行并行想要的输入形状。于是一整层只需要末尾一次通信。换成先行后列，中间就得凑一次，一层要两次 all-reduce --Megatron-LM 那篇论文最核心的设计就是这个顺序。注意力层是同一个套路：QKV 投影按头切等价于列并行，输出投影按行切。\n\n张量并行的通信频率极高。数据并行一步只 all-reduce 一次，而张量并行一个 Transformer 层就要两次（注意力一次、前馈一次），反向再两次，80 层的模型每步就是 320 次集合操作。这个频率决定了它对延迟极其敏感，也决定了它不能跨机。\n\n机内的 NVLink 和跨机的 InfiniBand 带宽差将近一个数量级，延迟差三倍。所以现实中的并行策略是分层的：张量并行只在机内，流水线并行跨机（每级之间只传一次激活），数据并行在最外层（每步一次 all-reduce，频率最低）。这几个维度的排布顺序，几乎完全由「这一维通信多频繁」决定。",
+          "en": "When a model no longer fits on one GPU, individual weight matrices get split across GPUs, and how you split them matters. A feed-forward layer is two matmuls: split the first by columns (each GPU computes a vertical strip of the intermediate, independently, with no communication) and the second by rows (each GPU multiplies its strip by the matching horizontal strip and gets a partial sum). Summing the partials needs one all-reduce.\n\nThe key is that column-parallel output has exactly the shape row-parallel wants as input, so a whole layer needs one collective at the end. Row-then-column would need one in the middle as well, two per layer. That ordering is the core design of the Megatron-LM paper. Attention follows the same pattern: splitting QKV by head is equivalent to column parallel, and the output projection splits by row.\n\nTensor parallelism communicates extremely often. Data parallelism all-reduces once per step; tensor parallelism does it twice per Transformer layer (attention, feed-forward) plus twice more in backward, so an 80-layer model issues 320 collectives per step. That frequency makes it acutely latency-sensitive, and it is why it cannot span nodes.\n\nIn-node NVLink and cross-node InfiniBand differ by nearly an order of magnitude in bandwidth and threefold in latency. Real parallel strategies are therefore layered: tensor parallelism stays in-node, pipeline parallelism goes across nodes (one activation transfer per stage boundary), and data parallelism sits outermost with one all-reduce per step. The ordering of these dimensions is decided almost entirely by how often each one communicates."
         }
       }
     ]

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1840,6 +1840,51 @@ const primers = {
         + 'overhead. Communication optimisation is almost never about moving less data.'
       )
     ),
+    'tensor-parallel': t(
+      p(
+        '模型大到一张卡放不下时，就得把单个权重矩阵切开放到多张卡上。'
+        + '切法有讲究：一个前馈层是两次矩阵乘，'
+        + '第一次按列切（每张卡算出中间结果的一竖条，各算各的、不需要通信），'
+        + '第二次按行切（每张卡拿自己那一竖条乘对应的横条，得到一个部分和）。'
+        + '所有部分和加起来才是答案，这需要一次 all-reduce。',
+        '关键在于列并行的输出形状正好是行并行想要的输入形状。'
+        + '于是一整层只需要末尾一次通信。'
+        + '换成先行后列，中间就得凑一次，一层要两次 all-reduce --'
+        + 'Megatron-LM 那篇论文最核心的设计就是这个顺序。'
+        + '注意力层是同一个套路：QKV 投影按头切等价于列并行，输出投影按行切。',
+        '张量并行的通信频率极高。数据并行一步只 all-reduce 一次，'
+        + '而张量并行一个 Transformer 层就要两次（注意力一次、前馈一次），'
+        + '反向再两次，80 层的模型每步就是 320 次集合操作。'
+        + '这个频率决定了它对延迟极其敏感，也决定了它不能跨机。',
+        '机内的 NVLink 和跨机的 InfiniBand 带宽差将近一个数量级，延迟差三倍。'
+        + '所以现实中的并行策略是分层的：张量并行只在机内，'
+        + '流水线并行跨机（每级之间只传一次激活），'
+        + '数据并行在最外层（每步一次 all-reduce，频率最低）。'
+        + '这几个维度的排布顺序，几乎完全由「这一维通信多频繁」决定。'
+      ),
+      p(
+        'When a model no longer fits on one GPU, individual weight matrices get split across GPUs, '
+        + 'and how you split them matters. A feed-forward layer is two matmuls: split the first by '
+        + 'columns (each GPU computes a vertical strip of the intermediate, independently, with no '
+        + 'communication) and the second by rows (each GPU multiplies its strip by the matching '
+        + 'horizontal strip and gets a partial sum). Summing the partials needs one all-reduce.',
+        'The key is that column-parallel output has exactly the shape row-parallel wants as input, '
+        + 'so a whole layer needs one collective at the end. Row-then-column would need one in the '
+        + 'middle as well, two per layer. That ordering is the core design of the Megatron-LM paper. '
+        + 'Attention follows the same pattern: splitting QKV by head is equivalent to column '
+        + 'parallel, and the output projection splits by row.',
+        'Tensor parallelism communicates extremely often. Data parallelism all-reduces once per '
+        + 'step; tensor parallelism does it twice per Transformer layer (attention, feed-forward) '
+        + 'plus twice more in backward, so an 80-layer model issues 320 collectives per step. That '
+        + 'frequency makes it acutely latency-sensitive, and it is why it cannot span nodes.',
+        'In-node NVLink and cross-node InfiniBand differ by nearly an order of magnitude in '
+        + 'bandwidth and threefold in latency. Real parallel strategies are therefore layered: '
+        + 'tensor parallelism stays in-node, pipeline parallelism goes across nodes (one activation '
+        + 'transfer per stage boundary), and data parallelism sits outermost with one all-reduce per '
+        + 'step. The ordering of these dimensions is decided almost entirely by how often each one '
+        + 'communicates.'
+      )
+    ),
   },
 
   'intranet-k8s': {

--- a/public/projects.json
+++ b/public/projects.json
@@ -26745,7 +26745,7 @@
             }
           },
           "files": {
-            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n\n          // 每一\"层\"的梯度有多少个元素\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // TODO: 每层各发一次 —— 32 次集合操作。\n          //       为 4 个 float 发一次 all-reduce，等于为 16 字节付一整套\n          //       ring 的固定开销。改成攒够 128 个元素再发。\n          int offset = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            int n = vec_get(sizes, layer);\n            ncclGroupStart();\n            for (int d = 0; d < N; ++d) {\n              ncclAllReduce(grad[d] + offset, out[d] + offset, n,\n                            ncclFloat, ncclSum, comms[d], 0);\n            }\n            ncclGroupEnd();\n            offset += n;\n          }\n\n          // 每张卡的第 0 个结果写回平台的缓冲区\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n\n          // 每一\"层\"的梯度有多少个元素\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N, 0);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // TODO: 每层各发一次 —— 32 次集合操作。\n          //       为 4 个 float 发一次 all-reduce，等于为 16 字节付一整套\n          //       ring 的固定开销。改成攒够 128 个元素再发。\n          int offset = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            int n = vec_get(sizes, layer);\n            ncclGroupStart();\n            for (int d = 0; d < N; ++d) {\n              ncclAllReduce(grad[d] + offset, out[d] + offset, n,\n                            ncclFloat, ncclSum, comms[d], 0);\n            }\n            ncclGroupEnd();\n            offset += n;\n          }\n\n          // 每张卡的第 0 个结果写回平台的缓冲区\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
           },
           "bench": {
             "sources": [
@@ -26763,7 +26763,7 @@
             "launches": []
           },
           "referenceFiles": {
-            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n          const int BUCKET = 128;\n\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // 梯度在显存里是连着放的，所以一桶就是一段连续区间：\n          // 记住起点与已攒长度，攒够了发一次\n          int start = 0;\n          int pending = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            pending += vec_get(sizes, layer);\n            // 最后一桶不管攒够没有都要发 —— 漏了它，最后几层的梯度\n            // 永远不同步，而训练照常收敛，只是各卡悄悄分叉\n            int last = layer == LAYERS - 1 ? 1 : 0;\n            if (pending >= BUCKET || last == 1) {\n              ncclGroupStart();\n              for (int d = 0; d < N; ++d) {\n                ncclAllReduce(grad[d] + start, out[d] + start, pending,\n                              ncclFloat, ncclSum, comms[d], 0);\n              }\n              ncclGroupEnd();\n              start += pending;\n              pending = 0;\n            }\n          }\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+            "/root/dataparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"containers.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int LAYERS = 32;\n          const int TOTAL = 1408;\n          const int BUCKET = 128;\n\n          int sizes = vec_new();\n          vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 256);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n            vec_push(sizes, 8);\n            vec_push(sizes, 128);\n            vec_push(sizes, 4);\n            vec_push(sizes, 4);\n            vec_push(sizes, 64);\n            vec_push(sizes, 8);\n\n          int comms[8];\n          ncclCommInitAll(comms, N, 0);\n\n          int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* g; float* o;\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(g, (float)(d + 1), 64);\n            grad[d] = g; out[d] = o;\n          }\n\n          // 梯度在显存里是连着放的，所以一桶就是一段连续区间：\n          // 记住起点与已攒长度，攒够了发一次\n          int start = 0;\n          int pending = 0;\n          for (int layer = 0; layer < LAYERS; ++layer) {\n            pending += vec_get(sizes, layer);\n            // 最后一桶不管攒够没有都要发 —— 漏了它，最后几层的梯度\n            // 永远不同步，而训练照常收敛，只是各卡悄悄分叉\n            int last = layer == LAYERS - 1 ? 1 : 0;\n            if (pending >= BUCKET || last == 1) {\n              ncclGroupStart();\n              for (int d = 0; d < N; ++d) {\n                ncclAllReduce(grad[d] + start, out[d] + start, pending,\n                              ncclFloat, ncclSum, comms[d], 0);\n              }\n              ncclGroupEnd();\n              start += pending;\n              pending = 0;\n            }\n          }\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
           }
         },
         "specs": [
@@ -26834,6 +26834,154 @@
         "primer": {
           "zh": "数据并行是最简单的并行策略：每张卡放一份完整的模型、喂不同的数据，反向传播之后把梯度加起来，人人都拿到同一个和，再各自更新。加梯度这一步就是 all-reduce，真实工程里用 NCCL 做。\n\nNCCL 的调用是流序异步的，不是同步返回的函数。单线程管多张卡时必须用 group 语义：把所有卡的调用夹在 ncclGroupStart 与 ncclGroupEnd 之间一起发。因为每个 NCCL 调用都可能阻塞在等对端上，不成组就会死锁 --这一条 NVIDIA 的文档里明写着。\n\n真正的性能问题在别处。一个模型有几十上百层，每层的梯度大小差别极大：有的几百万个参数，有的只有几个偏置。为几个 float 发一次 all-reduce，等于为几十字节的数据付一整套 ring 的固定开销。解法是分桶：把连续的层攒到一定大小再发一次。\n\nPyTorch 的 DDP 默认就这么做，桶大小默认 25 MiB。还有一个更妙的细节：DDP 是按参数的反向顺序分桶的。因为反向传播从最后一层往前算，最后一层的梯度最先就绪；按反向顺序分桶，第一个桶在反向刚开始不久就能发出去，于是通信和剩下的反向计算重叠了起来。值得注意的是分桶前后搬运的总字节数一个不差，省的全是每消息的固定开销，通信优化几乎从来不是少搬点数据。",
           "en": "Data parallelism is the simplest strategy: every GPU holds a full copy of the model, is fed different data, and after backpropagation the gradients are summed so everyone has the same total before updating. Summing them is an all-reduce, done with NCCL in practice.\n\nNCCL calls are stream-ordered and asynchronous, not synchronous functions. With one thread driving several GPUs, group semantics are mandatory: put every GPU call between ncclGroupStart and ncclGroupEnd. Each NCCL call can block waiting on a peer, so without grouping you deadlock, and NVIDIA documents this explicitly.\n\nThe real performance problem is elsewhere. A model has dozens or hundreds of layers whose gradients vary enormously: millions of parameters in some, a handful of biases in others. Issuing an all-reduce for a few floats means paying a full ring of fixed overhead to move a few dozen bytes. The fix is bucketing: batch consecutive layers up to a size and send once.\n\nPyTorch DDP does this by default with a 25 MiB bucket. There is a neater detail too: DDP buckets in reverse parameter order, because backpropagation runs from the last layer backwards and the last layer is ready first. In reverse order the first bucket can go out shortly after backward starts, overlapping communication with the rest of the backward pass. Note that bucketing moves exactly the same total bytes; all it saves is per-message overhead. Communication optimisation is almost never about moving less data."
+        }
+      },
+      {
+        "id": "tensor-parallel",
+        "title": {
+          "zh": "张量并行 —— 一层只该通信一次，而且不能跨机",
+          "en": "Tensor parallelism — one collective per layer, and never across nodes"
+        },
+        "goal": {
+          "zh": "模型大到一张卡放不下时，就得把**单个权重矩阵**切开放到多张卡上 ——\n这就是张量并行。这一关有 16 张卡（两台 8 卡机），做 8 路张量并行。\n\n一个前馈层是两次矩阵乘：`y = (x W1) W2`。切法有讲究：\n\n- **列并行**切 W1 的列。每张卡算出中间结果的一竖条 ——\n  各算各的，**不需要通信**。\n- **行并行**切 W2 的行。每张卡拿自己那一竖条中间结果，\n  乘 W2 的对应横条，得到一个**部分和**。\n  所有卡的部分和加起来才是答案 —— 这里需要一次 all-reduce。\n\n关键在于**列并行的输出形状正好是行并行想要的输入形状**。\n于是一整层只需要**末尾一次** all-reduce。\n\n`tensorparallel.cu` 现在有两个问题：\n\n1. 它在两次矩阵乘**中间**也 all-reduce 了一次 —— 把分片的中间结果凑全。\n   凑全了才能做行并行？不对，行并行要的就是分片的。\n2. 它挑的 8 张卡是 0-3 和 8-11 —— **摊在两台机器上了**。\n\n第二条的代价比看上去大得多。这一关的两条链路：\n\n| | 单向带宽 | 延迟 |\n| --- | --- | --- |\n| NVLink 4（机内） | 450 GB/s | 1.5 µs |\n| InfiniBand NDR（跨机） | 50 GB/s | 5 µs |\n\n**差 9 倍。** 而张量并行是每层都要通信的 ——\n数据并行一步只 all-reduce 一次，张量并行 80 层就是 80 次。\n这就是「scale-up 走 NVLink，scale-out 走 IB」那条铁律的由来。\n\n```bash\nnvcc -o bench tensorparallel.cu && ./bench\n```\n\n**通关标准**\n\n- 结果正确\n- **走 IB 的字节数为 0** —— 8 路张量并行必须落在同一台机器里\n- 通信总量 ≤ 240 KB（起始版是 252 KB）",
+          "en": "When a model is too large for one GPU, individual **weight matrices** get split across GPUs.\nThat is tensor parallelism. This stage has 16 GPUs (two 8-GPU nodes) and does 8-way TP.\n\nA feed-forward layer is two matmuls: `y = (x W1) W2`. How you split them matters:\n\n- **Column parallel** splits W1 by columns. Each GPU computes one vertical strip of the\n  intermediate result, independently, with **no communication**.\n- **Row parallel** splits W2 by rows. Each GPU takes its own strip of the intermediate,\n  multiplies by the matching horizontal strip of W2, and gets a **partial sum**. Summing all\n  the partials gives the answer, and that needs one all-reduce.\n\nThe key is that **column-parallel output has exactly the shape row-parallel wants as input**,\nso a whole layer needs only **one all-reduce, at the end**.\n\n`tensorparallel.cu` has two problems:\n\n1. It also all-reduces **between** the two matmuls, to assemble the full intermediate. But row\n   parallel wants the sharded one, not the full one.\n2. The 8 GPUs it picks are 0-3 and 8-11, **spread across two nodes**.\n\nThe second costs far more than it looks. The two links here:\n\n| | one-way bandwidth | latency |\n| --- | --- | --- |\n| NVLink 4 (in-node) | 450 GB/s | 1.5 µs |\n| InfiniBand NDR (cross-node) | 50 GB/s | 5 µs |\n\n**A factor of nine.** And tensor parallelism communicates every layer: data parallelism\nall-reduces once per step, TP does it 80 times for 80 layers. That is where the rule\n\"scale up over NVLink, scale out over InfiniBand\" comes from.\n\n```bash\nnvcc -o bench tensorparallel.cu && ./bench\n```\n\n**To pass**\n\n- correct results\n- **zero bytes over InfiniBand**: 8-way TP has to fit in one node\n- at most 240 KB of communication (252 KB to start)"
+        },
+        "checklist": [
+          {
+            "zh": "去掉两次矩阵乘中间那次 all-reduce",
+            "en": "Remove the all-reduce between the two matmuls"
+          },
+          {
+            "zh": "把 8 路张量并行落在同一台机器的 8 张卡上",
+            "en": "Put the 8-way TP group on one node's 8 GPUs"
+          },
+          {
+            "zh": "末尾保留那一次 all-reduce —— 部分和必须加起来",
+            "en": "Keep the final all-reduce: the partial sums do have to be summed"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "`ncclCommInitAll` 的第三个参数 `devlist` 决定第 i 个 rank 在哪张卡上。**它不是摆设** —— ring 是按实际的卡走的。",
+            "en": "The third argument to `ncclCommInitAll`, `devlist`, decides which GPU each rank sits on. **It is not decorative**: the ring follows the actual GPUs."
+          },
+          {
+            "zh": "列并行之后每张卡手上是中间结果的一竖条，正好就是行并行要的那一片 —— 什么都不用做，直接喂给第二次矩阵乘。",
+            "en": "After the column-parallel step each GPU holds one vertical strip of the intermediate, which is exactly the slice row parallel needs. Feed it straight into the second matmul."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**以为行并行需要完整的中间结果。** 正相反 —— 行并行要的就是分片的那一条。凑全了再切开，等于白白通信一次。",
+            "en": "**Thinking row parallel needs the full intermediate.** The opposite is true: it wants exactly the shard. Assembling the whole thing and re-splitting it is a wasted collective."
+          },
+          {
+            "zh": "**把 TP 组摊到两台机器上。** 结果完全正确，只是慢得多 —— 而且慢的方式很隐蔽：单看一层的耗时只是\"有点慢\"，乘上 80 层就是训练吞吐掉一半。`comm.bytesByLink.ib` 是唯一能直接看出来的地方。",
+            "en": "**Spreading the TP group across nodes.** The results are perfectly correct, just much slower, and slower in a sneaky way: one layer merely looks a bit slow, but across 80 layers it halves training throughput. `comm.bytesByLink.ib` is the one place it shows directly."
+          }
+        ],
+        "extension": {
+          "zh": "Megatron-LM 那篇论文（2019）提出的就是这个切法，而\"列并行接行并行\"这个顺序是它最核心的设计 ——换成\"行并行接列并行\"，中间就得通信一次，一层两次 all-reduce。\n\n注意力层是同一个套路：QKV 投影按**头**切（等价于列并行），输出投影按行切，于是整个注意力块也只需要末尾一次 all-reduce。一个 Transformer 层因此是**两次** all-reduce（注意力一次、前馈一次），反向传播再两次。80 层的模型每步就是 320 次集合操作 ——这个频率解释了为什么张量并行对延迟极其敏感。\n\n所以现实中的并行策略是分层的：**张量并行只在机内**（8 张卡，NVLink），**流水线并行跨机**（IB，每级之间只传一次激活），**数据并行在最外层**（每步一次 all-reduce，频率最低）。Megatron 的 6D 并行就是这几个维度的组合，而维度的排布顺序几乎完全由\"这一维通信多频繁\"决定。\n\n顺带一提，这一关的两条链路差 9 倍带宽、3 倍延迟。GB200 NVL72 把 72 张卡用 NVLink 5 连成一个域，就是为了把\"机内\"这个范围从 8 张卡扩到 72 张 ——于是张量并行的可用宽度一下子大了 9 倍。",
+          "en": "Megatron-LM (2019) introduced this split, and the column-then-row ordering is its core design. Row-then-column would need a collective in the middle, two all-reduces per layer.\n\nAttention layers follow the same pattern: QKV projections split by **head** (equivalent to column parallel), the output projection splits by row, so an attention block also needs only one all-reduce at the end. A Transformer layer is therefore **two** all-reduces (attention, feed-forward) plus two more in backward. For an 80-layer model that is 320 collectives per step, and that frequency is why tensor parallelism is so latency-sensitive.\n\nReal parallel strategies are layered accordingly: **tensor parallelism stays in-node** (8 GPUs, NVLink), **pipeline parallelism goes across nodes** (InfiniBand, one activation transfer per stage boundary), and **data parallelism sits outermost** (one all-reduce per step, the lowest frequency). Megatron's 6D parallelism combines these dimensions, and their ordering is decided almost entirely by how often each one communicates.\n\nIncidentally, the two links here differ by 9x in bandwidth and 3x in latency. GB200 NVL72 connects 72 GPUs into one NVLink 5 domain precisely to stretch \"in-node\" from 8 GPUs to 72, making the usable width for tensor parallelism nine times larger."
+        },
+        "gpu": {
+          "world": {
+            "globalBytes": 2097152,
+            "cluster": {
+              "devices": 16,
+              "devicesPerNode": 8
+            }
+          },
+          "files": {
+            "/root/tensorparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n// y = x W，W 是 [hidden, shard] 的一片\n__global__ void matmulShard(const float* x, const float* W, float* y,\n                            int tokens, int hidden, int shard) {\n  int t = blockIdx.x;\n  int c = threadIdx.x;\n  if (c >= shard) return;\n  float acc = 0.0f;\n  for (int k = 0; k < hidden; ++k) acc = fmaf(x[t * hidden + k], W[k * shard + c], acc);\n  y[t * shard + c] = acc;\n}\n\n\n        int main(void) {\n          const int TP = 8;\n          const int HIDDEN = 128;\n          const int TOKENS = 32;\n          const int SHARD = HIDDEN / TP;\n\n          // TODO: 这 8 张卡摊在两台机器上了（0-3 在节点 0，8-11 在节点 1）。\n          //       8 路张量并行必须落在同一台机器里。\n          int devs[16];\n          devs[0] = 0; devs[1] = 1; devs[2] = 2; devs[3] = 3;\n          devs[4] = 8; devs[5] = 9; devs[6] = 10; devs[7] = 11;\n\n          int comms[16];\n          ncclCommInitAll(comms, TP, devs);\n\n          int x[16]; int w1[16]; int mid[16]; int w2[16]; int part[16]; int outb[16];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float* a; float* b; float* c; float* d2; float* e; float* f;\n            cudaMalloc((void**)&a, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&b, HIDDEN * SHARD * 4);\n            cudaMalloc((void**)&c, TOKENS * SHARD * 4);\n            cudaMalloc((void**)&d2, SHARD * HIDDEN * 4);\n            cudaMalloc((void**)&e, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&f, TOKENS * HIDDEN * 4);\n            fill<<<1, 64>>>(a, 0.1f, 64);\n            fill<<<1, 64>>>(b, 0.01f, 64);\n            fill<<<1, 64>>>(d2, 0.02f, 64);\n            x[i] = a; w1[i] = b; mid[i] = c; w2[i] = d2; part[i] = e; outb[i] = f;\n          }\n\n          // 列并行：各算各的一竖条，不需要通信\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(x[i], w1[i], mid[i], TOKENS, HIDDEN, SHARD);\n          }\n\n          // TODO: 这一次 all-reduce 是多余的。行并行要的就是分片的中间结果，\n          //       凑全了再切开等于白白通信一次。\n          ncclGroupStart();\n          for (int i = 0; i < TP; ++i) {\n            ncclAllReduce(mid[i], mid[i], TOKENS * SHARD, ncclFloat, ncclSum, comms[i], 0);\n          }\n          ncclGroupEnd();\n\n          // 行并行：得到部分和\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(mid[i], w2[i], part[i], TOKENS, SHARD, HIDDEN);\n          }\n\n          // 部分和相加 —— 这一次是必须的\n          ncclGroupStart();\n          for (int i = 0; i < TP; ++i) {\n            ncclAllReduce(part[i], outb[i], TOKENS * HIDDEN, ncclFloat, ncclSum, comms[i], 0);\n          }\n          ncclGroupEnd();\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float one[1];\n            cudaMemcpy(one, outb[i], 4, cudaMemcpyDeviceToHost);\n            host[i] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, TP * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/tensorparallel.cu"
+            ],
+            "buffers": [
+              {
+                "name": "check",
+                "length": 8,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": []
+          },
+          "referenceFiles": {
+            "/root/tensorparallel.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"nccl.h\"\n\n        __global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n// y = x W，W 是 [hidden, shard] 的一片\n__global__ void matmulShard(const float* x, const float* W, float* y,\n                            int tokens, int hidden, int shard) {\n  int t = blockIdx.x;\n  int c = threadIdx.x;\n  if (c >= shard) return;\n  float acc = 0.0f;\n  for (int k = 0; k < hidden; ++k) acc = fmaf(x[t * hidden + k], W[k * shard + c], acc);\n  y[t * shard + c] = acc;\n}\n\n\n        int main(void) {\n          const int TP = 8;\n          const int HIDDEN = 128;\n          const int TOKENS = 32;\n          const int SHARD = HIDDEN / TP;\n\n          // 8 路张量并行落在节点 0 的 8 张卡上 —— 全走 NVLink\n          int devs[16];\n          for (int i = 0; i < TP; ++i) devs[i] = i;\n\n          int comms[16];\n          ncclCommInitAll(comms, TP, devs);\n\n          int x[16]; int w1[16]; int mid[16]; int w2[16]; int part[16]; int outb[16];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float* a; float* b; float* c; float* d2; float* e; float* f;\n            cudaMalloc((void**)&a, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&b, HIDDEN * SHARD * 4);\n            cudaMalloc((void**)&c, TOKENS * SHARD * 4);\n            cudaMalloc((void**)&d2, SHARD * HIDDEN * 4);\n            cudaMalloc((void**)&e, TOKENS * HIDDEN * 4);\n            cudaMalloc((void**)&f, TOKENS * HIDDEN * 4);\n            fill<<<1, 64>>>(a, 0.1f, 64);\n            fill<<<1, 64>>>(b, 0.01f, 64);\n            fill<<<1, 64>>>(d2, 0.02f, 64);\n            x[i] = a; w1[i] = b; mid[i] = c; w2[i] = d2; part[i] = e; outb[i] = f;\n          }\n\n          // 列并行：各算各的一竖条\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(x[i], w1[i], mid[i], TOKENS, HIDDEN, SHARD);\n          }\n\n          // **这里什么都不做。** 列并行的输出形状正好是行并行想要的输入形状 ——\n          // 凑全了再切开等于白白通信一次\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            matmulShard<<<TOKENS, 32>>>(mid[i], w2[i], part[i], TOKENS, SHARD, HIDDEN);\n          }\n\n          // 一整层唯一的一次通信：把部分和加起来\n          ncclGroupStart();\n          for (int i = 0; i < TP; ++i) {\n            ncclAllReduce(part[i], outb[i], TOKENS * HIDDEN, ncclFloat, ncclSum, comms[i], 0);\n          }\n          ncclGroupEnd();\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int i = 0; i < TP; ++i) {\n            cudaSetDevice(devs[i]);\n            float one[1];\n            cudaMemcpy(one, outb[i], 4, cudaMemcpyDeviceToHost);\n            host[i] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, TP * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "tensorparallel.spec.ts",
+            "content": "const lab = require('@gpu/lab');\nconst TP = 8;\n\ndescribe('张量并行', () => {\n  it('八张卡的结果一致且有限', async () => {\n    await lab.buildAndRun();\n    const check = lab.buffer('check');\n    for (let i = 0; i < TP; i += 1) {\n      expect(Number.isFinite(check[i])).toBe(true);\n      expect(Math.abs(check[i] - check[0])).toBeLessThanOrEqual(1e-4);\n    }\n    // all-reduce 真的做了：部分和加起来不会是 0\n    expect(Math.abs(check[0])).toBeGreaterThan(0);\n  });\n\n  it('**一个字节都不该走 IB** —— 8 路张量并行必须落在同一台机器里', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().bytesByLink.ib).toBe(0);\n  });\n\n  it('一整层只通信一次', async () => {\n    await lab.buildAndRun();\n    // 一次 all-reduce = 2(n-1) × n 条消息\n    expect(lab.comm().messages).toBe(2 * (TP - 1) * TP);\n  });\n\n  it('通信总量降下来了', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().bytes).toBeLessThanOrEqual(240 * 1024);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.comm.bytesByLink.ib",
+            "op": "lte",
+            "value": 0,
+            "label": {
+              "zh": "走 IB 的字节数 —— 张量并行跨机就是被这条抓住的",
+              "en": "bytes over InfiniBand: this is the gate that catches TP spanning nodes"
+            },
+            "unit": "byte",
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.comm.bytes",
+            "op": "lte",
+            "value": 245760,
+            "label": {
+              "zh": "通信总量（起始版是 252KB，多了中间那次多余的 all-reduce）",
+              "en": "total communication (252KB to start, including the redundant middle all-reduce)"
+            },
+            "unit": "byte",
+            "dimension": "throughput"
+          },
+          {
+            "metric": "gpu.comm.messages",
+            "op": "lte",
+            "value": 112,
+            "label": {
+              "zh": "消息条数 —— 一整层只该有一次 all-reduce",
+              "en": "messages: a whole layer should need only one all-reduce"
+            },
+            "unit": "message",
+            "dimension": "throughput"
+          }
+        ],
+        "focus": [
+          "throughput",
+          "correctness"
+        ],
+        "primer": {
+          "zh": "模型大到一张卡放不下时，就得把单个权重矩阵切开放到多张卡上。切法有讲究：一个前馈层是两次矩阵乘，第一次按列切（每张卡算出中间结果的一竖条，各算各的、不需要通信），第二次按行切（每张卡拿自己那一竖条乘对应的横条，得到一个部分和）。所有部分和加起来才是答案，这需要一次 all-reduce。\n\n关键在于列并行的输出形状正好是行并行想要的输入形状。于是一整层只需要末尾一次通信。换成先行后列，中间就得凑一次，一层要两次 all-reduce --Megatron-LM 那篇论文最核心的设计就是这个顺序。注意力层是同一个套路：QKV 投影按头切等价于列并行，输出投影按行切。\n\n张量并行的通信频率极高。数据并行一步只 all-reduce 一次，而张量并行一个 Transformer 层就要两次（注意力一次、前馈一次），反向再两次，80 层的模型每步就是 320 次集合操作。这个频率决定了它对延迟极其敏感，也决定了它不能跨机。\n\n机内的 NVLink 和跨机的 InfiniBand 带宽差将近一个数量级，延迟差三倍。所以现实中的并行策略是分层的：张量并行只在机内，流水线并行跨机（每级之间只传一次激活），数据并行在最外层（每步一次 all-reduce，频率最低）。这几个维度的排布顺序，几乎完全由「这一维通信多频繁」决定。",
+          "en": "When a model no longer fits on one GPU, individual weight matrices get split across GPUs, and how you split them matters. A feed-forward layer is two matmuls: split the first by columns (each GPU computes a vertical strip of the intermediate, independently, with no communication) and the second by rows (each GPU multiplies its strip by the matching horizontal strip and gets a partial sum). Summing the partials needs one all-reduce.\n\nThe key is that column-parallel output has exactly the shape row-parallel wants as input, so a whole layer needs one collective at the end. Row-then-column would need one in the middle as well, two per layer. That ordering is the core design of the Megatron-LM paper. Attention follows the same pattern: splitting QKV by head is equivalent to column parallel, and the output projection splits by row.\n\nTensor parallelism communicates extremely often. Data parallelism all-reduces once per step; tensor parallelism does it twice per Transformer layer (attention, feed-forward) plus twice more in backward, so an 80-layer model issues 320 collectives per step. That frequency makes it acutely latency-sensitive, and it is why it cannot span nodes.\n\nIn-node NVLink and cross-node InfiniBand differ by nearly an order of magnitude in bandwidth and threefold in latency. Real parallel strategies are therefore layered: tensor parallelism stays in-node, pipeline parallelism goes across nodes (one activation transfer per stage boundary), and data parallelism sits outermost with one all-reduce per step. The ordering of these dimensions is decided almost entirely by how often each one communicates."
         }
       }
     ]

--- a/src/lib/gpulab/cluster/nccl.ts
+++ b/src/lib/gpulab/cluster/nccl.ts
@@ -40,8 +40,16 @@ function combine(a: number, b: number, op: RedOp): number {
   }
 }
 
-/** 一次集合操作里，每个 rank 的收发缓冲区 */
+/**
+ * 一次集合操作里，每个 rank 的收发缓冲区。
+ *
+ * `device` 是这个 rank **实际在哪张卡上**，来自 `ncclCommInitAll` 的
+ * devlist。环是按这个走的，不是按 rank 号 —— 一个 TP 组摊在两台机器上
+ * 时，环上就会有跨机的边，`comm.bytesByLink.ib` 立刻暴增。
+ * 少了这一层映射，"张量并行必须留在机内"这条约束就演不出来。
+ */
 export interface CommBuffers {
+  device: number;
   send: number;
   recv: number;
 }
@@ -89,7 +97,7 @@ export function ringAllReduce(
         index: sendIndex,
         values: data[rank].slice(start, end),
       });
-      cluster.account(rank, (rank + 1) % n, (end - start) * 4);
+      cluster.account(buffers[rank].device, buffers[(rank + 1) % n].device, (end - start) * 4);
     }
     for (const item of pending) {
       const { start, end } = range(item.index);
@@ -110,7 +118,7 @@ export function ringAllReduce(
         index: sendIndex,
         values: data[rank].slice(start, end),
       });
-      cluster.account(rank, (rank + 1) % n, (end - start) * 4);
+      cluster.account(buffers[rank].device, buffers[(rank + 1) % n].device, (end - start) * 4);
     }
     for (const item of pending) {
       const { start, end } = range(item.index);
@@ -129,7 +137,7 @@ export function ringAllGather(cluster: Cluster, buffers: CommBuffers[], count: n
     parts.push(cluster.copyOut(buffers[rank].send, count));
   }
   for (let step = 0; step < n - 1; step += 1) {
-    for (let rank = 0; rank < n; rank += 1) cluster.account(rank, (rank + 1) % n, count * 4);
+    for (let rank = 0; rank < n; rank += 1) cluster.account(buffers[rank].device, buffers[(rank + 1) % n].device, count * 4);
   }
   const all = new Float32Array(n * count);
   for (let rank = 0; rank < n; rank += 1) all.set(parts[rank], rank * count);
@@ -147,7 +155,7 @@ export function ringReduceScatter(
     data.push(cluster.copyOut(buffers[rank].send, total));
   }
   for (let step = 0; step < n - 1; step += 1) {
-    for (let rank = 0; rank < n; rank += 1) cluster.account(rank, (rank + 1) % n, recvCount * 4);
+    for (let rank = 0; rank < n; rank += 1) cluster.account(buffers[rank].device, buffers[(rank + 1) % n].device, recvCount * 4);
   }
   for (let rank = 0; rank < n; rank += 1) {
     const out = new Float32Array(recvCount);
@@ -181,7 +189,7 @@ export function treeBroadcast(
         if (!have.includes(candidate)) { target = candidate; break; }
       }
       if (target < 0) break;
-      cluster.account(source, target, count * 4);
+      cluster.account(buffers[source].device, buffers[target].device, count * 4);
       have.push(target);
     }
   }
@@ -196,7 +204,7 @@ export function treeReduce(
   const data: Float32Array[] = [];
   for (let rank = 0; rank < n; rank += 1) data.push(cluster.copyOut(buffers[rank].send, count));
   for (let rank = 0; rank < n; rank += 1) {
-    if (rank !== root) cluster.account(rank, root, count * 4);
+    if (rank !== root) cluster.account(buffers[rank].device, buffers[root].device, count * 4);
   }
   const out = new Float32Array(count);
   for (let i = 0; i < count; i += 1) {

--- a/src/lib/gpulab/cluster/run.ts
+++ b/src/lib/gpulab/cluster/run.ts
@@ -98,16 +98,20 @@ export function runClusterHost(
       const view = new Int32Array(hostLocal.bytes, address, values.length);
       for (let i = 0; i < values.length; i += 1) view[i] = values[i] | 0;
     },
+    readHostInts: (address, count) => (
+      Array.from(new Int32Array(hostLocal.bytes, address, count))
+    ),
     collective: (kind, ranks, count, op, root) => {
+      // 环按**实际的卡**走，不是按 rank 号 —— 一个组摊在两台机器上时，
+      // 环上就会有跨机的边，`comm.bytesByLink.ib` 立刻暴增
       const sorted = ranks.slice().sort((a, b) => a.device - b.device);
       if (sorted.length < 1) return;
-      for (let i = 0; i < sorted.length; i += 1) {
-        if (sorted[i].device !== i) {
-          throw new HostRuntimeError(
-            `${kind}：group 里的通信子应该是 0..${sorted.length - 1} 各一个，`
-            + `实际有 ${sorted.map((r) => r.device).join(', ')}`
-          );
+      const seen = new Set<number>();
+      for (const rank of sorted) {
+        if (seen.has(rank.device)) {
+          throw new HostRuntimeError(`${kind}：设备 ${rank.device} 在同一个 group 里出现了两次`);
         }
+        seen.add(rank.device);
       }
       const reduce = redOpOf(op);
       switch (kind) {

--- a/src/lib/gpulab/host/headers.ts
+++ b/src/lib/gpulab/host/headers.ts
@@ -151,11 +151,12 @@ half __nv_cvt_fp8_to_halfraw(int storage, int interpretation);
 
 export const NCCL_H = `/* nccl.h -- 集合通信
  *
- * 名字与参数顺序和真 NCCL 一致。两处偏差：
+ * 名字与参数顺序和真 NCCL 一致。一处偏差：
+ * 通信子是一个 int（就是它所在那张卡的编号），不是不透明句柄。
  *
- * 1. ncclCommInitAll 的真签名是 (comms, ndev, devlist)。这里省掉 devlist ——
- *    设备固定就是 0..ndev-1。comms 仍然按真 API 那样被填上。
- * 2. 通信子是一个 int（就是 rank 号），不是不透明句柄。
+ * devlist 决定第 i 个 rank 在哪张卡上。**它不是摆设** ——
+ * ring 是按实际的卡走的，一个组摊在两台机器上时环上就会有跨机的边。
+ * 传 0 表示用 0..ndev-1。
  *
  * ⚠️ **单线程管多张卡时，集合操作必须放在 ncclGroupStart / ncclGroupEnd 之间。**
  * 每个 NCCL 调用都可能阻塞在等对端上，不成组就会死锁 ——
@@ -176,7 +177,7 @@ export const NCCL_H = `/* nccl.h -- 集合通信
 
 #define ncclSuccess 0
 
-int ncclCommInitAll(int* comms, int ndev);
+int ncclCommInitAll(int* comms, int ndev, const int* devlist);
 int ncclCommDestroy(int comm);
 
 int ncclGroupStart(void);

--- a/src/lib/gpulab/host/runtime.ts
+++ b/src/lib/gpulab/host/runtime.ts
@@ -45,6 +45,8 @@ export interface HostEnvironment {
   deviceCount?(): number;
   /** 往宿主端的 int 数组里写 —— ncclCommInitAll 的出参是这么给的 */
   writeHostInts?(address: number, values: number[]): void;
+  /** 读宿主端的 int 数组 —— ncclCommInitAll 的 devlist 是这么收的 */
+  readHostInts?(address: number, count: number): number[];
   setDevice?(index: number): void;
   getDevice?(): number;
   peerCopy?(dst: number, dstDevice: number, src: number, srcDevice: number, bytes: number): void;
@@ -282,8 +284,9 @@ export class HostRuntime implements HostServices {
 
       /* ---- NCCL ---- */
       case HOST.ncclCommInitAll: {
-        // comms 是一个 int 数组，第 i 项是设备 i 的通信子。
-        // 这个子集里通信子就是 rank 号加一（0 留给"没初始化"）。
+        // 真签名是 (comms, ndev, devlist)。通信子在这个子集里就是
+        // **它所在的那张卡的编号** —— 于是集合操作能知道环上每一跳
+        // 走的是哪条链路。devlist 传 0 表示用 0..ndev-1。
         const count = args[1] | 0;
         const env = this.requireCluster('ncclCommInitAll');
         if (count > env.deviceCount!()) {
@@ -295,7 +298,17 @@ export class HostRuntime implements HostServices {
         // 真 API 是 ncclCommInitAll(comms, ndev, devlist)，把每个设备的
         // 通信子写进 comms。这个子集里通信子就是 rank 号本身，
         // devlist 省掉了（设备固定是 0..n-1），这条偏差写在 nccl.h 里。
-        env.writeHostInts!(args[0] | 0, Array.from({ length: count }, (_, i) => i));
+        const devlist = (args[2] | 0) !== 0
+          ? env.readHostInts!(args[2] | 0, count)
+          : Array.from({ length: count }, (_, i) => i);
+        for (const device of devlist) {
+          if (device < 0 || device >= env.deviceCount!()) {
+            throw new HostRuntimeError(
+              `devlist 里有编号 ${device} 的设备，但一共只有 ${env.deviceCount!()} 张卡`
+            );
+          }
+        }
+        env.writeHostInts!(args[0] | 0, devlist);
         return 0;
       }
       case HOST.ncclCommDestroy:

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -222,7 +222,7 @@ const HOST_FNS: Record<string, { fn: HostFn; arity: number; scalar: 'int' | 'voi
   cudaMemcpyPeer: { fn: 'cudaMemcpyPeer', arity: 5, scalar: 'int' },
 
   // NCCL。真 API 的形状：通信子按设备各一个，集合操作在 group 里发起。
-  ncclCommInitAll: { fn: 'ncclCommInitAll', arity: 2, scalar: 'int' },
+  ncclCommInitAll: { fn: 'ncclCommInitAll', arity: 3, scalar: 'int' },
   // 下面几个的参数个数与真 nccl.h 一致
   ncclCommDestroy: { fn: 'ncclCommDestroy', arity: 1, scalar: 'int' },
   ncclGroupStart: { fn: 'ncclGroupStart', arity: 0, scalar: 'int' },
@@ -384,6 +384,14 @@ class Compiler {
         elementBytes: pointer ? sizeOf((param.type as { to: CudaType }).to) : 4,
       });
     });
+
+    if (this.ctx.host) {
+      // 宿主侧把 local 空间的头 4 个字节留空，**让 0 号地址不属于任何变量**。
+      // 不留的话第一个局部数组的地址正好是 0，而真 C 里 0 是空指针 ——
+      // `ncclCommInitAll(comms, n, devs)` 里 devs 传 0 表示"用默认设备表"，
+      // 于是一个合法的 devs 会被当成没传。踩过一次，很难查。
+      this.localBytes = 4;
+    }
 
     for (const [name, value] of Object.entries(DEVICE_CONSTANTS)) {
       const reg = this.constant(value, 'i32', this.kernel.span.line);

--- a/tests/gpulab/cluster.test.ts
+++ b/tests/gpulab/cluster.test.ts
@@ -137,7 +137,7 @@ describe('NCCL', () => {
     int main(void) {
       const int N = 16;
       int comms[8];
-      ncclCommInitAll(comms, ${n});
+      ncclCommInitAll(comms, ${n}, 0);
       int send[8]; int recv[8];
       for (int d = 0; d < ${n}; ++d) {
         cudaSetDevice(d);
@@ -190,7 +190,7 @@ describe('NCCL', () => {
     await expect(run(`
       int main(void) {
         int comms[8];
-        ncclCommInitAll(comms, 2);
+        ncclCommInitAll(comms, 2, 0);
         int send[8]; int recv[8];
         for (int d = 0; d < 2; ++d) {
           cudaSetDevice(d);
@@ -209,7 +209,7 @@ describe('NCCL', () => {
       int main(void) {
         const int N = 4;
         int comms[8];
-        ncclCommInitAll(comms, 4);
+        ncclCommInitAll(comms, 4, 0);
         int send[8]; int recv[8];
         for (int d = 0; d < 4; ++d) {
           cudaSetDevice(d);
@@ -240,7 +240,7 @@ describe('NCCL', () => {
       int main(void) {
         const int PER = 4;
         int comms[8];
-        ncclCommInitAll(comms, 4);
+        ncclCommInitAll(comms, 4, 0);
         int send[8]; int recv[8];
         for (int d = 0; d < 4; ++d) {
           cudaSetDevice(d);
@@ -269,7 +269,7 @@ describe('确定性', () => {
       int main(void) {
         const int N = 32;
         int comms[8];
-        ncclCommInitAll(comms, 4);
+        ncclCommInitAll(comms, 4, 0);
         int send[8]; int recv[8];
         for (int d = 0; d < 4; ++d) {
           cudaSetDevice(d);


### PR DESCRIPTION
16 张卡（两台 8 卡机），8 路张量并行。起始版两个问题叠在一起：中间多做一次
all-reduce，且 8 张卡摊在两台机器上。

| | 通信总量 | 走 IB | 通信耗时 |
| --- | --- | --- | --- |
| 起始 | 258,048 | 64,512 | 0.253 ms |
| 参考 | 229,376 | **0** | **0.056 ms** |

## 教学点
**列并行的输出形状正好是行并行想要的输入形状** —— 所以一整层只需要末尾一次
all-reduce。Megatron-LM 最核心的设计就是这个顺序；反过来（先行后列）中间就得凑一次。

跨机的代价比看上去大：NVLink 450 GB/s 对 IB 50 GB/s，**差 9 倍**，而张量并行
**每层都通信**（一层两次 + 反向两次，80 层就是每步 320 次集合操作）。这就是
「scale-up 走 NVLink、scale-out 走 IB」的由来。

门槛里 `bytesByLink.ib` 必须为 0 —— 跨机版**结果完全正确**，只是慢，而且慢得
隐蔽：单看一层只是「有点慢」，乘上 80 层就是吞吐掉一半。

## 这一关逼出来的两处实现
1. **恢复 `ncclCommInitAll` 的 `devlist` 参数**。之前省掉了它、通信子到设备是恒等映射，于是「跨机」根本演不出来 —— ring 永远按 rank 号走 0→1→2。现在环按**实际的卡**走。
2. **宿主 local 空间保留头 4 字节，让 0 号地址不属于任何变量**。不留的话第一个局部数组地址正好是 0，而 C 里 0 是空指针 —— 一个合法的 `devs` 会被当成没传。这个坑我踩了一次：devlist 加好了，跨机字节数还是 0。

## 验证
`tests/gpulab/stages.test.ts` **73/73**；`tsc` / `projects:verify` / `npm test` 10/10 / `npm run build` 含 check-bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)