### PR TITLE
feat(gpulab): 补上 AI 助手与 AI 复盘，并对齐两个工作台的能力

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -683,5 +683,38 @@
     "title": "This section could not be displayed",
     "body": "The project data is malformed, so this part of the page failed to render. The rest of the app is still usable.",
     "retry": "Try again"
+  },
+  "gpulab": {
+    "chat": {
+      "tab": "AI assistant",
+      "title": "Optimisation assistant",
+      "empty": "I can see your current kernel source, the measured value of every gate from the last run, the sectors and bank conflicts on the profile panel, and the commands you recently ran. When a counter is off target, ask — I will connect \"which number is wrong\" to \"which lines cause it\". You do the editing; I do not touch the code.",
+      "placeholder": "Ask about this stage… (Enter to send, Shift+Enter for a new line)",
+      "prompts": {
+        "gateShortfall": "Which gate is off, and by how much?",
+        "whyFailing": "What is the failing test case asserting?",
+        "lastError": "Why did the last command fail?",
+        "whereToLook": "Where in the source should I look now?",
+        "explainStage": "What exactly am I optimising in this stage?"
+      }
+    },
+    "review": {
+      "title": "AI review",
+      "subtitle": "Judges how you optimised, not whether the gate went green",
+      "request": "Request review",
+      "running": "Reviewing…",
+      "empty": "Come here after finishing a stage (or when stuck). The AI reads your source and the commands you ran: was the change aimed at the real bottleneck, did you measure before changing, is the result still correct, and did the gate pass through real optimisation or a shortcut.",
+      "issues": "Worth fixing",
+      "strengths": "Done well",
+      "nextSteps": "Next steps",
+      "noWorld": "The device is not ready yet — wait for the terminal before requesting a review.",
+      "dimensions": {
+        "optimization": "Optimisation",
+        "measurement": "Measure first",
+        "correctness": "Correctness kept",
+        "legitimacy": "Gate legitimacy",
+        "understanding": "Understanding"
+      }
+    }
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -683,5 +683,38 @@
     "title": "这部分内容无法显示",
     "body": "项目数据有问题，这一块渲染失败了。应用的其余部分仍然可用。",
     "retry": "重试"
+  },
+  "gpulab": {
+    "chat": {
+      "tab": "AI 助手",
+      "title": "优化助手",
+      "empty": "我看得到你当前的 kernel 源码、上次验收每条门槛的实测值、剖析面板上的扇区数与 bank 冲突、以及终端里最近敲的命令。指标没到线就问，我帮你把「哪个数不对」对到「源码的哪几行」上 —— 代码由你自己改，我不碰。",
+      "placeholder": "问一个关于当前这一关的问题…（Enter 发送，Shift+Enter 换行）",
+      "prompts": {
+        "gateShortfall": "没到线的那条门槛，差在哪儿？",
+        "whyFailing": "验收没过的那条用例在检查什么？",
+        "lastError": "上一条命令为什么报错？",
+        "whereToLook": "现在该往源码的哪儿看？",
+        "explainStage": "这一关到底要我优化什么？"
+      }
+    },
+    "review": {
+      "title": "AI 复盘",
+      "subtitle": "评的是你怎么优化的，不是门槛过没过",
+      "request": "让 AI 复盘",
+      "running": "复盘中…",
+      "empty": "跑完一关（或者卡住了）之后来这里。AI 会顺着你的源码和敲过的命令看一遍：改动是不是冲着瓶颈去的、有没有先量再改、结果还对不对，以及门槛是真优化过去的还是钻空子过去的。",
+      "issues": "值得改的地方",
+      "strengths": "做得好的地方",
+      "nextSteps": "下一步",
+      "noWorld": "设备还没就绪，先等终端起来再复盘。",
+      "dimensions": {
+        "optimization": "优化思路",
+        "measurement": "先量再改",
+        "correctness": "正确性保持",
+        "legitimacy": "门槛的成色",
+        "understanding": "机制理解"
+      }
+    }
   }
 }

--- a/pages/api/gpu-chat.ts
+++ b/pages/api/gpu-chat.ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  abortSignalFor,
+  AIProviderConfig,
+  ChatMessage,
+  NoProviderError,
+  streamAI,
+  statusForError,
+} from '../../src/lib/server/aiProvider';
+import { buildGpuContext, GpuContext } from '../../src/lib/server/gpuPrompt';
+
+/*
+ * 请求体上限，理由同 ops-chat：上下文在客户端就被压成了定长摘要
+ * （src/lib/gpulab/lab/aicontext.ts），实测几十 KB，测试盯着 200KB 这条线。
+ * 2mb 是十倍余量。responseLimit 关掉是因为回答是流式的。
+ */
+export const config = {
+  api: {
+    responseLimit: false,
+    bodyParser: { sizeLimit: '2mb' },
+  },
+};
+
+interface GpuChatRequest {
+  messages: ChatMessage[];
+  context: GpuContext;
+  language: 'en' | 'zh';
+  config?: AIProviderConfig;
+}
+
+/**
+ * 只读，而且明说 —— 理由和 ops 一字不差：判定读的就是执行结果。
+ *
+ * 能替学员改 kernel 的助手等于能替他通关，那门槛这件事本身就没意义了。
+ * 区别在于「不代劳」在这里要说得更细：GPU 场景下学员最想要的就是
+ * 「你直接把优化后的 kernel 写给我」，所以提示词里把这条单独拎出来。
+ */
+function systemPrompt(language: 'en' | 'zh'): string {
+  if (language === 'zh') {
+    return `你是一位资深的 CUDA 性能工程师，正坐在用户旁边，看着同一块屏幕，陪他做一个 GPU 优化关卡。
+
+你能看到的东西都在下面的上下文里：关卡要求与门槛、上一次验收每条门槛的**实测值**、他当前的 kernel 源码、剖析计量（扇区数、bank 冲突、占用率、DRAM 字节、指令分布）、竞态报告，以及他终端里最近敲的命令。
+
+**你没有手。** 你不能改他的代码，也不能替他跑验收 —— 手是用户的。
+
+规则：
+1. **先看门槛的实测值，再看源码。** 这一类关卡里，学员十有八九是「结果算对了但某个指标没到线」。先说清楚是哪个计量差多少，再回到源码里指出是哪几行造成的。
+2. **不要整段重写他的 kernel。** 可以给出关键的几行、或者一个改法的骨架，但要让他自己动手改。他明确要完整实现时才给，并且说明为什么这样写。
+3. **把计量和代码连起来。** 「sectorsPerRequest 是 9.4 而不是 4」这句话本身没用，要说成「因为第 N 行按列走，相邻 lane 的地址差了一整行，所以一次请求散到 9 个扇区」。
+4. 上下文里的计量是**上一次运行**的结果。他改完代码之后数字就过期了，让他重新 \`nvcc\` + \`ncu\` 再看。
+5. 需要更多信息时，给出**具体可敲的命令**（\`ncu ./bench\`、\`compute-sanitizer --tool racecheck ./bench\`），用独立的 \`\`\`bash 代码块，并说清要从输出里看什么。
+6. **模拟周期数只能同关相对比较**，没有真卡校准。不要用它讲绝对性能，也不要拿它和真实 GPU 的数字比。
+7. 门槛是结构性计量（扇区数、字节数、消息数），不是跑分。要让他明白优化的是**结构**，不是让某个数字变小。
+8. 分清「计量里客观是什么」和「你的推测」。前者引用上下文里的数，后者要说明这是推测、以及怎么量出来验证。
+9. 用 Markdown，用中文回答。`;
+  }
+
+  return `You are a senior CUDA performance engineer sitting next to the user, looking at the same screen, working through a GPU optimisation stage with them.
+
+Everything you can see is in the context below: the stage requirements and its gates, the **measured value** of every gate from the last verification run, their current kernel source, the profile counters (sectors per request, bank conflicts, occupancy, DRAM bytes, instruction mix), the race report, and the commands they recently ran.
+
+**You have no hands.** You cannot edit their code or run verification for them — the hands are theirs.
+
+Rules:
+1. **Read the measured gate values before the source.** In these stages they are almost always in the position of "the result is correct but one metric is off target". Say which counter is off and by how much, then go back to the source and point at the lines responsible.
+2. **Do not rewrite their whole kernel.** Give the key lines or a skeleton of the change, but leave the editing to them. Only give a full implementation if they explicitly ask, and explain why it is written that way.
+3. **Connect counters to code.** "sectorsPerRequest is 9.4 instead of 4" on its own is useless. Say "because line N walks down a column, adjacent lanes are a full row apart, so one request scatters across 9 sectors".
+4. The counters in context are from the **last run**. Once they edit, those numbers are stale — tell them to re-run \`nvcc\` and \`ncu\`.
+5. When you need more, give a **concrete command** (\`ncu ./bench\`, \`compute-sanitizer --tool racecheck ./bench\`) in its own \`\`\`bash block, and say what to look for.
+6. **Simulated cycle counts are only comparable within this stage** — they are not calibrated against real hardware. Never use them to talk about absolute performance or compare against a real GPU.
+7. Gates are structural counters (sectors, bytes, messages), not a benchmark score. Make sure they understand they are optimising the **structure**, not making a number smaller.
+8. Separate what the counters objectively show from what you suspect. Quote the numbers for the former; label the latter as a hypothesis and say how to measure it.
+9. Use Markdown. Answer in English.`;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // aiConfig 而不是 config：模块顶上那个 export const config 是路由配置
+    const { messages, context, language = 'zh', config: aiConfig } = req.body as GpuChatRequest;
+
+    if (!Array.isArray(messages)) {
+      return res.status(400).json({ error: 'Messages array is required' });
+    }
+    if (!context || typeof context !== 'object') {
+      return res.status(400).json({ error: 'GPU context is required' });
+    }
+
+    const fullMessages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt(language) },
+      { role: 'system', content: buildGpuContext(context, language) },
+      ...messages,
+    ];
+
+    await streamAI(res, fullMessages, aiConfig, {
+      temperature: 0.5,
+      maxTokens: 2500,
+      format: 'sse',
+      signal: abortSignalFor(res),
+    });
+  } catch (error) {
+    console.error('GPU chat error:', error);
+    const message =
+      error instanceof NoProviderError ? error.message : (error as Error).message || 'Failed to get AI response';
+    if (!res.headersSent) return res.status(statusForError(error)).json({ error: message });
+    res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+    res.end();
+  }
+}

--- a/pages/api/gpu-review.ts
+++ b/pages/api/gpu-review.ts
@@ -1,0 +1,170 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  abortSignalFor,
+  AIProviderConfig,
+  ChatMessage,
+  extractJson,
+  NoProviderError,
+  streamStructured,
+  statusForError,
+} from '../../src/lib/server/aiProvider';
+import { buildGpuContext, GpuContext, GPU_REVIEW_MAX_CHARS } from '../../src/lib/server/gpuPrompt';
+import { GPU_DIMENSION_KEYS } from '../../src/lib/engineering/types';
+import type { GpuReview } from '../../src/lib/engineering/types';
+
+/*
+ * 请求体上限，理由同 gpu-chat：上下文是客户端压出来的定长摘要。
+ * 复盘比对话多带一整条命令序列，实测也就几十 KB。
+ */
+export const config = {
+  api: {
+    responseLimit: false,
+    bodyParser: { sizeLimit: '2mb' },
+  },
+};
+
+interface GpuReviewRequest {
+  context: GpuContext;
+  language: 'en' | 'zh';
+  config?: AIProviderConfig;
+}
+
+const REVIEW_SCHEMA = `{
+  "summary": "2-4 sentences: how did they optimise this kernel, and would you trust this change in a real inference engine",
+  "dimensions": [
+    { "key": "optimization|measurement|correctness|legitimacy|understanding", "score": 0-100, "comment": "one concrete sentence" }
+  ],
+  "issues": [
+    {
+      "title": "short problem statement",
+      "severity": "blocker|major|minor|nit",
+      "where": "the kernel lines, the counter, or the command this is about",
+      "detail": "why this matters on a real GPU, not just for the gate",
+      "suggestion": "the smallest concrete change"
+    }
+  ],
+  "strengths": ["what they genuinely did well"],
+  "nextSteps": ["what to do before calling this stage done"]
+}`;
+
+/**
+ * 复盘评的是优化，不是代码风格。
+ *
+ * 这一关里学员改的是一个 kernel，目标是把某个结构性计量压下去。所以能评的是：
+ * 他有没有先量再改、改动是不是冲着瓶颈去的、结果还对不对、
+ * 以及最要紧的一条 —— 门槛是**真的优化**过去的，还是钻空子过去的。
+ *
+ * 最后这条是 GPU 场景独有的，而且是这份提示词存在的主要理由：
+ * 把问题规模改小、把 kernel 掏空只留下写结果、把循环次数减掉，
+ * 都能让某个计量掉下来而用例照样绿。`legitimacy` 这个维度专门盯它。
+ */
+function systemPrompt(language: 'en' | 'zh'): string {
+  const shared = `You are a senior CUDA performance engineer reviewing how someone optimised a kernel in a hands-on GPU stage. You can see the stage requirements and its gates, the measured value of every gate, their current kernel source, the profile counters, the race report, and the commands they ran in order.
+
+Judge how they optimised, in order of importance:
+1. **legitimacy** — did they actually optimise, or did they game the gate? Shrinking the problem size, deleting work the stage is supposed to do, hollowing out the kernel so it only writes the expected result, dropping loop iterations, moving work to the host — all of these can make a counter fall while the test cases stay green. This is the single most important thing to check. If the source no longer does the work the stage describes, say so loudly, no matter how green everything is.
+2. **correctness** — is the result still right, and would it stay right outside the tested shapes? Look for tail handling (n not a multiple of the block size), missing __syncthreads, races the sanitizer reported, and reliance on a particular launch geometry.
+3. **optimization** — is the change aimed at the actual bottleneck? Coalescing when the problem was coalescing, tiling when it was DRAM traffic, avoiding bank conflicts when it was shared memory. Changing something that was never the constraint is not optimisation.
+4. **measurement** — did they measure before and after, or guess? The command history shows whether they ran ncu/compute-sanitizer or just recompiled and hoped.
+5. **understanding** — does the code read like someone who knows why the counter moved, or like someone who tried things until it went green?
+
+Hard rules:
+- **A passing gate does NOT mean they optimised well.** Gates are structural counters; a shortcut can satisfy them. Check the source actually still does the stage's work.
+- **Never judge on simulated cycle counts.** They are not calibrated against real hardware and are only comparable within one stage. Judge on the structural counters: sectors per request, DRAM bytes, bank conflicts, local memory bytes, message counts.
+- Judge what is actually in the context. Never invent code they did not write or counters that are not there.
+- Every issue must point at something concrete: quote the lines or name the counter in "where".
+- Prefer a few findings that matter over a list of nitpicks. Severity reflects what it would cost on a real GPU.
+- Scores are calibrated: 90+ means you would take this change into a real inference engine, 70 means it works but you would ask questions in review, below 50 means something is actually wrong with the approach.
+- Return ONLY valid JSON matching the schema. No markdown fences, no commentary outside the JSON.`;
+
+  const localised =
+    language === 'zh'
+      ? '\n\nAll human-readable text inside the JSON (summary, comment, title, where, detail, suggestion, strengths, nextSteps) MUST be written in Chinese.'
+      : '\n\nAll human-readable text inside the JSON must be written in English.';
+
+  return shared + localised;
+}
+
+function normalise(review: any, language: 'en' | 'zh'): GpuReview {
+  const allowedSeverity = ['blocker', 'major', 'minor', 'nit'];
+
+  const dimensions = Array.isArray(review?.dimensions)
+    ? review.dimensions
+        .filter((item: any) => (GPU_DIMENSION_KEYS as readonly string[]).includes(item?.key))
+        .map((item: any) => ({
+          key: item.key,
+          score: Math.max(0, Math.min(100, Math.round(Number(item.score) || 0))),
+          comment: String(item.comment || ''),
+        }))
+    : [];
+
+  const issues = Array.isArray(review?.issues)
+    ? review.issues.slice(0, 12).map((item: any) => ({
+        title: String(item?.title || 'Issue'),
+        severity: allowedSeverity.includes(item?.severity) ? item.severity : 'minor',
+        where: item?.where ? String(item.where) : undefined,
+        detail: String(item?.detail || ''),
+        suggestion: item?.suggestion ? String(item.suggestion) : undefined,
+      }))
+    : [];
+
+  return {
+    summary: String(review?.summary || (language === 'zh' ? '（模型没有给出总结）' : '(no summary returned)')),
+    dimensions,
+    issues,
+    strengths: Array.isArray(review?.strengths) ? review.strengths.slice(0, 8).map(String) : [],
+    nextSteps: Array.isArray(review?.nextSteps) ? review.nextSteps.slice(0, 8).map(String) : [],
+  };
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // aiConfig 而不是 config：模块顶上那个 export const config 是路由配置
+    const { context, language = 'zh', config: aiConfig } = req.body as GpuReviewRequest;
+
+    if (!context || typeof context !== 'object') {
+      return res.status(400).json({ error: 'GPU context is required' });
+    }
+    // 查到字段一级：只判 snapshot 存在的话，一个 {} 会在排版时抛出去变成 500
+    const snapshot = context.snapshot as Partial<typeof context.snapshot> | undefined;
+    if (!snapshot || !Array.isArray(snapshot.sources) || !Array.isArray(snapshot.commands)) {
+      return res.status(400).json({ error: 'A GPU snapshot is required to review a kernel stage' });
+    }
+
+    const userContent = [
+      buildGpuContext(context, language, GPU_REVIEW_MAX_CHARS),
+      '',
+      language === 'zh'
+        ? '请按上面的标准复盘这一关的优化过程，并严格按下面的 JSON 结构返回：'
+        : 'Review how this kernel was optimised and return exactly this JSON structure:',
+      REVIEW_SCHEMA,
+    ].join('\n\n');
+
+    const messages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt(language) },
+      { role: 'user', content: userContent },
+    ];
+
+    await streamStructured(res, messages, aiConfig, {
+      temperature: 0.3,
+      maxTokens: 4000,
+      signal: abortSignalFor(res),
+      onComplete: (raw) => ({ review: normalise(extractJson<any>(raw), language) }),
+    });
+  } catch (error) {
+    console.error('GPU review error:', error);
+    const message =
+      error instanceof NoProviderError ? error.message : (error as Error).message || 'Failed to generate review';
+    if (res.headersSent) {
+      res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'done' })}\n\n`);
+      res.end();
+      return;
+    }
+    return res.status(statusForError(error)).json({ error: message });
+  }
+}

--- a/src/components/gpulab/GpuChat.tsx
+++ b/src/components/gpulab/GpuChat.tsx
@@ -1,0 +1,126 @@
+/**
+ * gpulab 工作台里的 AI 助手
+ *
+ * 位置和 ops 那边一样：右侧那组 tab 里的一页，和终端、IDE、剖析并列，
+ * 不是浮动弹窗 —— 学员问问题时几乎总是对着剖析面板上的某个数或者终端里的报错，
+ * 弹窗会把要问的那段挡住。
+ *
+ * 上下文在**每次发送时**现取：他改一行代码、重跑一次 ncu，数字就全变了，
+ * 缓存下来的快照第二个问题就已经过期。
+ */
+import { useCallback, useMemo } from 'react';
+import { Text } from '@mantine/core';
+import { IconRobot } from '@tabler/icons-react';
+import { useI18n, useTranslation } from '../../contexts/I18nContext';
+import { useAiConfig } from '../../hooks/useAiConfig';
+import { useChatStream, StreamMessage } from '../../hooks/useChatStream';
+import ChatPanel from '../chat/ChatPanel';
+import { buildGpuSnapshot, summarizeGpuReport } from '../../lib/gpulab/lab/aicontext';
+import type { GpuWorld } from '../../lib/gpulab/lab';
+import type { CommandRecord } from '../../lib/labkit/machine';
+import type { LocalizedText, MetricGate, StageRunReport } from '../../lib/engineering/types';
+
+export interface GpuChatProps {
+  projectTitle: LocalizedText;
+  projectSummary: LocalizedText;
+  stageTitle: LocalizedText;
+  stageGoal: LocalizedText;
+  stageIndex: number;
+  stageCount: number;
+  checklist?: LocalizedText[];
+  gates?: MetricGate[];
+  world: GpuWorld | null;
+  history: CommandRecord[];
+  /** 学员当前的源码：路径 -> 内容 */
+  sources: Record<string, string>;
+  report: StageRunReport | null;
+}
+
+export default function GpuChat(props: GpuChatProps) {
+  const { t } = useTranslation();
+  const { locale } = useI18n();
+  // locale 是宽字符串；门槛标签要按语言取，这里收窄一次
+  const lang: 'en' | 'zh' = locale === 'en' ? 'en' : 'zh';
+  const { config } = useAiConfig();
+
+  const {
+    world, history, sources, report, gates,
+    projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+  } = props;
+
+  const buildBody = useCallback(
+    (chatHistory: StreamMessage[], input: string) => ({
+      messages: [...chatHistory, { role: 'user' as const, content: input }].map((message) => ({
+        role: message.role,
+        content: message.content,
+      })),
+      language: locale,
+      config,
+      context: {
+        projectTitle,
+        projectSummary,
+        stageIndex,
+        stageCount,
+        stageTitle,
+        stageGoal,
+        checklist,
+        // 还没跑过验收时，至少让 AI 知道这一关要达到什么
+        gates: gates?.map((gate) => ({
+          metric: gate.metric, label: gate.label, op: gate.op, value: gate.value, unit: gate.unit,
+        })),
+        // 世界还没起来时只发关卡信息 —— 总比整个面板不能用强
+        snapshot: world ? buildGpuSnapshot(world, { sources, history }) : undefined,
+        report: summarizeGpuReport(report, lang),
+      },
+    }),
+    [
+      config, locale, lang, world, sources, history, report, gates,
+      projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+    ]
+  );
+
+  const chat = useChatStream({ url: '/api/gpu-chat', body: buildBody });
+
+  /**
+   * 快捷提问跟着现场走。
+   *
+   * 和 ops 的差别就在这里：ops 优先问「上一条命令为什么报错」，
+   * 而 GPU 这边最常见的处境是用例全绿、某条门槛红着 —— 那才是第一个该问的。
+   */
+  const quickPrompts = useMemo(() => {
+    const prompts: string[] = [];
+    const failedGate = report?.gates?.find((gate) => !gate.passed);
+    const failedCase = report?.cases?.some((item) => !item.passed && item.error !== 'skipped');
+    const last = history[history.length - 1];
+
+    if (failedGate) prompts.push(t('gpulab.chat.prompts.gateShortfall'));
+    if (failedCase) prompts.push(t('gpulab.chat.prompts.whyFailing'));
+    if (last && last.code !== 0) prompts.push(t('gpulab.chat.prompts.lastError'));
+    prompts.push(t('gpulab.chat.prompts.whereToLook'));
+    prompts.push(t('gpulab.chat.prompts.explainStage'));
+    return prompts;
+  }, [history, report, t]);
+
+  return (
+    <ChatPanel
+      messages={chat.messages}
+      isStreaming={chat.isStreaming}
+      error={chat.error}
+      onSend={chat.send}
+      onStop={chat.stop}
+      onClear={chat.clear}
+      onRetry={chat.retry}
+      onDismissError={() => chat.setError(null)}
+      quickPrompts={quickPrompts}
+      placeholder={t('gpulab.chat.placeholder')}
+      emptyState={
+        <>
+          <IconRobot size={44} opacity={0.35} />
+          <Text size="sm" c="dimmed" ta="center" maw={420}>
+            {t('gpulab.chat.empty')}
+          </Text>
+        </>
+      }
+    />
+  );
+}

--- a/src/components/gpulab/GpuReview.tsx
+++ b/src/components/gpulab/GpuReview.tsx
@@ -1,0 +1,140 @@
+/**
+ * gpulab 工作台的 AI 复盘
+ *
+ * 和 ops 的复盘并列，但评的东西不一样：那边评「这一关他是怎么操作过来的」，
+ * 这边评**优化本身** —— 有没有先量再改、改动是不是冲着瓶颈去的、结果还对不对，
+ * 以及最要紧的一条：门槛是真的优化过去的，还是把 kernel 掏空蒙过去的。
+ *
+ * 位置同 ops：左栏「验收」旁边，不在右栏。右栏是干活的地方（终端、IDE、剖析），
+ * 左栏是读长文的地方，而复盘正是一篇要从头读到尾的长文。
+ *
+ * 排版复用 ReviewPanel，和代码形态、ops 是同一套结构，只换维度和文案。
+ */
+import { useCallback, useMemo, useState } from 'react';
+import { useI18n, useTranslation } from '../../contexts/I18nContext';
+import { useAiConfig } from '../../hooks/useAiConfig';
+import { requestStructuredStream } from '../../lib/streamRequest';
+import ReviewPanel from '../engineering/ReviewPanel';
+import type { ReviewPanelData, ReviewPanelStrings } from '../engineering/ReviewPanel';
+import { buildGpuSnapshot, summarizeGpuReport, GPU_SNAPSHOT_LIMITS } from '../../lib/gpulab/lab/aicontext';
+import type { GpuWorld } from '../../lib/gpulab/lab';
+import type { CommandRecord } from '../../lib/labkit/machine';
+import type {
+  GpuReview as GpuReviewData, LocalizedText, MetricGate, StageRunReport,
+} from '../../lib/engineering/types';
+
+export interface GpuReviewProps {
+  projectTitle: LocalizedText;
+  projectSummary: LocalizedText;
+  stageTitle: LocalizedText;
+  stageGoal: LocalizedText;
+  stageIndex: number;
+  stageCount: number;
+  checklist?: LocalizedText[];
+  gates?: MetricGate[];
+  world: GpuWorld | null;
+  history: CommandRecord[];
+  sources: Record<string, string>;
+  report: StageRunReport | null;
+}
+
+export default function GpuReview(props: GpuReviewProps) {
+  const { t } = useTranslation();
+  const { locale } = useI18n();
+  // locale 是宽字符串；门槛标签要按语言取，这里收窄一次
+  const lang: 'en' | 'zh' = locale === 'en' ? 'en' : 'zh';
+  const { config } = useAiConfig();
+
+  const [review, setReview] = useState<GpuReviewData | null>(null);
+  const [draft, setDraft] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    world, history, sources, report, gates,
+    projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+  } = props;
+
+  const handleRequest = useCallback(async () => {
+    if (!world) {
+      setError(t('gpulab.review.noWorld'));
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setDraft('');
+
+    try {
+      const data = await requestStructuredStream<{ review: GpuReviewData }>(
+        '/api/gpu-review',
+        {
+          language: locale,
+          config,
+          context: {
+            projectTitle,
+            projectSummary,
+            stageIndex,
+            stageCount,
+            stageTitle,
+            stageGoal,
+            checklist,
+            gates: gates?.map((gate) => ({
+              metric: gate.metric, label: gate.label, op: gate.op, value: gate.value, unit: gate.unit,
+            })),
+            // 复盘要看完整的编译-测量-再改的过程，不是最近几条 ——
+            // 「有没有先量再改」这件事就藏在命令的顺序里
+            snapshot: buildGpuSnapshot(world, {
+              sources, history, limits: GPU_SNAPSHOT_LIMITS.review,
+            }),
+            report: summarizeGpuReport(report, lang),
+          },
+        },
+        { onDelta: (_chunk, full) => setDraft(full) }
+      );
+      setReview(data.review);
+    } catch (requestError) {
+      setError((requestError as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    config, locale, lang, world, sources, history, report, gates, t,
+    projectTitle, projectSummary, stageTitle, stageGoal, stageIndex, stageCount, checklist,
+  ]);
+
+  const strings = useMemo<ReviewPanelStrings>(
+    () => ({
+      title: t('gpulab.review.title'),
+      subtitle: t('gpulab.review.subtitle'),
+      request: t('gpulab.review.request'),
+      running: t('gpulab.review.running'),
+      empty: t('gpulab.review.empty'),
+      issues: t('gpulab.review.issues'),
+      strengths: t('gpulab.review.strengths'),
+      nextSteps: t('gpulab.review.nextSteps'),
+      dimensionLabel: (key) => t(`gpulab.review.dimensions.${key}`),
+    }),
+    [t]
+  );
+
+  // where -> file：面板右上角那行小字，这里放的是代码位置或者计量名
+  const data = useMemo<ReviewPanelData | null>(
+    () =>
+      review
+        ? { ...review, issues: review.issues.map((issue) => ({ ...issue, file: issue.where })) }
+        : null,
+    [review]
+  );
+
+  return (
+    <ReviewPanel
+      review={data}
+      loading={loading}
+      error={error}
+      draft={draft}
+      onRequest={handleRequest}
+      strings={strings}
+    />
+  );
+}

--- a/src/components/gpulab/GpuWorkspace.tsx
+++ b/src/components/gpulab/GpuWorkspace.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mantine/core';
 import {
   IconAlertTriangle, IconChartHistogram, IconCpu, IconFileCode,
-  IconPlayerPlay, IconRefresh, IconSitemap, IconTerminal2,
+  IconPlayerPlay, IconRefresh, IconRobot, IconSitemap, IconTerminal2,
 } from '@tabler/icons-react';
 import { useMantineColorScheme } from '@mantine/core';
 import Editor from '@monaco-editor/react';
@@ -25,6 +25,8 @@ import MarkdownRenderer from '../MarkdownRenderer';
 import ErrorBoundary from '../ErrorBoundary';
 import { RunReportPanel } from '../engineering/ResultPanels';
 import WorkbenchSplit from '../workbench/WorkbenchSplit';
+import GpuChat from './GpuChat';
+import GpuReview from './GpuReview';
 import { useGpuWorkspace } from '../../hooks/useGpuWorkspace';
 import { runGpuStage } from '../../lib/gpulab/lab';
 import { resolveTranspiler } from '../../lib/engineering/transpile';
@@ -145,6 +147,25 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
     // 同一份内容也写进草稿，刷新页面之后还在
     if (stage?.gpu?.files?.[activePath] !== undefined) handleFileChange(activePath, value);
   }, [activePath, gpu, stage?.gpu, handleFileChange]);
+
+  /**
+   * 学员当前的源码，喂给 AI 的那一份。
+   *
+   * 从 vfs 现读而不是用 stage 里那份原始内容 —— 他在编辑器里改过、
+   * 在终端里 `cp` 出来的，都要算数。挂在 revision 上：写盘和敲命令都会 +1。
+   */
+  const aiSources = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const path of gpu.sourcePaths) {
+      try {
+        out[path] = gpu.readFile(path);
+      } catch {
+        /* 文件被删掉了就跳过 */
+      }
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gpu.sourcePaths, gpu.revision, gpu.generation, gpu.status]);
 
   const registerInsert = useCallback((insert: ((command: string) => void) | null) => {
     insertRef.current = insert;
@@ -295,6 +316,7 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                   <Tabs.Tab value="result" fz="xs">
                     验收{report ? ` · ${report.totals.passed}/${report.totals.total}` : ''}
                   </Tabs.Tab>
+                  <Tabs.Tab value="review" fz="xs">复盘</Tabs.Tab>
                 </Tabs.List>
                 <Tabs.Panel value="goal" style={{ flex: 1, minHeight: 0 }}>
                   <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
@@ -337,6 +359,30 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                       : <Text size="xs" c="dimmed">还没跑过验收</Text>}
                   </ScrollArea>
                 </Tabs.Panel>
+                {/*
+                  复盘放左栏而不是右栏：右栏是干活的地方（终端、IDE、剖析），
+                  左栏是读长文的地方，而复盘正是一篇要从头读到尾的长文。同 ops。
+                */}
+                <Tabs.Panel value="review" style={{ flex: 1, minHeight: 0 }}>
+                  <ScrollArea h="100%" type="auto" p="sm" className="panel-scroll">
+                    <ErrorBoundary fallback={renderPanelError}>
+                      <GpuReview
+                        projectTitle={project.title}
+                        projectSummary={project.summary}
+                        stageTitle={stage.title}
+                        stageGoal={stage.goal}
+                        stageIndex={stageIndex}
+                        stageCount={project.stages.length}
+                        checklist={stage.checklist}
+                        gates={stage.gates}
+                        world={gpu.world}
+                        history={gpu.history}
+                        sources={aiSources}
+                        report={report}
+                      />
+                    </ErrorBoundary>
+                  </ScrollArea>
+                </Tabs.Panel>
               </Tabs>
             )}
             right={(
@@ -363,6 +409,9 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                       集群
                     </Tabs.Tab>
                   )}
+                  <Tabs.Tab value="chat" fz="xs" leftSection={<IconRobot size={13} />}>
+                    AI 助手
+                  </Tabs.Tab>
                 </Tabs.List>
 
                 <Tabs.Panel value="terminal" style={{ flex: 1, minHeight: 0 }}>
@@ -445,6 +494,25 @@ export default function GpuWorkspace({ session, registerClearResults }: GpuWorks
                     </ErrorBoundary>
                   </Tabs.Panel>
                 )}
+
+                <Tabs.Panel value="chat" style={{ flex: 1, minHeight: 0 }}>
+                  <ErrorBoundary fallback={renderPanelError}>
+                    <GpuChat
+                      projectTitle={project.title}
+                      projectSummary={project.summary}
+                      stageTitle={stage.title}
+                      stageGoal={stage.goal}
+                      stageIndex={stageIndex}
+                      stageCount={project.stages.length}
+                      checklist={stage.checklist}
+                      gates={stage.gates}
+                      world={gpu.world}
+                      history={gpu.history}
+                      sources={aiSources}
+                      report={report}
+                    />
+                  </ErrorBoundary>
+                </Tabs.Panel>
 
               </Tabs>
             )}

--- a/src/hooks/useGpuWorkspace.ts
+++ b/src/hooks/useGpuWorkspace.ts
@@ -11,6 +11,9 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CommandRecord } from '../lib/labkit/machine';
+
+/** 哪些扩展名算「源码」，值得出现在 IDE 里（nvcc 产出的 bench 二进制不算） */
+const SOURCE_EXTENSIONS = ['.cu', '.cuh', '.h', '.hpp', '.c', '.cc', '.cpp'];
 import { buildWorld, type GpuWorld, type GpuWorldSpec } from '../lib/gpulab/lab';
 import type { GpuStageSpec } from '../lib/engineering/types';
 
@@ -137,13 +140,33 @@ export function useGpuWorkspace(options: UseGpuWorkspaceOptions): GpuWorkspaceSt
     setGeneration((value) => value + 1);
   }, []);
 
+  /**
+   * IDE 里能打开的文件。
+   *
+   * 曾经只取关卡声明的那份清单，并且钉在 stageKey 上 —— 于是学员在终端里
+   * `cp reduce.cu backup.cu` 建出来的文件，IDE 里**永远看不到**。
+   * ops 那边的文件树是机器磁盘的实时投影（`vfs.toFileMap('/root')` 挂在 revision 上），
+   * 这里对齐同一个语义。
+   *
+   * 只是不能整份端上来：nvcc 会往磁盘写一个真的 `bench` 可执行文件
+   * （见 lab/cli.ts），把它塞进 Monaco 没有意义。所以按扩展名筛一遍源码。
+   */
   const sourcePaths = useMemo(() => {
     const declared = options.stage?.bench?.sources ?? options.world?.bench?.sources ?? [];
     const fromFiles = Object.keys(options.stage?.files ?? {});
-    // 声明过的源文件排在前面，其余（头文件之类）跟在后面
-    return [...new Set([...declared, ...fromFiles])];
+    const live: string[] = [];
+    try {
+      const cwd = world?.machine.cwd ?? '/root';
+      for (const path of Object.keys(world?.machine.vfs.toFileMap(cwd) ?? {})) {
+        if (SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext))) live.push(path);
+      }
+    } catch {
+      /* 世界还没起来就只有声明的那些 */
+    }
+    // 声明过的源文件排在前面，其余（头文件、学员自己建的）跟在后面
+    return [...new Set([...declared, ...fromFiles, ...live.sort()])];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stageKey]);
+  }, [stageKey, world, revision]);
 
   // 提示符跟着 cwd 走，所以要挂在 revision 上重算
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/engineering/types.ts
+++ b/src/lib/engineering/types.ts
@@ -720,3 +720,36 @@ export interface OpsReview {
   strengths: string[];
   nextSteps: string[];
 }
+
+/* ------------------------------------------------------------------
+ * GPU 复盘
+ *
+ * 又是一套维度，理由和 ops 一样：评的东西不同。
+ * 代码形态评「这段代码能不能合」，ops 评「这一关他是怎么操作过来的」，
+ * GPU 这边评的是**优化本身**：他有没有先量再改、改动是不是冲着瓶颈去的、
+ * 结果还对不对、以及 —— 最要紧的一条 —— 门槛是真的优化过去的，
+ * 还是把问题规模改小、把 kernel 掏空之类蒙过去的。
+ * ------------------------------------------------------------------ */
+
+export const GPU_DIMENSION_KEYS = [
+  'optimization', 'measurement', 'correctness', 'legitimacy', 'understanding',
+] as const;
+
+export type GpuDimensionKey = (typeof GPU_DIMENSION_KEYS)[number];
+
+export interface GpuReviewIssue {
+  title: string;
+  severity: 'blocker' | 'major' | 'minor' | 'nit';
+  /** 出问题的地方：一段 kernel 代码、一个计量、或者一条命令 */
+  where?: string;
+  detail: string;
+  suggestion?: string;
+}
+
+export interface GpuReview {
+  summary: string;
+  dimensions: Array<{ key: GpuDimensionKey; score: number; comment: string }>;
+  issues: GpuReviewIssue[];
+  strengths: string[];
+  nextSteps: string[];
+}

--- a/src/lib/gpulab/lab/aicontext.ts
+++ b/src/lib/gpulab/lab/aicontext.ts
@@ -1,0 +1,342 @@
+/**
+ * 把一个 GPU 世界压成 AI 能吃下的快照
+ *
+ * 和 ops 那边同一个思路（裁剪发生在客户端，服务端只排版），但**要给的东西完全不同**。
+ *
+ * ops 的学员卡住时，答案通常在上一条命令的报错里。GPU 这边不是：
+ * 学员最常见的处境是「结果算对了，但某个指标没到线」—— 代码能跑、用例全绿、
+ * 就是门槛红着。这种时候光看报错没有用，得知道**差多少、差在哪个计量上**。
+ * 所以这份快照的重心是：当前 kernel 源码 + 上次验收的门槛实测值 + 剖析计量。
+ *
+ * **绝对不要把访存轨迹放进来。** `AccessTrace` 是逐次访存的记录，
+ * 一个 N=256 的 GEMM 就是几十万条；它存在的意义是算出扇区数与 bank 冲突数，
+ * 而那两个数已经在 metrics 里了。要的是结论，不是原始轨迹。
+ *
+ * 所有上限都写在这个文件里，`tests/gpulab/aicontext.test.ts` 盯着它们。
+ */
+import type { CommandRecord } from '../../labkit/machine';
+import type { GateResult, StageRunReport } from '../../engineering/types';
+import { HOST_HEADERS } from '../host/headers';
+import { gpuMetricTree } from './runner';
+import type { GpuWorld } from './world';
+
+/**
+ * 终端历史的预算，两种用法差别很大，所以做成两套（同 ops）。
+ *
+ * 对话是「看着刚才那条 nvcc 报错问」：条数少，单条输出要给全 ——
+ * `ncu` 的一节输出、compute-sanitizer 的竞态报告都不短，截狠了等于没给。
+ * 复盘问的是「这一关他是怎么优化过来的」：**编译与验收的先后顺序**本身就是被评的东西，
+ * 所以条数放宽、单条压短。
+ */
+export interface GpuSnapshotLimits {
+  commands: number;
+  commandOutput: number;
+}
+
+const CHAT_LIMITS: GpuSnapshotLimits = { commands: 8, commandOutput: 1600 };
+const REVIEW_LIMITS: GpuSnapshotLimits = { commands: 40, commandOutput: 500 };
+
+export const GPU_SNAPSHOT_LIMITS = { chat: CHAT_LIMITS, review: REVIEW_LIMITS };
+
+/**
+ * 单个源文件截到多少字符。
+ *
+ * 给得比 ops 的文件预算宽：那边的 manifest 是配角，这边的 kernel 源码是**主角** ——
+ * 少给一半等于让 AI 对着半个 kernel 猜。一关的 .cu 通常一两百行，8000 字符够装。
+ */
+const MAX_SOURCE_CHARS = 8000;
+/** 所有源文件加起来的预算 */
+const MAX_SOURCES_TOTAL = 20000;
+/** 最多带几个源文件 */
+const MAX_SOURCES = 6;
+/** 失败用例最多带几条 */
+const MAX_FAILING_CASES = 6;
+/** 单条失败用例的报错截到多少字符 */
+const MAX_CASE_ERROR = 800;
+/** 单条命令本身截到多少字符 */
+const MAX_COMMAND_TEXT = 300;
+/**
+ * 竞态最多带几条。
+ *
+ * sanitizer 自己上限 32 条，但同一个 bug 往往报出几十条长得一模一样的记录。
+ * 带前几条 + 总数就够定位了，剩下的让学员自己跑 compute-sanitizer 看。
+ */
+const MAX_RACES = 5;
+
+export interface GpuSnapshotSource {
+  path: string;
+  content: string;
+  truncated: boolean;
+}
+
+export interface GpuSnapshotCommand {
+  command: string;
+  code: number;
+  output: string;
+}
+
+export interface GpuSnapshotRace {
+  space: 'global' | 'shared';
+  address: number;
+  firstLine: number;
+  secondLine: number;
+}
+
+/** 剖析面板上那些数，摊平成一层，名字和门槛里写的 metric 路径对得上 */
+export interface GpuSnapshotProfile {
+  device: string;
+  sectorsPerRequest: number;
+  globalLoadSectors: number;
+  globalStoreSectors: number;
+  dramReadBytes: number;
+  dramWriteBytes: number;
+  sharedBankConflicts: number;
+  localBytes: number;
+  divergentBranches: number;
+  activeLaneRatio: number;
+  atomics: number;
+  inst: { warpExecuted: number; fma: number; ldst: number; sfu: number; mma: number };
+  launch: { blocks: number; warps: number; barriers: number; kernels: number };
+  registersPerThread: number;
+  occupancy: number;
+  warpsPerSm: number;
+  memoryPeakBytes: number;
+  arithmeticIntensity: number;
+  /** 模拟周期数：**只能同关相对比较，不能当绝对值**，提示词里也这么写 */
+  cycles: number;
+  bottleneck: string;
+}
+
+/** 集群关卡才有 */
+export interface GpuSnapshotCluster {
+  comm: unknown;
+  pipeline: unknown;
+  imbalance: number;
+}
+
+export interface GpuSnapshot {
+  profile: GpuSnapshotProfile | null;
+  sources: GpuSnapshotSource[];
+  commands: GpuSnapshotCommand[];
+  races: GpuSnapshotRace[];
+  raceTotal: number;
+  cluster: GpuSnapshotCluster | null;
+  omitted: { sources: number; commands: number; races: number };
+}
+
+export interface GpuSnapshotOptions {
+  /** 学员正在编辑的源码：路径 -> 内容 */
+  sources?: Record<string, string>;
+  history?: CommandRecord[];
+  limits?: Partial<GpuSnapshotLimits>;
+}
+
+function clip(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}\n…（截断，原文 ${text.length} 字符）`;
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/** 计量树是 unknown 的嵌套，取一个路径上的数 */
+function at(tree: Record<string, unknown>, path: string): number {
+  let node: unknown = tree;
+  for (const key of path.split('.')) {
+    if (!node || typeof node !== 'object') return 0;
+    node = (node as Record<string, unknown>)[key];
+  }
+  return num(node);
+}
+
+function buildProfile(world: GpuWorld): GpuSnapshotProfile | null {
+  let tree: Record<string, unknown>;
+  try {
+    tree = gpuMetricTree(world);
+  } catch {
+    // 世界还没跑过 kernel 时取计量可能抛，这时没有剖析数据也是合理状态
+    return null;
+  }
+  const timing = tree.timing as { cycles?: number } | undefined;
+  return {
+    device: world.gpu.device?.name ?? 'unknown',
+    sectorsPerRequest: at(tree, 'global.sectorsPerRequest'),
+    globalLoadSectors: at(tree, 'global.loadSectors'),
+    globalStoreSectors: at(tree, 'global.storeSectors'),
+    dramReadBytes: at(tree, 'memory.readBytes'),
+    dramWriteBytes: at(tree, 'memory.writeBytes'),
+    sharedBankConflicts: at(tree, 'shared.bankConflicts'),
+    localBytes: at(tree, 'local.bytes'),
+    divergentBranches: at(tree, 'warp.divergentBranches'),
+    activeLaneRatio: at(tree, 'warp.activeLaneRatio'),
+    atomics: at(tree, 'atomics'),
+    inst: {
+      warpExecuted: at(tree, 'inst.warpExecuted'),
+      fma: at(tree, 'inst.fma'),
+      ldst: at(tree, 'inst.ldst'),
+      sfu: at(tree, 'inst.sfu'),
+      mma: at(tree, 'inst.mma'),
+    },
+    launch: {
+      blocks: at(tree, 'launch.blocks'),
+      warps: at(tree, 'launch.warps'),
+      barriers: at(tree, 'launch.barriers'),
+      kernels: at(tree, 'launch.kernels'),
+    },
+    registersPerThread: at(tree, 'registers.perThread'),
+    occupancy: at(tree, 'occupancy.theoretical'),
+    warpsPerSm: at(tree, 'occupancy.warpsPerSm'),
+    memoryPeakBytes: at(tree, 'memoryPeakBytes'),
+    arithmeticIntensity: at(tree, 'arithmeticIntensity'),
+    cycles: num(timing?.cycles),
+    bottleneck: String((world.gpu.timing?.() as { bottleneck?: string } | undefined)?.bottleneck ?? ''),
+  };
+}
+
+export function buildGpuSnapshot(world: GpuWorld, options: GpuSnapshotOptions = {}): GpuSnapshot {
+  const limits: GpuSnapshotLimits = { ...CHAT_LIMITS, ...(options.limits ?? {}) };
+
+  /*
+   * 源码：kernel 是主角，先给声明过的那些。
+   *
+   * **平台的只读头文件要剔掉。** containers.h / engine.h / cuda_runtime.h 这些
+   * 是平台发的，学员改不了也不会改，每一关内容还完全一样 ——
+   * 把它们塞进去只会挤掉真正的 kernel（实测第 5 关就被 cluster.h 占了一段预算）。
+   * 模型需要知道这些接口时，提示词里让它让学员 `cat containers.h` 就够了。
+   *
+   * IDE 里仍然照常列出来：学员是要读它们的，那是另一回事。
+   */
+  const entries = Object.entries(options.sources ?? {})
+    .filter(([path]) => !(path in HOST_HEADERS));
+  const sources: GpuSnapshotSource[] = [];
+  let sourceBudget = MAX_SOURCES_TOTAL;
+  for (const [path, content] of entries) {
+    if (sources.length >= MAX_SOURCES || sourceBudget <= 0) break;
+    const room = Math.min(MAX_SOURCE_CHARS, sourceBudget);
+    const truncated = content.length > room;
+    const text = truncated ? clip(content, room) : content;
+    sources.push({ path, content: text, truncated });
+    sourceBudget -= text.length;
+  }
+
+  const history = options.history ?? [];
+  const recent = history.slice(-limits.commands);
+  const commands: GpuSnapshotCommand[] = recent.map((record) => ({
+    command: clip(record.command ?? '', MAX_COMMAND_TEXT),
+    code: num(record.code),
+    // stderr 在前：nvcc 的报错在 stderr 上，截断时不能先把它扔掉
+    output: clip(
+      [record.stderr, record.stdout].filter(Boolean).join('\n').trim(),
+      limits.commandOutput
+    ),
+  }));
+
+  let races: GpuSnapshotRace[] = [];
+  let raceTotal = 0;
+  try {
+    const report = world.gpu.sanitizerReport();
+    raceTotal = report.races.length + report.truncated;
+    races = report.races.slice(0, MAX_RACES).map((race) => ({
+      space: race.space,
+      address: race.address,
+      firstLine: race.first.line,
+      secondLine: race.second.line,
+    }));
+  } catch {
+    /* 没跑过就没有报告 */
+  }
+
+  let cluster: GpuSnapshotCluster | null = null;
+  if (world.cluster) {
+    try {
+      cluster = {
+        comm: world.cluster.comm,
+        pipeline: world.cluster.pipeline,
+        imbalance: num(world.cluster.imbalance()),
+      };
+    } catch {
+      cluster = null;
+    }
+  }
+
+  return {
+    profile: buildProfile(world),
+    sources,
+    commands,
+    races,
+    raceTotal,
+    cluster,
+    omitted: {
+      sources: Math.max(0, entries.length - sources.length),
+      commands: Math.max(0, history.length - commands.length),
+      races: Math.max(0, raceTotal - races.length),
+    },
+  };
+}
+
+export interface GpuGateSummary {
+  metric: string;
+  label: string;
+  op: string;
+  target: number;
+  actual: number;
+  passed: boolean;
+  unit?: string;
+}
+
+export interface GpuReportSummary {
+  status: string;
+  passed: number;
+  total: number;
+  failing: Array<{ name: string; error: string }>;
+  /** **全部**门槛，不只失败的：AI 要看得出「哪些已经到线了，别把它们改坏」 */
+  gates: GpuGateSummary[];
+  error?: string;
+}
+
+function gateLabel(gate: GateResult['gate'], language: 'en' | 'zh'): string {
+  const label = gate.label as unknown;
+  if (typeof label === 'string') return label;
+  if (label && typeof label === 'object') {
+    const localized = label as Record<string, string>;
+    return localized[language] ?? localized.zh ?? localized.en ?? gate.metric;
+  }
+  return gate.metric;
+}
+
+/**
+ * 把上次验收压成摘要。
+ *
+ * **门槛全带上，并且带实测值** —— 这是这个场景最关键的一段上下文。
+ * 「sectorsPerRequest 要 ≤ 4.5，实测 9.43」和「有个门槛没过」是完全不同的信息量：
+ * 前者能直接推出「访存没合并，差一倍多」，后者只能让 AI 泛泛地讲优化。
+ */
+export function summarizeGpuReport(
+  report: StageRunReport | null,
+  language: 'en' | 'zh' = 'zh'
+): GpuReportSummary | null {
+  if (!report) return null;
+  return {
+    status: report.status,
+    passed: report.totals.passed,
+    total: report.totals.total,
+    failing: report.cases
+      .filter((item) => !item.passed && item.error !== 'skipped')
+      .slice(0, MAX_FAILING_CASES)
+      .map((item) => ({
+        name: `${item.suite} > ${item.name}`,
+        error: clip(item.error ?? '', MAX_CASE_ERROR),
+      })),
+    gates: (report.gates ?? []).map((result) => ({
+      metric: result.gate.metric,
+      label: gateLabel(result.gate, language),
+      op: result.gate.op,
+      target: result.gate.value,
+      actual: result.actual,
+      passed: result.passed,
+      unit: result.gate.unit,
+    })),
+    ...(report.error ? { error: clip(report.error, MAX_CASE_ERROR) } : {}),
+  };
+}

--- a/src/lib/server/gpuPrompt.ts
+++ b/src/lib/server/gpuPrompt.ts
@@ -1,0 +1,225 @@
+/**
+ * 把 GPU 世界的快照排成给模型看的上下文
+ *
+ * 裁剪已经在客户端做完了（见 src/lib/gpulab/lab/aicontext.ts），这里只负责排版 ——
+ * 以及再兜一次总量：客户端是可以被绕过的，服务端不该假设请求体是善意的。
+ *
+ * **排版顺序就是重要性顺序，而这个顺序和 ops 那边不一样。**
+ * ops 是「先关卡、再终端、再集群哪儿不对」，因为答案通常在上一条报错里。
+ * GPU 这边最常见的处境是「跑通了但指标没到线」，所以顺序是：
+ * 关卡要求与门槛 → 上次验收的门槛实测值 → 当前 kernel 源码 → 剖析计量
+ * → 竞态 → 集群通信 → 终端最近几条。
+ * 门槛实测值排在源码前面，是因为它决定了「该往源码的哪儿看」。
+ */
+import type { LocalizedText } from '../engineering/types';
+import type { GpuSnapshot, GpuReportSummary } from '../gpulab/lab/aicontext';
+
+export interface GpuContext {
+  projectTitle?: LocalizedText;
+  projectSummary?: LocalizedText;
+  stageIndex?: number;
+  stageCount?: number;
+  stageTitle?: LocalizedText;
+  stageGoal?: LocalizedText;
+  checklist?: LocalizedText[];
+  /** 关卡声明的门槛（还没跑验收时也能让 AI 知道要达到什么） */
+  gates?: Array<{ metric: string; label?: LocalizedText; op: string; value: number; unit?: string }>;
+  snapshot?: GpuSnapshot;
+  report?: GpuReportSummary | null;
+}
+
+const MAX_TOTAL_CHARS = 40000;
+export const GPU_REVIEW_MAX_CHARS = 60000;
+
+function pick(text: LocalizedText | undefined, language: 'en' | 'zh'): string {
+  if (!text) return '';
+  return text[language] || text.zh || text.en || '';
+}
+
+/** 大数字读起来费劲，给个人类单位；门槛比对用的还是原始值 */
+function bytes(value: number): string {
+  if (!Number.isFinite(value)) return '0';
+  if (value >= 1024 * 1024) return `${(value / 1024 / 1024).toFixed(2)} MB (${value} B)`;
+  if (value >= 1024) return `${(value / 1024).toFixed(1)} KB (${value} B)`;
+  return `${value} B`;
+}
+
+const OP_TEXT: Record<string, string> = {
+  lte: '≤', gte: '≥', lt: '<', gt: '>', eq: '=',
+};
+
+/**
+ * 门槛那一行是这份上下文里信息密度最高的一行，所以写全：
+ * 指标路径、要求、实测、还差多少。「差多少」是模型自己算容易算错的东西，直接给。
+ */
+function gateLine(
+  gate: { metric: string; label: string; op: string; target: number; actual: number; passed: boolean; unit?: string },
+  zh: boolean
+): string {
+  const mark = gate.passed ? '✓' : '✗';
+  const unit = gate.unit ? ` ${gate.unit}` : '';
+  const op = OP_TEXT[gate.op] ?? gate.op;
+  const head = `  ${mark} ${gate.label} [${gate.metric}] ${zh ? '要求' : 'requires'} ${op} ${gate.target}${unit}，${zh ? '实测' : 'measured'} ${gate.actual}${unit}`;
+  if (gate.passed) return head;
+
+  // 还差多少：比值比差值好读 —— 「超出 2.1 倍」比「超出 4.93」更能指方向
+  const { op: rawOp, target, actual } = gate;
+  let gap = '';
+  if ((rawOp === 'lte' || rawOp === 'lt') && target > 0 && actual > target) {
+    gap = zh ? `，超出 ${(actual / target).toFixed(2)} 倍` : `, ${(actual / target).toFixed(2)}x over`;
+  } else if ((rawOp === 'gte' || rawOp === 'gt') && actual > 0 && actual < target) {
+    gap = zh ? `，只到要求的 ${((actual / target) * 100).toFixed(0)}%` : `, only ${((actual / target) * 100).toFixed(0)}% of target`;
+  }
+  return head + gap;
+}
+
+export function buildGpuContext(
+  context: GpuContext,
+  language: 'en' | 'zh',
+  maxChars: number = MAX_TOTAL_CHARS
+): string {
+  const zh = language === 'zh';
+  const sections: string[] = [];
+
+  /**
+   * 排版之前先把形状补齐。
+   *
+   * 这个函数是路由的最后一站，而请求体是外面来的 —— 一个缺了 sources 的
+   * snapshot 不该让整个路由抛 500。
+   */
+  const snapshot: GpuSnapshot = {
+    profile: null,
+    sources: [],
+    commands: [],
+    races: [],
+    raceTotal: 0,
+    cluster: null,
+    omitted: { sources: 0, commands: 0, races: 0 },
+    ...(context.snapshot ?? {}),
+  };
+  snapshot.sources = Array.isArray(snapshot.sources) ? snapshot.sources : [];
+  snapshot.commands = Array.isArray(snapshot.commands) ? snapshot.commands : [];
+  snapshot.races = Array.isArray(snapshot.races) ? snapshot.races : [];
+
+  /* ---- 关卡 ---- */
+  const stageHead = [
+    `${zh ? '项目' : 'Project'}: ${pick(context.projectTitle, language)}`,
+    pick(context.projectSummary, language),
+    `${zh ? '关卡' : 'Stage'} ${(context.stageIndex ?? 0) + 1}/${context.stageCount ?? '?'}: ${pick(context.stageTitle, language)}`,
+    '',
+    pick(context.stageGoal, language),
+  ].filter(Boolean).join('\n');
+  sections.push(`## ${zh ? '这一关' : 'This stage'}\n${stageHead}`);
+
+  if (context.checklist?.length) {
+    sections.push(
+      `## ${zh ? '通关标准' : 'Done when'}\n` +
+      context.checklist.map((item) => `- ${pick(item, language)}`).join('\n')
+    );
+  }
+
+  /* ---- 门槛：这是最要紧的一段 ---- */
+  const report = context.report;
+  if (report?.gates?.length) {
+    const failing = report.gates.filter((gate) => !gate.passed);
+    const passing = report.gates.filter((gate) => gate.passed);
+    const lines: string[] = [];
+    if (failing.length) {
+      lines.push(zh ? '没到线的：' : 'Not met:');
+      lines.push(...failing.map((gate) => gateLine(gate, zh)));
+    }
+    if (passing.length) {
+      lines.push(zh ? '已经到线的（改动别把它们弄坏）：' : 'Already met (do not regress these):');
+      lines.push(...passing.map((gate) => gateLine(gate, zh)));
+    }
+    sections.push(`## ${zh ? '上次验收的门槛' : 'Gates from the last run'}\n${lines.join('\n')}`);
+  } else if (context.gates?.length) {
+    // 还没跑过验收：至少让 AI 知道这一关要达到什么
+    sections.push(
+      `## ${zh ? '这一关的门槛（还没跑过验收）' : 'Gates for this stage (not run yet)'}\n` +
+      context.gates.map((gate) => {
+        const op = OP_TEXT[gate.op] ?? gate.op;
+        const unit = gate.unit ? ` ${gate.unit}` : '';
+        return `  · ${pick(gate.label, language) || gate.metric} [${gate.metric}] ${op} ${gate.value}${unit}`;
+      }).join('\n')
+    );
+  }
+
+  /* ---- 验收用例 ---- */
+  if (report) {
+    const head = `${zh ? '状态' : 'Status'}: ${report.status} — ${report.passed}/${report.total} ${zh ? '用例通过' : 'cases passed'}`;
+    const failing = report.failing?.length
+      ? '\n' + report.failing.map((item) => `  ✗ ${item.name}\n    ${item.error.split('\n').join('\n    ')}`).join('\n')
+      : '';
+    const err = report.error ? `\n${zh ? '运行错误' : 'Run error'}: ${report.error}` : '';
+    sections.push(`## ${zh ? '上次验收' : 'Last verification'}\n${head}${failing}${err}`);
+  }
+
+  /* ---- 当前 kernel 源码 ---- */
+  if (snapshot.sources.length) {
+    const body = snapshot.sources
+      .map((file) => `### ${file.path}${file.truncated ? zh ? '（已截断）' : ' (truncated)' : ''}\n\`\`\`cuda\n${file.content}\n\`\`\``)
+      .join('\n\n');
+    sections.push(`## ${zh ? '学员当前的源码' : 'Their current source'}\n${body}`);
+  }
+
+  /* ---- 剖析计量 ---- */
+  const profile = snapshot.profile;
+  if (profile) {
+    const lines = [
+      `${zh ? '设备' : 'Device'}: ${profile.device}`,
+      `${zh ? '访存合并' : 'Coalescing'}: sectorsPerRequest = ${profile.sectorsPerRequest.toFixed(2)} (${zh ? '完全合并 4.0，完全发散 32.0' : '4.0 fully coalesced, 32.0 fully scattered'})`,
+      `${zh ? '全局访存扇区' : 'Global sectors'}: load ${profile.globalLoadSectors}, store ${profile.globalStoreSectors}`,
+      `DRAM: read ${bytes(profile.dramReadBytes)}, write ${bytes(profile.dramWriteBytes)}`,
+      `${zh ? '共享内存 bank 冲突' : 'Shared bank conflicts'}: ${profile.sharedBankConflicts}`,
+      `${zh ? '本地内存（寄存器溢出）' : 'Local memory (register spill)'}: ${bytes(profile.localBytes)}`,
+      `${zh ? '分支发散' : 'Divergent branches'}: ${profile.divergentBranches}, ${zh ? '活跃 lane 比例' : 'active lane ratio'} ${profile.activeLaneRatio.toFixed(3)}`,
+      `${zh ? '原子操作' : 'Atomics'}: ${profile.atomics}`,
+      `${zh ? '指令' : 'Instructions'}: warp ${profile.inst.warpExecuted}, fma ${profile.inst.fma}, ldst ${profile.inst.ldst}, sfu ${profile.inst.sfu}, mma ${profile.inst.mma}`,
+      `${zh ? '启动' : 'Launch'}: ${profile.launch.blocks} blocks, ${profile.launch.warps} warps, ${profile.launch.barriers} barriers, ${profile.launch.kernels} kernels`,
+      `${zh ? '寄存器/线程' : 'Registers/thread'}: ${profile.registersPerThread}, ${zh ? '理论占用率' : 'theoretical occupancy'} ${(profile.occupancy * 100).toFixed(1)}% (${profile.warpsPerSm} warps/SM)`,
+      `${zh ? '显存峰值' : 'Peak device memory'}: ${bytes(profile.memoryPeakBytes)}`,
+      `${zh ? '算术强度' : 'Arithmetic intensity'}: ${profile.arithmeticIntensity.toFixed(3)} FLOP/byte`,
+      // 周期数放最后并且带上警告：它是估的，不能当绝对值用
+      `${zh ? '模拟周期' : 'Simulated cycles'}: ${profile.cycles}${profile.bottleneck ? `, ${zh ? '瓶颈' : 'bottleneck'} ${profile.bottleneck}` : ''} — ${zh ? '**只能同关相对比较，没有真卡校准，不要当绝对性能**' : '**relative comparison within this stage only; not calibrated against real hardware**'}`,
+    ];
+    sections.push(`## ${zh ? '剖析计量（上次运行）' : 'Profile counters (last run)'}\n${lines.join('\n')}`);
+  }
+
+  /* ---- 竞态 ---- */
+  if (snapshot.raceTotal > 0) {
+    const lines = snapshot.races.map(
+      (race) => `  ${race.space} @ 0x${race.address.toString(16)} — ${zh ? '行' : 'line'} ${race.firstLine} ↔ ${race.secondLine}`
+    );
+    const more = snapshot.omitted.races > 0
+      ? `\n  ${zh ? `（还有 ${snapshot.omitted.races} 条同类记录没列出来）` : `(${snapshot.omitted.races} more not listed)`}`
+      : '';
+    sections.push(`## ${zh ? 'compute-sanitizer 竞态' : 'compute-sanitizer races'}\n${zh ? '共' : 'total'} ${snapshot.raceTotal}\n${lines.join('\n')}${more}`);
+  }
+
+  /* ---- 集群 ---- */
+  if (snapshot.cluster) {
+    sections.push(
+      `## ${zh ? '集群通信' : 'Cluster communication'}\n` +
+      `${zh ? '通信量' : 'comm'}: ${JSON.stringify(snapshot.cluster.comm)}\n` +
+      `${zh ? '流水线' : 'pipeline'}: ${JSON.stringify(snapshot.cluster.pipeline)}\n` +
+      `${zh ? '负载不均衡度' : 'imbalance'}: ${snapshot.cluster.imbalance.toFixed(4)}`
+    );
+  }
+
+  /* ---- 终端 ---- */
+  if (snapshot.commands.length) {
+    const lines = snapshot.commands.map((entry) => {
+      const mark = entry.code === 0 ? '' : ` (exit ${entry.code})`;
+      return `$ ${entry.command}${mark}\n${entry.output || (zh ? '（无输出）' : '(no output)')}`;
+    });
+    const more = snapshot.omitted.commands > 0
+      ? `\n${zh ? `（更早的 ${snapshot.omitted.commands} 条没列出来）` : `(${snapshot.omitted.commands} earlier commands not listed)`}`
+      : '';
+    sections.push(`## ${zh ? '终端最近的命令' : 'Recent terminal commands'}\n${lines.join('\n\n')}${more}`);
+  }
+
+  const text = sections.join('\n\n');
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n\n…${zh ? '（上下文超长，已截断）' : '(context truncated)'}`;
+}

--- a/src/lib/server/gpuPrompt.ts
+++ b/src/lib/server/gpuPrompt.ts
@@ -44,6 +44,20 @@ function bytes(value: number): string {
   return `${value} B`;
 }
 
+/**
+ * 数字排版。
+ *
+ * 整数原样，小数最多四位。理由不只是好看：模拟周期打成 `8.583259701492537`
+ * 会给出一种「这个数精确到 10^-15」的暗示，而它下一行就写着「没有真卡校准」——
+ * 两句话互相矛盾的时候，模型信哪一句是没法预期的。
+ * 门槛的实测值同理：`0.9705882352941176` 里有用的信息只有前几位。
+ */
+function n(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  if (Number.isInteger(value)) return String(value);
+  return String(Number(value.toFixed(4)));
+}
+
 const OP_TEXT: Record<string, string> = {
   lte: '≤', gte: '≥', lt: '<', gt: '>', eq: '=',
 };
@@ -59,7 +73,7 @@ function gateLine(
   const mark = gate.passed ? '✓' : '✗';
   const unit = gate.unit ? ` ${gate.unit}` : '';
   const op = OP_TEXT[gate.op] ?? gate.op;
-  const head = `  ${mark} ${gate.label} [${gate.metric}] ${zh ? '要求' : 'requires'} ${op} ${gate.target}${unit}，${zh ? '实测' : 'measured'} ${gate.actual}${unit}`;
+  const head = `  ${mark} ${gate.label} [${gate.metric}] ${zh ? '要求' : 'requires'} ${op} ${n(gate.target)}${unit}，${zh ? '实测' : 'measured'} ${n(gate.actual)}${unit}`;
   if (gate.passed) return head;
 
   // 还差多少：比值比差值好读 —— 「超出 2.1 倍」比「超出 4.93」更能指方向
@@ -140,7 +154,7 @@ export function buildGpuContext(
       context.gates.map((gate) => {
         const op = OP_TEXT[gate.op] ?? gate.op;
         const unit = gate.unit ? ` ${gate.unit}` : '';
-        return `  · ${pick(gate.label, language) || gate.metric} [${gate.metric}] ${op} ${gate.value}${unit}`;
+        return `  · ${pick(gate.label, language) || gate.metric} [${gate.metric}] ${op} ${n(gate.value)}${unit}`;
       }).join('\n')
     );
   }
@@ -181,7 +195,7 @@ export function buildGpuContext(
       `${zh ? '显存峰值' : 'Peak device memory'}: ${bytes(profile.memoryPeakBytes)}`,
       `${zh ? '算术强度' : 'Arithmetic intensity'}: ${profile.arithmeticIntensity.toFixed(3)} FLOP/byte`,
       // 周期数放最后并且带上警告：它是估的，不能当绝对值用
-      `${zh ? '模拟周期' : 'Simulated cycles'}: ${profile.cycles}${profile.bottleneck ? `, ${zh ? '瓶颈' : 'bottleneck'} ${profile.bottleneck}` : ''} — ${zh ? '**只能同关相对比较，没有真卡校准，不要当绝对性能**' : '**relative comparison within this stage only; not calibrated against real hardware**'}`,
+      `${zh ? '模拟周期' : 'Simulated cycles'}: ${n(profile.cycles)}${profile.bottleneck ? `, ${zh ? '瓶颈' : 'bottleneck'} ${profile.bottleneck}` : ''} — ${zh ? '**只能同关相对比较，没有真卡校准，不要当绝对性能**' : '**relative comparison within this stage only; not calibrated against real hardware**'}`,
     ];
     sections.push(`## ${zh ? '剖析计量（上次运行）' : 'Profile counters (last run)'}\n${lines.join('\n')}`);
   }

--- a/tests/engineering/workspace-parity.test.ts
+++ b/tests/engineering/workspace-parity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * 两个实战工作台的能力对齐
+ *
+ * ## 这道闸门也是补出来的，而且是第二次
+ *
+ * 第一次是 gpulab 的工作台 UI 整个没写（见 workspace-dispatch.test.ts）。
+ * 第二次是 gpulab 有了工作台，但**没有 AI 助手也没有复盘** —— ops 那边两样都有，
+ * gpu 这边直到用户提出来才发现。两次是同一个形态：
+ * ops 先落地，gpu 后落地，中间漏掉的能力没有任何东西在盯。
+ *
+ * 所以这条用例问得同样笨：**ops 有的这几样东西，gpu 必须也有。**
+ * 它拦不住「gpu 的实现质量不如 ops」，但拦得住「gpu 压根没有这一样」——
+ * 而后者才是连着发生了两次的事。
+ *
+ * 只对齐**两边都该有**的能力。拓扑图、包路径是 K8s 独有的，
+ * 剖析、访存是 GPU 独有的，那些不在这张表里。
+ */
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..');
+
+function read(relative: string): string {
+  return readFileSync(join(ROOT, relative), 'utf8');
+}
+
+const OPS_WORKSPACE = 'src/components/opslab/OpsWorkspace.tsx';
+const GPU_WORKSPACE = 'src/components/gpulab/GpuWorkspace.tsx';
+
+describe('AI 能力', () => {
+  /** 两边都要有的那几样：对话路由、复盘路由、上下文裁剪、两个组件 */
+  const PAIRS: Array<{ what: string; ops: string; gpu: string }> = [
+    { what: '对话路由', ops: 'pages/api/ops-chat.ts', gpu: 'pages/api/gpu-chat.ts' },
+    { what: '复盘路由', ops: 'pages/api/ops-review.ts', gpu: 'pages/api/gpu-review.ts' },
+    { what: '提示词排版', ops: 'src/lib/server/opsPrompt.ts', gpu: 'src/lib/server/gpuPrompt.ts' },
+    { what: '上下文裁剪', ops: 'src/lib/opslab/lab/aicontext.ts', gpu: 'src/lib/gpulab/lab/aicontext.ts' },
+    { what: '对话组件', ops: 'src/components/opslab/OpsChat.tsx', gpu: 'src/components/gpulab/GpuChat.tsx' },
+    { what: '复盘组件', ops: 'src/components/opslab/OpsReview.tsx', gpu: 'src/components/gpulab/GpuReview.tsx' },
+  ];
+
+  it.each(PAIRS)('$what：ops 有，gpu 也必须有', ({ ops, gpu }) => {
+    // 先确认 ops 那边真的存在 —— 否则这条用例会因为「两边都没有」而假通过
+    expect(existsSync(join(ROOT, ops))).toBe(true);
+    expect(existsSync(join(ROOT, gpu))).toBe(true);
+  });
+
+  it('两个工作台都把对话挂进了右栏 tab', () => {
+    for (const file of [OPS_WORKSPACE, GPU_WORKSPACE]) {
+      const source = read(file);
+      expect(source).toMatch(/Tabs\.Tab value="chat"/);
+      expect(source).toMatch(/Tabs\.Panel value="chat"/);
+    }
+  });
+
+  it('两个工作台都把复盘挂进了左栏 tab', () => {
+    for (const file of [OPS_WORKSPACE, GPU_WORKSPACE]) {
+      const source = read(file);
+      expect(source).toMatch(/Tabs\.Tab value="review"/);
+      expect(source).toMatch(/Tabs\.Panel value="review"/);
+    }
+  });
+
+  it('两套复盘维度各自定义，不能互相借用', () => {
+    const types = read('src/lib/engineering/types.ts');
+    expect(types).toContain('OPS_DIMENSION_KEYS');
+    expect(types).toContain('GPU_DIMENSION_KEYS');
+  });
+
+  it('两边的文案键都齐，中英各一份', () => {
+    const zh = JSON.parse(read('locales/zh.json'));
+    const en = JSON.parse(read('locales/en.json'));
+    for (const locale of [zh, en]) {
+      for (const namespace of ['opslab', 'gpulab']) {
+        expect(locale[namespace]?.chat?.placeholder).toBeTruthy();
+        expect(locale[namespace]?.review?.title).toBeTruthy();
+        expect(Object.keys(locale[namespace]?.review?.dimensions ?? {}).length).toBeGreaterThanOrEqual(5);
+      }
+    }
+  });
+});
+
+describe('IDE 的文件列表是磁盘的实时投影', () => {
+  /**
+   * gpu 这边曾经只取关卡声明的那份清单，并且钉死在 stageKey 上 ——
+   * 学员在终端里 `cp` 出来的文件，IDE 里永远看不到。ops 那边一直是实时投影。
+   */
+  it('两边都从 vfs 现读，而不是只认关卡声明的清单', () => {
+    expect(read(OPS_WORKSPACE)).toContain('toFileMap');
+    expect(read('src/hooks/useGpuWorkspace.ts')).toContain('toFileMap');
+  });
+});
+
+describe('只读，不代劳', () => {
+  /**
+   * 两个助手都不能替学员动手：判定读的就是执行结果，
+   * 能替他改代码 / 改集群的助手等于能替他通关。
+   * 这条盯的是提示词里那句话没被删掉。
+   */
+  it('两份提示词里都写着「没有手」', () => {
+    expect(read('pages/api/ops-chat.ts')).toContain('You have no hands');
+    expect(read('pages/api/gpu-chat.ts')).toContain('You have no hands');
+  });
+
+  it('两个对话路由都不导出任何能改世界的东西', () => {
+    for (const file of ['pages/api/ops-chat.ts', 'pages/api/gpu-chat.ts']) {
+      const source = read(file);
+      // 路由只该 stream 出去，不该 import 执行器 / 判定器
+      expect(source).not.toContain('runGpuStage');
+      expect(source).not.toContain('runOpsStage');
+      expect(source).not.toContain('writeFile');
+    }
+  });
+});

--- a/tests/gpulab/aicontext-size.test.ts
+++ b/tests/gpulab/aicontext-size.test.ts
@@ -1,0 +1,111 @@
+/**
+ * 真实关卡下的上下文体积
+ *
+ * 上面那组（aicontext.test.ts）用的是合成素材，盯的是上限。
+ * 这一条跑**项目里真的关卡**：真的 kernel、真的门槛、真的验收报告，
+ * 量出来的比值才是「裁剪有没有意义」的答案。
+ *
+ * 挑集群关是因为它是最坏情况：源码最长、通信计量最多，还多一份流水线数据。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { buildWorld, runGpuStage } from '../../src/lib/gpulab/lab';
+import { buildGpuSnapshot, summarizeGpuReport } from '../../src/lib/gpulab/lab/aicontext';
+import { buildGpuContext } from '../../src/lib/server/gpuPrompt';
+import { createTranspiler } from '../../src/lib/engineering/transpile';
+import type {
+  EngineeringProject, GpuStageSpec, ProjectStage,
+} from '../../src/lib/engineering/types';
+import type { CommandRecord } from '../../src/lib/labkit/machine';
+
+jest.setTimeout(600_000);
+
+const PROJECTS: EngineeringProject[] = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../../projects/projects.json'), 'utf8')
+);
+const project = PROJECTS.find((item) => item.workspace?.kind === 'gpu')!;
+const transpile = createTranspiler(ts);
+
+/** 拿一关来跑：铺参考解、编译、跑、profile，然后量上下文 */
+async function measure(stageIndex: number) {
+  const stage = project.stages[stageIndex];
+  const gpu = (stage as ProjectStage & { gpu?: GpuStageSpec }).gpu ?? {};
+  const worldSpec = project.workspace?.kind === 'gpu' ? project.workspace.world : undefined;
+
+  const world = buildWorld({
+    ...(worldSpec ?? {}),
+    ...(gpu.world ?? {}),
+    ...(gpu.sharedBytesPerBlock ? { sharedBytesPerBlock: gpu.sharedBytesPerBlock } : {}),
+    machine: {
+      ...(worldSpec?.machine ?? {}),
+      files: {
+        ...(worldSpec?.machine?.files ?? {}),
+        ...(gpu.files ?? {}),
+        ...(gpu.referenceFiles ?? {}),
+      },
+    },
+    bench: gpu.bench ?? worldSpec?.bench,
+  });
+
+  for (const command of gpu.setupCommands ?? []) await world.run(command);
+  for (const command of gpu.referenceCommands ?? []) await world.run(command);
+  // 学员真会敲的那几条
+  await world.run('ncu ./bench');
+  await world.run('compute-sanitizer --tool racecheck ./bench');
+
+  const report = await runGpuStage({
+    world, specs: stage.specs ?? [], gates: stage.gates ?? [], transpile,
+  });
+
+  const history = world.machine.transcript() as CommandRecord[];
+  const sources: Record<string, string> = {};
+  for (const [p, content] of Object.entries(gpu.referenceFiles ?? {})) sources[p] = String(content);
+
+  // 原始素材：整棵磁盘 + 全部命令 + 完整计量树 + 完整报告
+  const raw = JSON.stringify({
+    files: world.machine.vfs.toFileMap('/'),
+    history,
+    metrics: world.gpu.metrics(),
+    sanitizer: world.gpu.sanitizerReport(),
+    report,
+  });
+
+  const snapshot = buildGpuSnapshot(world, { sources, history });
+  const payload = JSON.stringify({
+    messages: [{ role: 'user', content: '这条门槛差在哪' }],
+    context: {
+      snapshot,
+      report: summarizeGpuReport(report),
+      stageTitle: stage.title,
+      stageGoal: stage.goal,
+    },
+  });
+  const prompt = buildGpuContext(
+    { snapshot, report: summarizeGpuReport(report), stageTitle: stage.title, stageGoal: stage.goal } as never,
+    'zh'
+  );
+
+  return { stage, raw, payload, prompt, snapshot, history };
+}
+
+it('真实关卡（集群关，最坏情况）的上下文体积', async () => {
+  const last = project.stages.length - 1;
+  const { stage, raw, payload, prompt, snapshot, history } = await measure(last);
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `\n  第 ${last + 1} 关「${stage.title.zh}」\n` +
+    `  原始素材 ${(raw.length / 1024).toFixed(1)} KB` +
+    ` -> 请求体 ${(payload.length / 1024).toFixed(1)} KB` +
+    ` -> 排版后 ${(prompt.length / 1024).toFixed(1)} KB\n` +
+    `  （命令 ${history.length} 条，带进去 ${snapshot.commands.length} 条；` +
+    `源码 ${snapshot.sources.length} 份）\n`
+  );
+
+  // 真实关卡下必须是小几十 KB 量级，离 1mb 差着两个数量级
+  expect(payload.length).toBeLessThan(120_000);
+  // 也不能压成空壳：门槛与源码是这个场景的主角
+  expect(prompt).toContain('sectorsPerRequest');
+  expect(snapshot.sources.length).toBeGreaterThan(0);
+});

--- a/tests/gpulab/aicontext.test.ts
+++ b/tests/gpulab/aicontext.test.ts
@@ -1,0 +1,218 @@
+/**
+ * 喂给 AI 的 GPU 快照
+ *
+ * 这一组存在的理由和 ops 那边一样：工程对话曾经把整个工作区发上去，
+ * 撞在 Next 默认的 1mb 请求体上限上，中等项目直接 413 —— 不是变慢，是不可用。
+ *
+ * GPU 这边有一个 ops 没有的失控源：**访存轨迹**。一个 N=256 的 GEMM 的
+ * AccessTrace 是几十万条记录，真塞进去请求体直接以 MB 计。所以这里除了盯体积，
+ * 还专门有一条盯「轨迹没被带进去」—— 需要的是它算出来的结论（扇区数、bank 冲突），
+ * 不是原始轨迹。
+ */
+import { createGpuWorld } from '../../src/lib/gpulab/lab';
+import {
+  buildGpuSnapshot, summarizeGpuReport, GPU_SNAPSHOT_LIMITS,
+} from '../../src/lib/gpulab/lab/aicontext';
+import { buildGpuContext, GPU_REVIEW_MAX_CHARS } from '../../src/lib/server/gpuPrompt';
+import type { GpuWorld } from '../../src/lib/gpulab/lab';
+import type { StageRunReport } from '../../src/lib/engineering/types';
+import type { CommandRecord } from '../../src/lib/labkit/machine';
+
+jest.setTimeout(120_000);
+
+const WORLD_SPEC = {
+  seed: 20260826,
+  device: 'H100' as const,
+  globalBytes: 8 * 1024 * 1024,
+  sharedBytesPerBlock: 48 * 1024,
+  machine: { hostname: 'gpu-01', user: 'root', cwd: '/root' },
+};
+
+function world(): GpuWorld {
+  return createGpuWorld(WORLD_SPEC);
+}
+
+function command(line: string, code: number, output: string): CommandRecord {
+  return { command: line, code, stdout: output, stderr: code === 0 ? '' : output, at: 0 } as CommandRecord;
+}
+
+function report(overrides: Partial<StageRunReport> = {}): StageRunReport {
+  return {
+    status: 'failed',
+    totals: { total: 4, passed: 3, failed: 1 },
+    cases: [
+      { suite: '正确性', name: '结果对得上', passed: true, durationMs: 3 },
+      { suite: '合并访问', name: '扇区数达标', passed: false, durationMs: 5, error: 'x'.repeat(4000) },
+    ],
+    gates: [
+      {
+        gate: {
+          metric: 'gpu.global.sectorsPerRequest', op: 'lte', value: 4.5,
+          label: { zh: '每次访存打到的 32B 扇区数', en: 'sectors per request' }, unit: 'sector/req',
+        },
+        actual: 9.43,
+        passed: false,
+      },
+      {
+        gate: {
+          metric: 'gpu.sanitizer.races', op: 'eq', value: 0,
+          label: { zh: '数据竞态', en: 'data races' },
+        },
+        actual: 0,
+        passed: true,
+      },
+    ],
+    metrics: {} as StageRunReport['metrics'],
+    console: [],
+    wallClockMs: 12,
+    ...overrides,
+  } as StageRunReport;
+}
+
+describe('体积', () => {
+  /**
+   * 这一条是这组测试存在的理由。
+   *
+   * 六个大源文件 + 40 条各 20KB 输出的命令，原始素材是好几 MB；
+   * 压出来必须远低于 Next 的默认 1mb，就算将来有人把 sizeLimit 改回默认值也不该挂。
+   */
+  it('大量源码与长输出下请求体远低于 1mb', () => {
+    const sources: Record<string, string> = {};
+    for (let i = 0; i < 12; i += 1) sources[`/root/kernel-${i}.cu`] = 'a'.repeat(30000);
+    const history = Array.from({ length: 40 }, (_, i) =>
+      command(`nvcc -o bench k${i}.cu`, i % 3 === 0 ? 1 : 0, 'z'.repeat(20000)));
+
+    const snapshot = buildGpuSnapshot(world(), { sources, history });
+    const payload = JSON.stringify({
+      messages: [{ role: 'user', content: '为什么没到线' }],
+      context: { snapshot, report: summarizeGpuReport(report()) },
+    });
+
+    expect(payload.length).toBeLessThan(200_000);
+    // 也不能压过头压成空壳
+    expect(snapshot.sources.length).toBeGreaterThan(0);
+    expect(snapshot.commands.length).toBe(GPU_SNAPSHOT_LIMITS.chat.commands);
+  });
+
+  it('**平台的只读头文件不进上下文** —— 每关都一样，只会挤掉真正的 kernel', () => {
+    const snapshot = buildGpuSnapshot(world(), {
+      sources: {
+        '/root/reduce.cu': '__global__ void k() {}',
+        '/root/containers.h': 'x'.repeat(5000),
+        '/root/cluster.h': 'y'.repeat(5000),
+        '/root/cuda_runtime.h': 'z'.repeat(5000),
+      },
+    });
+    expect(snapshot.sources.map((file) => file.path)).toEqual(['/root/reduce.cu']);
+  });
+
+  it('源文件有总预算，超了就不再带', () => {
+    const sources: Record<string, string> = {};
+    for (let i = 0; i < 10; i += 1) sources[`/root/f-${i}.cu`] = 'b'.repeat(9000);
+    const snapshot = buildGpuSnapshot(world(), { sources });
+
+    const total = snapshot.sources.reduce((sum, file) => sum + file.content.length, 0);
+    expect(total).toBeLessThanOrEqual(22000);
+    expect(snapshot.sources.length).toBeLessThan(10);
+    expect(snapshot.omitted.sources).toBeGreaterThan(0);
+  });
+
+  it('对话与复盘是两套预算：复盘条数多、单条短', () => {
+    const history = Array.from({ length: 60 }, (_, i) => command(`ncu ./bench # ${i}`, 0, 'y'.repeat(5000)));
+    const chat = buildGpuSnapshot(world(), { history });
+    const review = buildGpuSnapshot(world(), { history, limits: GPU_SNAPSHOT_LIMITS.review });
+
+    expect(chat.commands.length).toBe(8);
+    expect(review.commands.length).toBe(40);
+    // 复盘看的是顺序，单条截得更狠
+    expect(review.commands[0].output.length).toBeLessThan(chat.commands[0].output.length);
+  });
+
+  it('**访存轨迹不会被带进快照** —— 它有几十万条，要的是它算出来的扇区数', () => {
+    const snapshot = buildGpuSnapshot(world(), { sources: { '/root/k.cu': 'int x;' } });
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain('trace');
+    expect(serialized).not.toContain('accesses');
+    // 但结论要在
+    expect(snapshot.profile).not.toBeNull();
+    expect(snapshot.profile).toHaveProperty('sectorsPerRequest');
+    expect(snapshot.profile).toHaveProperty('sharedBankConflicts');
+  });
+
+  it('服务端还会再兜一次总量 —— 客户端是可以被绕过的', () => {
+    const huge = {
+      snapshot: {
+        ...buildGpuSnapshot(world()),
+        // 伪造一个没经过客户端裁剪的请求
+        sources: [{ path: '/root/evil.cu', content: 'q'.repeat(500000), truncated: false }],
+      },
+    };
+    const text = buildGpuContext(huge as never, 'zh');
+    expect(text.length).toBeLessThanOrEqual(40000 + 200);
+  });
+});
+
+describe('门槛摘要 —— 这个场景最关键的一段上下文', () => {
+  it('带上每条门槛的指标名、目标值与实测值', () => {
+    const summary = summarizeGpuReport(report());
+    expect(summary).not.toBeNull();
+    const gate = summary!.gates.find((item) => item.metric === 'gpu.global.sectorsPerRequest');
+    expect(gate).toMatchObject({ op: 'lte', target: 4.5, actual: 9.43, passed: false });
+  });
+
+  it('**已经通过的门槛也带上** —— AI 得知道哪些别改坏', () => {
+    const summary = summarizeGpuReport(report());
+    expect(summary!.gates.some((gate) => gate.passed)).toBe(true);
+    expect(summary!.gates).toHaveLength(2);
+  });
+
+  it('门槛标签按语言取', () => {
+    expect(summarizeGpuReport(report(), 'en')!.gates[0].label).toBe('sectors per request');
+    expect(summarizeGpuReport(report(), 'zh')!.gates[0].label).toBe('每次访存打到的 32B 扇区数');
+  });
+
+  it('排版里写出「差多少」，模型不用自己算', () => {
+    const text = buildGpuContext({ report: summarizeGpuReport(report()) } as never, 'zh');
+    expect(text).toContain('9.43');
+    expect(text).toContain('4.5');
+    // 9.43 / 4.5 = 2.10
+    expect(text).toContain('2.10');
+  });
+
+  it('没跑过验收时用关卡声明的门槛，不至于什么都不知道', () => {
+    const text = buildGpuContext({
+      gates: [{ metric: 'gpu.memory.readBytes', op: 'lte', value: 1024, unit: 'B' }],
+    } as never, 'zh');
+    expect(text).toContain('gpu.memory.readBytes');
+    expect(text).toContain('1024');
+  });
+
+  it('失败用例的报错会截断但不丢', () => {
+    const summary = summarizeGpuReport(report());
+    expect(summary!.failing).toHaveLength(1);
+    expect(summary!.failing[0].error.length).toBeLessThan(1000);
+  });
+});
+
+describe('排版', () => {
+  it('缺字段的 snapshot 不该让排版抛异常', () => {
+    expect(() => buildGpuContext({ snapshot: {} } as never, 'zh')).not.toThrow();
+    expect(() => buildGpuContext({} as never, 'en')).not.toThrow();
+  });
+
+  it('周期数旁边必须写着「只能相对比较」', () => {
+    const snapshot = buildGpuSnapshot(world());
+    const text = buildGpuContext({ snapshot } as never, 'zh');
+    expect(text).toMatch(/相对比较/);
+  });
+
+  it('命令输出里 stderr 排在 stdout 前面 —— nvcc 的报错在 stderr 上', () => {
+    const record = { command: 'nvcc bench.cu', code: 1, stdout: 'OUT', stderr: 'ERR', at: 0 } as CommandRecord;
+    const snapshot = buildGpuSnapshot(world(), { history: [record] });
+    expect(snapshot.commands[0].output.indexOf('ERR')).toBeLessThan(snapshot.commands[0].output.indexOf('OUT'));
+  });
+
+  it('复盘的额度比对话高', () => {
+    expect(GPU_REVIEW_MAX_CHARS).toBeGreaterThan(40000);
+  });
+});

--- a/tests/gpulab/aicontext.test.ts
+++ b/tests/gpulab/aicontext.test.ts
@@ -179,6 +179,19 @@ describe('门槛摘要 —— 这个场景最关键的一段上下文', () => {
     expect(text).toContain('2.10');
   });
 
+  it('**数字不打成 16 位小数** —— 下一行写着「没有真卡校准」，上一行却精确到 10^-15，模型信哪句都不对', () => {
+    const noisy = report({
+      gates: [{
+        gate: { metric: 'gpu.warp.activeLaneRatio', op: 'gte', value: 0.9, label: { zh: '活跃 lane 占比', en: 'active lanes' } },
+        actual: 0.9705882352941176,
+        passed: true,
+      }],
+    });
+    const text = buildGpuContext({ report: summarizeGpuReport(noisy) } as never, 'zh');
+    expect(text).toContain('0.9706');
+    expect(text).not.toContain('0.9705882352941176');
+  });
+
   it('没跑过验收时用关卡声明的门槛，不至于什么都不知道', () => {
     const text = buildGpuContext({
       gates: [{ metric: 'gpu.memory.readBytes', op: 'lte', value: 1024, unit: 'B' }],


### PR DESCRIPTION
ops 工作台有对话和复盘，gpu 工作台一样都没有。这是**第二次**发现同一形态的缺口（上次是整个工作台 UI 没写），所以除了补功能，也补了盯它的用例。

## 上下文喂的是这个场景真正有用的东西

GPU 的处境和 ops 不一样。ops 的学员卡住时答案通常在上一条命令的报错里；GPU 这边最常见的是**「结果算对了，但某个指标没到线」**——光看报错没用，得知道差多少、差在哪个计量上。所以排版顺序是：

```
关卡与门槛 → 上次验收每条门槛的实测值 → 当前 kernel 源码 → 剖析计量
→ 竞态 → 集群通信 → 终端最近的命令
```

门槛那一节**排在源码前面**，因为它决定了该往源码的哪儿看。而且直接写出「差多少」——这是模型自己算容易算错的东西。真实 e2e 抓到的那一段：

```
## 上次验收的门槛
没到线的：
  ✗ 原子操作次数（未优化时是 4096） [gpu.atomics] 要求 ≤ 128，实测 4096，超出 32.00 倍
  ✗ warp 内交换指令数 [gpu.warp.shuffles] 要求 ≥ 1，实测 0
已经到线的（改动别把它们弄坏）：
  ✓ 数据竞态 [gpu.sanitizer.races] 要求 = 0，实测 0
  ✓ 活跃 lane 占比 [gpu.warp.activeLaneRatio] 要求 ≥ 0.9，实测 0.9705882352941176
```

通过的门槛也带上 —— AI 得知道哪些别改坏。

## 体积

裁剪在客户端做，服务端只排版并**再兜一次总量**（客户端可以被绕过）。

| | |
|---|---|
| 合成最坏情况 | 原始 **1.11 MB** → 请求体 **33.4 KB** |
| 真实第 29 关（集群关，最坏） | 13.6 KB → 7.5 KB → 排版后 5.1 KB |

**访存轨迹绝不进上下文。** 一个 N=256 的 GEMM 有几十万条记录，而它存在的意义就是算出扇区数和 bank 冲突 —— 那两个数已经在计量里了。有一条用例专门盯这个。

顺带剔掉平台的六个只读头文件（`containers.h` / `cuda_runtime.h` …）：学员改不了、每关还完全一样，塞进去只会挤掉真正的 kernel。**这是 e2e 里发现的**——第 5 关实测被 `cluster.h` 占掉一段预算，剔除后请求体 13.2 KB → 7.0 KB。IDE 里照常列出来，那是另一回事。

## 只读，不代劳

和 ops 一个规矩，理由也一样：判定读的就是执行结果，能替学员改 kernel 的助手等于能替他通关。GPU 这边额外把「**不要整段重写他的 kernel**」单独写进提示词 —— 这正是学员最想要的那件事。

## 复盘维度按 GPU 场景重定，没照抄 ops 的排查路径那套

`optimization` / `measurement` / `correctness` / `legitimacy` / `understanding`

其中 **`legitimacy`（门槛的成色）是这套提示词存在的主要理由**：把问题规模改小、把 kernel 掏空只留下写结果、把循环次数减掉，都能让计量掉下来而用例照样绿。提示词里把「门槛过了不等于优化对了」写死，并且明令**不许拿模拟周期数评分**（没有真卡校准）。

## 顺带查出来的另外两个「ops 有、gpu 没有」

按你说的列了清单对比两边，除了 AI 这两样，还有：

1. **IDE 的文件列表是死的** —— 只取关卡声明的清单且钉在 `stageKey` 上，学员在终端里 `cp` 出来的文件**永远看不到**。ops 一直是 `vfs.toFileMap()` 的实时投影。已对齐（按扩展名筛，nvcc 产出的 `bench` 二进制不进 IDE）。
2. **三个测试文件从没进过测试清单**（`tests/build`、`tests/trace`）—— 上一个 PR 已补，`npm test` 从 10/10 变成 12/12。

其余差异是**领域独有**，不该对齐：拓扑图 / 包路径 / 事件与变更是 K8s 的，剖析 / 访存 / 集群是 GPU 的。

新增 `workspace-parity.test.ts` 盯这件事不再发生：ops 有的六样东西 gpu 必须也有，两边的 tab、维度常量、中英文案、以及「没有手」那句话都盯住。它**刻意先断言 ops 那边存在**，否则「两边都没有」会假通过。

## 验证

- `npm test` **12/12**，`tsc --noEmit` 干净
- 在 `electron-builder` 打出的 **.app** 里，用本地 OpenAI 兼容 mock 实测对话与复盘两条链路都通：mock 收到 2 条请求（对话 7.0KB、复盘 7.6KB），上下文七个小节齐全，门槛实测值、kernel 源码、真实 `ncu` 输出都在，轨迹与只读头文件都不在
- 复盘在左栏渲染出 GPU 维度：门槛的成色 88 / 优化思路 82 / 正确性保持 90 / 先量再改 70 / 机制理解 78

⚠️ **provider 锁在 mock 上**：只改渲染进程内存里的配置，用户 `~/.offline-leet-practice/config.json` 的 sha256 前后一致，真实 deepseek key 全程没被碰。

一个如实说明：e2e 是浏览器直连打包应用的 HTTP 服务跑的，走的是产物里的 Next 服务与 JS bundle，但不是 Electron 渲染进程本身（那条路径下 `electronAPI` 会优先读磁盘配置，而我不想碰你的真 key）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)