### PR TITLE
feat(gpulab): GPU 工作台（二）—— 访存面板

### DIFF
--- a/src/components/gpulab/GpuWorkspace.tsx
+++ b/src/components/gpulab/GpuWorkspace.tsx
@@ -15,7 +15,7 @@ import {
   ScrollArea, Select, Stack, Tabs, Text, Tooltip,
 } from '@mantine/core';
 import {
-  IconAlertTriangle, IconChartHistogram, IconFileCode,
+  IconAlertTriangle, IconChartHistogram, IconCpu, IconFileCode,
   IconPlayerPlay, IconRefresh, IconTerminal2,
 } from '@tabler/icons-react';
 import { useMantineColorScheme } from '@mantine/core';
@@ -35,6 +35,7 @@ const WorkbenchTerminal = dynamic(
   () => import('../workbench/WorkbenchTerminal'), { ssr: false }
 );
 const ProfilePanel = dynamic(() => import('./ProfilePanel'), { ssr: false });
+const MemoryPanel = dynamic(() => import('./MemoryPanel'), { ssr: false });
 
 export interface GpuWorkspaceProps {
   session: ProjectSession;
@@ -347,6 +348,9 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                   <Tabs.Tab value="profile" fz="xs" leftSection={<IconChartHistogram size={13} />}>
                     剖析
                   </Tabs.Tab>
+                  <Tabs.Tab value="memory" fz="xs" leftSection={<IconCpu size={13} />}>
+                    访存
+                  </Tabs.Tab>
                 </Tabs.List>
 
                 <Tabs.Panel value="terminal" style={{ flex: 1, minHeight: 0 }}>
@@ -413,6 +417,12 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                 <Tabs.Panel value="profile" style={{ flex: 1, minHeight: 0 }}>
                   <ErrorBoundary fallback={renderPanelError}>
                     <ProfilePanel world={gpu.world} revision={gpu.revision} onInsert={insertCommand} />
+                  </ErrorBoundary>
+                </Tabs.Panel>
+
+                <Tabs.Panel value="memory" style={{ flex: 1, minHeight: 0 }}>
+                  <ErrorBoundary fallback={renderPanelError}>
+                    <MemoryPanel world={gpu.world} revision={gpu.revision} />
                   </ErrorBoundary>
                 </Tabs.Panel>
 

--- a/src/components/gpulab/MemoryPanel.tsx
+++ b/src/components/gpulab/MemoryPanel.tsx
@@ -1,0 +1,320 @@
+/**
+ * 访存面板：warp 热图 + 共享内存 bank 视图
+ *
+ * **这是这个工作台区别于「在真卡上跑一跑」的地方** —— 真卡上你看不见这些。
+ * `ncu` 给的是聚合之后的数（扇区总数、冲突路数），而
+ * 「为什么改一下下标 DRAM 字节就掉了 8 倍」要看的是分布：
+ * 合并的时候 32 个 lane 挤进 4 个格子，不合并的时候散成 32 个点。
+ *
+ * 轨迹是**按需采样**的：点一下按钮单独跑一遍，不影响学员刚跑出来的指标。
+ */
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert, Badge, Button, Group, ScrollArea, Select, Stack, Table, Text, Tooltip,
+} from '@mantine/core';
+import { AccessTrace, banksOf, sectorsOf } from '../../lib/gpulab';
+import { runBench, type GpuWorld } from '../../lib/gpulab/lab';
+import type { AccessRecord } from '../../lib/gpulab';
+
+export interface MemoryPanelProps {
+  world: GpuWorld | null;
+  revision: number;
+}
+
+const WARP = 32;
+
+/** 一个 lane 格子的颜色：按它落在第几组循环取色，好把「相邻 lane 是否连续」看出来 */
+function laneColor(groupIndex: number, total: number): string {
+  if (total <= 1) return 'var(--mantine-color-teal-6)';
+  const hue = Math.round((groupIndex / total) * 300);
+  return `hsl(${hue}, 62%, 48%)`;
+}
+
+/**
+ * warp 访存热图。
+ *
+ * 上面一行 32 个格子是 lane，下面按 32B 扇区分组 ——
+ * 一个扇区一个色块，色块里写着这一格聚了几个 lane。
+ * **合并 = 少数几个宽色块；不合并 = 32 个窄条。**
+ */
+function SectorMap({ record }: { record: AccessRecord }) {
+  const view = useMemo(() => sectorsOf(record), [record]);
+  const laneToGroup = useMemo(() => {
+    const map = new Int32Array(WARP).fill(-1);
+    view.forEach((item, index) => item.lanes.forEach((lane) => { map[lane] = index; }));
+    return map;
+  }, [view]);
+
+  return (
+    <Stack gap={6}>
+      <Group gap={2} wrap="nowrap">
+        {Array.from({ length: WARP }, (_, lane) => {
+          const group = laneToGroup[lane];
+          const address = record.addresses[lane];
+          return (
+            <Tooltip
+              key={lane}
+              label={address < 0
+                ? `lane ${lane}：不活跃`
+                : `lane ${lane} → 地址 ${address}，扇区 ${address >> 5}`}
+              position="top"
+            >
+              <div
+                style={{
+                  width: 16, height: 22, borderRadius: 2,
+                  background: group < 0 ? 'var(--app-border)' : laneColor(group, view.length),
+                  opacity: group < 0 ? 0.35 : 1,
+                  flexShrink: 0,
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Group>
+      <Text size="10px" c="dimmed">
+        上面 32 格是 warp 的 32 个 lane，同色 = 落在同一个 32B 扇区
+      </Text>
+
+      <Group gap={3} wrap="wrap">
+        {view.map((item, index) => (
+          <Tooltip
+            key={item.sector}
+            label={`扇区 ${item.sector}（字节 ${item.sector * 32}~${item.sector * 32 + 31}）：lane ${item.lanes.join(', ')}`}
+          >
+            <div
+              style={{
+                background: laneColor(index, view.length),
+                color: 'white', fontSize: 10, borderRadius: 3,
+                padding: '2px 6px', flexShrink: 0,
+              }}
+            >
+              #{item.sector} · {item.lanes.length}
+            </div>
+          </Tooltip>
+        ))}
+      </Group>
+      <Text size="10px" c="dimmed">
+        下面每一块是一个 32B 扇区，写着聚了几个 lane。
+        <Text span fw={700} size="10px">搬回来的是整个扇区</Text> ——
+        {view.length} 个扇区 = {view.length * 32} 字节，真正用上的只有{' '}
+        {record.addresses.reduce((sum, a) => sum + (a >= 0 ? 1 : 0), 0) * 4} 字节。
+      </Text>
+    </Stack>
+  );
+}
+
+/**
+ * 共享内存 bank 视图。
+ *
+ * 32 个 bank 一行，冲突的那些标红。鼠标停上去说清是哪两个 lane 撞在了
+ * 同一个 bank 的不同地址上 —— 加一列 padding 之后整行变绿，
+ * 这个变化在这张图上是一眼的事。
+ */
+function BankMap({ record }: { record: AccessRecord }) {
+  const view = useMemo(() => banksOf(record), [record]);
+  const worst = Math.max(1, ...view.map((bank) => bank.ways));
+
+  return (
+    <Stack gap={6}>
+      <Group gap={2} wrap="nowrap">
+        {view.map((bank) => {
+          const conflicted = bank.ways > 1;
+          const idle = bank.ways === 0;
+          return (
+            <Tooltip
+              key={bank.bank}
+              multiline
+              w={280}
+              label={idle
+                ? `bank ${bank.bank}：这一条没人访问`
+                : conflicted
+                  ? `bank ${bank.bank}：${bank.ways} 个不同地址，要发 ${bank.ways} 次。`
+                    + bank.groups.map((g) => `\n  地址 ${g.address} ← lane ${g.lanes.join(', ')}`).join('')
+                  : `bank ${bank.bank}：1 个地址（lane ${bank.groups[0].lanes.join(', ')}）`
+                    + (bank.groups[0].lanes.length > 1 ? ' —— 同地址是广播，不算冲突' : '')}
+              position="top"
+            >
+              <div
+                style={{
+                  width: 16, height: 22, borderRadius: 2, flexShrink: 0,
+                  background: idle
+                    ? 'var(--app-border)'
+                    : conflicted
+                      ? `hsl(0, 70%, ${62 - (bank.ways / worst) * 22}%)`
+                      : 'var(--mantine-color-teal-6)',
+                  opacity: idle ? 0.35 : 1,
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Group>
+      <Group gap="xs">
+        <Text size="10px" c="dimmed">32 个 bank</Text>
+        <Badge size="xs" variant="light" color="teal">无冲突</Badge>
+        <Badge size="xs" variant="light" color="red">
+          冲突（最坏 {worst} 路）
+        </Badge>
+      </Group>
+      <Text size="10px" c="dimmed">
+        同一个 bank 里<Text span fw={700} size="10px">同地址是广播</Text>，一次就够；
+        不同地址才要串行发多次。
+      </Text>
+    </Stack>
+  );
+}
+
+export default function MemoryPanel({ world, revision }: MemoryPanelProps) {
+  const [trace, setTrace] = useState<AccessTrace | null>(null);
+  const [sampling, setSampling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  /** 世界变了（又跑了一次 kernel），上一次的采样就作废 */
+  const staleKey = useMemo(() => revision, [revision]);
+  const [tracedAt, setTracedAt] = useState(-1);
+  const stale = trace !== null && tracedAt !== staleKey;
+
+  const sample = useCallback(async () => {
+    if (!world) return;
+    setSampling(true);
+    setError(null);
+    try {
+      const collector = new AccessTrace({ limit: 512 });
+      const outcome = await runBench(world, '/root/bench', { trace: collector });
+      if (outcome.code !== 0) {
+        setError(outcome.stderr.trim() || '跑挂了');
+        setTrace(null);
+        return;
+      }
+      setTrace(collector);
+      setTracedAt(staleKey);
+      setSelected(collector.records.length ? '0' : null);
+    } catch (sampleError) {
+      setError(sampleError instanceof Error ? sampleError.message : String(sampleError));
+      setTrace(null);
+    } finally {
+      setSampling(false);
+    }
+  }, [world, staleKey]);
+
+  if (!world) return <Text size="xs" c="dimmed" p="sm">设备还没准备好</Text>;
+
+  const records = trace?.records ?? [];
+  const record = selected !== null ? records[Number(selected)] : undefined;
+
+  return (
+    <ScrollArea h="100%" type="auto">
+      <Stack gap="sm" p="sm">
+        <Group gap="xs" align="flex-start">
+          <Button size="compact-xs" onClick={sample} loading={sampling}>
+            {trace ? '重新采样' : '采样一次'}
+          </Button>
+          {trace && (
+            <Badge size="sm" variant="light" color={stale ? 'yellow' : 'gray'}>
+              {records.length} 条访存
+              {trace.truncated > 0 ? `（还有 ${trace.truncated} 条没记）` : ''}
+            </Badge>
+          )}
+        </Group>
+
+        <Text size="10px" c="dimmed">
+          采样会<Text span fw={700} size="10px">单独跑一遍</Text>
+          <Text span ff="monospace" size="10px"> ./bench</Text>，不影响你刚跑出来的指标。
+          真卡上看不到这张图：ncu 给的是聚合数，看不见 32 个 lane 各自打到了哪。
+        </Text>
+
+        {stale && (
+          <Alert color="yellow" variant="light" p="xs">
+            <Text size="10px">代码或设备状态变过了，这份采样是旧的。重新采一次。</Text>
+          </Alert>
+        )}
+
+        {error && (
+          <Alert color="red" p="xs">
+            <Text size="xs" style={{ whiteSpace: 'pre-wrap' }}>{error}</Text>
+          </Alert>
+        )}
+
+        {!trace && !error && (
+          <Text size="xs" c="dimmed">
+            先在终端里编译一次（<Text span ff="monospace" size="xs">nvcc -o bench 源文件</Text>），
+            然后点「采样一次」。
+          </Text>
+        )}
+
+        {records.length > 0 && (
+          <>
+            <Select
+              size="xs"
+              label="选一条访存指令"
+              value={selected}
+              onChange={setSelected}
+              maxDropdownHeight={280}
+              data={records.map((item, index) => ({
+                value: String(index),
+                label: `#${index} 第 ${item.line} 行 · ${item.space} ${item.kind}`
+                  + (item.space === 'global' ? ` · ${item.sectors} 扇区` : '')
+                  + (item.space === 'shared' ? ` · ${item.bankConflicts} 路冲突` : '')
+                  + ` · block ${item.blockIndex} warp ${item.warpIndex}`,
+              }))}
+            />
+
+            {record && (
+              <Stack gap="sm">
+                <Table withTableBorder fz="xs" verticalSpacing={2} horizontalSpacing={8}>
+                  <Table.Tbody>
+                    <Table.Tr>
+                      <Table.Td>源码行号</Table.Td>
+                      <Table.Td align="right">第 {record.line} 行</Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Td>空间 / 方向</Table.Td>
+                      <Table.Td align="right">{record.space} {record.kind}</Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Td>活跃 lane</Table.Td>
+                      <Table.Td align="right">
+                        {record.addresses.reduce((sum, a) => sum + (a >= 0 ? 1 : 0), 0)} / 32
+                      </Table.Td>
+                    </Table.Tr>
+                    {record.space === 'global' && (
+                      <Table.Tr>
+                        <Table.Td>打到的 32B 扇区</Table.Td>
+                        <Table.Td align="right">
+                          {record.sectors}（合并是 4，完全不合并是 32）
+                        </Table.Td>
+                      </Table.Tr>
+                    )}
+                    {record.space === 'shared' && (
+                      <Table.Tr>
+                        <Table.Td>bank 冲突</Table.Td>
+                        <Table.Td align="right">{record.bankConflicts} 路</Table.Td>
+                      </Table.Tr>
+                    )}
+                  </Table.Tbody>
+                </Table>
+
+                {record.space === 'global' && <SectorMap record={record} />}
+                {record.space === 'shared' && <BankMap record={record} />}
+                {record.space === 'local' && (
+                  <Alert color="orange" variant="light" p="xs">
+                    <Text size="10px">
+                      这是 <Text span fw={700} size="10px">local memory</Text> 的访问 ——
+                      有数组没能待在寄存器里。
+                      它在物理上就是显存，慢得和全局访存一样。
+                    </Text>
+                  </Alert>
+                )}
+              </Stack>
+            )}
+          </>
+        )}
+
+        {trace && records.length === 0 && (
+          <Text size="xs" c="dimmed">这一遍一条访存都没有。</Text>
+        )}
+      </Stack>
+    </ScrollArea>
+  );
+}

--- a/src/lib/gpulab/index.ts
+++ b/src/lib/gpulab/index.ts
@@ -16,6 +16,7 @@ import { H100, computeOccupancy, type DeviceSpec } from './device';
 import { estimateTiming, roofline, type RooflinePoint, type TimingResult } from './timing';
 import { LinearMemory } from './vm/memory';
 import { RaceDetector, formatRaceReports, type SanitizerReport } from './vm/sanitizer';
+import type { AccessTrace } from './vm/trace';
 import { dim3, emptyCounters, launchKernel, type Dim3, type GpuCounters, type LaunchConfig, type KernelArg } from './vm/vm';
 
 export { CudaSyntaxError, parseCuda, resetCudaParser } from './cuda/parser';
@@ -29,6 +30,8 @@ export type { TimingResult, RooflinePoint, TimingSpec, UnitCycles } from './timi
 export type { DeviceSpec, Occupancy } from './device';
 export type { StaticMetrics } from './metrics';
 export { RaceDetector, formatRaceReports } from './vm/sanitizer';
+export { AccessTrace, sectorsOf, banksOf } from './vm/trace';
+export type { AccessRecord, AccessKind, AccessSpace, SectorView, BankView } from './vm/trace';
 export type { SanitizerReport, RaceReport } from './vm/sanitizer';
 export type { GpuMetrics } from './metrics';
 export type { CompiledKernel } from './ir/types';
@@ -269,6 +272,31 @@ export class GpuDevice {
     });
     if (options.racecheck) this.lastSanitizer = { races, truncated };
     return { stdout: output.join('') };
+  }
+
+  /**
+   * 跑一遍 kernel，同时记下每一条访存打到了哪些地址。
+   *
+   * 和 racecheck 一样是**额外**跑的一遍，所以要先把真实那一遍的指标存住 ——
+   * 门槛读的是真实那一遍。少了这一步，采样一次访存就会把学员刚跑出来的
+   * 数字冲掉，而面板上看不出发生过这件事。
+   */
+  launchWithTrace(
+    kernel: CompiledKernel | ExecutableKernel,
+    config: LaunchConfig,
+    args: KernelArg[],
+    trace: AccessTrace
+  ): void {
+    const preserved = this.snapshotCounters();
+    const threadsPerBlock = config.block.x * config.block.y * config.block.z;
+    this.lastStatic = staticMetricsOf(this.device, kernel, threadsPerBlock);
+    launchKernel(kernel, config, args, {
+      memory: this.memory,
+      sharedCapacity: this.sharedCapacity,
+      maxWarpInsts: this.maxWarpInsts,
+      trace,
+    });
+    this.restoreCounters(preserved);
   }
 
   /**

--- a/src/lib/gpulab/lab/cli.ts
+++ b/src/lib/gpulab/lab/cli.ts
@@ -14,6 +14,7 @@
  */
 import type { CommandHandler, CommandResult } from '../../labkit/machine';
 import { compileProgram } from '../index';
+import type { AccessTrace } from '../vm/trace';
 import { runClusterHost } from '../cluster/run';
 import { CudaCompileError } from '../cuda/lower';
 import { CudaSyntaxError } from '../cuda/parser';
@@ -163,6 +164,13 @@ function diagnose(error: unknown, source: string, fileName: string): string {
 export interface RunOptions {
   /** 开着 racecheck 跑 */
   racecheck?: boolean;
+  /**
+   * 开着访存轨迹跑。
+   *
+   * 和 racecheck 一样是额外的一遍：真实那一遍的指标要原样留着，
+   * 否则「采样一次访存」会把学员刚跑出来的数字冲掉。
+   */
+  trace?: AccessTrace;
 }
 
 export class BenchError extends Error {
@@ -194,7 +202,9 @@ export async function runBench(
 
   // racecheck 是**额外**跑的一遍，不能把真实那一遍的指标冲掉 ——
   // 门槛读的是真实那一遍。先存住，跑完再放回去。
-  const preserved = options.racecheck ? world.gpu.snapshotCounters() : null;
+  const preserved = (options.racecheck || options.trace)
+    ? world.gpu.snapshotCounters()
+    : null;
 
   // 重新建一台干净的设备：显存内容、分配游标、指标全部归零
   if (world.cluster) world.cluster.reset();
@@ -262,7 +272,11 @@ export async function runBench(
     });
 
     try {
-      if (options.racecheck) {
+      if (options.trace) {
+        world.gpu.launchWithTrace(kernel, {
+          grid: toDim3(launch.grid), block: toDim3(launch.block),
+        }, args, options.trace);
+      } else if (options.racecheck) {
         world.gpu.launchWithRacecheck(kernel, {
           grid: toDim3(launch.grid), block: toDim3(launch.block),
         }, args);

--- a/src/lib/gpulab/vm/trace.ts
+++ b/src/lib/gpulab/vm/trace.ts
@@ -1,0 +1,133 @@
+/**
+ * 访存轨迹
+ *
+ * 真卡上你**看不见**这些：一条访存指令里 32 个 lane 各自打到了哪个 32B 扇区、
+ * 哪两个 lane 撞在同一个 bank 上。`ncu` 给的是聚合之后的数（扇区总数、
+ * 冲突路数），而"为什么改一下下标 DRAM 字节就掉了 8 倍"要看的是那张图。
+ *
+ * ## 按需开启
+ *
+ * 和 racecheck 一样：不给就一行额外代码都不跑。每条访存记 32 个地址，
+ * 一个稍大的 kernel 有几十万条访存 —— 常开的话内存和吞吐都受不了。
+ * 所以工作台上是一个「采样一次」按钮，单独跑一遍。
+ *
+ * ## 为什么有上限
+ *
+ * 上限不是防御性编程，是**面板本身就用不了那么多**：
+ * 学员一次只看得懂一条指令的一张图。超出上限的丢掉，
+ * 并且**如实报告丢了多少** —— 悄悄截断会让人以为"这个 kernel 只访存了 512 次"。
+ */
+import { WARP_SIZE } from './memory';
+
+export type AccessKind = 'load' | 'store';
+export type AccessSpace = 'global' | 'shared' | 'local';
+
+export interface AccessRecord {
+  /** 源码行号 */
+  line: number;
+  kind: AccessKind;
+  space: AccessSpace;
+  /** 32 个 lane 的字节地址；不活跃的 lane 是 -1 */
+  addresses: Int32Array;
+  activeMask: number;
+  /** 这一条打到几个 32B 扇区（global 才有意义） */
+  sectors: number;
+  /** 这一条要发几路（shared 才有意义）。0 表示无冲突 */
+  bankConflicts: number;
+  blockIndex: number;
+  warpIndex: number;
+}
+
+export interface TraceOptions {
+  /** 最多记多少条 */
+  limit?: number;
+}
+
+export class AccessTrace {
+  readonly records: AccessRecord[] = [];
+  /** 因为超出上限被丢掉的条数 */
+  truncated = 0;
+  private readonly limit: number;
+
+  constructor(options: TraceOptions = {}) {
+    this.limit = options.limit ?? 512;
+  }
+
+  record(
+    line: number, kind: AccessKind, space: AccessSpace,
+    addresses: Int32Array, activeMask: number,
+    sectors: number, bankConflicts: number,
+    blockIndex: number, warpIndex: number
+  ): void {
+    if (this.records.length >= this.limit) {
+      this.truncated += 1;
+      return;
+    }
+    // 地址数组是 VM 复用的那一块，必须拷一份 —— 不拷的话
+    // 所有记录最后都指向同一份内容，而且是最后一条的内容
+    const copy = new Int32Array(WARP_SIZE);
+    for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+      copy[lane] = (activeMask & (1 << lane)) ? addresses[lane] : -1;
+    }
+    this.records.push({
+      line, kind, space, addresses: copy, activeMask,
+      sectors, bankConflicts, blockIndex, warpIndex,
+    });
+  }
+}
+
+/** 一条访存记录按 32B 扇区聚合之后的样子 —— 热图画的就是这个 */
+export interface SectorView {
+  /** 扇区号（地址 >> 5），按升序 */
+  sector: number;
+  /** 打到这个扇区的 lane */
+  lanes: number[];
+}
+
+export function sectorsOf(record: AccessRecord): SectorView[] {
+  const byS = new Map<number, number[]>();
+  for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+    const address = record.addresses[lane];
+    if (address < 0) continue;
+    const sector = address >> 5;
+    const list = byS.get(sector);
+    if (list) list.push(lane);
+    else byS.set(sector, [lane]);
+  }
+  return [...byS.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([sector, lanes]) => ({ sector, lanes }));
+}
+
+/** 一条共享内存访问按 bank 聚合 */
+export interface BankView {
+  bank: number;
+  /** 打到这个 bank 的 lane，按地址分组 —— **同地址是广播，不算冲突** */
+  groups: Array<{ address: number; lanes: number[] }>;
+  /** 要发几路。1 表示无冲突 */
+  ways: number;
+}
+
+export function banksOf(record: AccessRecord): BankView[] {
+  const byBank = new Map<number, Map<number, number[]>>();
+  for (let lane = 0; lane < WARP_SIZE; lane += 1) {
+    const address = record.addresses[lane];
+    if (address < 0) continue;
+    // 共享内存按 4 字节一个 word，32 个 bank 轮流
+    const bank = (address >> 2) % WARP_SIZE;
+    let group = byBank.get(bank);
+    if (!group) { group = new Map(); byBank.set(bank, group); }
+    const lanesAt = group.get(address);
+    if (lanesAt) lanesAt.push(lane);
+    else group.set(address, [lane]);
+  }
+  const out: BankView[] = [];
+  for (let bank = 0; bank < WARP_SIZE; bank += 1) {
+    const group = byBank.get(bank);
+    if (!group) { out.push({ bank, groups: [], ways: 0 }); continue; }
+    const groups = [...group.entries()].map(([address, lanes]) => ({ address, lanes }));
+    // **同一个 bank 里同一个地址是广播，一次就够** —— 冲突算的是不同地址的个数
+    out.push({ bank, groups, ways: groups.length });
+  }
+  return out;
+}

--- a/src/lib/gpulab/vm/vm.ts
+++ b/src/lib/gpulab/vm/vm.ts
@@ -32,6 +32,7 @@ import {
   countBankConflicts, countSectors,
 } from './memory';
 import type { RaceDetector } from './sanitizer';
+import type { AccessSpace, AccessTrace } from './trace';
 
 export interface Dim3 {
   x: number;
@@ -191,6 +192,14 @@ export interface RunOptions {
    */
   raceDetector?: RaceDetector;
   /**
+   * 访存轨迹。
+   *
+   * **按需开启**，和 racecheck 一个路子：不给就一行额外代码都不跑。
+   * 每条访存要拷 32 个地址，常开的话内存与吞吐都受不了 ——
+   * 工作台上是一个「采样一次」按钮，单独跑一遍。
+   */
+  trace?: AccessTrace;
+  /**
    * 宿主服务：CUDA runtime、printf、容器、起 kernel。
    *
    * **只有跑宿主程序时才给。** 设备侧的 kernel 里根本编不出 hostcall
@@ -224,6 +233,12 @@ export interface HostServices {
 }
 
 const DEFAULT_MAX_WARP_INSTS = 200_000_000;
+
+/** SPACE 的数值码 → 名字。轨迹里要存名字，查表比每次判分支便宜 */
+const SPACE_NAMES: AccessSpace[] = [];
+SPACE_NAMES[SPACE.GLOBAL] = 'global';
+SPACE_NAMES[SPACE.SHARED] = 'shared';
+SPACE_NAMES[SPACE.LOCAL] = 'local';
 
 export function launchKernel(
   kernel: CompiledKernel | ExecutableKernel,
@@ -398,7 +413,10 @@ class Executor {
     const hostArgs = this.hostArgs;
     const counters = this.counters;
     const detector = this.options.raceDetector;
+    const trace = this.options.trace;
     const warpBase = warp.index * WARP_SIZE;
+    // 轨迹里要标出是哪个 block 的 —— 三维网格摊成一个序号
+    const blockOrdinal = trace ? (bz * grid.y + by) * grid.x + bx : 0;
 
     // 计数器用局部变量攒着，出口再写回（理由见文件头第 3 条）
     let warpInsts = 0;
@@ -590,14 +608,24 @@ class Executor {
                 : ty === TY.U32 ? memory.readU32(address)
                 : memory.readI32(address);
             }
+            let loadSectors = 0;
+            let loadConflicts = 0;
             if (space === SPACE.GLOBAL) {
+              loadSectors = countSectors(addresses, active);
               counters.globalLoadRequests += 1;
-              counters.globalLoadSectors += countSectors(addresses, active);
+              counters.globalLoadSectors += loadSectors;
             } else if (space === SPACE.SHARED) {
+              loadConflicts = countBankConflicts(addresses, active);
               counters.sharedLoadRequests += 1;
-              counters.sharedBankConflicts += countBankConflicts(addresses, active);
+              counters.sharedBankConflicts += loadConflicts;
             } else {
               counters.localReadBytes += lanes * 4;
+            }
+            if (trace) {
+              trace.record(
+                lines[pc], 'load', SPACE_NAMES[space], addresses, active,
+                loadSectors, loadConflicts, blockOrdinal, warp.index
+              );
             }
             // local memory 是线程私有的，不可能有竞态，不用喂给检测器
             if (detector && space !== SPACE.LOCAL) {
@@ -630,14 +658,24 @@ class Executor {
               else if (ty === TY.U32) memory.writeU32(address, value);
               else memory.writeI32(address, value);
             }
+            let storeSectors = 0;
+            let storeConflicts = 0;
             if (space === SPACE.GLOBAL) {
+              storeSectors = countSectors(addresses, active);
               counters.globalStoreRequests += 1;
-              counters.globalStoreSectors += countSectors(addresses, active);
+              counters.globalStoreSectors += storeSectors;
             } else if (space === SPACE.SHARED) {
+              storeConflicts = countBankConflicts(addresses, active);
               counters.sharedStoreRequests += 1;
-              counters.sharedBankConflicts += countBankConflicts(addresses, active);
+              counters.sharedBankConflicts += storeConflicts;
             } else {
               counters.localWriteBytes += lanes * 4;
+            }
+            if (trace) {
+              trace.record(
+                lines[pc], 'store', SPACE_NAMES[space], addresses, active,
+                storeSectors, storeConflicts, blockOrdinal, warp.index
+              );
             }
             if (detector && space !== SPACE.LOCAL) {
               const name = space === SPACE.GLOBAL ? 'global' : 'shared';

--- a/tests/gpulab/trace.test.ts
+++ b/tests/gpulab/trace.test.ts
@@ -1,0 +1,160 @@
+/**
+ * 访存轨迹
+ *
+ * 这套用例钉住的是**图上会看到什么**：合并的时候 32 个 lane 挤进 4 个扇区，
+ * 不合并的时候散成 32 个；共享内存里同地址是广播不是冲突。
+ * 这三条正是访存面板存在的理由 —— 真卡上 ncu 只给聚合数，看不见分布。
+ */
+import { AccessTrace, GpuDevice, banksOf, compileSource, dim3, sectorsOf } from '../../src/lib/gpulab';
+
+jest.setTimeout(180_000);
+
+async function trace(source: string, name: string, n = 32) {
+  const kernel = (await compileSource(source)).get(name)!;
+  const gpu = new GpuDevice({ globalBytes: 1024 * 1024 });
+  const din = gpu.malloc(4096 * 4);
+  const dout = gpu.malloc(4096 * 4);
+  gpu.copyIn(din, Float32Array.from({ length: 4096 }, (_, i) => i));
+  const collector = new AccessTrace();
+  gpu.launchWithTrace(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, n], collector);
+  return { collector, gpu };
+}
+
+describe('全局访存的分布', () => {
+  it('**合并的时候 32 个 lane 挤进 4 个扇区**', async () => {
+    const { collector } = await trace(`
+      __global__ void seq(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        if (i < n) out[i] = in[i];
+      }
+    `, 'seq');
+    const loads = collector.records.filter((r) => r.kind === 'load' && r.space === 'global');
+    expect(loads.length).toBe(1);
+    const view = sectorsOf(loads[0]);
+    // 32 个 float = 128 字节 = 4 个 32B 扇区
+    expect(view.length).toBe(4);
+    expect(view[0].lanes).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(loads[0].sectors).toBe(4);
+  });
+
+  it('**跨步访问散成 32 个扇区** —— 一眼看得出为什么慢 8 倍', async () => {
+    const { collector } = await trace(`
+      __global__ void strided(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        if (i < n) out[i] = in[i * 32];
+      }
+    `, 'strided');
+    const loads = collector.records.filter((r) => r.kind === 'load' && r.space === 'global');
+    const view = sectorsOf(loads[0]);
+    expect(view.length).toBe(32);
+    // 每个扇区只有一个 lane —— 搬了 32 × 32 字节，用上的只有 32 × 4
+    expect(view.every((item) => item.lanes.length === 1)).toBe(true);
+    expect(loads[0].sectors).toBe(32);
+  });
+
+  it('不活跃的 lane 在图上是空的，不是 0 号地址', async () => {
+    const { collector } = await trace(`
+      __global__ void half(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        if (i < n) out[i] = in[i];
+      }
+    `, 'half', 8);
+    const loads = collector.records.filter((r) => r.kind === 'load' && r.space === 'global');
+    const record = loads[0];
+    for (let lane = 8; lane < 32; lane += 1) expect(record.addresses[lane]).toBe(-1);
+    expect(sectorsOf(record).length).toBe(1);
+  });
+});
+
+describe('共享内存的 bank 分布', () => {
+  it('**同一个 bank 里同地址是广播，不算冲突**', async () => {
+    const { collector } = await trace(`
+      __global__ void broadcast(const float* in, float* out, int n) {
+        __shared__ float s[32];
+        int i = threadIdx.x;
+        s[i] = in[i];
+        __syncthreads();
+        // 32 个 lane 都读 s[0]：同一个 bank、同一个地址 —— 一次广播
+        out[i] = s[0];
+      }
+    `, 'broadcast');
+    const reads = collector.records.filter((r) => r.space === 'shared' && r.kind === 'load');
+    const last = reads[reads.length - 1];
+    const banks = banksOf(last);
+    const bank0 = banks[0];
+    expect(bank0.groups.length).toBe(1);
+    expect(bank0.groups[0].lanes.length).toBe(32);
+    // 一个地址 = 一路，不是 32 路
+    expect(bank0.ways).toBe(1);
+    expect(last.bankConflicts).toBe(0);
+  });
+
+  it('**同一个 bank 里不同地址才是冲突**', async () => {
+    const { collector } = await trace(`
+      __global__ void conflict(const float* in, float* out, int n) {
+        __shared__ float s[1024];
+        int i = threadIdx.x;
+        s[i * 32] = in[i];
+        __syncthreads();
+        out[i] = s[i * 32];
+      }
+    `, 'conflict');
+    const reads = collector.records.filter((r) => r.space === 'shared' && r.kind === 'load');
+    const last = reads[reads.length - 1];
+    const banks = banksOf(last);
+    // 步长 32 个 float 让所有 lane 落到同一个 bank，而且地址各不相同
+    const busy = banks.filter((bank) => bank.ways > 0);
+    expect(busy.length).toBe(1);
+    expect(busy[0].ways).toBe(32);
+    expect(last.bankConflicts).toBe(31);
+  });
+});
+
+describe('轨迹本身的边界', () => {
+  it('超出上限如实报告丢了多少，不悄悄截断', async () => {
+    const collector = new AccessTrace({ limit: 4 });
+    const kernel = (await compileSource(`
+      __global__ void many(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        for (int k = 0; k < 20; ++k) out[i] = out[i] + in[i];
+      }
+    `)).get('many')!;
+    const gpu = new GpuDevice({ globalBytes: 65536 });
+    const din = gpu.malloc(128);
+    const dout = gpu.malloc(128);
+    gpu.launchWithTrace(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, 32], collector);
+    expect(collector.records.length).toBe(4);
+    expect(collector.truncated).toBeGreaterThan(0);
+  });
+
+  it('**采样不会冲掉真实那一遍的指标**', async () => {
+    const kernel = (await compileSource(`
+      __global__ void seq(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        if (i < n) out[i] = in[i];
+      }
+    `)).get('seq')!;
+    const gpu = new GpuDevice({ globalBytes: 65536 });
+    const din = gpu.malloc(128);
+    const dout = gpu.malloc(128);
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, 32]);
+    const before = JSON.stringify(gpu.metrics());
+    gpu.launchWithTrace(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, 32], new AccessTrace());
+    expect(JSON.stringify(gpu.metrics())).toBe(before);
+  });
+
+  it('不开轨迹时记录是空的', async () => {
+    const kernel = (await compileSource(`
+      __global__ void seq(const float* in, float* out, int n) {
+        int i = threadIdx.x;
+        if (i < n) out[i] = in[i];
+      }
+    `)).get('seq')!;
+    const gpu = new GpuDevice({ globalBytes: 65536 });
+    const din = gpu.malloc(128);
+    const dout = gpu.malloc(128);
+    const collector = new AccessTrace();
+    gpu.launch(kernel, { grid: dim3(1), block: dim3(32) }, [din, dout, 32]);
+    expect(collector.records.length).toBe(0);
+  });
+});


### PR DESCRIPTION
**这是这个工作台区别于「在真卡上跑一跑」的地方。** ncu 给的是聚合数（扇区总数、
冲突路数），而「为什么改一下下标 DRAM 字节就掉了 8 倍」要看的是**分布**：
32 个 lane 各自打到了哪。真卡上看不见这个。

## VM 侧加访存轨迹
和 racecheck 一个路子：**按需开启**，不给就一行额外代码都不跑 —— 每条访存要拷
32 个地址，常开的话内存与吞吐都受不了。

`launchWithTrace` 单独跑一遍，**并且把真实那一遍的指标存住再还原** —— 少了这一步，
采样会把学员刚跑出来的数字冲掉，而面板上看不出发生过这件事。超出上限的记录
**如实报告丢了多少**，不悄悄截断。

## 两张图
- **warp 热图**：上面 32 格是 lane、同色 = 同一个 32B 扇区；下面每块是一个扇区，写着聚了几个 lane，并算出「搬回来多少 / 真正用上多少」
- **bank 视图**：32 个 bank 一行，冲突标红，hover 说清是哪两个 lane 撞在同一个 bank 的**不同地址**上。**同地址是广播不算冲突** —— 这一条在用例里钉死了

## 在 dev 里对照验过（第 2 关）
| | 扇区数 | 图上的样子 | 搬回来 / 用上 |
| --- | --- | --- | --- |
| 起始（跨步） | 32 | 32 个窄条，每条 1 个 lane | 1024 B / 128 B |
| 参考（合并） | **4** | **4 个宽块，每块 8 个 lane** | 128 B / 128 B |

## 验证
`tests/gpulab/trace.test.ts` 8 条；`npm test` 10/10；`projects:verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)