### PR TITLE
fix(workbench): AI 助手面板撑满右栏，左栏正文排版按窄栏重做

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -208,10 +208,15 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({ content, stream
       );
     },
     
-    // Custom paragraph renderer
+    /*
+     * 段落。
+     *
+     * 1.75 而不是 1.6：中文是全高方块字，没有西文的升部降部撑开行间，
+     * 同样的数值看上去要挤一档。这里改了对聊天气泡同样生效 —— 那边也是中英混排。
+     */
     p({ children }: any) {
       return (
-        <Text mb="sm" style={{ lineHeight: 1.6 }}>
+        <Text mb="sm" style={{ lineHeight: 1.75 }}>
           {children}
         </Text>
       );
@@ -220,13 +225,20 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({ content, stream
     // Custom blockquote renderer
     blockquote({ children }: any) {
       return (
-        <Paper 
-          p="md" 
-          withBorder 
-          style={{ 
-            borderLeft: '4px solid #339af0',
+        /*
+         * 引用块。
+         *
+         * 原本左边框是写死的 `#339af0`：主题色换了它不跟着换，暗色下那条蓝也偏亮。
+         * 改成主题变量，并且去掉外框只留左边这一竖 —— 引用是「插进正文的一段话」，
+         * 四面都描边会让它看起来像一个独立的卡片，打断阅读。
+         */
+        <Paper
+          p="sm"
+          style={{
+            borderLeft: '3px solid var(--mantine-color-blue-filled)',
+            borderRadius: 0,
             backgroundColor: colorScheme === 'dark' ? 'var(--mantine-color-dark-6)' : 'var(--mantine-color-gray-0)',
-            color: colorScheme === 'dark' ? 'var(--mantine-color-gray-1)' : undefined
+            color: colorScheme === 'dark' ? 'var(--mantine-color-gray-1)' : undefined,
           }}
         >
           {children}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -125,6 +125,32 @@ export default function ChatPanel({
     viewport.scrollTop = viewport.scrollHeight;
   }, [messages]);
 
+  /**
+   * 尺寸或内容高度变了也要重新贴底。
+   *
+   * 工作台里这栏的宽度是可以拖的，一拖内容重排、总高度变，原来贴着底部的视图
+   * 就浮到中间去了 —— 看起来像「消息没滚到底」。同样只在**本来就贴着底**时才动，
+   * 用户正在往回翻历史时拖分隔条不会被拽走。
+   *
+   * **要盯的是内容那一层，不只是视口。** 只观察视口的话，回调在视口尺寸变化的
+   * 那一帧就跑了，而此时里面的文字还没重新折行；等它折完，总高度又长了一截，
+   * 于是又不贴底了。实测拖宽左栏（对话变窄、文字折行变多）必现，
+   * 而后续几次拖动反而正常 —— 因为那时高度已经稳定。观察内容元素就没有这个时序问题。
+   */
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || typeof ResizeObserver === 'undefined') return;
+    const stickToBottom = () => {
+      if (!pinnedRef.current) return;
+      viewport.scrollTop = viewport.scrollHeight;
+    };
+    const observer = new ResizeObserver(stickToBottom);
+    observer.observe(viewport);
+    const content = viewport.firstElementChild;
+    if (content) observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
+
   const submit = () => {
     const text = input.trim();
     if (!text || isStreaming) return;
@@ -137,9 +163,20 @@ export default function ChatPanel({
   const canRetry = !isStreaming && (Boolean(error) || Boolean(lastMessage?.error));
 
   return (
-    <Stack gap={0} style={{ flex: 1, minHeight: 0 }}>
+    /*
+     * 高度要同时应付两种父容器。
+     *
+     * 弹窗形态（AIChatDialog / EngineeringChat）把它放进一个 `display: flex` 的
+     * 列容器里，`flex: 1` 就够了。但工作台形态放进的是 Mantine 的 `Tabs.Panel` ——
+     * **那是个 `display: block` 的 div**，`flex` 在里面是死的，于是整个面板
+     * 缩到内容高度：实测 Panel 有 580px，面板只有 313px，输入框下面空了 267px。
+     *
+     * 所以两条都写上：`height: 100%` 管住块级父容器，`flex: 1` 管住弹性父容器。
+     * 弹性容器里 `flex-basis: 0%` 会盖掉 `height`，两者不打架。
+     */
+    <Stack gap={0} style={{ flex: 1, minHeight: 0, height: '100%', width: '100%' }}>
       <ScrollArea
-        style={{ flex: 1, padding: 16 }}
+        style={{ flex: 1, minHeight: 0, padding: 16 }}
         viewportRef={viewportRef}
         onScrollPositionChange={handleScroll}
       >

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -381,8 +381,19 @@ a {
  * 而我们要的正是"最小内容宽度不能超过面板"。
  */
 .panel-scroll {
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  /*
+   * `break-word` 而不是 `anywhere`。
+   *
+   * 当初写 `anywhere` 是因为视口内层是 `display: table`、宽度由内容决定，
+   * 必须让长单词参与「最小内容宽度」的计算才不会把面板顶开。
+   * 上面那条把它改回 `display: block` + `min-width: 0` 之后，**宽度是外面定死的**，
+   * 最小内容宽度不再有话语权 —— 于是可以换成只在「这个词自己一行都放不下」时才断。
+   *
+   * 差别在观感上很实在：`compute-sanitizer`、`vecAdd<<<4, 256>>>`、
+   * `gpu.comm.bytesByLink.ib` 这些不再被从中间劈开。
+   * 实测 464 个测量点，换成 break-word 之后横向溢出仍然是 0。
+   */
+  overflow-wrap: break-word;
   /*
    * `text-spacing-trim: space-all` 关掉全角标点的挤压。
    *
@@ -431,6 +442,119 @@ a {
 .panel-scroll svg[id^='mermaid-'] {
   max-width: 100%;
   height: auto;
+}
+
+/* ------------------------------------------------------------------
+ * 左栏的正文排版
+ *
+ * 三个实战工作台（code / ops / gpu）的左栏都挂 `.panel-scroll`，
+ * 所以这一段一改三边同时生效 —— 观感一致是靠共用这个类保证的，不是靠各自对齐。
+ *
+ * 这一栏的内容形态很固定：中英混排的说明文字、`##` 小节标题（一关平均六个）、
+ * 无序列表、对照表、命令行代码块。下面每一条都是冲着其中一样去的。
+ * ------------------------------------------------------------------ */
+
+/*
+ * 行距。
+ *
+ * 1.75 而不是 Latin 惯用的 1.5~1.6：中文是全高方块字，没有西文的升部降部留白，
+ * 同样的行距看上去要挤得多。窄栏里一行只有十几个字，行距不够时眼睛很容易串行。
+ */
+.panel-scroll li {
+  line-height: 1.75;
+}
+
+/*
+ * 列表的缩进。
+ *
+ * 浏览器默认 `padding-inline-start: 40px`。左栏拖到最窄时正文只有 216px，
+ * 40px 等于把 18% 的行长喂给了缩进，而这一栏的列表几乎都是「通关标准」那种短句，
+ * 本来就不需要深缩进。1.5em（24px）够把项目符号和正文分开了。
+ */
+.panel-scroll ul,
+.panel-scroll ol {
+  padding-inline-start: 1.5em;
+  margin-block: 0.6em;
+}
+
+/* 列表项之间留一点空隙，一条一条读得开 */
+.panel-scroll li + li {
+  margin-top: 0.35em;
+}
+
+/*
+ * 标题。
+ *
+ * Mantine 的 `Title order={1}` 是 34px —— 那是给整页正文用的尺寸，
+ * 放进 300px 出头的窄栏里像块广告牌。这里按栏宽重新定尺：层级主要靠**间距**
+ * 和 `##` 底下那条分隔线表达，字号只拉开一点点。
+ *
+ * `##` 单独给一条底线：一关平均六个小节，长文里没有视觉分隔的话，
+ * 滚起来是一整片灰色的字，找不到「这一段讲完了」的位置。
+ */
+.panel-scroll h1 {
+  font-size: 1.25rem;
+  line-height: 1.4;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+}
+
+.panel-scroll h2 {
+  font-size: 1.12rem;
+  line-height: 1.4;
+  margin-top: 1.5em;
+  margin-bottom: 0.55em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--mantine-color-default-border);
+}
+
+.panel-scroll h3 {
+  font-size: 1rem;
+  line-height: 1.45;
+  margin-top: 1.3em;
+  margin-bottom: 0.45em;
+}
+
+.panel-scroll h4,
+.panel-scroll h5,
+.panel-scroll h6 {
+  font-size: 0.94rem;
+  margin-top: 1.1em;
+  margin-bottom: 0.4em;
+}
+
+/*
+ * 行内代码。
+ *
+ * 这一栏里行内代码密度很高（变量名、指标名、命令），所以要**一眼能和正文分开**、
+ * 但又不能抢戏。给一点横向内边距和圆角就够，字号压到 0.88em 让它和中文的
+ * 视觉重量持平 —— 等宽字体在同样 font-size 下看着比中文大一号。
+ */
+.panel-scroll :not(pre) > code {
+  padding: 0.1em 0.34em;
+  border-radius: 3px;
+  font-size: 0.88em;
+}
+
+/*
+ * 表格。
+ *
+ * 对照表在窄栏里最吃宽度。字号收一点、单元格内边距收一点，
+ * 换来的是同样宽度下少折几行 —— 折行越多，表格越难横着读。
+ */
+.panel-scroll table {
+  font-size: 0.86em;
+}
+
+.panel-scroll th,
+.panel-scroll td {
+  padding: 4px 8px;
+  line-height: 1.55;
+}
+
+/* 代码块和上下文之间留出空隙，别和段落黏在一起 */
+.panel-scroll pre {
+  margin-block: 0.8em;
 }
 
 /* 编辑器左侧栏的断点标记。条件断点/日志断点用空心圆区分开。 */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -530,7 +530,14 @@ a {
  * 但又不能抢戏。给一点横向内边距和圆角就够，字号压到 0.88em 让它和中文的
  * 视觉重量持平 —— 等宽字体在同样 font-size 下看着比中文大一号。
  */
-.panel-scroll :not(pre) > code {
+/*
+ * 选择器要钉在 Mantine 的 Code 组件上，**不能写成 `:not(pre) > code`**。
+ * react-syntax-highlighter 渲染出来的结构是 `pre > div > code`，
+ * 那个 code 的父节点是 div 不是 pre，于是 `:not(pre) > code` 会把它一起命中 ——
+ * 代码块的字号被压成 0.88em，还平白多出一圈内边距和圆角。
+ * 行内代码走的是 MarkdownRenderer 里的 `<Code>`，认它的类名最准。
+ */
+.panel-scroll .mantine-Code-root {
   padding: 0.1em 0.34em;
   border-radius: 3px;
   font-size: 0.88em;


### PR DESCRIPTION
两件事都在同一层（面板的呈现），放一条分支。

## 一、AI 助手面板没有撑满（bug）

输入框浮在面板中间，下面空着一大片。

**根因**：`ChatPanel` 的根节点写的是 `flex: 1`，而工作台把它挂进的是 Mantine 的 `Tabs.Panel` —— **那是个 `display: block` 的 div**，`flex` 在里面完全是死的，于是面板缩到内容高度。实测：

| | 高度 |
|---|---|
| `Tabs.Panel` | 580px |
| `ChatPanel` 根节点 | **313px** |
| 输入框下面空的 | **267px** |

弹窗形态（`AIChatDialog` / `EngineeringChat`）把它放进的是 `display: flex` 的列容器，那边一直是对的 —— 所以这个 bug 只在两个工作台里出现，而且**ops 和 gpu 都有**（你猜得对，gpu 那份是照 ops 抄的）。改在共用的 `ChatPanel` 上，两边一起好。

修法是同时写 `height: 100%`（管块级父容器）和 `flex: 1`（管弹性父容器），弹性容器里 `flex-basis: 0%` 会盖掉 `height`，两者不打架。

**顺带修了一个拖动时的毛病**：左栏宽度一变，对话内容重新折行、总高度变，原本贴着底的视图就浮到中间，看着像「没滚到底」。加了 ResizeObserver 重新贴底，**盯的是内容元素而不只是视口** —— 只盯视口的话回调在文字重新折行之前就跑了，折完高度又长一截，于是又不贴底（实测拖宽左栏必现，而后续几次拖动反而正常，因为那时高度已经稳定）。仍然只在用户本来就贴着底时才动。

## 二、左栏正文排版

三个工作台的左栏都挂 `.panel-scroll`，所以改这一个类三边同时生效 —— 一致性是靠共用这个类保证的，不是靠各自对齐。

先数了一遍这栏到底在渲染什么，再决定改哪些：

| 元素 | 用量 |
|---|---|
| `##` 小标题 | 656 处，154 关里 104 关用到 |
| 表格 | 82 关 |
| 无序列表 | 133 关 |
| `#`/`###`/引用块 | **0** |

所以重点放在 h2、列表、表格、行内代码、正文行距上。

- **行距 1.6 → 1.75**。中文是全高方块字，没有西文的升部降部撑开行间，同样数值看上去要挤一档；窄栏里一行只有十几个字，行距不够容易串行。
- **列表缩进 40px → 1.5em**。左栏拖到最窄时正文只有 216px，浏览器默认那 40px 等于把 **18% 的行长**喂给缩进，而这栏的列表都是「通关标准」那种短句。
- **标题按栏宽重新定尺**，并给 `##` 加一条底线。Mantine 的 h1 是 34px，放进 300px 出头的窄栏像块广告牌；层级改为主要靠间距和分隔线表达。长文里没有视觉分隔就是一整片灰字，找不到「这一段讲完了」。
- **行内代码**给一点内边距和圆角，字号压到 0.88em —— 等宽字体在同样 font-size 下看着比中文大一号。
- **表格**字号和内边距都收一点：折行越多越难横着读。
- **引用块**左边框从写死的 `#339af0` 换成主题变量（原来主题换了它不跟着换，暗色下那条蓝偏亮），并去掉外框只留左边一竖。

### 一个能顺带改回来的东西

`overflow-wrap` 从 `anywhere` 换回 **`break-word`**。当初写 `anywhere` 是因为视口内层是 `display: table`、宽度由内容决定，必须让长单词参与最小内容宽度的计算才不会顶开面板。改成 `display: block` + `min-width: 0` 之后**宽度是外面定死的**，最小内容宽度不再有话语权，于是可以只在「这个词自己一行都放不下」时才断。

观感差别很实在 —— `compute-sanitizer`、`vecAdd<<<4, 256>>>`、`createCredentialStore(options)` 不再被从中间劈开。

### `text-spacing-trim` 重新评估的结论：保留

你提到它会让全角标点保持满宽、观感偏松，问是不是最优解。我重新想了一遍，**结论是保留**：换回 `normal` 就会把上一版修掉的那类溢出放回来 —— 浏览器按「挤压后」的宽度判断这行放得下，画出来却是原宽，差值没有上限，`break-all` / `line-break: anywhere` 一个都救不回来（因为浏览器根本不认为需要断）。这是拿一点观感换一类量不准的溢出。

另外值得一提：`normal` 那种挤压是 Chrome 123（2024）才有的行为，在那之前所有中文网页都是满宽标点 —— 所以「偏松」其实是大家看惯的样子，反而是挤压才是新的。

如果你更想要挤压后的紧凑感，我可以换回去，但那类溢出会跟着回来，这个取舍得你定。

## 验证

- **横向溢出扫描重跑**：11 个项目 154 关 × 左栏每个页签 × 240/340/620 三种宽度，**1236 个测量点，溢出 0**（比上次的 1149 多，因为 llm 多了「复盘」页签）。
- 单独验证 `break-word` 这一条：同一套扫描下 `anywhere` 与 `break-word` 各 464 个测量点，**都是 0**。
- **对话面板在打包产物里量**：面板 934×580、对话根 934×580，高度差 0、宽度差 0；空对话 / 8 组消息 / 拖到 240 与 960 各看过，输入框始终贴底（离底 12px = Paper 内边距），消息区内部滚动并自动滚到最新。
- `npm test` **12/12**，`tsc --noEmit` 干净。

截图对比在下面的评论里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)