### PR TITLE
feat(gpulab): 第 27 关 通信与计算重叠

### DIFF
--- a/projects/definitions/llm-accelerator.js
+++ b/projects/definitions/llm-accelerator.js
@@ -7089,6 +7089,393 @@ const STAGE_26 = {
 };
 
 /* ------------------------------------------------------------------ */
+/* 第 27 关：通信与计算重叠                                              */
+/* ------------------------------------------------------------------ */
+
+const OV_DEVICES = 8;
+const OV_CHUNKS = 8;
+const OV_CHUNK = 64;
+
+const OV_KERNELS = code`
+  // 反向传播算出一块梯度
+  __global__ void backwardChunk(float* grad, const float* act, int n) {
+    int i = threadIdx.x;
+    if (i < n) grad[i] = act[i] * 0.5f + 0.001f;
+  }
+  __global__ void fill(float* a, float v, int n) {
+    int i = threadIdx.x;
+    if (i < n) a[i] = v;
+  }
+`;
+
+const ovBench = {
+  sources: ['/root/overlap.cu'],
+  buffers: [
+    { name: 'check', length: OV_DEVICES, fill: { kind: 'zeros' } },
+  ],
+  launches: [],
+};
+
+const STAGE_27 = {
+  id: 'comm-compute-overlap',
+  title: t('通信与计算重叠 —— 别等算完了再发',
+    'Overlapping communication and computation — do not wait to finish computing'),
+  goal: t(
+    [
+      '第 23 关的梯度分桶把消息数降了下来，但那个版本仍然是**先算完再发**：',
+      '反向传播全部结束，才开始 all-reduce。这段时间里通信链路完全闲着，',
+      '而 all-reduce 期间计算单元又完全闲着。',
+      '',
+      '第 23 关的扩展里提过为什么 DDP 按参数的**反向顺序**分桶：',
+      '反向传播从最后一层往前算，最后一层的梯度最先就绪 ——',
+      '**第一个桶在反向刚开始不久就能发出去**。',
+      '',
+      '这一关把那件事做出来。反向分成 8 块，每算完一块就立刻发出去，',
+      '同时接着算下一块。要用两个流：',
+      '',
+      '```cuda',
+      'int compute;',
+      'cudaStreamCreate(&compute);',
+      '',
+      'for (int c = 0; c < CHUNKS; ++c) {',
+      '  // 这一块的反向挂在 compute 流上，**不等它**',
+      '  backwardChunk<<<1, 64, 0, compute>>>(grad + c * CHUNK, act, CHUNK);',
+      '  // 上一块的通信这时候发出去，和这一块的计算重叠',
+      '  ...',
+      '}',
+      '```',
+      '',
+      '重叠率是这么数的：**发起一次集合操作时，别的流上还有没有没同步过的 kernel。**',
+      '有就算这次通信重叠了。',
+      '',
+      '```',
+      '重叠率 = 重叠了的通信字节数 / 总通信字节数',
+      '```',
+      '',
+      '⚠️ 这个子集是**即时执行**的，流不改变执行顺序，也不检测跨流的数据竞争。',
+      '真卡上把有依赖的活放到不同的流上而不 `cudaStreamWaitEvent`，会静默出错。',
+      '这一关的分块之间本来就是独立的，所以不会踩到 —— 但别养成习惯。',
+      '',
+      '```bash',
+      'nvcc -o bench overlap.cu && ./bench',
+      '```',
+      '',
+      '**通关标准**',
+      '',
+      '- 重叠率 ≥ 0.7（先算完再发是 0）',
+      '- 通信总量与消息数都不变 —— 重叠不改变搬多少、发几条',
+    ].join('\n'),
+    [
+      'The gradient bucketing of stage 23 cut the message count, but it still **computes everything',
+      'before sending anything**: backward finishes, then the all-reduce starts. The links idle for',
+      'the whole backward pass, and the compute units idle for the whole all-reduce.',
+      '',
+      'Stage 23\'s extension mentioned why DDP buckets in **reverse** parameter order: backward runs',
+      'from the last layer forward, so the last layer\'s gradients are ready first and **the first',
+      'bucket can go out shortly after backward begins**.',
+      '',
+      'This stage builds that. Backward is split into 8 chunks; each one is sent as soon as it is',
+      'computed, while the next one computes. That needs two streams:',
+      '',
+      '```cuda',
+      'int compute;',
+      'cudaStreamCreate(&compute);',
+      '',
+      'for (int c = 0; c < CHUNKS; ++c) {',
+      '  // this chunk\'s backward goes on the compute stream, and we do NOT wait for it',
+      '  backwardChunk<<<1, 64, 0, compute>>>(grad + c * CHUNK, act, CHUNK);',
+      '  // the previous chunk\'s collective goes out now, overlapping this chunk\'s compute',
+      '  ...',
+      '}',
+      '```',
+      '',
+      'The overlap is counted like this: **when a collective is issued, is there unsynchronised',
+      'kernel work outstanding on another stream?** If so, that collective counts as overlapped.',
+      '',
+      '```',
+      'overlap = overlapped communication bytes / total communication bytes',
+      '```',
+      '',
+      '⚠️ This subset executes **eagerly**; streams do not change execution order and cross-stream',
+      'data hazards are not detected. On real hardware, putting dependent work on different streams',
+      'without `cudaStreamWaitEvent` fails silently. The chunks here are genuinely independent so it',
+      'cannot bite, but do not build the habit.',
+      '',
+      '```bash',
+      'nvcc -o bench overlap.cu && ./bench',
+      '```',
+      '',
+      '**To pass**',
+      '',
+      '- overlap ratio at least 0.7 (0 when computing before sending)',
+      '- unchanged total bytes and message count: overlap changes neither',
+    ].join('\n')
+  ),
+  checklist: [
+    t('建一个计算流', 'Create a compute stream'),
+    t('每算完一块就发一块，不等全部算完',
+      'Send each chunk as soon as it is computed, without waiting for the rest'),
+    t('计算挂在计算流上，通信留在默认流',
+      'Put the compute on the compute stream and leave the collectives on the default stream'),
+  ],
+  hints: [
+    t('顺序很关键：**先发起这一块的计算，再发上一块的通信**。'
+      + '反过来的话通信发出去时计算还没挂上，就不算重叠。',
+      'Order matters: **issue this chunk\'s compute first, then the previous chunk\'s collective**. '
+      + 'The other way round the collective goes out before any compute is outstanding, and does not '
+      + 'count as overlapped.'),
+    t('循环结束后还有最后一块没发 —— 补一次。',
+      'The last chunk is still unsent after the loop; flush it.'),
+  ],
+  pitfalls: [
+    t('**计算和通信放在同一个流上。** 真卡上同一个流是严格串行的，'
+      + '所以那根本没有重叠 —— 而代码看起来完全像是重叠了。'
+      + '这是这类优化里最常见的假重叠。',
+      '**Putting compute and communication on the same stream.** A stream is strictly serial on real '
+      + 'hardware, so nothing overlaps, while the code looks exactly as though it does. This is the '
+      + 'most common false overlap in this kind of optimisation.'),
+    t('**每块之后就 cudaStreamSynchronize。** 那等于把异步又变回同步了，'
+      + '重叠率直接掉回 0。同步要留到最后。',
+      '**Calling cudaStreamSynchronize after every chunk.** That turns the asynchrony back into '
+      + 'synchrony and the overlap ratio drops to zero. Synchronise at the end.'),
+  ],
+  extension: t(
+    '重叠是「不改变工作量、只改变时间安排」这一类优化里最纯粹的一个：'
+    + '通信总量不变、消息数不变、计算量不变，变的只是**发起的时机**。'
+    + '\n\n'
+    + '真实系统里重叠无处不在：'
+    + 'DDP 的反向顺序分桶（第 23 关）、'
+    + 'ZeRO-3 在用到某层权重之前就把它 all-gather 出来、'
+    + '流水线并行里一级的通信和另一级的计算天然重叠（第 26 关）、'
+    + '以及张量并行里把 all-reduce 拆开、和后面的矩阵乘按块交错。'
+    + '\n\n'
+    + '重叠的上限由两件事定死：**通信时间与计算时间的比值**，'
+    + '以及**依赖链允许你提前多久发出去**。'
+    + '如果通信比计算长，重叠再好也只是把计算藏进通信里，'
+    + '总时间还是通信时间 —— 这时候该做的是第 22、23 关那种降低通信本身的事。'
+    + '所以真实调优的顺序通常是：先看通信/计算比，比值小于 1 才值得花力气做重叠。'
+    + '\n\n'
+    + '还要提醒一句这个子集的边界：它是即时执行的，'
+    + '不检测跨流的数据竞争。真卡上流之间要靠 `cudaEvent` 建立依赖，'
+    + '而漏建依赖的错误和第 3 关那个共享内存竞态是同一类 ——'
+    + '**结果稳定地错，看起来像是算法不对。**',
+    'Overlap is the purest member of the "same work, different schedule" family: same total bytes, '
+    + 'same message count, same computation. Only the **timing of the issue** changes.\n\n'
+    + 'Real systems overlap everywhere: DDP\'s reverse-order bucketing (stage 23), ZeRO-3 '
+    + 'all-gathering a layer\'s weights before they are needed, pipeline parallelism where one '
+    + 'stage\'s communication naturally overlaps another\'s compute (stage 26), and tensor '
+    + 'parallelism splitting an all-reduce to interleave with the following matmul.\n\n'
+    + 'Two things cap how much overlap can buy: **the ratio of communication time to compute time**, '
+    + 'and **how far ahead the dependency chain lets you issue**. If communication takes longer than '
+    + 'compute, perfect overlap merely hides the compute inside the communication and the total is '
+    + 'still the communication time; at that point the thing to do is reduce communication itself, '
+    + 'as in stages 22 and 23. Real tuning therefore usually starts by measuring the '
+    + 'communication-to-compute ratio and only invests in overlap when it is below one.\n\n'
+    + 'One more note on this subset\'s boundary: it executes eagerly and does not detect cross-stream '
+    + 'data hazards. On real hardware streams are ordered with `cudaEvent`, and a missing dependency '
+    + 'is the same class of bug as the shared-memory race in stage 3: **stably wrong, and it looks '
+    + 'like the algorithm is broken.**'
+  ),
+  gpu: {
+    world: CLUSTER_WORLD,
+    files: {
+      '/root/overlap.cu': code`
+        #include "engine.h"
+        #include "cluster.h"
+        #include "cuda_runtime.h"
+        #include "nccl.h"
+
+        ${OV_KERNELS}
+
+        int main(void) {
+          const int N = ${OV_DEVICES};
+          const int CHUNKS = ${OV_CHUNKS};
+          const int CHUNK = ${OV_CHUNK};
+          const int TOTAL = CHUNKS * CHUNK;
+
+          int devs[8];
+          for (int d = 0; d < N; ++d) devs[d] = d;
+          int comms[8];
+          ncclCommInitAll(comms, N, devs);
+
+          int act[8]; int grad[8]; int out[8];
+          for (int d = 0; d < N; ++d) {
+            cudaSetDevice(d);
+            float* a; float* g; float* o;
+            cudaMalloc((void**)&a, TOTAL * 4);
+            cudaMalloc((void**)&g, TOTAL * 4);
+            cudaMalloc((void**)&o, TOTAL * 4);
+            fill<<<1, 64>>>(a, (float)(d + 1), 64);
+            act[d] = a; grad[d] = g; out[d] = o;
+          }
+
+          // TODO: 先把全部 8 块算完，再一块一块发出去。
+          //       反向的整段时间里链路闲着，通信的整段时间里算力闲着。
+          //       改成边算边发：这一块的计算挂在计算流上不等它，
+          //       同时把上一块的通信发出去。
+          for (int c = 0; c < CHUNKS; ++c) {
+            for (int d = 0; d < N; ++d) {
+              cudaSetDevice(d);
+              backwardChunk<<<1, 64>>>(grad[d] + c * CHUNK, act[d], CHUNK);
+            }
+          }
+          for (int c = 0; c < CHUNKS; ++c) {
+            ncclGroupStart();
+            for (int d = 0; d < N; ++d) {
+              ncclAllReduce(grad[d] + c * CHUNK, out[d] + c * CHUNK, CHUNK,
+                            ncclFloat, ncclSum, comms[d], 0);
+            }
+            ncclGroupEnd();
+          }
+
+          float* check = lab_buffer(0);
+          float host[8];
+          for (int d = 0; d < N; ++d) {
+            cudaSetDevice(d);
+            float one[1];
+            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);
+            host[d] = one[0];
+          }
+          cudaSetDevice(0);
+          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);
+          return 0;
+        }
+      `,
+    },
+    bench: ovBench,
+    referenceFiles: {
+      '/root/overlap.cu': code`
+        #include "engine.h"
+        #include "cluster.h"
+        #include "cuda_runtime.h"
+        #include "nccl.h"
+
+        ${OV_KERNELS}
+
+        int main(void) {
+          const int N = ${OV_DEVICES};
+          const int CHUNKS = ${OV_CHUNKS};
+          const int CHUNK = ${OV_CHUNK};
+          const int TOTAL = CHUNKS * CHUNK;
+
+          int devs[8];
+          for (int d = 0; d < N; ++d) devs[d] = d;
+          int comms[8];
+          ncclCommInitAll(comms, N, devs);
+
+          int act[8]; int grad[8]; int out[8];
+          for (int d = 0; d < N; ++d) {
+            cudaSetDevice(d);
+            float* a; float* g; float* o;
+            cudaMalloc((void**)&a, TOTAL * 4);
+            cudaMalloc((void**)&g, TOTAL * 4);
+            cudaMalloc((void**)&o, TOTAL * 4);
+            fill<<<1, 64>>>(a, (float)(d + 1), 64);
+            act[d] = a; grad[d] = g; out[d] = o;
+          }
+
+          // 计算挂在这个流上，通信留在默认流 —— 两个流才有重叠可言
+          int compute;
+          cudaStreamCreate(&compute);
+
+          for (int c = 0; c < CHUNKS; ++c) {
+            // 先发起这一块的计算，**不等它**
+            for (int d = 0; d < N; ++d) {
+              cudaSetDevice(d);
+              backwardChunk<<<1, 64, 0, compute>>>(grad[d] + c * CHUNK, act[d], CHUNK);
+            }
+            // 再把上一块的通信发出去 —— 这时计算流上还有活在飞，算重叠。
+            // 顺序反过来的话通信发出去时计算还没挂上，就不算了
+            if (c > 0) {
+              ncclGroupStart();
+              for (int d = 0; d < N; ++d) {
+                ncclAllReduce(grad[d] + (c - 1) * CHUNK, out[d] + (c - 1) * CHUNK, CHUNK,
+                              ncclFloat, ncclSum, comms[d], 0);
+              }
+              ncclGroupEnd();
+            }
+          }
+
+          // 最后一块还没发 —— 补上。这时计算流上仍有活，所以它也算重叠
+          ncclGroupStart();
+          for (int d = 0; d < N; ++d) {
+            ncclAllReduce(grad[d] + (CHUNKS - 1) * CHUNK, out[d] + (CHUNKS - 1) * CHUNK, CHUNK,
+                          ncclFloat, ncclSum, comms[d], 0);
+          }
+          ncclGroupEnd();
+          cudaStreamSynchronize(compute);
+          cudaStreamDestroy(compute);
+
+          float* check = lab_buffer(0);
+          float host[8];
+          for (int d = 0; d < N; ++d) {
+            cudaSetDevice(d);
+            float one[1];
+            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);
+            host[d] = one[0];
+          }
+          cudaSetDevice(0);
+          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);
+          return 0;
+        }
+      `,
+    },
+  },
+  specs: [
+    spec('overlap.spec.ts', code`
+      const lab = require('@gpu/lab');
+      const N = ${OV_DEVICES};
+      const CHUNKS = ${OV_CHUNKS};
+      const CHUNK = ${OV_CHUNK};
+
+      describe('通信与计算重叠', () => {
+        it('结果正确', async () => {
+          await lab.buildAndRun();
+          const check = lab.buffer('check');
+          // 第 d 张卡的激活是 d+1，梯度是 0.5(d+1)+0.001，八张卡加起来
+          let expected = 0;
+          for (let d = 0; d < N; d += 1) expected += 0.5 * (d + 1) + 0.001;
+          for (let d = 0; d < N; d += 1) {
+            expect(Math.abs(check[d] - expected)).toBeLessThanOrEqual(1e-4);
+          }
+        });
+
+        it('**重叠率上来了**', async () => {
+          await lab.buildAndRun();
+          expect(lab.comm().overlapRatio).toBeGreaterThanOrEqual(0.7);
+        });
+
+        it('通信总量没变 —— 重叠不改变搬多少', async () => {
+          await lab.buildAndRun();
+          expect(lab.comm().bytes).toBe(2 * (N - 1) * CHUNKS * CHUNK * 4);
+        });
+
+        it('消息数也没变 —— 还是 8 次集合操作', async () => {
+          await lab.buildAndRun();
+          expect(lab.comm().messages).toBe(CHUNKS * 2 * (N - 1) * N);
+        });
+      });
+    `),
+  ],
+  gates: [
+    ...SAFETY_GATES,
+    gate({
+      metric: 'gpu.comm.overlapRatio', op: 'gte', value: 0.7,
+      zh: '和计算重叠了的通信占比（先算完再发是 0）',
+      en: 'share of communication overlapped with compute (0 when computing first)',
+      unit: 'ratio', dimension: 'throughput',
+    }),
+    gate({
+      metric: 'gpu.comm.bytes', op: 'gte', value: 2 * 7 * 8 * 64 * 4,
+      zh: '通信总量 —— 重叠不改变搬多少，少了就是漏了块',
+      en: 'total bytes: overlap does not change this, so a drop means chunks were skipped',
+      unit: 'byte', dimension: 'correctness',
+    }),
+  ],
+  focus: ['throughput', 'correctness'],
+};
+
+/* ------------------------------------------------------------------ */
 
 module.exports = {
   id: 'llm-accelerator',
@@ -7155,5 +7542,5 @@ module.exports = {
   },
   workspace: { kind: 'gpu', world: WORLD },
   files: [],
-  stages: [STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12, STAGE_13, STAGE_14, STAGE_15, STAGE_16, STAGE_17, STAGE_18, STAGE_19, STAGE_20, STAGE_21, STAGE_22, STAGE_23, STAGE_24, STAGE_25, STAGE_26],
+  stages: [STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12, STAGE_13, STAGE_14, STAGE_15, STAGE_16, STAGE_17, STAGE_18, STAGE_19, STAGE_20, STAGE_21, STAGE_22, STAGE_23, STAGE_24, STAGE_25, STAGE_26, STAGE_27],
 };

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -27287,6 +27287,143 @@
           "zh": "张量并行只能在机内，模型再大就得按层切：每台机器负责几层，激活像流水线一样一级一级往前传。问题是流水线要填满才满负荷，第一个 microbatch 走到最后一级之前，后面的级都闲着；最后一个 microbatch 走完之前，前面的级也闲着。这段空转叫气泡。\n\nGPipe 的排程是把所有 microbatch 的前向做完，再全部做反向。这有两个代价：前向流水线要完全排空才开始反向，于是填充与排空各付了两次；而且每一级要同时存下所有 microbatch 的激活，因为每一份都得留到它自己的反向。\n\n1F1B 把这两件事一起解决。它让每一级热身若干次前向之后进入稳态，在稳态里前向反向交替、一步只做一件事。操作总数一件不多一件不少，变的只是顺序。流水线因此不再排空，气泡少一半；而且反向紧跟着前向，一份激活用完就能立刻复用，每级只需要与级数相当的槽位，而不是与 microbatch 数相当。\n\n再往下还有 interleaved 1F1B：把每台机器负责的层拆成几段不连续的，一台机器在流水线里出现多次，级数翻倍而气泡进一步下降，代价是通信次数成倍增加。还有 zero-bubble 的路子：把反向拆成算输入梯度与算权重梯度两半，后者不阻塞流水线、可以填进气泡里。这些都建立在同一个观察上，气泡是排程问题，不是带宽问题。",
           "en": "Tensor parallelism has to stay in-node, so larger models get split by layer: each machine owns a few layers and activations flow through like a pipeline. The catch is that a pipeline has to fill before it runs at capacity. Until the first microbatch reaches the last stage the later stages sit idle, and until the last microbatch finishes the earlier stages sit idle. That idleness is the bubble.\n\nGPipe schedules all forwards first, then all backwards. That costs twice: the forward pipeline drains completely before backward begins, so fill and drain are each paid twice, and every stage holds the activations of all microbatches at once, since each must survive until its own backward.\n\n1F1B fixes both. Each stage warms up with some forwards and then enters a steady state alternating forward and backward, one operation per step. The number of operations is unchanged; only the order differs. The pipeline never drains, roughly halving the bubble, and because each backward closely follows its forward an activation can be reused as soon as it is consumed, so a stage needs about as many slots as there are stages rather than as many as there are microbatches.\n\nBeyond this lies interleaved 1F1B, splitting each machine into several non-contiguous chunks so it appears in the pipeline more than once, multiplying the stage count and shrinking the bubble further at the cost of proportionally more transfers. There is also the zero-bubble line, splitting backward into input gradients and weight gradients where the latter does not block the pipeline and can be dropped into the bubbles. All of them rest on the same observation: the bubble is a scheduling problem, not a bandwidth one."
         }
+      },
+      {
+        "id": "comm-compute-overlap",
+        "title": {
+          "zh": "通信与计算重叠 —— 别等算完了再发",
+          "en": "Overlapping communication and computation — do not wait to finish computing"
+        },
+        "goal": {
+          "zh": "第 23 关的梯度分桶把消息数降了下来，但那个版本仍然是**先算完再发**：\n反向传播全部结束，才开始 all-reduce。这段时间里通信链路完全闲着，\n而 all-reduce 期间计算单元又完全闲着。\n\n第 23 关的扩展里提过为什么 DDP 按参数的**反向顺序**分桶：\n反向传播从最后一层往前算，最后一层的梯度最先就绪 ——\n**第一个桶在反向刚开始不久就能发出去**。\n\n这一关把那件事做出来。反向分成 8 块，每算完一块就立刻发出去，\n同时接着算下一块。要用两个流：\n\n```cuda\nint compute;\ncudaStreamCreate(&compute);\n\nfor (int c = 0; c < CHUNKS; ++c) {\n  // 这一块的反向挂在 compute 流上，**不等它**\n  backwardChunk<<<1, 64, 0, compute>>>(grad + c * CHUNK, act, CHUNK);\n  // 上一块的通信这时候发出去，和这一块的计算重叠\n  ...\n}\n```\n\n重叠率是这么数的：**发起一次集合操作时，别的流上还有没有没同步过的 kernel。**\n有就算这次通信重叠了。\n\n```\n重叠率 = 重叠了的通信字节数 / 总通信字节数\n```\n\n⚠️ 这个子集是**即时执行**的，流不改变执行顺序，也不检测跨流的数据竞争。\n真卡上把有依赖的活放到不同的流上而不 `cudaStreamWaitEvent`，会静默出错。\n这一关的分块之间本来就是独立的，所以不会踩到 —— 但别养成习惯。\n\n```bash\nnvcc -o bench overlap.cu && ./bench\n```\n\n**通关标准**\n\n- 重叠率 ≥ 0.7（先算完再发是 0）\n- 通信总量与消息数都不变 —— 重叠不改变搬多少、发几条",
+          "en": "The gradient bucketing of stage 23 cut the message count, but it still **computes everything\nbefore sending anything**: backward finishes, then the all-reduce starts. The links idle for\nthe whole backward pass, and the compute units idle for the whole all-reduce.\n\nStage 23's extension mentioned why DDP buckets in **reverse** parameter order: backward runs\nfrom the last layer forward, so the last layer's gradients are ready first and **the first\nbucket can go out shortly after backward begins**.\n\nThis stage builds that. Backward is split into 8 chunks; each one is sent as soon as it is\ncomputed, while the next one computes. That needs two streams:\n\n```cuda\nint compute;\ncudaStreamCreate(&compute);\n\nfor (int c = 0; c < CHUNKS; ++c) {\n  // this chunk's backward goes on the compute stream, and we do NOT wait for it\n  backwardChunk<<<1, 64, 0, compute>>>(grad + c * CHUNK, act, CHUNK);\n  // the previous chunk's collective goes out now, overlapping this chunk's compute\n  ...\n}\n```\n\nThe overlap is counted like this: **when a collective is issued, is there unsynchronised\nkernel work outstanding on another stream?** If so, that collective counts as overlapped.\n\n```\noverlap = overlapped communication bytes / total communication bytes\n```\n\n⚠️ This subset executes **eagerly**; streams do not change execution order and cross-stream\ndata hazards are not detected. On real hardware, putting dependent work on different streams\nwithout `cudaStreamWaitEvent` fails silently. The chunks here are genuinely independent so it\ncannot bite, but do not build the habit.\n\n```bash\nnvcc -o bench overlap.cu && ./bench\n```\n\n**To pass**\n\n- overlap ratio at least 0.7 (0 when computing before sending)\n- unchanged total bytes and message count: overlap changes neither"
+        },
+        "checklist": [
+          {
+            "zh": "建一个计算流",
+            "en": "Create a compute stream"
+          },
+          {
+            "zh": "每算完一块就发一块，不等全部算完",
+            "en": "Send each chunk as soon as it is computed, without waiting for the rest"
+          },
+          {
+            "zh": "计算挂在计算流上，通信留在默认流",
+            "en": "Put the compute on the compute stream and leave the collectives on the default stream"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "顺序很关键：**先发起这一块的计算，再发上一块的通信**。反过来的话通信发出去时计算还没挂上，就不算重叠。",
+            "en": "Order matters: **issue this chunk's compute first, then the previous chunk's collective**. The other way round the collective goes out before any compute is outstanding, and does not count as overlapped."
+          },
+          {
+            "zh": "循环结束后还有最后一块没发 —— 补一次。",
+            "en": "The last chunk is still unsent after the loop; flush it."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**计算和通信放在同一个流上。** 真卡上同一个流是严格串行的，所以那根本没有重叠 —— 而代码看起来完全像是重叠了。这是这类优化里最常见的假重叠。",
+            "en": "**Putting compute and communication on the same stream.** A stream is strictly serial on real hardware, so nothing overlaps, while the code looks exactly as though it does. This is the most common false overlap in this kind of optimisation."
+          },
+          {
+            "zh": "**每块之后就 cudaStreamSynchronize。** 那等于把异步又变回同步了，重叠率直接掉回 0。同步要留到最后。",
+            "en": "**Calling cudaStreamSynchronize after every chunk.** That turns the asynchrony back into synchrony and the overlap ratio drops to zero. Synchronise at the end."
+          }
+        ],
+        "extension": {
+          "zh": "重叠是「不改变工作量、只改变时间安排」这一类优化里最纯粹的一个：通信总量不变、消息数不变、计算量不变，变的只是**发起的时机**。\n\n真实系统里重叠无处不在：DDP 的反向顺序分桶（第 23 关）、ZeRO-3 在用到某层权重之前就把它 all-gather 出来、流水线并行里一级的通信和另一级的计算天然重叠（第 26 关）、以及张量并行里把 all-reduce 拆开、和后面的矩阵乘按块交错。\n\n重叠的上限由两件事定死：**通信时间与计算时间的比值**，以及**依赖链允许你提前多久发出去**。如果通信比计算长，重叠再好也只是把计算藏进通信里，总时间还是通信时间 —— 这时候该做的是第 22、23 关那种降低通信本身的事。所以真实调优的顺序通常是：先看通信/计算比，比值小于 1 才值得花力气做重叠。\n\n还要提醒一句这个子集的边界：它是即时执行的，不检测跨流的数据竞争。真卡上流之间要靠 `cudaEvent` 建立依赖，而漏建依赖的错误和第 3 关那个共享内存竞态是同一类 ——**结果稳定地错，看起来像是算法不对。**",
+          "en": "Overlap is the purest member of the \"same work, different schedule\" family: same total bytes, same message count, same computation. Only the **timing of the issue** changes.\n\nReal systems overlap everywhere: DDP's reverse-order bucketing (stage 23), ZeRO-3 all-gathering a layer's weights before they are needed, pipeline parallelism where one stage's communication naturally overlaps another's compute (stage 26), and tensor parallelism splitting an all-reduce to interleave with the following matmul.\n\nTwo things cap how much overlap can buy: **the ratio of communication time to compute time**, and **how far ahead the dependency chain lets you issue**. If communication takes longer than compute, perfect overlap merely hides the compute inside the communication and the total is still the communication time; at that point the thing to do is reduce communication itself, as in stages 22 and 23. Real tuning therefore usually starts by measuring the communication-to-compute ratio and only invests in overlap when it is below one.\n\nOne more note on this subset's boundary: it executes eagerly and does not detect cross-stream data hazards. On real hardware streams are ordered with `cudaEvent`, and a missing dependency is the same class of bug as the shared-memory race in stage 3: **stably wrong, and it looks like the algorithm is broken.**"
+        },
+        "gpu": {
+          "world": {
+            "globalBytes": 4194304,
+            "cluster": {
+              "devices": 8,
+              "devicesPerNode": 8
+            }
+          },
+          "files": {
+            "/root/overlap.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"cuda_runtime.h\"\n        #include \"nccl.h\"\n\n        // 反向传播算出一块梯度\n__global__ void backwardChunk(float* grad, const float* act, int n) {\n  int i = threadIdx.x;\n  if (i < n) grad[i] = act[i] * 0.5f + 0.001f;\n}\n__global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int CHUNKS = 8;\n          const int CHUNK = 64;\n          const int TOTAL = CHUNKS * CHUNK;\n\n          int devs[8];\n          for (int d = 0; d < N; ++d) devs[d] = d;\n          int comms[8];\n          ncclCommInitAll(comms, N, devs);\n\n          int act[8]; int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* a; float* g; float* o;\n            cudaMalloc((void**)&a, TOTAL * 4);\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(a, (float)(d + 1), 64);\n            act[d] = a; grad[d] = g; out[d] = o;\n          }\n\n          // TODO: 先把全部 8 块算完，再一块一块发出去。\n          //       反向的整段时间里链路闲着，通信的整段时间里算力闲着。\n          //       改成边算边发：这一块的计算挂在计算流上不等它，\n          //       同时把上一块的通信发出去。\n          for (int c = 0; c < CHUNKS; ++c) {\n            for (int d = 0; d < N; ++d) {\n              cudaSetDevice(d);\n              backwardChunk<<<1, 64>>>(grad[d] + c * CHUNK, act[d], CHUNK);\n            }\n          }\n          for (int c = 0; c < CHUNKS; ++c) {\n            ncclGroupStart();\n            for (int d = 0; d < N; ++d) {\n              ncclAllReduce(grad[d] + c * CHUNK, out[d] + c * CHUNK, CHUNK,\n                            ncclFloat, ncclSum, comms[d], 0);\n            }\n            ncclGroupEnd();\n          }\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/overlap.cu"
+            ],
+            "buffers": [
+              {
+                "name": "check",
+                "length": 8,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": []
+          },
+          "referenceFiles": {
+            "/root/overlap.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"cuda_runtime.h\"\n        #include \"nccl.h\"\n\n        // 反向传播算出一块梯度\n__global__ void backwardChunk(float* grad, const float* act, int n) {\n  int i = threadIdx.x;\n  if (i < n) grad[i] = act[i] * 0.5f + 0.001f;\n}\n__global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int CHUNKS = 8;\n          const int CHUNK = 64;\n          const int TOTAL = CHUNKS * CHUNK;\n\n          int devs[8];\n          for (int d = 0; d < N; ++d) devs[d] = d;\n          int comms[8];\n          ncclCommInitAll(comms, N, devs);\n\n          int act[8]; int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* a; float* g; float* o;\n            cudaMalloc((void**)&a, TOTAL * 4);\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(a, (float)(d + 1), 64);\n            act[d] = a; grad[d] = g; out[d] = o;\n          }\n\n          // 计算挂在这个流上，通信留在默认流 —— 两个流才有重叠可言\n          int compute;\n          cudaStreamCreate(&compute);\n\n          for (int c = 0; c < CHUNKS; ++c) {\n            // 先发起这一块的计算，**不等它**\n            for (int d = 0; d < N; ++d) {\n              cudaSetDevice(d);\n              backwardChunk<<<1, 64, 0, compute>>>(grad[d] + c * CHUNK, act[d], CHUNK);\n            }\n            // 再把上一块的通信发出去 —— 这时计算流上还有活在飞，算重叠。\n            // 顺序反过来的话通信发出去时计算还没挂上，就不算了\n            if (c > 0) {\n              ncclGroupStart();\n              for (int d = 0; d < N; ++d) {\n                ncclAllReduce(grad[d] + (c - 1) * CHUNK, out[d] + (c - 1) * CHUNK, CHUNK,\n                              ncclFloat, ncclSum, comms[d], 0);\n              }\n              ncclGroupEnd();\n            }\n          }\n\n          // 最后一块还没发 —— 补上。这时计算流上仍有活，所以它也算重叠\n          ncclGroupStart();\n          for (int d = 0; d < N; ++d) {\n            ncclAllReduce(grad[d] + (CHUNKS - 1) * CHUNK, out[d] + (CHUNKS - 1) * CHUNK, CHUNK,\n                          ncclFloat, ncclSum, comms[d], 0);\n          }\n          ncclGroupEnd();\n          cudaStreamSynchronize(compute);\n          cudaStreamDestroy(compute);\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "overlap.spec.ts",
+            "content": "const lab = require('@gpu/lab');\nconst N = 8;\nconst CHUNKS = 8;\nconst CHUNK = 64;\n\ndescribe('通信与计算重叠', () => {\n  it('结果正确', async () => {\n    await lab.buildAndRun();\n    const check = lab.buffer('check');\n    // 第 d 张卡的激活是 d+1，梯度是 0.5(d+1)+0.001，八张卡加起来\n    let expected = 0;\n    for (let d = 0; d < N; d += 1) expected += 0.5 * (d + 1) + 0.001;\n    for (let d = 0; d < N; d += 1) {\n      expect(Math.abs(check[d] - expected)).toBeLessThanOrEqual(1e-4);\n    }\n  });\n\n  it('**重叠率上来了**', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().overlapRatio).toBeGreaterThanOrEqual(0.7);\n  });\n\n  it('通信总量没变 —— 重叠不改变搬多少', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().bytes).toBe(2 * (N - 1) * CHUNKS * CHUNK * 4);\n  });\n\n  it('消息数也没变 —— 还是 8 次集合操作', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().messages).toBe(CHUNKS * 2 * (N - 1) * N);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.comm.overlapRatio",
+            "op": "gte",
+            "value": 0.7,
+            "label": {
+              "zh": "和计算重叠了的通信占比（先算完再发是 0）",
+              "en": "share of communication overlapped with compute (0 when computing first)"
+            },
+            "unit": "ratio",
+            "dimension": "throughput"
+          },
+          {
+            "metric": "gpu.comm.bytes",
+            "op": "gte",
+            "value": 28672,
+            "label": {
+              "zh": "通信总量 —— 重叠不改变搬多少，少了就是漏了块",
+              "en": "total bytes: overlap does not change this, so a drop means chunks were skipped"
+            },
+            "unit": "byte",
+            "dimension": "correctness"
+          }
+        ],
+        "focus": [
+          "throughput",
+          "correctness"
+        ],
+        "primer": {
+          "zh": "先算完再发，是分布式训练里最自然也最浪费的写法：反向传播的整段时间里通信链路完全闲着，all-reduce 的整段时间里计算单元又完全闲着。两件事本来可以同时做。\n\n做法是分块加多流。把梯度分成若干块，每算完一块就立刻发出去，同时接着算下一块。计算挂在一个流上、通信在另一个流上 --同一个流上是严格串行的，放在一起等于没重叠，而代码看起来完全像是重叠了。这是这类优化里最常见的假重叠。\n\n重叠是「不改变工作量、只改变时间安排」这一类优化里最纯粹的一个：通信总量不变、消息数不变、计算量不变，变的只是发起的时机。真实系统里它无处不在，DDP 按反向顺序分桶、ZeRO-3 在用到某层权重之前就把它取回来、流水线并行里一级的通信和另一级的计算天然重叠。\n\n重叠的上限由两件事定死：通信时间与计算时间的比值，以及依赖链允许你提前多久发出去。如果通信本来就比计算长，重叠再好也只是把计算藏进通信里，总时间还是通信时间，这时候该做的是降低通信本身。所以真实调优的顺序通常是先量通信与计算的比值，比值小于一才值得花力气做重叠。",
+          "en": "Computing everything before sending anything is the most natural and most wasteful shape in distributed training: the links idle through the whole backward pass, and the compute units idle through the whole all-reduce. Both could be happening at once.\n\nThe technique is chunking plus multiple streams. Split the gradients, send each chunk as soon as it is computed, and keep computing the next one meanwhile. Put the compute on one stream and the communication on another, because a single stream is strictly serial and putting both on it overlaps nothing while the code looks exactly as though it does. That is the most common false overlap in this kind of work.\n\nOverlap is the purest member of the \"same work, different schedule\" family: same total bytes, same message count, same computation, only the timing of the issue changes. Real systems overlap everywhere, from DDP bucketing in reverse order, to ZeRO-3 fetching a layer weights before they are needed, to pipeline parallelism where one stage communication naturally covers another stage compute.\n\nTwo things cap what overlap can buy: the ratio of communication time to compute time, and how far ahead the dependency chain lets you issue. If communication already takes longer than compute, perfect overlap merely hides the compute inside it and the total is still the communication time, at which point the thing to do is reduce communication itself. Real tuning therefore starts by measuring that ratio and only invests in overlap when it is below one."
+        }
       }
     ]
   },

--- a/projects/stage-primers.js
+++ b/projects/stage-primers.js
@@ -1977,6 +1977,50 @@ const primers = {
         + 'rest on the same observation: the bubble is a scheduling problem, not a bandwidth one.'
       )
     ),
+    'comm-compute-overlap': t(
+      p(
+        '先算完再发，是分布式训练里最自然也最浪费的写法：'
+        + '反向传播的整段时间里通信链路完全闲着，'
+        + 'all-reduce 的整段时间里计算单元又完全闲着。'
+        + '两件事本来可以同时做。',
+        '做法是分块加多流。把梯度分成若干块，每算完一块就立刻发出去，'
+        + '同时接着算下一块。计算挂在一个流上、通信在另一个流上 --'
+        + '同一个流上是严格串行的，放在一起等于没重叠，'
+        + '而代码看起来完全像是重叠了。这是这类优化里最常见的假重叠。',
+        '重叠是「不改变工作量、只改变时间安排」这一类优化里最纯粹的一个：'
+        + '通信总量不变、消息数不变、计算量不变，变的只是发起的时机。'
+        + '真实系统里它无处不在，DDP 按反向顺序分桶、'
+        + 'ZeRO-3 在用到某层权重之前就把它取回来、'
+        + '流水线并行里一级的通信和另一级的计算天然重叠。',
+        '重叠的上限由两件事定死：通信时间与计算时间的比值，'
+        + '以及依赖链允许你提前多久发出去。'
+        + '如果通信本来就比计算长，重叠再好也只是把计算藏进通信里，'
+        + '总时间还是通信时间，这时候该做的是降低通信本身。'
+        + '所以真实调优的顺序通常是先量通信与计算的比值，'
+        + '比值小于一才值得花力气做重叠。'
+      ),
+      p(
+        'Computing everything before sending anything is the most natural and most wasteful shape in '
+        + 'distributed training: the links idle through the whole backward pass, and the compute '
+        + 'units idle through the whole all-reduce. Both could be happening at once.',
+        'The technique is chunking plus multiple streams. Split the gradients, send each chunk as '
+        + 'soon as it is computed, and keep computing the next one meanwhile. Put the compute on one '
+        + 'stream and the communication on another, because a single stream is strictly serial and '
+        + 'putting both on it overlaps nothing while the code looks exactly as though it does. That '
+        + 'is the most common false overlap in this kind of work.',
+        'Overlap is the purest member of the "same work, different schedule" family: same total '
+        + 'bytes, same message count, same computation, only the timing of the issue changes. Real '
+        + 'systems overlap everywhere, from DDP bucketing in reverse order, to ZeRO-3 fetching a '
+        + 'layer weights before they are needed, to pipeline parallelism where one stage '
+        + 'communication naturally covers another stage compute.',
+        'Two things cap what overlap can buy: the ratio of communication time to compute time, and '
+        + 'how far ahead the dependency chain lets you issue. If communication already takes longer '
+        + 'than compute, perfect overlap merely hides the compute inside it and the total is still '
+        + 'the communication time, at which point the thing to do is reduce communication itself. '
+        + 'Real tuning therefore starts by measuring that ratio and only invests in overlap when it '
+        + 'is below one.'
+      )
+    ),
   },
 
   'intranet-k8s': {

--- a/public/projects.json
+++ b/public/projects.json
@@ -27287,6 +27287,143 @@
           "zh": "张量并行只能在机内，模型再大就得按层切：每台机器负责几层，激活像流水线一样一级一级往前传。问题是流水线要填满才满负荷，第一个 microbatch 走到最后一级之前，后面的级都闲着；最后一个 microbatch 走完之前，前面的级也闲着。这段空转叫气泡。\n\nGPipe 的排程是把所有 microbatch 的前向做完，再全部做反向。这有两个代价：前向流水线要完全排空才开始反向，于是填充与排空各付了两次；而且每一级要同时存下所有 microbatch 的激活，因为每一份都得留到它自己的反向。\n\n1F1B 把这两件事一起解决。它让每一级热身若干次前向之后进入稳态，在稳态里前向反向交替、一步只做一件事。操作总数一件不多一件不少，变的只是顺序。流水线因此不再排空，气泡少一半；而且反向紧跟着前向，一份激活用完就能立刻复用，每级只需要与级数相当的槽位，而不是与 microbatch 数相当。\n\n再往下还有 interleaved 1F1B：把每台机器负责的层拆成几段不连续的，一台机器在流水线里出现多次，级数翻倍而气泡进一步下降，代价是通信次数成倍增加。还有 zero-bubble 的路子：把反向拆成算输入梯度与算权重梯度两半，后者不阻塞流水线、可以填进气泡里。这些都建立在同一个观察上，气泡是排程问题，不是带宽问题。",
           "en": "Tensor parallelism has to stay in-node, so larger models get split by layer: each machine owns a few layers and activations flow through like a pipeline. The catch is that a pipeline has to fill before it runs at capacity. Until the first microbatch reaches the last stage the later stages sit idle, and until the last microbatch finishes the earlier stages sit idle. That idleness is the bubble.\n\nGPipe schedules all forwards first, then all backwards. That costs twice: the forward pipeline drains completely before backward begins, so fill and drain are each paid twice, and every stage holds the activations of all microbatches at once, since each must survive until its own backward.\n\n1F1B fixes both. Each stage warms up with some forwards and then enters a steady state alternating forward and backward, one operation per step. The number of operations is unchanged; only the order differs. The pipeline never drains, roughly halving the bubble, and because each backward closely follows its forward an activation can be reused as soon as it is consumed, so a stage needs about as many slots as there are stages rather than as many as there are microbatches.\n\nBeyond this lies interleaved 1F1B, splitting each machine into several non-contiguous chunks so it appears in the pipeline more than once, multiplying the stage count and shrinking the bubble further at the cost of proportionally more transfers. There is also the zero-bubble line, splitting backward into input gradients and weight gradients where the latter does not block the pipeline and can be dropped into the bubbles. All of them rest on the same observation: the bubble is a scheduling problem, not a bandwidth one."
         }
+      },
+      {
+        "id": "comm-compute-overlap",
+        "title": {
+          "zh": "通信与计算重叠 —— 别等算完了再发",
+          "en": "Overlapping communication and computation — do not wait to finish computing"
+        },
+        "goal": {
+          "zh": "第 23 关的梯度分桶把消息数降了下来，但那个版本仍然是**先算完再发**：\n反向传播全部结束，才开始 all-reduce。这段时间里通信链路完全闲着，\n而 all-reduce 期间计算单元又完全闲着。\n\n第 23 关的扩展里提过为什么 DDP 按参数的**反向顺序**分桶：\n反向传播从最后一层往前算，最后一层的梯度最先就绪 ——\n**第一个桶在反向刚开始不久就能发出去**。\n\n这一关把那件事做出来。反向分成 8 块，每算完一块就立刻发出去，\n同时接着算下一块。要用两个流：\n\n```cuda\nint compute;\ncudaStreamCreate(&compute);\n\nfor (int c = 0; c < CHUNKS; ++c) {\n  // 这一块的反向挂在 compute 流上，**不等它**\n  backwardChunk<<<1, 64, 0, compute>>>(grad + c * CHUNK, act, CHUNK);\n  // 上一块的通信这时候发出去，和这一块的计算重叠\n  ...\n}\n```\n\n重叠率是这么数的：**发起一次集合操作时，别的流上还有没有没同步过的 kernel。**\n有就算这次通信重叠了。\n\n```\n重叠率 = 重叠了的通信字节数 / 总通信字节数\n```\n\n⚠️ 这个子集是**即时执行**的，流不改变执行顺序，也不检测跨流的数据竞争。\n真卡上把有依赖的活放到不同的流上而不 `cudaStreamWaitEvent`，会静默出错。\n这一关的分块之间本来就是独立的，所以不会踩到 —— 但别养成习惯。\n\n```bash\nnvcc -o bench overlap.cu && ./bench\n```\n\n**通关标准**\n\n- 重叠率 ≥ 0.7（先算完再发是 0）\n- 通信总量与消息数都不变 —— 重叠不改变搬多少、发几条",
+          "en": "The gradient bucketing of stage 23 cut the message count, but it still **computes everything\nbefore sending anything**: backward finishes, then the all-reduce starts. The links idle for\nthe whole backward pass, and the compute units idle for the whole all-reduce.\n\nStage 23's extension mentioned why DDP buckets in **reverse** parameter order: backward runs\nfrom the last layer forward, so the last layer's gradients are ready first and **the first\nbucket can go out shortly after backward begins**.\n\nThis stage builds that. Backward is split into 8 chunks; each one is sent as soon as it is\ncomputed, while the next one computes. That needs two streams:\n\n```cuda\nint compute;\ncudaStreamCreate(&compute);\n\nfor (int c = 0; c < CHUNKS; ++c) {\n  // this chunk's backward goes on the compute stream, and we do NOT wait for it\n  backwardChunk<<<1, 64, 0, compute>>>(grad + c * CHUNK, act, CHUNK);\n  // the previous chunk's collective goes out now, overlapping this chunk's compute\n  ...\n}\n```\n\nThe overlap is counted like this: **when a collective is issued, is there unsynchronised\nkernel work outstanding on another stream?** If so, that collective counts as overlapped.\n\n```\noverlap = overlapped communication bytes / total communication bytes\n```\n\n⚠️ This subset executes **eagerly**; streams do not change execution order and cross-stream\ndata hazards are not detected. On real hardware, putting dependent work on different streams\nwithout `cudaStreamWaitEvent` fails silently. The chunks here are genuinely independent so it\ncannot bite, but do not build the habit.\n\n```bash\nnvcc -o bench overlap.cu && ./bench\n```\n\n**To pass**\n\n- overlap ratio at least 0.7 (0 when computing before sending)\n- unchanged total bytes and message count: overlap changes neither"
+        },
+        "checklist": [
+          {
+            "zh": "建一个计算流",
+            "en": "Create a compute stream"
+          },
+          {
+            "zh": "每算完一块就发一块，不等全部算完",
+            "en": "Send each chunk as soon as it is computed, without waiting for the rest"
+          },
+          {
+            "zh": "计算挂在计算流上，通信留在默认流",
+            "en": "Put the compute on the compute stream and leave the collectives on the default stream"
+          }
+        ],
+        "hints": [
+          {
+            "zh": "顺序很关键：**先发起这一块的计算，再发上一块的通信**。反过来的话通信发出去时计算还没挂上，就不算重叠。",
+            "en": "Order matters: **issue this chunk's compute first, then the previous chunk's collective**. The other way round the collective goes out before any compute is outstanding, and does not count as overlapped."
+          },
+          {
+            "zh": "循环结束后还有最后一块没发 —— 补一次。",
+            "en": "The last chunk is still unsent after the loop; flush it."
+          }
+        ],
+        "pitfalls": [
+          {
+            "zh": "**计算和通信放在同一个流上。** 真卡上同一个流是严格串行的，所以那根本没有重叠 —— 而代码看起来完全像是重叠了。这是这类优化里最常见的假重叠。",
+            "en": "**Putting compute and communication on the same stream.** A stream is strictly serial on real hardware, so nothing overlaps, while the code looks exactly as though it does. This is the most common false overlap in this kind of optimisation."
+          },
+          {
+            "zh": "**每块之后就 cudaStreamSynchronize。** 那等于把异步又变回同步了，重叠率直接掉回 0。同步要留到最后。",
+            "en": "**Calling cudaStreamSynchronize after every chunk.** That turns the asynchrony back into synchrony and the overlap ratio drops to zero. Synchronise at the end."
+          }
+        ],
+        "extension": {
+          "zh": "重叠是「不改变工作量、只改变时间安排」这一类优化里最纯粹的一个：通信总量不变、消息数不变、计算量不变，变的只是**发起的时机**。\n\n真实系统里重叠无处不在：DDP 的反向顺序分桶（第 23 关）、ZeRO-3 在用到某层权重之前就把它 all-gather 出来、流水线并行里一级的通信和另一级的计算天然重叠（第 26 关）、以及张量并行里把 all-reduce 拆开、和后面的矩阵乘按块交错。\n\n重叠的上限由两件事定死：**通信时间与计算时间的比值**，以及**依赖链允许你提前多久发出去**。如果通信比计算长，重叠再好也只是把计算藏进通信里，总时间还是通信时间 —— 这时候该做的是第 22、23 关那种降低通信本身的事。所以真实调优的顺序通常是：先看通信/计算比，比值小于 1 才值得花力气做重叠。\n\n还要提醒一句这个子集的边界：它是即时执行的，不检测跨流的数据竞争。真卡上流之间要靠 `cudaEvent` 建立依赖，而漏建依赖的错误和第 3 关那个共享内存竞态是同一类 ——**结果稳定地错，看起来像是算法不对。**",
+          "en": "Overlap is the purest member of the \"same work, different schedule\" family: same total bytes, same message count, same computation. Only the **timing of the issue** changes.\n\nReal systems overlap everywhere: DDP's reverse-order bucketing (stage 23), ZeRO-3 all-gathering a layer's weights before they are needed, pipeline parallelism where one stage's communication naturally overlaps another's compute (stage 26), and tensor parallelism splitting an all-reduce to interleave with the following matmul.\n\nTwo things cap how much overlap can buy: **the ratio of communication time to compute time**, and **how far ahead the dependency chain lets you issue**. If communication takes longer than compute, perfect overlap merely hides the compute inside the communication and the total is still the communication time; at that point the thing to do is reduce communication itself, as in stages 22 and 23. Real tuning therefore usually starts by measuring the communication-to-compute ratio and only invests in overlap when it is below one.\n\nOne more note on this subset's boundary: it executes eagerly and does not detect cross-stream data hazards. On real hardware streams are ordered with `cudaEvent`, and a missing dependency is the same class of bug as the shared-memory race in stage 3: **stably wrong, and it looks like the algorithm is broken.**"
+        },
+        "gpu": {
+          "world": {
+            "globalBytes": 4194304,
+            "cluster": {
+              "devices": 8,
+              "devicesPerNode": 8
+            }
+          },
+          "files": {
+            "/root/overlap.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"cuda_runtime.h\"\n        #include \"nccl.h\"\n\n        // 反向传播算出一块梯度\n__global__ void backwardChunk(float* grad, const float* act, int n) {\n  int i = threadIdx.x;\n  if (i < n) grad[i] = act[i] * 0.5f + 0.001f;\n}\n__global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int CHUNKS = 8;\n          const int CHUNK = 64;\n          const int TOTAL = CHUNKS * CHUNK;\n\n          int devs[8];\n          for (int d = 0; d < N; ++d) devs[d] = d;\n          int comms[8];\n          ncclCommInitAll(comms, N, devs);\n\n          int act[8]; int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* a; float* g; float* o;\n            cudaMalloc((void**)&a, TOTAL * 4);\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(a, (float)(d + 1), 64);\n            act[d] = a; grad[d] = g; out[d] = o;\n          }\n\n          // TODO: 先把全部 8 块算完，再一块一块发出去。\n          //       反向的整段时间里链路闲着，通信的整段时间里算力闲着。\n          //       改成边算边发：这一块的计算挂在计算流上不等它，\n          //       同时把上一块的通信发出去。\n          for (int c = 0; c < CHUNKS; ++c) {\n            for (int d = 0; d < N; ++d) {\n              cudaSetDevice(d);\n              backwardChunk<<<1, 64>>>(grad[d] + c * CHUNK, act[d], CHUNK);\n            }\n          }\n          for (int c = 0; c < CHUNKS; ++c) {\n            ncclGroupStart();\n            for (int d = 0; d < N; ++d) {\n              ncclAllReduce(grad[d] + c * CHUNK, out[d] + c * CHUNK, CHUNK,\n                            ncclFloat, ncclSum, comms[d], 0);\n            }\n            ncclGroupEnd();\n          }\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          },
+          "bench": {
+            "sources": [
+              "/root/overlap.cu"
+            ],
+            "buffers": [
+              {
+                "name": "check",
+                "length": 8,
+                "fill": {
+                  "kind": "zeros"
+                }
+              }
+            ],
+            "launches": []
+          },
+          "referenceFiles": {
+            "/root/overlap.cu": "        #include \"engine.h\"\n        #include \"cluster.h\"\n        #include \"cuda_runtime.h\"\n        #include \"nccl.h\"\n\n        // 反向传播算出一块梯度\n__global__ void backwardChunk(float* grad, const float* act, int n) {\n  int i = threadIdx.x;\n  if (i < n) grad[i] = act[i] * 0.5f + 0.001f;\n}\n__global__ void fill(float* a, float v, int n) {\n  int i = threadIdx.x;\n  if (i < n) a[i] = v;\n}\n\n\n        int main(void) {\n          const int N = 8;\n          const int CHUNKS = 8;\n          const int CHUNK = 64;\n          const int TOTAL = CHUNKS * CHUNK;\n\n          int devs[8];\n          for (int d = 0; d < N; ++d) devs[d] = d;\n          int comms[8];\n          ncclCommInitAll(comms, N, devs);\n\n          int act[8]; int grad[8]; int out[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float* a; float* g; float* o;\n            cudaMalloc((void**)&a, TOTAL * 4);\n            cudaMalloc((void**)&g, TOTAL * 4);\n            cudaMalloc((void**)&o, TOTAL * 4);\n            fill<<<1, 64>>>(a, (float)(d + 1), 64);\n            act[d] = a; grad[d] = g; out[d] = o;\n          }\n\n          // 计算挂在这个流上，通信留在默认流 —— 两个流才有重叠可言\n          int compute;\n          cudaStreamCreate(&compute);\n\n          for (int c = 0; c < CHUNKS; ++c) {\n            // 先发起这一块的计算，**不等它**\n            for (int d = 0; d < N; ++d) {\n              cudaSetDevice(d);\n              backwardChunk<<<1, 64, 0, compute>>>(grad[d] + c * CHUNK, act[d], CHUNK);\n            }\n            // 再把上一块的通信发出去 —— 这时计算流上还有活在飞，算重叠。\n            // 顺序反过来的话通信发出去时计算还没挂上，就不算了\n            if (c > 0) {\n              ncclGroupStart();\n              for (int d = 0; d < N; ++d) {\n                ncclAllReduce(grad[d] + (c - 1) * CHUNK, out[d] + (c - 1) * CHUNK, CHUNK,\n                              ncclFloat, ncclSum, comms[d], 0);\n              }\n              ncclGroupEnd();\n            }\n          }\n\n          // 最后一块还没发 —— 补上。这时计算流上仍有活，所以它也算重叠\n          ncclGroupStart();\n          for (int d = 0; d < N; ++d) {\n            ncclAllReduce(grad[d] + (CHUNKS - 1) * CHUNK, out[d] + (CHUNKS - 1) * CHUNK, CHUNK,\n                          ncclFloat, ncclSum, comms[d], 0);\n          }\n          ncclGroupEnd();\n          cudaStreamSynchronize(compute);\n          cudaStreamDestroy(compute);\n\n          float* check = lab_buffer(0);\n          float host[8];\n          for (int d = 0; d < N; ++d) {\n            cudaSetDevice(d);\n            float one[1];\n            cudaMemcpy(one, out[d], 4, cudaMemcpyDeviceToHost);\n            host[d] = one[0];\n          }\n          cudaSetDevice(0);\n          cudaMemcpy(check, host, N * 4, cudaMemcpyHostToDevice);\n          return 0;\n        }\n"
+          }
+        },
+        "specs": [
+          {
+            "path": "overlap.spec.ts",
+            "content": "const lab = require('@gpu/lab');\nconst N = 8;\nconst CHUNKS = 8;\nconst CHUNK = 64;\n\ndescribe('通信与计算重叠', () => {\n  it('结果正确', async () => {\n    await lab.buildAndRun();\n    const check = lab.buffer('check');\n    // 第 d 张卡的激活是 d+1，梯度是 0.5(d+1)+0.001，八张卡加起来\n    let expected = 0;\n    for (let d = 0; d < N; d += 1) expected += 0.5 * (d + 1) + 0.001;\n    for (let d = 0; d < N; d += 1) {\n      expect(Math.abs(check[d] - expected)).toBeLessThanOrEqual(1e-4);\n    }\n  });\n\n  it('**重叠率上来了**', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().overlapRatio).toBeGreaterThanOrEqual(0.7);\n  });\n\n  it('通信总量没变 —— 重叠不改变搬多少', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().bytes).toBe(2 * (N - 1) * CHUNKS * CHUNK * 4);\n  });\n\n  it('消息数也没变 —— 还是 8 次集合操作', async () => {\n    await lab.buildAndRun();\n    expect(lab.comm().messages).toBe(CHUNKS * 2 * (N - 1) * N);\n  });\n});\n"
+          }
+        ],
+        "gates": [
+          {
+            "metric": "gpu.sanitizer.races",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "数据竞态",
+              "en": "data races"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.sanitizer.warpSyncErrors",
+            "op": "eq",
+            "value": 0,
+            "label": {
+              "zh": "warp 同步用错",
+              "en": "warp sync errors"
+            },
+            "dimension": "correctness"
+          },
+          {
+            "metric": "gpu.comm.overlapRatio",
+            "op": "gte",
+            "value": 0.7,
+            "label": {
+              "zh": "和计算重叠了的通信占比（先算完再发是 0）",
+              "en": "share of communication overlapped with compute (0 when computing first)"
+            },
+            "unit": "ratio",
+            "dimension": "throughput"
+          },
+          {
+            "metric": "gpu.comm.bytes",
+            "op": "gte",
+            "value": 28672,
+            "label": {
+              "zh": "通信总量 —— 重叠不改变搬多少，少了就是漏了块",
+              "en": "total bytes: overlap does not change this, so a drop means chunks were skipped"
+            },
+            "unit": "byte",
+            "dimension": "correctness"
+          }
+        ],
+        "focus": [
+          "throughput",
+          "correctness"
+        ],
+        "primer": {
+          "zh": "先算完再发，是分布式训练里最自然也最浪费的写法：反向传播的整段时间里通信链路完全闲着，all-reduce 的整段时间里计算单元又完全闲着。两件事本来可以同时做。\n\n做法是分块加多流。把梯度分成若干块，每算完一块就立刻发出去，同时接着算下一块。计算挂在一个流上、通信在另一个流上 --同一个流上是严格串行的，放在一起等于没重叠，而代码看起来完全像是重叠了。这是这类优化里最常见的假重叠。\n\n重叠是「不改变工作量、只改变时间安排」这一类优化里最纯粹的一个：通信总量不变、消息数不变、计算量不变，变的只是发起的时机。真实系统里它无处不在，DDP 按反向顺序分桶、ZeRO-3 在用到某层权重之前就把它取回来、流水线并行里一级的通信和另一级的计算天然重叠。\n\n重叠的上限由两件事定死：通信时间与计算时间的比值，以及依赖链允许你提前多久发出去。如果通信本来就比计算长，重叠再好也只是把计算藏进通信里，总时间还是通信时间，这时候该做的是降低通信本身。所以真实调优的顺序通常是先量通信与计算的比值，比值小于一才值得花力气做重叠。",
+          "en": "Computing everything before sending anything is the most natural and most wasteful shape in distributed training: the links idle through the whole backward pass, and the compute units idle through the whole all-reduce. Both could be happening at once.\n\nThe technique is chunking plus multiple streams. Split the gradients, send each chunk as soon as it is computed, and keep computing the next one meanwhile. Put the compute on one stream and the communication on another, because a single stream is strictly serial and putting both on it overlaps nothing while the code looks exactly as though it does. That is the most common false overlap in this kind of work.\n\nOverlap is the purest member of the \"same work, different schedule\" family: same total bytes, same message count, same computation, only the timing of the issue changes. Real systems overlap everywhere, from DDP bucketing in reverse order, to ZeRO-3 fetching a layer weights before they are needed, to pipeline parallelism where one stage communication naturally covers another stage compute.\n\nTwo things cap what overlap can buy: the ratio of communication time to compute time, and how far ahead the dependency chain lets you issue. If communication already takes longer than compute, perfect overlap merely hides the compute inside it and the total is still the communication time, at which point the thing to do is reduce communication itself. Real tuning therefore starts by measuring that ratio and only invests in overlap when it is below one."
+        }
       }
     ]
   },

--- a/src/lib/gpulab/cluster/cluster.ts
+++ b/src/lib/gpulab/cluster/cluster.ts
@@ -73,6 +73,16 @@ export interface CommMetrics {
    */
   maxDeviceBytes: number;
   /**
+   * 和计算重叠了的通信字节数。
+   *
+   * 判据是**结构性的**：发起这次集合操作时，别的流上还有没有同步过的
+   * kernel。有就算重叠。这不看模拟耗时 —— 它回答的是"你有没有把通信
+   * 发在计算还在飞的时候"，而那正是重叠这件事的全部内容。
+   */
+  overlappedBytes: number;
+  /** 重叠了的比例 */
+  overlapRatio: number;
+  /**
    * 算法带宽与总线带宽。
    *
    * nccl-tests 的口径：algbw = 字节数 / 耗时，
@@ -88,7 +98,7 @@ export function emptyCommMetrics(): CommMetrics {
     bytes: 0, messages: 0,
     bytesByLink: { nvlink: 0, pcie: 0, ib: 0 },
     messagesByLink: { nvlink: 0, pcie: 0, ib: 0 },
-    seconds: 0, maxDeviceBytes: 0, algbw: 0, busbw: 0,
+    seconds: 0, maxDeviceBytes: 0, overlappedBytes: 0, overlapRatio: 0, algbw: 0, busbw: 0,
   };
 }
 
@@ -277,6 +287,11 @@ export class Cluster {
     this.account(srcDevice, dstDevice, bytes);
   }
 
+  /** 记一次和计算重叠了的通信 */
+  accountOverlap(bytes: number): void {
+    this.comm.overlappedBytes += bytes;
+  }
+
   /** 记一次跨卡传输 */
   account(from: number, to: number, bytes: number): void {
     const link = linkBetween(from, to, this.spec);
@@ -311,6 +326,9 @@ export class Cluster {
    * （all-reduce 就是缓冲区大小），`factor` 是集合操作的修正因子。
    */
   finishBandwidth(payloadBytes: number, factor: number): void {
+    this.comm.overlapRatio = this.comm.bytes > 0
+      ? this.comm.overlappedBytes / this.comm.bytes
+      : 0;
     if (this.comm.seconds <= 0) return;
     this.comm.algbw = payloadBytes / this.comm.seconds;
     this.comm.busbw = this.comm.algbw * factor;

--- a/src/lib/gpulab/cluster/run.ts
+++ b/src/lib/gpulab/cluster/run.ts
@@ -65,7 +65,7 @@ export function runClusterHost(
       const local = cluster.localAddress(address, device, 'cudaMemset');
       new Uint8Array(cluster.devices[device].memory.bytes, local, bytes).fill(value & 0xff);
     },
-    launch: (name, grid, block, args, line) => {
+    launch: (name, grid, block, args, line, _stream) => {
       const kernel = kernels.get(name);
       if (!kernel) {
         throw new HostRuntimeError(
@@ -102,7 +102,7 @@ export function runClusterHost(
     readHostInts: (address, count) => (
       Array.from(new Int32Array(hostLocal.bytes, address, count))
     ),
-    collective: (kind, ranks, count, op, root) => {
+    collective: (kind, ranks, count, op, root, overlapped) => {
       // 环按**实际的卡**走，不是按 rank 号 —— 一个组摊在两台机器上时，
       // 环上就会有跨机的边，`comm.bytesByLink.ib` 立刻暴增
       const sorted = ranks.slice().sort((a, b) => a.device - b.device);
@@ -115,6 +115,7 @@ export function runClusterHost(
         seen.add(rank.device);
       }
       const reduce = redOpOf(op);
+      const before = cluster.comm.bytes;
       switch (kind) {
         case 'allreduce': ringAllReduce(cluster, sorted, count, reduce); break;
         case 'allgather': ringAllGather(cluster, sorted, count); break;
@@ -125,6 +126,11 @@ export function runClusterHost(
       }
       const bytes = count * 4 * (kind === 'reducescatter' ? sorted.length : 1);
       if (bytes > payload) { payload = bytes; factorKind = kind; }
+      if (overlapped) {
+        // 这一次集合操作搬了多少，就算多少重叠。
+        // before/after 相减而不是重新算一遍，免得两处口径分家
+        cluster.accountOverlap(cluster.comm.bytes - before);
+      }
     },
   };
 

--- a/src/lib/gpulab/cuda/ast.ts
+++ b/src/lib/gpulab/cuda/ast.ts
@@ -205,6 +205,8 @@ export type Stmt =
       kernel: string;
       grid: Expr[];
       block: Expr[];
+      /** `<<<g, b, 0, stream>>>` 的第四个参数。不写就是默认流（0） */
+      stream?: Expr;
       args: Expr[];
       span: SourceSpan;
     };

--- a/src/lib/gpulab/cuda/lower.ts
+++ b/src/lib/gpulab/cuda/lower.ts
@@ -578,8 +578,13 @@ function lowerLaunch(node: TsNode, syntax: TsNode, span: SourceSpan): Stmt {
 
   const config = namedChildren(syntax);
   if (config.length < 2) fail(syntax, '<<<>>> 里至少要写 grid 与 block 两个参数');
-  if (config.length > 2) {
-    fail(syntax, '<<<>>> 的第三、四个参数（动态共享内存、流）暂不支持 —— '
+  if (config.length === 3) {
+    fail(syntax, '<<<>>> 只写三个参数的话第三个是动态共享内存 —— 那个还不支持。'
+      + '要指定流请写成 <<<grid, block, 0, stream>>>');
+  }
+  if (config.length > 4) fail(syntax, '<<<>>> 最多四个参数');
+  if (config.length === 4 && config[2].text.trim() !== '0') {
+    fail(syntax, '动态共享内存暂不支持，第三个参数必须写 0 —— '
       + '共享内存请用 __shared__ 静态声明');
   }
 
@@ -591,6 +596,7 @@ function lowerLaunch(node: TsNode, syntax: TsNode, span: SourceSpan): Stmt {
     kernel: callee.text,
     grid: lowerDim(config[0]),
     block: lowerDim(config[1]),
+    ...(config.length === 4 ? { stream: lowerExpr(config[3]) } : {}),
     args,
     span,
   };

--- a/src/lib/gpulab/host/headers.ts
+++ b/src/lib/gpulab/host/headers.ts
@@ -90,6 +90,22 @@ int cudaMemcpy(void* dst, const void* src, int bytes, int kind);
 int cudaMemset(void* devicePtr, int value, int bytes);
 int cudaDeviceSynchronize(void);
 
+/* ---- 流 ----
+ *
+ * 起 kernel 时指定流：kernel<<<grid, block, 0, stream>>>(...)
+ * 第三个参数（动态共享内存）必须写 0，那个还不支持。
+ *
+ * ⚠️ **一处要说清楚的偏差**：这个模拟器是**即时执行**的 ——
+ * kernel 在 launch 那一刻就跑完了，流不改变执行顺序，也**不检测
+ * 跨流的数据竞争**。流在这里的作用是记账：平台据此回答
+ * "发起这次集合通信时，别的流上还有没有计算在飞"，也就是重叠率。
+ *
+ * 真卡上把有依赖的活放到不同的流上而不 cudaStreamWaitEvent，
+ * 是一个会静默出错的严重问题。这个子集查不出来，别养成习惯。 */
+int cudaStreamCreate(int* stream);
+int cudaStreamSynchronize(int stream);
+int cudaStreamDestroy(int stream);
+
 /* ---- CUDA Graph ----
  *
  * 把一串 launch 录下来，之后一次重放。省下来的是**提交开销** ——

--- a/src/lib/gpulab/host/runtime.ts
+++ b/src/lib/gpulab/host/runtime.ts
@@ -29,8 +29,10 @@ export interface HostEnvironment {
   /** 在两个地址空间之间搬字节 */
   copy(dst: number, src: number, bytes: number, kind: number): void;
   memset(address: number, value: number, bytes: number): void;
-  /** 起一个 kernel，同步执行完 */
-  launch(name: string, grid: Dim3, block: Dim3, args: number[], line: number): void;
+  /** 起一个 kernel，同步执行完。`stream` 只影响重叠计量，不影响执行 */
+  launch(
+    name: string, grid: Dim3, block: Dim3, args: number[], line: number, stream: number
+  ): void;
   /**
    * 重放一整张 graph。
    *
@@ -58,7 +60,9 @@ export interface HostEnvironment {
     ranks: Array<{ device: number; send: number; recv: number }>,
     count: number,
     op: number,
-    root: number
+    root: number,
+    /** 发起时别的流上还有计算在飞 */
+    overlapped: boolean
   ): void;
   /**
    * 关卡在 `BenchSpec.buffers` 里声明的第 index 个缓冲区。
@@ -107,6 +111,8 @@ interface PendingCollective {
   op: number;
   comm: number;
   root: number;
+  /** 这次调用挂在哪个流上 */
+  stream: number;
 }
 
 /** 一个宿主程序跑起来需要的全部状态 */
@@ -125,6 +131,15 @@ export class HostRuntime implements HostServices {
    */
   private group: PendingCollective[] | null = null;
   private commCount = 0;
+  /**
+   * 每个流上有多少件还没同步的活。
+   *
+   * **模拟器是即时执行的**，kernel 在 launch 那一刻就跑完了。
+   * 这张表纯粹是记账：它回答"发起这次集合通信的时候，
+   * 别的流上还有没有计算在飞"—— 也就是重叠率量的那件事。
+   */
+  private readonly outstanding = new Map<number, number>();
+  private nextStream = 1;
 
   constructor(
     private readonly env: HostEnvironment,
@@ -145,13 +160,18 @@ export class HostRuntime implements HostServices {
     }
   }
 
-  launch(name: string, grid: Dim3, block: Dim3, args: number[], line: number): void {
+  launch(
+    name: string, grid: Dim3, block: Dim3, args: number[], line: number, stream = 0
+  ): void {
     if (this.capturing) {
       // 捕获期间**不执行**，只录下来 —— 和真 CUDA 一样
       this.capturing.push({ kind: 'launch', name, grid, block, args: args.slice(), line });
       return;
     }
-    this.env.launch(name, grid, block, args, line);
+    // 这个流上多了一件"还没同步"的活。**执行是即时的** ——
+    // 这只是记账，用来回答"发起集合操作时还有没有计算在飞"。
+    this.outstanding.set(stream, (this.outstanding.get(stream) ?? 0) + 1);
+    this.env.launch(name, grid, block, args, line, stream);
   }
 
   private requireCluster(what: string): HostEnvironment {
@@ -170,9 +190,9 @@ export class HostRuntime implements HostServices {
    */
   private enqueue(
     kind: string, send: number, recv: number, count: number,
-    op: number, comm: number, root: number
+    op: number, comm: number, root: number, stream = 0
   ): number {
-    const item: PendingCollective = { kind, send, recv, count, op, comm, root };
+    const item: PendingCollective = { kind, send, recv, count, op, comm, root, stream };
     if (this.group) {
       this.group.push(item);
       return 0;
@@ -190,6 +210,13 @@ export class HostRuntime implements HostServices {
   private flushGroup(pending: PendingCollective[]): void {
     if (!pending.length) return;
     const env = this.requireCluster('NCCL');
+    // 发起这次通信时，**别的流**上还有没有没同步的计算？
+    // 有就算重叠 —— 这是个结构性的判断，和模拟耗时无关
+    let elsewhere = 0;
+    for (const [stream, count] of this.outstanding) {
+      if (stream !== pending[0].stream) elsewhere += count;
+    }
+    const overlapped = elsewhere > 0;
     // 同一种操作、同一批 rank 的调用凑成一次集合操作
     const byKind = new Map<string, PendingCollective[]>();
     for (const item of pending) {
@@ -202,7 +229,7 @@ export class HostRuntime implements HostServices {
       const ranks = list.map((item) => ({
         device: item.comm, send: item.send, recv: item.recv,
       }));
-      env.collective!(list[0].kind, ranks, list[0].count, list[0].op, list[0].root);
+      env.collective!(list[0].kind, ranks, list[0].count, list[0].op, list[0].root, overlapped);
     }
   }
 
@@ -280,6 +307,20 @@ export class HostRuntime implements HostServices {
       case HOST.cudaSetDevice:
         this.requireCluster('cudaSetDevice').setDevice!(args[0] | 0);
         return 0;
+      /* ---- 流 ---- */
+      case HOST.cudaStreamCreate: {
+        const handle = this.nextStream;
+        this.nextStream += 1;
+        this.outstanding.set(handle, 0);
+        return handle;
+      }
+      case HOST.cudaStreamSynchronize:
+        this.outstanding.set(args[0] | 0, 0);
+        return 0;
+      case HOST.cudaStreamDestroy:
+        this.outstanding.delete(args[0] | 0);
+        return 0;
+
       case HOST.pipe_step:
         this.requireCluster('pipe_step').pipeStep!();
         return 0;
@@ -338,15 +379,15 @@ export class HostRuntime implements HostServices {
       //   Broadcast(send, recv, count, datatype, root, comm, stream)
       //   Reduce(send, recv, count, datatype, op, root, comm, stream)
       case HOST.ncclAllReduce:
-        return this.enqueue('allreduce', args[0], args[1], args[2] | 0, args[4] | 0, args[5] | 0, -1);
+        return this.enqueue('allreduce', args[0], args[1], args[2] | 0, args[4] | 0, args[5] | 0, -1, args[6] | 0);
       case HOST.ncclAllGather:
-        return this.enqueue('allgather', args[0], args[1], args[2] | 0, 0, args[4] | 0, -1);
+        return this.enqueue('allgather', args[0], args[1], args[2] | 0, 0, args[4] | 0, -1, args[5] | 0);
       case HOST.ncclReduceScatter:
-        return this.enqueue('reducescatter', args[0], args[1], args[2] | 0, args[4] | 0, args[5] | 0, -1);
+        return this.enqueue('reducescatter', args[0], args[1], args[2] | 0, args[4] | 0, args[5] | 0, -1, args[6] | 0);
       case HOST.ncclBroadcast:
-        return this.enqueue('broadcast', args[0], args[1], args[2] | 0, 0, args[5] | 0, args[4] | 0);
+        return this.enqueue('broadcast', args[0], args[1], args[2] | 0, 0, args[5] | 0, args[4] | 0, args[6] | 0);
       case HOST.ncclReduce:
-        return this.enqueue('reduce', args[0], args[1], args[2] | 0, args[4] | 0, args[6] | 0, args[5] | 0);
+        return this.enqueue('reduce', args[0], args[1], args[2] | 0, args[4] | 0, args[6] | 0, args[5] | 0, args[7] | 0);
       case HOST.ncclSend:
       case HOST.ncclRecv:
         throw new HostRuntimeError(
@@ -354,6 +395,9 @@ export class HostRuntime implements HostServices {
         );
 
       case HOST.cudaDeviceSynchronize:
+        // 同步所有流：之后再发集合操作就不算重叠了
+        this.outstanding.clear();
+        this.nextStream = this.nextStream;
         // 我们的 launch 是同步的，所以这里没有实际工作。**保留它不是装样子**：
         // 真卡上少写这一句、紧接着读回结果，是最经典的一类 bug，
         // 关卡的正文会讲到，代码里出现过学员才有印象。

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -214,7 +214,7 @@ export class GpuDevice {
       memset: (address, value, bytes) => {
         new Uint8Array(this.memory.bytes, address, bytes).fill(value & 0xff);
       },
-      launch: (name, grid, block, args, line) => {
+      launch: (name, grid, block, args, line, _stream) => {
         const kernel = kernels.get(name);
         if (!kernel) {
           throw new HostRuntimeError(

--- a/src/lib/gpulab/ir/compile.ts
+++ b/src/lib/gpulab/ir/compile.ts
@@ -221,6 +221,9 @@ const HOST_FNS: Record<string, { fn: HostFn; arity: number; scalar: 'int' | 'voi
   cudaGetDevice: { fn: 'cudaGetDevice', arity: 1, scalar: 'int' },
   cudaMemcpyPeer: { fn: 'cudaMemcpyPeer', arity: 5, scalar: 'int' },
   pipe_step: { fn: 'pipe_step', arity: 0, scalar: 'void' },
+  cudaStreamSynchronize: { fn: 'cudaStreamSynchronize', arity: 1, scalar: 'int' },
+  cudaStreamDestroy: { fn: 'cudaStreamDestroy', arity: 1, scalar: 'int' },
+  cudaStreamCreate: { fn: 'cudaStreamCreate', arity: 1, scalar: 'int' },
 
   // NCCL。真 API 的形状：通信子按设备各一个，集合操作在 group 里发起。
   ncclCommInitAll: { fn: 'ncclCommInitAll', arity: 3, scalar: 'int' },
@@ -278,6 +281,7 @@ const HOST_OUT_PARAM: Record<string, { at: number; hint: string }> = {
   cudaMalloc: { at: 0, hint: '(void**)&指针变量' },
   cudaGetDeviceCount: { at: 0, hint: '&变量' },
   cudaGetDevice: { at: 0, hint: '&变量' },
+  cudaStreamCreate: { at: 0, hint: '&变量' },
   cudaStreamEndCapture: { at: 1, hint: '&变量' },
   cudaGraphInstantiate: { at: 0, hint: '&变量' },
 };
@@ -1713,8 +1717,14 @@ class Compiler {
     const grid = dim(node.grid);
     const block = dim(node.block);
     const args = node.args.map((arg) => this.expr(arg).reg);
+    const stream = node.stream
+      ? this.convert(this.expr(node.stream), { kind: 'scalar', scalar: 'int' }, node.span.line).reg
+      : undefined;
     const site = this.launches.length;
-    this.launches.push({ kernel: node.kernel, grid, block, args, line: node.span.line });
+    this.launches.push({
+      kernel: node.kernel, grid, block, args, line: node.span.line,
+      ...(stream !== undefined ? { stream } : {}),
+    });
     this.emit({ op: 'launch', site, line: node.span.line }, node.span.line);
   }
 

--- a/src/lib/gpulab/ir/program.ts
+++ b/src/lib/gpulab/ir/program.ts
@@ -75,6 +75,8 @@ export const HOST: Record<HostFn, number> = {
   cudaGraphDestroy: 44, cudaGraphExecDestroy: 45,
   cudaGetDeviceCount: 50, cudaSetDevice: 51, cudaGetDevice: 52, cudaMemcpyPeer: 53,
   pipe_step: 54,
+  cudaStreamCreate: 55, cudaStreamSynchronize: 56, cudaStreamDestroy: 57,
+  cudaDeviceSynchronizeAll: 58,
   ncclCommInitAll: 60, ncclCommDestroy: 61,
   ncclGroupStart: 62, ncclGroupEnd: 63,
   ncclAllReduce: 64, ncclAllGather: 65, ncclReduceScatter: 66,

--- a/src/lib/gpulab/ir/types.ts
+++ b/src/lib/gpulab/ir/types.ts
@@ -188,6 +188,9 @@ export type HostFn =
   | 'cudaGetDeviceCount' | 'cudaSetDevice' | 'cudaGetDevice' | 'cudaMemcpyPeer'
   /** 流水线调度：声明一个步边界，气泡率靠它数出来 */
   | 'pipe_step'
+  /** 流 */
+  | 'cudaStreamCreate' | 'cudaStreamSynchronize' | 'cudaStreamDestroy'
+  | 'cudaDeviceSynchronizeAll'
   /** NCCL 集合通信 */
   | 'ncclCommInitAll' | 'ncclCommDestroy'
   | 'ncclGroupStart' | 'ncclGroupEnd'
@@ -205,6 +208,8 @@ export interface LaunchSite {
   block: number[];
   /** 实参寄存器；指针参数里装的是地址 */
   args: number[];
+  /** 流的寄存器。没指定就是默认流 */
+  stream?: number;
   /** 每个实参是不是指针 —— 运行时要按这个决定怎么解释 */
   line: number;
 }

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -215,7 +215,9 @@ export interface HostServices {
   /** 一次运行时调用；返回值写回 dst 寄存器 */
   call(fn: number, args: number[], line: number): number;
   /** `kernel<<<grid, block>>>(args)` */
-  launch(name: string, grid: Dim3, block: Dim3, args: number[], line: number): void;
+  launch(
+    name: string, grid: Dim3, block: Dim3, args: number[], line: number, stream: number
+  ): void;
 }
 
 const DEFAULT_MAX_WARP_INSTS = 200_000_000;
@@ -828,7 +830,10 @@ class Executor {
             };
             hostArgs.length = 0;
             for (const reg of site.args) hostArgs.push(regs[reg * WARP_SIZE]);
-            services.launch(site.kernel, grid, block, hostArgs.slice(), lines[pc]);
+            const stream = site.stream !== undefined
+              ? regs[site.stream * WARP_SIZE] | 0
+              : 0;
+            services.launch(site.kernel, grid, block, hostArgs.slice(), lines[pc], stream);
             instBookkeeping += lanes;
             pc += 1;
             break;

--- a/tests/gpulab/overlap.test.ts
+++ b/tests/gpulab/overlap.test.ts
@@ -1,0 +1,192 @@
+/**
+ * 通信与计算的重叠
+ *
+ * 重叠率的判据是**结构性的**：发起集合操作时，别的流上还有没有
+ * 没同步过的 kernel。这套用例把这个判据的边界钉住 ——
+ * 尤其是"同步过了就不算"和"同一个流上不算"。
+ */
+import { Cluster, SINGLE_NODE_8, compileProgram, runClusterHost } from '../../src/lib/gpulab';
+
+jest.setTimeout(180_000);
+
+const KERNELS = `
+__global__ void work(float* a, int n) {
+  int i = threadIdx.x;
+  if (i < n) a[i] = a[i] * 1.0009765625f;
+}
+`;
+
+async function run(body: string, devices = 4) {
+  const cluster = new Cluster({
+    spec: { ...SINGLE_NODE_8, devices }, globalBytes: 1024 * 1024,
+  });
+  const program = await compileProgram(
+    `${KERNELS}\n#include "cluster.h"\n#include "nccl.h"\n#include "cuda_runtime.h"\n${body}`
+  );
+  runClusterHost(cluster, program.host!, program.kernels);
+  return cluster;
+}
+
+const SETUP = `
+  const int N = 4;
+  const int COUNT = 64;
+  int devs[8]; for (int d = 0; d < N; ++d) devs[d] = d;
+  int comms[8]; ncclCommInitAll(comms, N, devs);
+  int send[8]; int recv[8]; int other[8];
+  for (int d = 0; d < N; ++d) {
+    cudaSetDevice(d);
+    float* s; float* r; float* o;
+    cudaMalloc((void**)&s, COUNT * 4);
+    cudaMalloc((void**)&r, COUNT * 4);
+    cudaMalloc((void**)&o, COUNT * 4);
+    send[d] = s; recv[d] = r; other[d] = o;
+  }
+`;
+
+describe('重叠率', () => {
+  it('通信前什么计算都没发 —— 重叠率 0', async () => {
+    const cluster = await run(`
+      int main(void) {
+        ${SETUP}
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        return 0;
+      }
+    `);
+    expect(cluster.comm.overlapRatio).toBe(0);
+  });
+
+  it('**别的流上有计算在飞 —— 重叠率 1**', async () => {
+    const cluster = await run(`
+      int main(void) {
+        ${SETUP}
+        int stream;
+        cudaStreamCreate(&stream);
+        for (int d = 0; d < N; ++d) {
+          cudaSetDevice(d);
+          work<<<1, 64, 0, stream>>>(other[d], COUNT);
+        }
+        // 计算还挂在 stream 上没同步，这时发通信 —— 重叠
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        cudaStreamSynchronize(stream);
+        return 0;
+      }
+    `);
+    expect(cluster.comm.overlapRatio).toBe(1);
+  });
+
+  it('先同步再通信 —— 不算重叠', async () => {
+    const cluster = await run(`
+      int main(void) {
+        ${SETUP}
+        int stream;
+        cudaStreamCreate(&stream);
+        for (int d = 0; d < N; ++d) {
+          cudaSetDevice(d);
+          work<<<1, 64, 0, stream>>>(other[d], COUNT);
+        }
+        cudaStreamSynchronize(stream);   // 等完了才发
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        return 0;
+      }
+    `);
+    expect(cluster.comm.overlapRatio).toBe(0);
+  });
+
+  it('**计算和通信在同一个流上 —— 不算重叠**', async () => {
+    // 真卡上同一个流是严格串行的，这是最常见的"以为重叠了其实没有"
+    const cluster = await run(`
+      int main(void) {
+        ${SETUP}
+        for (int d = 0; d < N; ++d) {
+          cudaSetDevice(d);
+          work<<<1, 64, 0, 0>>>(other[d], COUNT);
+        }
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        return 0;
+      }
+    `);
+    expect(cluster.comm.overlapRatio).toBe(0);
+  });
+
+  it('一半重叠一半不重叠', async () => {
+    const cluster = await run(`
+      int main(void) {
+        ${SETUP}
+        int stream;
+        cudaStreamCreate(&stream);
+        // 第一次：没有计算在飞
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        // 第二次：有
+        for (int d = 0; d < N; ++d) {
+          cudaSetDevice(d);
+          work<<<1, 64, 0, stream>>>(other[d], COUNT);
+        }
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        return 0;
+      }
+    `);
+    expect(cluster.comm.overlapRatio).toBeCloseTo(0.5, 6);
+  });
+
+  it('cudaDeviceSynchronize 也会清掉在飞的计算', async () => {
+    const cluster = await run(`
+      int main(void) {
+        ${SETUP}
+        int stream;
+        cudaStreamCreate(&stream);
+        for (int d = 0; d < N; ++d) {
+          cudaSetDevice(d);
+          work<<<1, 64, 0, stream>>>(other[d], COUNT);
+        }
+        cudaDeviceSynchronize();
+        ncclGroupStart();
+        for (int d = 0; d < N; ++d) {
+          ncclAllReduce(send[d], recv[d], COUNT, ncclFloat, ncclSum, comms[d], 0);
+        }
+        ncclGroupEnd();
+        return 0;
+      }
+    `);
+    expect(cluster.comm.overlapRatio).toBe(0);
+  });
+});
+
+describe('流的语法', () => {
+  it('第三个参数必须写 0 —— 动态共享内存还不支持', async () => {
+    await expect(compileProgram(`
+      ${KERNELS}
+      int main(void) { work<<<1, 64, 4096, 0>>>(0, 1); return 0; }
+    `)).rejects.toThrow(/动态共享内存/);
+  });
+
+  it('只写三个参数会说清该怎么写', async () => {
+    await expect(compileProgram(`
+      ${KERNELS}
+      int main(void) { work<<<1, 64, 0>>>(0, 1); return 0; }
+    `)).rejects.toThrow(/<<<grid, block, 0, stream>>>/);
+  });
+});


### PR DESCRIPTION
起始版先算完 8 块梯度再一块块发：反向的整段时间里链路闲着，all-reduce 的整段
时间里算力闲着。改成边算边发后重叠率 **0 → 1.0**，而**通信总量与消息数一个都没变**。

## 重叠率是结构量，不是耗时
判据：发起一次集合操作时，别的流上还有没有没同步过的 kernel。有就算重叠。
它回答的是「你有没有把通信发在计算还在飞的时候」—— 那正是重叠的全部内容。

用例把边界钉住，尤其两条：
- **计算和通信在同一个流上不算重叠**（真卡上同一个流严格串行）—— 这是这类优化里最常见的**假重叠**，代码看起来完全像是重叠了
- 先 `cudaStreamSynchronize` 再发也不算

## 新增：流
`<<<grid, block, 0, stream>>>` 四参数形式（第三个必须是 0），
`cudaStreamCreate` / `Synchronize` / `Destroy`。

**一处必须说清楚的偏差**（写在 `cuda_runtime.h` 与关卡正文里）：这个模拟器是
**即时执行**的 —— kernel 在 launch 那一刻就跑完了，流不改变执行顺序，也**不检测
跨流的数据竞争**。流在这里的作用是记账。真卡上把有依赖的活放到不同流上而不
`cudaStreamWaitEvent` 会静默出错，这个子集查不出来。

与其做半个能用的竞争检测，不如把边界说清楚。

## 验证
`tests/gpulab/overlap.test.ts` 8 条 + `stages.test.ts` **82/82**；
`tsc` / `projects:verify` / `npm test` 10/10 / `npm run build` 含 check-bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)