### PR TITLE
fix(workbench): 左侧任务面板不再被宽内容顶出横向滚动条

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -108,7 +108,19 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({ content, stream
           </SyntaxHighlighter>
         );
       }
-      
+
+      /*
+       * 没标语言的围栏（``` 直接跟内容）走下面的行内分支。
+       *
+       * **不能在这里判 `!inline` 然后渲染成块级** —— react-markdown 新版
+       * 不再传 `inline` 属性，于是行内代码也会走进那条分支，
+       * 结果是把 <pre> 渲染进 <p>，DOM 嵌套非法（React 会告警，
+       * 浏览器会把 <p> 提前闭合，段落排版直接乱掉）。
+       *
+       * 宽度约束交给 CSS：react-markdown 会把围栏包成 <pre><code>，
+       * 而 `.panel-scroll pre` 已经给了 max-width + overflow-x（见 globals.css）。
+       */
+
       // Inline code
       return (
         <Code {...props}>
@@ -117,12 +129,29 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({ content, stream
       );
     },
     
-    // Custom table renderer using Mantine Table
+    /*
+     * 表格。
+     *
+     * 外面包一层**自己横向滚动**的容器：markdown 表格没有宽度上限，
+     * 列一多（gpulab 那几关的对照表有五六列）就会把整个说明面板顶开，
+     * 而面板被顶开之后旁边的段落会被视口裁掉半句话。
+     *
+     * `minWidth: 'min-content'` 是关键的一半：不给的话表格会被压到每个字
+     * 一行，读起来比横向滚还糟。让它保持"内容最小宽度"，超出的部分滚。
+     */
     table({ children }: any) {
       return (
-        <Table striped highlightOnHover withTableBorder withColumnBorders>
-          {children}
-        </Table>
+        <Box style={{ maxWidth: '100%', overflowX: 'auto' }}>
+          <Table
+            striped
+            highlightOnHover
+            withTableBorder
+            withColumnBorders
+            style={{ minWidth: 'min-content' }}
+          >
+            {children}
+          </Table>
+        </Box>
       );
     },
     

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -136,8 +136,12 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({ content, stream
      * 列一多（gpulab 那几关的对照表有五六列）就会把整个说明面板顶开，
      * 而面板被顶开之后旁边的段落会被视口裁掉半句话。
      *
-     * `minWidth: 'min-content'` 是关键的一半：不给的话表格会被压到每个字
-     * 一行，读起来比横向滚还糟。让它保持"内容最小宽度"，超出的部分滚。
+     * `minWidth: 'min-content'` 是关键的一半：让表格保持"内容最小宽度"，
+     * 超出的部分在这层容器里滚，而不是把面板顶开。
+     *
+     * 注意它得配合 globals.css 里 `.panel-scroll table` 那条才有意义 ——
+     * 面板整体开了 `overflow-wrap: anywhere`，若不在单元格里收回来，
+     * min-content 会退化成「每列一个字符」，这个 `min-width` 就等于没写。
      */
     table({ children }: any) {
       return (

--- a/src/components/gpulab/GpuWorkspace.tsx
+++ b/src/components/gpulab/GpuWorkspace.tsx
@@ -278,6 +278,12 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
             })}
           </Group>
 
+          {/*
+            左栏的每一页都挂 `panel-scroll`（见 globals.css）。
+            Mantine 的 ScrollArea 视口内层是 display: table，会收缩包裹到最宽的那个子元素 ——
+            说明里有一个宽代码块，整页的段落就都按那个宽度排，于是左栏出现横向滚动条、
+            文字被裁掉半句。panel-scroll 把它改回 block，宽内容各自横向滚。
+          */}
           <WorkbenchSplit
             storageKey={SPLIT_KEY}
             collapseLabel="展开任务栏"
@@ -291,7 +297,7 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                   </Tabs.Tab>
                 </Tabs.List>
                 <Tabs.Panel value="goal" style={{ flex: 1, minHeight: 0 }}>
-                  <ScrollArea h="100%" type="auto" p="sm">
+                  <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                     <MarkdownRenderer content={pick(stage.goal)} />
                     {(stage.checklist ?? []).length > 0 && (
                       <Stack gap={4} mt="md">
@@ -320,12 +326,12 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                   </ScrollArea>
                 </Tabs.Panel>
                 <Tabs.Panel value="primer" style={{ flex: 1, minHeight: 0 }}>
-                  <ScrollArea h="100%" type="auto" p="sm">
+                  <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                     <MarkdownRenderer content={pick(stage.primer)} />
                   </ScrollArea>
                 </Tabs.Panel>
                 <Tabs.Panel value="result" style={{ flex: 1, minHeight: 0 }}>
-                  <ScrollArea h="100%" type="auto" p="sm">
+                  <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                     {report
                       ? <RunReportPanel report={report} />
                       : <Text size="xs" c="dimmed">还没跑过验收</Text>}

--- a/src/components/opslab/OpsWorkspace.tsx
+++ b/src/components/opslab/OpsWorkspace.tsx
@@ -303,6 +303,12 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
           * 现在终端、IDE、拓扑并列成 tab —— 同一时刻只看一样东西，
           * 每样都占满整个右栏，而不是四块互相挤。
           */}
+        {/*
+          左栏的每一页都挂 `panel-scroll`（见 globals.css）。
+          Mantine 的 ScrollArea 视口内层是 display: table，会收缩包裹到最宽的那个子元素 ——
+          说明里有一个宽代码块，整页的段落就都按那个宽度排，于是左栏出现横向滚动条、
+          文字被裁掉半句。panel-scroll 把它改回 block，宽内容各自横向滚。
+        */}
         <WorkbenchSplit
           storageKey={SPLIT_KEY}
           collapseLabel="展开任务栏"
@@ -317,7 +323,7 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 <Tabs.Tab value="review" fz="xs">复盘</Tabs.Tab>
               </Tabs.List>
               <Tabs.Panel value="goal" style={{ flex: 1, minHeight: 0 }}>
-                <ScrollArea h="100%" type="auto" p="sm">
+                <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                   <MarkdownRenderer content={pick(stage.goal)} />
                   {(stage.checklist ?? []).length > 0 && (
                     <Stack gap={4} mt="md">
@@ -330,12 +336,12 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 </ScrollArea>
               </Tabs.Panel>
               <Tabs.Panel value="primer" style={{ flex: 1, minHeight: 0 }}>
-                <ScrollArea h="100%" type="auto" p="sm">
+                <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                   <MarkdownRenderer content={pick(stage.primer)} />
                 </ScrollArea>
               </Tabs.Panel>
               <Tabs.Panel value="result" style={{ flex: 1, minHeight: 0 }}>
-                <ScrollArea h="100%" type="auto" p="sm">
+                <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                   {report
                     ? <RunReportPanel report={report} />
                     : <Text size="xs" c="dimmed">还没跑过验收</Text>}
@@ -346,7 +352,7 @@ export default function OpsWorkspace({ session, registerClearResults }: OpsWorks
                 * 把 replicas 调成 0 也能让 CrashLoopBackOff 消失。
                 */}
               <Tabs.Panel value="review" style={{ flex: 1, minHeight: 0 }}>
-                <ScrollArea h="100%" type="auto" p="sm">
+                <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
                   <ErrorBoundary fallback={renderPanelError}>
                     <OpsReview
                       key={reviewKey}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -371,6 +371,60 @@ a {
   overflow-x: auto;
 }
 
+/*
+ * 长单词与长 URL。
+ *
+ * 中文段落自己会换行，但 `--kv-cache-dtype-skip-layers` 这种带连字符的长标识、
+ * 门槛指标名（`gpu.comm.bytesByLink.ib`）、以及正文里的长 URL 都是一个"词"，
+ * 不给断点的话它会把整段撑成一行。`anywhere` 而不是 `break-word`：
+ * 后者只在这一行放不下时才断，前者会参与最小内容宽度的计算 ——
+ * 而我们要的正是"最小内容宽度不能超过面板"。
+ */
+.panel-scroll {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  /*
+   * `text-spacing-trim: space-all` 关掉全角标点的挤压。
+   *
+   * 默认的 `normal` 会把 `（`　`）` 这类全角标点压掉半个字宽，**但只压在断行测量上，
+   * 画出来的行盒还是原宽**。于是出现一种没法靠任何换行属性救回来的溢出：
+   * 「原子操作次数 ≤ 128（4096 / 32）」这一行，浏览器按 236px 算判定放得下，
+   * 实际画成 244px —— 两个全角括号各差 4px。宽度落在这条缝里时（第 5 关 300px 左右）
+   * 面板就多出 8px 横向滚动，而 break-all / line-break: anywhere 全都无效，
+   * 因为浏览器根本不认为需要断。
+   *
+   * 关掉挤压之后测量和绘制对上了，同一行在 236px 处正常折成两行。
+   * 代价是全角标点保持满宽，CJK 排版略松一点 —— 用一点观感换掉一类量不准的溢出。
+   */
+  text-spacing-trim: space-all;
+}
+
+/*
+ * 表格。
+ *
+ * Markdown 表格没有宽度上限，列一多就把面板顶开。这里让它在自己的容器里横向滚 ——
+ * 容器由 MarkdownRenderer 包出来（见那边的 table 渲染器）。
+ * 这条兜底是给不经过那个渲染器的表格用的（比如面板自己写的 <Table>）。
+ */
+.panel-scroll table {
+  max-width: 100%;
+}
+
+/*
+ * mermaid 图的兜底。
+ *
+ * 实测 mermaid 自己就带 `width="100%"` 加上行内的 `max-width`（等于图的固有宽度），
+ * 所以默认配置下它本来就会跟着面板缩，这条规则量下来是零改变。留着是防
+ * `useMaxWidth: false` —— 那种配置下 SVG 会拿到固定像素宽，窄面板会被直接顶开。
+ *
+ * **选择器必须钉死在 mermaid 的产物上**：写成 `.panel-scroll svg` 会一并命中
+ * 左栏里的 Tabler 图标，`height: auto` 会盖掉它们的 height 属性。
+ */
+.panel-scroll svg[id^='mermaid-'] {
+  max-width: 100%;
+  height: auto;
+}
+
 /* 编辑器左侧栏的断点标记。条件断点/日志断点用空心圆区分开。 */
 .algolocal-bp::before {
   content: '';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -404,10 +404,18 @@ a {
  *
  * Markdown 表格没有宽度上限，列一多就把面板顶开。这里让它在自己的容器里横向滚 ——
  * 容器由 MarkdownRenderer 包出来（见那边的 table 渲染器）。
- * 这条兜底是给不经过那个渲染器的表格用的（比如面板自己写的 <Table>）。
+ * `max-width` 这条兜底是给不经过那个渲染器的表格用的（比如面板自己写的 <Table>）。
+ *
+ * **单元格里要把上面那条 `anywhere` 收回来。** `anywhere` 会参与最小内容宽度的计算，
+ * 于是表格的 min-content 变成「每列一个字符」，列宽被压到极限、Latin 单词从中间断开
+ * （第 29 关那张四列表实测把 `prefill` 断成 `prefi` + `ll`，首列只有 32px）。
+ * 换成 `break-word`：只有单词自己一行都放不下时才断，min-content 回到「最长的那个词」，
+ * 同一张表首列 51px、`prefill` 完整。真放不下的时候还有外面那层容器横向滚兜底。
  */
 .panel-scroll table {
   max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
 /*


### PR DESCRIPTION
## 问题

k8s（ops 工作台）和 llm-accelerator（gpu 工作台）的**左侧任务面板**内容不随宽度自适应，拖窄之后整块面板出现横向滚动条、文字被视口裁掉半句。

## 查下来是四类原因叠在一起

第 1 类是主因，另外三类在窄宽度下才露出来。定位过程是逐类量出来的，不是猜的。

### 1. ScrollArea 视口内层是 `display: table`（主因）

Mantine/Radix 的 ScrollArea 视口内层 div 是 `display: table`，会**收缩包裹到最宽的那个子元素**。于是说明里只要有一个宽代码块，整页的段落就都按那个宽度排，`max-width: 100%` 完全不起作用。

实测：左栏视口 `clientWidth=316` / `scrollWidth=675`，溢出 359px；连一个四个字的 `<H2>` 都被撑到 675px。

代码类项目早就有一条 `.panel-scroll` 修好了这件事（`display: block !important` + `min-width: 0 !important`），但两个新工作台从来没挂上这个 class。这次给 `OpsWorkspace` 的 4 个和 `GpuWorkspace` 的 3 个 ScrollArea 补上。

### 2. 宽表格

markdown 表格没有宽度上限，列一多就把面板顶开。改成包一层自己横向滚的容器，保留 `min-width: min-content` —— 不给的话表格会被压到每格一个字，比横向滚还难读。

### 3. 长单词 / 长标识符

`gpu.comm.bytesByLink.ib` 这种门槛指标名、长 URL 在中文段落里是一个不可断的「词」。加 `overflow-wrap: anywhere`（而不是 `break-word`）—— 前者会参与最小内容宽度的计算，而我们要的正是「最小内容宽度不能超过面板」。

### 4. 全角标点的挤压（这条最绕）

`text-spacing-trim` 默认（`normal`）会把 `（` `）` 压掉半个字宽，**但只压在断行测量上，画出来的行盒还是原宽**。于是出现一类没法靠任何换行属性救回来的溢出：

> 「原子操作次数 ≤ 128（4096 / 32）」这一行，浏览器按 236px 判定放得下，实际画成 244px —— 两个全角括号各差 4px。

`word-break: break-all`、`line-break: anywhere` 全都无效，因为浏览器根本不认为需要断。用一个脱离应用 DOM 的裸 `<div>` 也能复现，确认是浏览器层面的行为。改成 `text-spacing-trim: space-all` 关掉挤压，测量和绘制对上，同一行在 236px 处正常折成两行。

代价是全角标点保持满宽，CJK 排版略松一点。

## 一处刻意收窄的选择器

mermaid 那条兜底规则钉死在 `svg[id^='mermaid-']`，不是 `.panel-scroll svg`。实测 mermaid 自己就带 `width="100%"` 和行内 `max-width`，本来就会跟着面板缩（把这条规则删掉，量出来零改变）；留着只是防 `useMaxWidth: false`。写成 `.panel-scroll svg` 会顺带命中左栏的 Tabler 图标，`height: auto` 会盖掉它们的 height 属性。

## 验证

**全部在 `electron-builder` 打出的 `.app` 里跑的**，不是 dev server。

| 项目 | 关卡 | 测量点 | 横向溢出 |
|---|---|---|---|
| llm-accelerator（gpu） | 29 | 261 | 0 |
| intranet-k8s（ops） | 23 | 276 | 0 |
| database-engine | 12 | 72 | 0 |
| enterprise-auth | 12 | 72 | 0 |
| enterprise-im | 12 | 72 | 0 |
| message-broker | 12 | 72 | 0 |
| modern-compiler | 10 | 60 | 0 |
| modern-os-kernel | 10 | 60 | 0 |
| order-event-pipeline | 11 | 66 | 0 |
| rate-limited-gateway | 11 | 66 | 0 |
| resilient-fetch-pipeline | 12 | 72 | 0 |
| **合计** | **154** | **1149** | **0** |

每个测量点 = 一关 × 左栏一个页签 × 一种宽度。宽度取最窄 240（`WorkbenchSplit` 的 `minLeftWidth`，也就是真能拖到的下限）、默认 340、最宽 960（1440px 窗口下 `total - minRightWidth`）。

补充验证：

- **反向验证**：把 `.panel-scroll` 的 5 条规则从样式表里删掉再跑同一套扫描，261 个测量点里 **62 个溢出，最大 479px**。说明这套扫描抓得住这个 bug，0 不是因为它什么都测不到。
- **连续宽度扫描**：第 5 关（原先唯一还剩残留的那关）220–420px 每 4px 一档共 51 档，溢出 0。
- **代码块仍然自己滚**：最窄 240px 下，代码块自己的滚动容器 216 可见 / 397 内容，能滚到底（`scrollLeft` 到 181），面板本身 0 溢出。
- **mermaid**：`参考架构` 页的图是异步渲染的，等真出了 SVG 再量 —— 10 关全部 172 / 232 / 512 跟着面板缩，溢出 0。（第一版扫描在 SVG 还没渲染出来时就量了，等于没测到，已修正。）
- `npm test` **10/10 test suites passed**；`tsc --noEmit` 干净。

## 影响面

只动了 CSS 与 markdown 表格的包装层，没有改任何判题、引擎或数据。代码类项目本来就靠 `.panel-scroll` 工作，这次只是让它们也享受到 2/3/4 三条新规则（上表已逐个复测）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)